### PR TITLE
Issue #10: external threads/messages -> communication work items

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -33,6 +33,17 @@ Adds to `work_item`:
   - `normalized_value` is maintained by a DB trigger and is globally unique per `(endpoint_type, normalized_value)`
   - `allow_privileged_actions` is **never** allowed via `phone` endpoints (DB check constraint)
 
+## External messages (Issue #10)
+
+- `external_thread`
+  - Links a contact endpoint to an external conversation/thread identifier (e.g. Twilio conversation SID, Telegram chat id)
+  - Unique per `(channel, external_thread_key)`
+- `external_message`
+  - Messages within a thread (`direction`: `inbound|outbound`)
+- `work_item_communication`
+  - Subtype table attaching an actionable communication task to a thread/message
+  - A trigger forces the parent `work_item.task_type = 'communication'`
+
 Notes:
 
 - IDs are UUIDv7 generated in Postgres via `new_uuid()`.

--- a/migrations/006_external_messages_threads_work_items.down.sql
+++ b/migrations/006_external_messages_threads_work_items.down.sql
@@ -1,0 +1,13 @@
+-- Issue #10 rollback
+
+DROP TRIGGER IF EXISTS trg_work_item_communication_enforce_type ON work_item_communication;
+DROP FUNCTION IF EXISTS work_item_communication_enforce_type();
+
+DROP TABLE IF EXISTS work_item_communication;
+DROP TABLE IF EXISTS external_message;
+DROP TABLE IF EXISTS external_thread;
+
+DROP TYPE IF EXISTS communication_action;
+DROP TYPE IF EXISTS message_direction;
+
+-- NOTE: we do not remove enum values from work_item_task_type (Postgres doesn't support it safely).

--- a/migrations/006_external_messages_threads_work_items.up.sql
+++ b/migrations/006_external_messages_threads_work_items.up.sql
@@ -1,0 +1,80 @@
+-- Issue #10: inbound external messages -> threads/work items
+
+-- Add a task_type for communication-driven work
+DO $$ BEGIN
+  ALTER TYPE work_item_task_type ADD VALUE IF NOT EXISTS 'communication';
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
+  CREATE TYPE message_direction AS ENUM ('inbound', 'outbound');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
+  CREATE TYPE communication_action AS ENUM ('reply_required', 'follow_up');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+CREATE TABLE external_thread (
+  id uuid PRIMARY KEY DEFAULT new_uuid(),
+  endpoint_id uuid NOT NULL REFERENCES contact_endpoint(id) ON DELETE CASCADE,
+  channel contact_endpoint_type NOT NULL,
+  external_thread_key text NOT NULL CHECK (length(trim(external_thread_key)) > 0),
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT external_thread_key_unique UNIQUE (channel, external_thread_key)
+);
+
+CREATE INDEX external_thread_endpoint_idx ON external_thread(endpoint_id);
+
+CREATE TABLE external_message (
+  id uuid PRIMARY KEY DEFAULT new_uuid(),
+  thread_id uuid NOT NULL REFERENCES external_thread(id) ON DELETE CASCADE,
+  external_message_key text NOT NULL CHECK (length(trim(external_message_key)) > 0),
+  direction message_direction NOT NULL,
+  body text,
+  raw jsonb NOT NULL DEFAULT '{}'::jsonb,
+  received_at timestamptz NOT NULL DEFAULT now(),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT external_message_key_unique UNIQUE (thread_id, external_message_key)
+);
+
+CREATE INDEX external_message_thread_idx ON external_message(thread_id);
+CREATE INDEX external_message_received_at_idx ON external_message(received_at);
+
+-- Subtype table: a work item that represents an actionable communication
+CREATE TABLE work_item_communication (
+  work_item_id uuid PRIMARY KEY REFERENCES work_item(id) ON DELETE CASCADE,
+  thread_id uuid NOT NULL REFERENCES external_thread(id) ON DELETE RESTRICT,
+  message_id uuid REFERENCES external_message(id) ON DELETE SET NULL,
+  action communication_action NOT NULL DEFAULT 'reply_required',
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX work_item_communication_thread_idx ON work_item_communication(thread_id);
+
+CREATE OR REPLACE FUNCTION work_item_communication_enforce_type()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  -- Ensure the parent work item is marked as a communication task.
+  UPDATE work_item
+    SET task_type = 'communication'
+  WHERE id = NEW.work_item_id;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_work_item_communication_enforce_type ON work_item_communication;
+CREATE TRIGGER trg_work_item_communication_enforce_type
+BEFORE INSERT OR UPDATE OF work_item_id
+ON work_item_communication
+FOR EACH ROW
+EXECUTE FUNCTION work_item_communication_enforce_type();

--- a/tests/external_messages.test.ts
+++ b/tests/external_messages.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { Pool } from 'pg';
+import { runMigrate } from './helpers/migrate.js';
+
+describe('External inbound messages -> threads -> work items', () => {
+  let pool: Pool;
+
+  beforeAll(async () => {
+    runMigrate('up');
+    pool = new Pool({
+      host: process.env.PGHOST || 'localhost',
+      port: parseInt(process.env.PGPORT || '5432'),
+      user: process.env.PGUSER || 'clawdbot',
+      password: process.env.PGPASSWORD || 'clawdbot',
+      database: process.env.PGDATABASE || 'clawdbot',
+    });
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  it('links an inbound external message thread to a communication work item', async () => {
+    const c = await pool.query(`INSERT INTO contact (display_name) VALUES ('Sender') RETURNING id`);
+    const contactId = c.rows[0].id as string;
+
+    const endpoint = await pool.query(
+      `INSERT INTO contact_endpoint (contact_id, endpoint_type, endpoint_value)
+       VALUES ($1, 'phone', $2)
+       RETURNING id`,
+      [contactId, '+15551234567']
+    );
+    const endpointId = endpoint.rows[0].id as string;
+
+    const thread = await pool.query(
+      `INSERT INTO external_thread (endpoint_id, channel, external_thread_key)
+       VALUES ($1, 'phone', $2)
+       RETURNING id`,
+      [endpointId, 'twilio:SMXXXXXXXXXXXXXXXX']
+    );
+    const threadId = thread.rows[0].id as string;
+
+    const msg = await pool.query(
+      `INSERT INTO external_message (thread_id, external_message_key, direction, body)
+       VALUES ($1, $2, 'inbound', 'hello')
+       RETURNING id`,
+      [threadId, 'twilio:MMYYYYYYYYYYYYYYYY']
+    );
+    const msgId = msg.rows[0].id as string;
+
+    const wi = await pool.query(`INSERT INTO work_item (title) VALUES ('Reply required') RETURNING id`);
+    const workItemId = wi.rows[0].id as string;
+
+    await pool.query(
+      `INSERT INTO work_item_communication (work_item_id, thread_id, message_id, action)
+       VALUES ($1, $2, $3, 'reply_required')`,
+      [workItemId, threadId, msgId]
+    );
+
+    const joined = await pool.query(
+      `SELECT w.task_type::text as task_type, t.external_thread_key, m.direction::text as direction
+       FROM work_item w
+       JOIN work_item_communication wc ON wc.work_item_id = w.id
+       JOIN external_thread t ON t.id = wc.thread_id
+       JOIN external_message m ON m.id = wc.message_id
+       WHERE w.id = $1`,
+      [workItemId]
+    );
+
+    expect(joined.rows[0].task_type).toBe('communication');
+    expect(joined.rows[0].external_thread_key).toBe('twilio:SMXXXXXXXXXXXXXXXX');
+    expect(joined.rows[0].direction).toBe('inbound');
+  });
+
+  it('enforces uniqueness of (channel, external_thread_key)', async () => {
+    const c = await pool.query(`INSERT INTO contact (display_name) VALUES ('Sender2') RETURNING id`);
+    const contactId = c.rows[0].id as string;
+
+    const endpoint = await pool.query(
+      `INSERT INTO contact_endpoint (contact_id, endpoint_type, endpoint_value)
+       VALUES ($1, 'phone', $2)
+       RETURNING id`,
+      [contactId, '+15550001111']
+    );
+    const endpointId = endpoint.rows[0].id as string;
+
+    await pool.query(
+      `INSERT INTO external_thread (endpoint_id, channel, external_thread_key)
+       VALUES ($1, 'phone', 'twilio:thread-1')`,
+      [endpointId]
+    );
+
+    await expect(
+      pool.query(
+        `INSERT INTO external_thread (endpoint_id, channel, external_thread_key)
+         VALUES ($1, 'phone', 'twilio:thread-1')`,
+        [endpointId]
+      )
+    ).rejects.toThrow(/external_thread/);
+  });
+});


### PR DESCRIPTION
Adds schema to represent inbound/outbound external communications and attach them to actionable work items.

- Adds external_thread, external_message
- Adds work_item_communication subtype table for reply-required tasks
- Adds enum values + triggers to keep work_item.task_type in sync
- Adds tests + schema docs

Closes #10