### PR TITLE
Issue #20: dashboard UI at /dashboard

### DIFF
--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -130,6 +130,198 @@ export function buildServer(options: ProjectsApiOptions = {}): FastifyInstance {
     return reply.send({ email: result.rows[0].email });
   });
 
+  app.get('/api/work-items', async (_req, reply) => {
+    const pool = createPool();
+    const result = await pool.query(
+      `SELECT id::text as id, title, status, priority::text as priority, task_type::text as task_type,
+              created_at, updated_at
+         FROM work_item
+        ORDER BY created_at DESC
+        LIMIT 50`
+    );
+    await pool.end();
+    return reply.send({ items: result.rows });
+  });
+
+  app.get('/api/inbox', async (_req, reply) => {
+    const pool = createPool();
+    const result = await pool.query(
+      `SELECT wi.id::text as work_item_id,
+              wi.title,
+              wic.action::text as action,
+              et.channel::text as channel,
+              et.external_thread_key,
+              em.body as last_message_body,
+              em.received_at as last_message_received_at
+         FROM work_item_communication wic
+         JOIN work_item wi ON wi.id = wic.work_item_id
+         JOIN external_thread et ON et.id = wic.thread_id
+         LEFT JOIN external_message em ON em.id = wic.message_id
+        ORDER BY wi.created_at DESC
+        LIMIT 50`
+    );
+    await pool.end();
+    return reply.send({ items: result.rows });
+  });
+
+  app.get('/dashboard', async (req, reply) => {
+    const sessionId = (req.cookies as Record<string, string | undefined>)[sessionCookieName];
+    let email: string | null = null;
+
+    if (sessionId) {
+      const pool = createPool();
+      const result = await pool.query(
+        `SELECT email
+           FROM auth_session
+          WHERE id = $1
+            AND revoked_at IS NULL
+            AND expires_at > now()`,
+        [sessionId]
+      );
+      await pool.end();
+      if (result.rows.length > 0) email = result.rows[0].email as string;
+    }
+
+    const html = email
+      ? `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>clawdbot-projects dashboard</title>
+  <style>
+    body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,Noto Sans,sans-serif; margin:24px; max-width: 980px}
+    code{background:#f2f2f2; padding:2px 4px; border-radius:4px}
+    .row{display:flex; gap:12px; align-items:center; flex-wrap:wrap}
+    input,button{font-size:14px; padding:8px 10px}
+    table{border-collapse:collapse; width:100%}
+    th,td{border-bottom:1px solid #eee; padding:8px; text-align:left; font-size:14px}
+  </style>
+</head>
+<body>
+  <h1>Dashboard</h1>
+  <p>Logged in as <code>${email}</code></p>
+
+  <h2>Create work item</h2>
+  <div class="row">
+    <input id="title" placeholder="Title" size="40" />
+    <input id="description" placeholder="Description (optional)" size="50" />
+    <button id="create">Create</button>
+  </div>
+
+  <h2>Recent work items</h2>
+  <table>
+    <thead><tr><th>Title</th><th>Status</th><th>Priority</th><th>Type</th><th>Created</th></tr></thead>
+    <tbody id="items"></tbody>
+  </table>
+
+  <h2>Inbox (communication tasks)</h2>
+  <table>
+    <thead><tr><th>Title</th><th>Action</th><th>Channel</th><th>Thread</th><th>Last message</th></tr></thead>
+    <tbody id="inbox"></tbody>
+  </table>
+
+  <script>
+    async function refresh() {
+      const res = await fetch('/api/work-items');
+      const data = await res.json();
+      document.getElementById('items').innerHTML = data.items.map(i =>
+        '<tr>' +
+          '<td>' + escapeHtml(i.title) + '</td>' +
+          '<td>' + i.status + '</td>' +
+          '<td>' + i.priority + '</td>' +
+          '<td>' + i.task_type + '</td>' +
+          '<td>' + new Date(i.created_at).toLocaleString() + '</td>' +
+        '</tr>'
+      ).join('');
+
+      const inboxRes = await fetch('/api/inbox');
+      const inbox = await inboxRes.json();
+      document.getElementById('inbox').innerHTML = inbox.items.map(i =>
+        '<tr>' +
+          '<td>' + escapeHtml(i.title) + '</td>' +
+          '<td>' + i.action + '</td>' +
+          '<td>' + i.channel + '</td>' +
+          '<td>' + escapeHtml(i.external_thread_key) + '</td>' +
+          '<td>' + escapeHtml(i.last_message_body || '') + '</td>' +
+        '</tr>'
+      ).join('');
+    }
+
+    function escapeHtml(s){
+      return String(s).replace(/[&<>\"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','\"':'&quot;','\'':'&#39;'}[c]));
+    }
+
+    document.getElementById('create').addEventListener('click', async () => {
+      const title = document.getElementById('title').value;
+      const description = document.getElementById('description').value;
+      const res = await fetch('/api/work-items', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ title, description })
+      });
+      if (!res.ok) {
+        alert('Failed: ' + (await res.text()));
+        return;
+      }
+      document.getElementById('title').value = '';
+      document.getElementById('description').value = '';
+      await refresh();
+    });
+
+    refresh();
+  </script>
+</body>
+</html>`
+      : `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>clawdbot-projects login</title>
+  <style>
+    body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,Noto Sans,sans-serif; margin:24px; max-width: 720px}
+    code{background:#f2f2f2; padding:2px 4px; border-radius:4px}
+    input,button{font-size:14px; padding:8px 10px}
+  </style>
+</head>
+<body>
+  <h1>Dashboard login</h1>
+  <p>Request a magic link (15 minutes). If email delivery isn't configured, the link will be shown here.</p>
+
+  <div>
+    <input id="email" placeholder="you@example.com" size="32" />
+    <button id="send">Request login link</button>
+  </div>
+
+  <pre id="out"></pre>
+
+  <script>
+    document.getElementById('send').addEventListener('click', async () => {
+      const email = document.getElementById('email').value;
+      const res = await fetch('/api/auth/request-link', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ email })
+      });
+      const out = document.getElementById('out');
+      if (!res.ok) {
+        out.textContent = 'Failed: ' + (await res.text());
+        return;
+      }
+      const data = await res.json();
+      out.innerHTML = 'Login link: <a href="' + data.loginUrl + '">' + data.loginUrl + '</a>';
+    });
+  </script>
+</body>
+</html>`;
+
+    return reply
+      .code(200)
+      .header('content-type', 'text/html; charset=utf-8')
+      .send(html);
+  });
+
   app.post('/api/work-items', async (req, reply) => {
     const body = req.body as { title?: string; description?: string | null };
     if (!body?.title || body.title.trim().length === 0) {

--- a/tests/dashboard.test.ts
+++ b/tests/dashboard.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { runMigrate } from './helpers/migrate.js';
+import { buildServer } from '../src/api/server.js';
+
+describe('/dashboard UI', () => {
+  const app = buildServer();
+
+  beforeAll(async () => {
+    runMigrate('up');
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('shows login UI when not authenticated', async () => {
+    const res = await app.inject({ method: 'GET', url: '/dashboard' });
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-type']).toMatch(/text\/html/);
+    expect(res.body).toContain('Dashboard login');
+  });
+
+  it('shows dashboard when authenticated', async () => {
+    const request = await app.inject({
+      method: 'POST',
+      url: '/api/auth/request-link',
+      payload: { email: 'dash@example.com' },
+    });
+    const { loginUrl } = request.json() as { loginUrl: string };
+    const token = new URL(loginUrl).searchParams.get('token');
+
+    const consume = await app.inject({
+      method: 'GET',
+      url: `/api/auth/consume?token=${token}`,
+      headers: { accept: 'application/json' },
+    });
+
+    const setCookie = consume.headers['set-cookie'];
+    const cookieHeader = Array.isArray(setCookie) ? setCookie[0] : setCookie;
+    const sessionCookie = cookieHeader.split(';')[0];
+
+    const dash = await app.inject({
+      method: 'GET',
+      url: '/dashboard',
+      headers: { cookie: sessionCookie },
+    });
+
+    expect(dash.statusCode).toBe(200);
+    expect(dash.body).toContain('Dashboard');
+    expect(dash.body).toContain('Logged in as');
+  });
+});


### PR DESCRIPTION
Closes #20.

Adds a minimal, internet-facing /dashboard page served by the API:
- When not authenticated: email input + button to request a magic link (shows link)
- When authenticated: create work item + list recent work items + inbox table

Also adds /api/work-items (list) and /api/inbox endpoints used by the UI, plus tests.