### PR TITLE
Issue #4: priority, task types, scheduling constraints

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -2,16 +2,26 @@
 
 This repo is migration-first. The authoritative schema is in `migrations/`.
 
-## Work items (Issue #3)
+## Work items
+
+### Core model (Issue #3)
 
 Core tables:
 
 - `work_item`
-  - Generic task/issue/initiative record (higher-level typing comes in later issues).
+  - Generic task/issue/initiative record.
 - `work_item_participant`
   - People/agents involved in a work item. For now participants are stored as a string label.
 - `work_item_dependency`
   - Directed dependency edges between work items (e.g. `kind='blocks'`).
+
+### Planning fields (Issue #4)
+
+Adds to `work_item`:
+
+- `priority` (`work_item_priority` enum: `P0..P4`)
+- `task_type` (`work_item_task_type` enum: `general|coding|admin|ops|research|meeting`)
+- `not_before` / `not_after` scheduling window with check constraint (`not_before <= not_after` when both are set)
 
 Notes:
 

--- a/migrations/004_work_item_planning_fields.down.sql
+++ b/migrations/004_work_item_planning_fields.down.sql
@@ -1,0 +1,16 @@
+-- Issue #4 rollback
+
+DROP INDEX IF EXISTS work_item_not_after_idx;
+DROP INDEX IF EXISTS work_item_not_before_idx;
+DROP INDEX IF EXISTS work_item_priority_idx;
+
+ALTER TABLE work_item DROP CONSTRAINT IF EXISTS work_item_schedule_window_check;
+
+ALTER TABLE work_item
+  DROP COLUMN IF EXISTS not_after,
+  DROP COLUMN IF EXISTS not_before,
+  DROP COLUMN IF EXISTS task_type,
+  DROP COLUMN IF EXISTS priority;
+
+DROP TYPE IF EXISTS work_item_task_type;
+DROP TYPE IF EXISTS work_item_priority;

--- a/migrations/004_work_item_planning_fields.up.sql
+++ b/migrations/004_work_item_planning_fields.up.sql
@@ -1,0 +1,34 @@
+-- Issue #4: Priority + task types + scheduling constraints
+
+DO $$ BEGIN
+  CREATE TYPE work_item_priority AS ENUM ('P0', 'P1', 'P2', 'P3', 'P4');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
+  CREATE TYPE work_item_task_type AS ENUM (
+    'general',
+    'coding',
+    'admin',
+    'ops',
+    'research',
+    'meeting'
+  );
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+ALTER TABLE work_item
+  ADD COLUMN priority work_item_priority NOT NULL DEFAULT 'P2',
+  ADD COLUMN task_type work_item_task_type NOT NULL DEFAULT 'general',
+  ADD COLUMN not_before timestamptz,
+  ADD COLUMN not_after timestamptz;
+
+ALTER TABLE work_item
+  ADD CONSTRAINT work_item_schedule_window_check
+  CHECK (not_before IS NULL OR not_after IS NULL OR not_before <= not_after);
+
+CREATE INDEX work_item_priority_idx ON work_item(priority);
+CREATE INDEX work_item_not_before_idx ON work_item(not_before);
+CREATE INDEX work_item_not_after_idx ON work_item(not_after);

--- a/tests/work_item_planning_fields.test.ts
+++ b/tests/work_item_planning_fields.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { Pool } from 'pg';
+import { runMigrate } from './helpers/migrate.js';
+
+describe('Work item planning fields (priority/type/scheduling)', () => {
+  let pool: Pool;
+
+  beforeAll(async () => {
+    runMigrate('up');
+    pool = new Pool({
+      host: process.env.PGHOST || 'localhost',
+      port: parseInt(process.env.PGPORT || '5432'),
+      user: process.env.PGUSER || 'clawdbot',
+      password: process.env.PGPASSWORD || 'clawdbot',
+      database: process.env.PGDATABASE || 'clawdbot',
+    });
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  it('adds priority and type columns with defaults', async () => {
+    const inserted = await pool.query(
+      `INSERT INTO work_item (title) VALUES ('Planning fields')
+       RETURNING priority::text as priority, task_type::text as task_type`
+    );
+
+    expect(inserted.rows[0].priority).toMatch(/^P[0-4]$/);
+    expect(typeof inserted.rows[0].task_type).toBe('string');
+    expect(inserted.rows[0].task_type.length).toBeGreaterThan(0);
+  });
+
+  it('allows scheduling constraints and rejects impossible windows', async () => {
+    const ok = await pool.query(
+      `INSERT INTO work_item (title, not_before, not_after)
+       VALUES ('Window ok', now(), now() + interval '1 hour')
+       RETURNING id`
+    );
+    expect(ok.rows.length).toBe(1);
+
+    await expect(
+      pool.query(
+        `INSERT INTO work_item (title, not_before, not_after)
+         VALUES ('Window bad', now() + interval '2 hour', now() + interval '1 hour')`
+      )
+    ).rejects.toThrow(/work_item/);
+  });
+});


### PR DESCRIPTION
Adds planning/scheduling fields to work items.

- Adds enums: work_item_priority (P0..P4) and work_item_task_type
- Adds work_item columns: priority, task_type, not_before, not_after
- Adds check constraint for scheduling window
- Adds tests + docs updates

Closes #4