### PR TITLE
Issue #21: Traefik route for /dashboard

### DIFF
--- a/ops/systemd/clawdbot-projects.service
+++ b/ops/systemd/clawdbot-projects.service
@@ -1,0 +1,27 @@
+# Reference systemd unit for the VM.
+# Install to: /etc/systemd/system/clawdbot-projects.service
+
+[Unit]
+Description=clawdbot-projects API (serves /dashboard)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=clawdbot
+Group=clawdbot
+WorkingDirectory=/home/clawdbot/clawd/clawdbot-projects
+
+Environment=HOST=127.0.0.1
+Environment=PORT=3000
+Environment=PUBLIC_BASE_URL=https://clawdbot.public-servers.sy3.aperim.net
+
+# DB defaults are fine for local VM usage (localhost:5432, clawdbot/clawdbot).
+# Override via Environment=PGHOST=..., etc if needed.
+
+ExecStart=/home/clawdbot/.local/share/pnpm/pnpm api:dev
+Restart=on-failure
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target

--- a/ops/traefik/dynamic.yml
+++ b/ops/traefik/dynamic.yml
@@ -1,0 +1,31 @@
+# Reference config for the VM's Traefik file-provider.
+# On the VM this lives at: /opt/traefik/dynamic.yml
+
+http:
+  routers:
+    clawdbot-hooks:
+      rule: "Host(`clawdbot.public-servers.sy3.aperim.net`) && PathPrefix(`/hooks`)"
+      entryPoints:
+        - websecure
+      tls:
+        certResolver: cloudflare
+      service: clawdbot-gateway
+
+    clawdbot-projects:
+      rule: "Host(`clawdbot.public-servers.sy3.aperim.net`) && (PathPrefix(`/dashboard`) || PathPrefix(`/api`) || Path(`/health`))"
+      entryPoints:
+        - websecure
+      tls:
+        certResolver: cloudflare
+      service: clawdbot-projects
+
+  services:
+    clawdbot-gateway:
+      loadBalancer:
+        servers:
+          - url: "http://127.0.0.1:18789"
+
+    clawdbot-projects:
+      loadBalancer:
+        servers:
+          - url: "http://127.0.0.1:3000"


### PR DESCRIPTION
Closes #21.

- Adds reference Traefik dynamic.yml for routing /dashboard + /api to the projects service
- Adds reference systemd unit to run the service on 127.0.0.1:3000

(Also applied these changes on the VM at /opt/traefik/dynamic.yml and installed /etc/systemd/system/clawdbot-projects.service.)