### PR TITLE
Fix magic-link email From: Projects <projects@execdesk.ai>

### DIFF
--- a/src/email/magicLink.ts
+++ b/src/email/magicLink.ts
@@ -1,6 +1,6 @@
 import { getPostmarkTransactionalToken, sendPostmarkEmail } from './postmark.js';
 
-const DEFAULT_FROM = 'news.updates@execdesk.ai';
+const DEFAULT_FROM = 'Projects <projects@execdesk.ai>';
 const DEFAULT_REPLY_TO = 'quasar@execdesk.ai';
 
 export type SendMagicLinkArgs = {

--- a/tests/postmark_magic_link_email.test.ts
+++ b/tests/postmark_magic_link_email.test.ts
@@ -60,7 +60,7 @@ describe('Postmark delivery for magic-link auth', () => {
     expect(init.headers['X-Postmark-Server-Token']).toBe('test-token');
 
     const body = JSON.parse(init.body);
-    expect(body.From).toBe('news.updates@execdesk.ai');
+    expect(body.From).toBe('Projects <projects@execdesk.ai>');
     expect(body.ReplyTo).toBe('quasar@execdesk.ai');
     expect(body.To).toBe('test@example.com');
     expect(body.Subject).toMatch(/login link/i);


### PR DESCRIPTION
Implements issue #32: change Postmark magic-link sender From to "Projects <projects@execdesk.ai>" while keeping Reply-To as "quasar@execdesk.ai".

- Updates default sender in `src/email/magicLink.ts`
- Updates unit test expectations