### PR TITLE
Issue #9: contacts + endpoints + trust model

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -23,6 +23,16 @@ Adds to `work_item`:
 - `task_type` (`work_item_task_type` enum: `general|coding|admin|ops|research|meeting`)
 - `not_before` / `not_after` scheduling window with check constraint (`not_before <= not_after` when both are set)
 
+## Contacts (Issue #9)
+
+- `contact`
+  - `display_name`, optional `notes`
+  - coarse trust flags: `allow_schedule`, `allow_auto_reply_safe_only`
+- `contact_endpoint`
+  - typed endpoints (`phone`, `email`, `telegram`, ...)
+  - `normalized_value` is maintained by a DB trigger and is globally unique per `(endpoint_type, normalized_value)`
+  - `allow_privileged_actions` is **never** allowed via `phone` endpoints (DB check constraint)
+
 Notes:
 
 - IDs are UUIDv7 generated in Postgres via `new_uuid()`.

--- a/migrations/005_contacts_endpoints_trust.down.sql
+++ b/migrations/005_contacts_endpoints_trust.down.sql
@@ -1,0 +1,10 @@
+-- Issue #9 rollback
+
+DROP TRIGGER IF EXISTS trg_contact_endpoint_normalize ON contact_endpoint;
+DROP FUNCTION IF EXISTS contact_endpoint_set_normalized_value();
+
+DROP TABLE IF EXISTS contact_endpoint;
+DROP FUNCTION IF EXISTS normalize_contact_endpoint_value(contact_endpoint_type, text);
+DROP TYPE IF EXISTS contact_endpoint_type;
+
+DROP TABLE IF EXISTS contact;

--- a/migrations/005_contacts_endpoints_trust.up.sql
+++ b/migrations/005_contacts_endpoints_trust.up.sql
@@ -1,0 +1,82 @@
+-- Issue #9: Contacts + endpoints + trust model (cross-channel)
+
+CREATE TABLE contact (
+  id uuid PRIMARY KEY DEFAULT new_uuid(),
+  display_name text NOT NULL CHECK (length(trim(display_name)) > 0),
+  notes text,
+
+  -- Trust / automation policy flags (coarse, safe-by-default)
+  allow_schedule boolean NOT NULL DEFAULT false,
+  allow_auto_reply_safe_only boolean NOT NULL DEFAULT false,
+
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+DO $$ BEGIN
+  CREATE TYPE contact_endpoint_type AS ENUM (
+    'phone',
+    'email',
+    'telegram',
+    'slack',
+    'github',
+    'webhook'
+  );
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+-- Normalization helpers keep the DB as the source-of-truth.
+CREATE OR REPLACE FUNCTION normalize_contact_endpoint_value(p_type contact_endpoint_type, p_value text)
+RETURNS text
+LANGUAGE sql
+IMMUTABLE
+AS $$
+  SELECT CASE p_type
+    WHEN 'email' THEN lower(trim(p_value))
+    WHEN 'telegram' THEN lower(regexp_replace(trim(p_value), '^@', ''))
+    WHEN 'phone' THEN regexp_replace(trim(p_value), '[^0-9+]', '', 'g')
+    ELSE lower(trim(p_value))
+  END;
+$$;
+
+CREATE TABLE contact_endpoint (
+  id uuid PRIMARY KEY DEFAULT new_uuid(),
+  contact_id uuid NOT NULL REFERENCES contact(id) ON DELETE CASCADE,
+  endpoint_type contact_endpoint_type NOT NULL,
+  endpoint_value text NOT NULL CHECK (length(trim(endpoint_value)) > 0),
+  normalized_value text NOT NULL,
+
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+
+  -- Policy: privileged actions are never allowed via SMS/phone endpoints.
+  allow_privileged_actions boolean NOT NULL DEFAULT false,
+
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+
+  CONSTRAINT contact_endpoint_normalized_unique UNIQUE (endpoint_type, normalized_value),
+  CONSTRAINT contact_endpoint_no_privileged_via_phone CHECK (
+    NOT (endpoint_type = 'phone' AND allow_privileged_actions)
+  )
+);
+
+CREATE INDEX contact_display_name_idx ON contact(display_name);
+CREATE INDEX contact_endpoint_contact_idx ON contact_endpoint(contact_id);
+
+CREATE OR REPLACE FUNCTION contact_endpoint_set_normalized_value()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  NEW.normalized_value := normalize_contact_endpoint_value(NEW.endpoint_type, NEW.endpoint_value);
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_contact_endpoint_normalize ON contact_endpoint;
+CREATE TRIGGER trg_contact_endpoint_normalize
+BEFORE INSERT OR UPDATE OF endpoint_type, endpoint_value
+ON contact_endpoint
+FOR EACH ROW
+EXECUTE FUNCTION contact_endpoint_set_normalized_value();

--- a/tests/contacts.test.ts
+++ b/tests/contacts.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { Pool } from 'pg';
+import { runMigrate } from './helpers/migrate.js';
+
+describe('Contacts + endpoints + trust model', () => {
+  let pool: Pool;
+
+  beforeAll(async () => {
+    runMigrate('up');
+    pool = new Pool({
+      host: process.env.PGHOST || 'localhost',
+      port: parseInt(process.env.PGPORT || '5432'),
+      user: process.env.PGUSER || 'clawdbot',
+      password: process.env.PGPASSWORD || 'clawdbot',
+      database: process.env.PGDATABASE || 'clawdbot',
+    });
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  it('normalizes email endpoints and enforces uniqueness on normalized value', async () => {
+    const c = await pool.query(`INSERT INTO contact (display_name) VALUES ('Troy') RETURNING id`);
+    const contactId = c.rows[0].id as string;
+
+    const e1 = await pool.query(
+      `INSERT INTO contact_endpoint (contact_id, endpoint_type, endpoint_value)
+       VALUES ($1, 'email', $2)
+       RETURNING normalized_value`,
+      [contactId, '  Troy@Example.COM  ']
+    );
+    expect(e1.rows[0].normalized_value).toBe('troy@example.com');
+
+    // Global uniqueness: normalized email cannot belong to multiple contacts
+    const c2 = await pool.query(`INSERT INTO contact (display_name) VALUES ('Other') RETURNING id`);
+    const contactId2 = c2.rows[0].id as string;
+
+    await expect(
+      pool.query(
+        `INSERT INTO contact_endpoint (contact_id, endpoint_type, endpoint_value)
+         VALUES ($1, 'email', $2)`,
+        [contactId2, 'troy@example.com']
+      )
+    ).rejects.toThrow(/contact_endpoint/);
+  });
+
+  it('normalizes telegram handles by stripping @ and lowercasing', async () => {
+    const c = await pool.query(`INSERT INTO contact (display_name) VALUES ('Matty') RETURNING id`);
+    const contactId = c.rows[0].id as string;
+
+    const e1 = await pool.query(
+      `INSERT INTO contact_endpoint (contact_id, endpoint_type, endpoint_value)
+       VALUES ($1, 'telegram', $2)
+       RETURNING normalized_value`,
+      [contactId, ' @SomeUser ']
+    );
+
+    expect(e1.rows[0].normalized_value).toBe('someuser');
+  });
+
+  it('disallows privileged actions via SMS/phone endpoints by policy', async () => {
+    const c = await pool.query(`INSERT INTO contact (display_name) VALUES ('Ops') RETURNING id`);
+    const contactId = c.rows[0].id as string;
+
+    await expect(
+      pool.query(
+        `INSERT INTO contact_endpoint (contact_id, endpoint_type, endpoint_value, allow_privileged_actions)
+         VALUES ($1, 'phone', $2, true)`,
+        [contactId, '+1 (555) 123-4567']
+      )
+    ).rejects.toThrow(/no_privileged_via_phone/);
+  });
+});


### PR DESCRIPTION
Implements contacts, their endpoints, and coarse trust policy flags.

- Adds contact + contact_endpoint tables
- Adds endpoint normalization function + trigger (email/telegram/phone)
- Adds uniqueness constraint on (endpoint_type, normalized_value)
- Enforces policy: privileged actions are never allowed via phone/SMS endpoints
- Adds tests + schema docs update

Closes #9