### PR TITLE
Issue #27: Send dashboard magic links via Postmark

### DIFF
--- a/src/email/magicLink.ts
+++ b/src/email/magicLink.ts
@@ -1,0 +1,46 @@
+import { getPostmarkTransactionalToken, sendPostmarkEmail } from './postmark.js';
+
+const DEFAULT_FROM = 'news.updates@execdesk.ai';
+const DEFAULT_REPLY_TO = 'quasar@execdesk.ai';
+
+export type SendMagicLinkArgs = {
+  toEmail: string;
+  loginUrl: string;
+};
+
+export async function sendMagicLinkEmail(args: SendMagicLinkArgs): Promise<{ delivered: boolean }> {
+  // Avoid sending real email during unit tests unless explicitly enabled.
+  if (process.env.NODE_ENV === 'test' && process.env.POSTMARK_ENABLE_TEST_SEND !== '1') {
+    return { delivered: false };
+  }
+
+  const token = await getPostmarkTransactionalToken();
+  if (!token) return { delivered: false };
+
+  const subject = 'Your ExecDesk dashboard login link';
+  const textBody = `Use this link to sign in (valid for 15 minutes):\n\n${args.loginUrl}\n\nIf you did not request this, you can ignore this email.`;
+  const htmlBody = `<!doctype html>
+<html>
+  <body style="font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif;">
+    <p>Use this link to sign in (valid for 15 minutes):</p>
+    <p><a href="${escapeHtmlAttr(args.loginUrl)}">Sign in to the dashboard</a></p>
+    <p style="color:#666; font-size: 13px;">If you did not request this, you can ignore this email.</p>
+  </body>
+</html>`;
+
+  await sendPostmarkEmail(token, {
+    From: process.env.POSTMARK_FROM || DEFAULT_FROM,
+    To: args.toEmail,
+    Subject: subject,
+    TextBody: textBody,
+    HtmlBody: htmlBody,
+    ReplyTo: process.env.POSTMARK_REPLY_TO || DEFAULT_REPLY_TO,
+    MessageStream: process.env.POSTMARK_MESSAGE_STREAM || 'outbound',
+  });
+
+  return { delivered: true };
+}
+
+function escapeHtmlAttr(s: string): string {
+  return s.replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]!));
+}

--- a/src/email/postmark.ts
+++ b/src/email/postmark.ts
@@ -1,0 +1,57 @@
+import { readFile } from 'node:fs/promises';
+
+export type PostmarkEmail = {
+  From: string;
+  To: string;
+  Subject: string;
+  TextBody?: string;
+  HtmlBody?: string;
+  ReplyTo?: string;
+  MessageStream?: string;
+};
+
+export type PostmarkSendResult = {
+  To: string;
+  SubmittedAt: string;
+  MessageID: string;
+  ErrorCode: number;
+  Message: string;
+};
+
+const DEFAULT_TOKEN_FILE = '/home/clawdbot/.postmark_transactional_token';
+
+export async function getPostmarkTransactionalToken(): Promise<string | null> {
+  if (process.env.POSTMARK_TRANSACTIONAL_TOKEN && process.env.POSTMARK_TRANSACTIONAL_TOKEN.trim()) {
+    return process.env.POSTMARK_TRANSACTIONAL_TOKEN.trim();
+  }
+
+  const tokenFile = process.env.POSTMARK_TRANSACTIONAL_TOKEN_FILE || DEFAULT_TOKEN_FILE;
+  try {
+    const token = (await readFile(tokenFile, 'utf-8')).trim();
+    return token.length ? token : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function sendPostmarkEmail(
+  token: string,
+  email: PostmarkEmail
+): Promise<PostmarkSendResult> {
+  const res = await fetch('https://api.postmarkapp.com/email', {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      'X-Postmark-Server-Token': token,
+    },
+    body: JSON.stringify(email),
+  });
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new Error(`Postmark send failed (${res.status}): ${body || res.statusText}`);
+  }
+
+  return (await res.json()) as PostmarkSendResult;
+}

--- a/tests/postmark_magic_link_email.test.ts
+++ b/tests/postmark_magic_link_email.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeAll, afterAll, vi, beforeEach, afterEach } from 'vitest';
+import { runMigrate } from './helpers/migrate.js';
+import { buildServer } from '../src/api/server.js';
+
+describe('Postmark delivery for magic-link auth', () => {
+  const app = buildServer();
+
+  const originalEnv = { ...process.env };
+
+  beforeAll(async () => {
+    runMigrate('up');
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+    process.env = originalEnv;
+  });
+
+  beforeEach(() => {
+    process.env.NODE_ENV = 'test';
+    process.env.POSTMARK_ENABLE_TEST_SEND = '1';
+    process.env.POSTMARK_TRANSACTIONAL_TOKEN = 'test-token';
+
+    globalThis.fetch = vi.fn(async (_url: any, _init: any) => {
+      return new Response(
+        JSON.stringify({
+          To: 'test@example.com',
+          SubmittedAt: new Date().toISOString(),
+          MessageID: '00000000-0000-0000-0000-000000000000',
+          ErrorCode: 0,
+          Message: 'OK',
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      );
+    }) as any;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.env.POSTMARK_ENABLE_TEST_SEND = undefined;
+    process.env.POSTMARK_TRANSACTIONAL_TOKEN = undefined;
+  });
+
+  it('sends a transactional email via Postmark and does not return the loginUrl in the API response', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/auth/request-link',
+      payload: { email: 'test@example.com' },
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(res.json()).toEqual({ ok: true });
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+
+    const [url, init] = (globalThis.fetch as any).mock.calls[0] as [string, any];
+    expect(url).toBe('https://api.postmarkapp.com/email');
+    expect(init.method).toBe('POST');
+    expect(init.headers['X-Postmark-Server-Token']).toBe('test-token');
+
+    const body = JSON.parse(init.body);
+    expect(body.From).toBe('news.updates@execdesk.ai');
+    expect(body.ReplyTo).toBe('quasar@execdesk.ai');
+    expect(body.To).toBe('test@example.com');
+    expect(body.Subject).toMatch(/login link/i);
+    expect(body.TextBody).toMatch(/\/api\/auth\/consume\?token=/);
+    expect(body.HtmlBody).toMatch(/\/api\/auth\/consume\?token=/);
+  });
+});


### PR DESCRIPTION
Implements Postmark transactional email for dashboard magic-link login.\n\n- Reads Postmark token from POSTMARK_TRANSACTIONAL_TOKEN or /home/clawdbot/.postmark_transactional_token (no secrets committed)\n- Sends login link email from news.updates@execdesk.ai with Reply-To quasar@execdesk.ai\n- /api/auth/request-link no longer returns loginUrl when email is delivered\n- Dashboard UI now shows a generic success message unless loginUrl is present (dev fallback)\n- Adds unit test mocking Postmark HTTP