### PR TITLE
Issue #19: magic-link auth + 7d sessions

### DIFF
--- a/migrations/008_magic_link_auth.down.sql
+++ b/migrations/008_magic_link_auth.down.sql
@@ -1,0 +1,4 @@
+-- Issue #19: rollback auth tables
+
+DROP TABLE IF EXISTS auth_session;
+DROP TABLE IF EXISTS auth_magic_link;

--- a/migrations/008_magic_link_auth.up.sql
+++ b/migrations/008_magic_link_auth.up.sql
@@ -1,0 +1,25 @@
+-- Issue #19: magic-link auth (15m) + 7d session cookies
+
+CREATE TABLE auth_magic_link (
+  id uuid PRIMARY KEY DEFAULT new_uuid(),
+  email text NOT NULL CHECK (position('@' in email) > 1),
+  token_sha256 text NOT NULL CHECK (length(token_sha256) = 64),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  expires_at timestamptz NOT NULL,
+  used_at timestamptz,
+  CONSTRAINT auth_magic_link_token_unique UNIQUE (token_sha256)
+);
+
+CREATE INDEX auth_magic_link_email_idx ON auth_magic_link(email);
+CREATE INDEX auth_magic_link_expires_at_idx ON auth_magic_link(expires_at);
+
+CREATE TABLE auth_session (
+  id uuid PRIMARY KEY DEFAULT new_uuid(),
+  email text NOT NULL CHECK (position('@' in email) > 1),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  expires_at timestamptz NOT NULL,
+  revoked_at timestamptz
+);
+
+CREATE INDEX auth_session_email_idx ON auth_session(email);
+CREATE INDEX auth_session_expires_at_idx ON auth_session(expires_at);

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "vitest": "^4.0.18"
   },
   "dependencies": {
+    "@fastify/cookie": "^11.0.2",
     "@types/pg": "^8.16.0",
     "fastify": "^5.7.2",
     "pg": "^8.17.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@fastify/cookie':
+        specifier: ^11.0.2
+        version: 11.0.2
       '@types/pg':
         specifier: ^8.16.0
         version: 8.16.0
@@ -191,6 +194,9 @@ packages:
 
   '@fastify/ajv-compiler@4.0.5':
     resolution: {integrity: sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==}
+
+  '@fastify/cookie@11.0.2':
+    resolution: {integrity: sha512-GWdwdGlgJxyvNv+QcKiGNevSspMQXncjMZ1J8IvuDQk0jvkzgWWZFNC2En3s+nHndZBGV8IbLwOI/sxCZw/mzA==}
 
   '@fastify/error@4.2.0':
     resolution: {integrity: sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ==}
@@ -451,6 +457,9 @@ packages:
 
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  fastify-plugin@5.1.0:
+    resolution: {integrity: sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==}
 
   fastify@5.7.2:
     resolution: {integrity: sha512-dBJolW+hm6N/yJVf6J5E1BxOBNkuXNl405nrfeR8SpvGWG3aCC2XDHyiFBdow8Win1kj7sjawQc257JlYY6M/A==}
@@ -860,6 +869,11 @@ snapshots:
       ajv-formats: 3.0.1(ajv@8.17.1)
       fast-uri: 3.1.0
 
+  '@fastify/cookie@11.0.2':
+    dependencies:
+      cookie: 1.1.1
+      fastify-plugin: 5.1.0
+
   '@fastify/error@4.2.0': {}
 
   '@fastify/fast-json-stringify-compiler@5.0.3':
@@ -1099,6 +1113,8 @@ snapshots:
       fast-decode-uri-component: 1.0.1
 
   fast-uri@3.1.0: {}
+
+  fastify-plugin@5.1.0: {}
 
   fastify@5.7.2:
     dependencies:

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { runMigrate } from './helpers/migrate.js';
+import { buildServer } from '../src/api/server.js';
+
+describe('Magic-link auth + sessions', () => {
+  const app = buildServer();
+
+  beforeAll(async () => {
+    runMigrate('up');
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('issues a magic link and creates a 7-day session on consume', async () => {
+    const request = await app.inject({
+      method: 'POST',
+      url: '/api/auth/request-link',
+      payload: { email: 'test@example.com' },
+    });
+
+    expect(request.statusCode).toBe(201);
+    const { loginUrl } = request.json() as { loginUrl: string };
+    expect(loginUrl).toMatch(/\/api\/auth\/consume\?token=/);
+
+    const token = new URL(loginUrl).searchParams.get('token');
+    expect(token).toBeTruthy();
+
+    const consume = await app.inject({
+      method: 'GET',
+      url: `/api/auth/consume?token=${token}`,
+      headers: { accept: 'application/json' },
+    });
+
+    expect(consume.statusCode).toBe(200);
+    expect(consume.json()).toEqual({ ok: true });
+
+    const setCookie = consume.headers['set-cookie'];
+    expect(setCookie).toBeTruthy();
+
+    const cookieHeader = Array.isArray(setCookie) ? setCookie[0] : setCookie;
+    const sessionCookie = cookieHeader.split(';')[0];
+
+    const me = await app.inject({
+      method: 'GET',
+      url: '/api/me',
+      headers: {
+        cookie: sessionCookie,
+      },
+    });
+
+    expect(me.statusCode).toBe(200);
+    expect(me.json()).toEqual({ email: 'test@example.com' });
+  });
+});


### PR DESCRIPTION
Closes #19.

- Adds auth_magic_link (15m expiry, single-use) and auth_session (7d) tables
- Adds /api/auth/request-link and /api/auth/consume to issue/consume links
- Sets an httpOnly session cookie (projects_session)
- Adds /api/me endpoint for session validation
- Includes tests