### PR TITLE
test: isolate DB state to fix flakey vitest runs

### DIFF
--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -1,17 +1,26 @@
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { Pool } from 'pg';
 import { runMigrate } from './helpers/migrate.js';
+import { createTestPool, truncateAllTables } from './helpers/db.js';
 import { buildServer } from '../src/api/server.js';
 
 describe('Backend API service', () => {
   const app = buildServer();
+  let pool: Pool;
 
   beforeAll(async () => {
     runMigrate('up');
+    pool = createTestPool();
     await app.ready();
+  });
+
+  beforeEach(async () => {
+    await truncateAllTables(pool);
   });
 
   afterAll(async () => {
     await app.close();
+    await pool.end();
   });
 
   it('exposes /health', async () => {

--- a/tests/contacts.test.ts
+++ b/tests/contacts.test.ts
@@ -1,19 +1,18 @@
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
 import { Pool } from 'pg';
 import { runMigrate } from './helpers/migrate.js';
+import { createTestPool, truncateAllTables } from './helpers/db.js';
 
 describe('Contacts + endpoints + trust model', () => {
   let pool: Pool;
 
   beforeAll(async () => {
     runMigrate('up');
-    pool = new Pool({
-      host: process.env.PGHOST || 'localhost',
-      port: parseInt(process.env.PGPORT || '5432'),
-      user: process.env.PGUSER || 'clawdbot',
-      password: process.env.PGPASSWORD || 'clawdbot',
-      database: process.env.PGDATABASE || 'clawdbot',
-    });
+    pool = createTestPool();
+  });
+
+  beforeEach(async () => {
+    await truncateAllTables(pool);
   });
 
   afterAll(async () => {

--- a/tests/dashboard.test.ts
+++ b/tests/dashboard.test.ts
@@ -1,17 +1,26 @@
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { Pool } from 'pg';
 import { runMigrate } from './helpers/migrate.js';
+import { createTestPool, truncateAllTables } from './helpers/db.js';
 import { buildServer } from '../src/api/server.js';
 
 describe('/dashboard UI', () => {
   const app = buildServer();
+  let pool: Pool;
 
   beforeAll(async () => {
     runMigrate('up');
+    pool = createTestPool();
     await app.ready();
+  });
+
+  beforeEach(async () => {
+    await truncateAllTables(pool);
   });
 
   afterAll(async () => {
     await app.close();
+    await pool.end();
   });
 
   it('shows login UI when not authenticated', async () => {

--- a/tests/external_messages.test.ts
+++ b/tests/external_messages.test.ts
@@ -1,19 +1,18 @@
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
 import { Pool } from 'pg';
 import { runMigrate } from './helpers/migrate.js';
+import { createTestPool, truncateAllTables } from './helpers/db.js';
 
 describe('External inbound messages -> threads -> work items', () => {
   let pool: Pool;
 
   beforeAll(async () => {
     runMigrate('up');
-    pool = new Pool({
-      host: process.env.PGHOST || 'localhost',
-      port: parseInt(process.env.PGPORT || '5432'),
-      user: process.env.PGUSER || 'clawdbot',
-      password: process.env.PGPASSWORD || 'clawdbot',
-      database: process.env.PGDATABASE || 'clawdbot',
-    });
+    pool = createTestPool();
+  });
+
+  beforeEach(async () => {
+    await truncateAllTables(pool);
   });
 
   afterAll(async () => {

--- a/tests/helpers/db.ts
+++ b/tests/helpers/db.ts
@@ -1,0 +1,84 @@
+/**
+ * Database test helpers for isolation and cleanup.
+ * @module tests/helpers/db
+ */
+
+import { Pool, type PoolConfig } from 'pg';
+
+/**
+ * Default PostgreSQL pool configuration for tests.
+ * Uses environment variables with sensible local dev defaults.
+ */
+export function getPoolConfig(): PoolConfig {
+  return {
+    host: process.env.PGHOST || 'localhost',
+    port: parseInt(process.env.PGPORT || '5432', 10),
+    user: process.env.PGUSER || 'clawdbot',
+    password: process.env.PGPASSWORD || 'clawdbot',
+    database: process.env.PGDATABASE || 'clawdbot',
+  };
+}
+
+/**
+ * Creates a new Pool instance with the default test configuration.
+ * @returns A new Pool instance
+ */
+export function createTestPool(): Pool {
+  return new Pool(getPoolConfig());
+}
+
+/**
+ * Tables to truncate in correct order to respect foreign key constraints.
+ * Listed in dependency order (children first, parents last).
+ */
+const APPLICATION_TABLES = [
+  // FK children first
+  'work_item_communication',
+  'external_message',
+  'external_thread',
+  'contact_endpoint',
+  'work_item_dependency',
+  'work_item_participant',
+  // Parents
+  'work_item',
+  'contact',
+  'auth_magic_link',
+  'auth_session',
+] as const;
+
+/**
+ * Truncates all application tables to reset test state.
+ * Uses TRUNCATE ... CASCADE to handle foreign keys properly.
+ * Preserves schema_migrations and system tables.
+ *
+ * @param pool - The PostgreSQL pool to use for the truncation
+ * @throws Error if truncation fails
+ *
+ * @example
+ * ```ts
+ * beforeEach(async () => {
+ *   await truncateAllTables(pool);
+ * });
+ * ```
+ */
+export async function truncateAllTables(pool: Pool): Promise<void> {
+  // Build a single TRUNCATE statement for efficiency
+  // Filter to tables that actually exist to avoid errors on partial migrations
+  const existingTables = await pool.query<{ tablename: string }>(
+    `SELECT tablename FROM pg_tables
+     WHERE schemaname = 'public'
+     AND tablename = ANY($1::text[])`,
+    [APPLICATION_TABLES]
+  );
+
+  const tablesToTruncate = existingTables.rows.map((r) => r.tablename);
+
+  if (tablesToTruncate.length === 0) {
+    return;
+  }
+
+  // TRUNCATE with CASCADE handles FK constraints
+  // RESTART IDENTITY resets sequences (auto-increment counters)
+  const tableList = tablesToTruncate.map((t) => `"${t}"`).join(', ');
+  await pool.query(`TRUNCATE TABLE ${tableList} RESTART IDENTITY CASCADE`);
+}

--- a/tests/work_item_planning_fields.test.ts
+++ b/tests/work_item_planning_fields.test.ts
@@ -1,19 +1,18 @@
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
 import { Pool } from 'pg';
 import { runMigrate } from './helpers/migrate.js';
+import { createTestPool, truncateAllTables } from './helpers/db.js';
 
 describe('Work item planning fields (priority/type/scheduling)', () => {
   let pool: Pool;
 
   beforeAll(async () => {
     runMigrate('up');
-    pool = new Pool({
-      host: process.env.PGHOST || 'localhost',
-      port: parseInt(process.env.PGPORT || '5432'),
-      user: process.env.PGUSER || 'clawdbot',
-      password: process.env.PGPASSWORD || 'clawdbot',
-      database: process.env.PGDATABASE || 'clawdbot',
-    });
+    pool = createTestPool();
+  });
+
+  beforeEach(async () => {
+    await truncateAllTables(pool);
   });
 
   afterAll(async () => {

--- a/tests/work_items.test.ts
+++ b/tests/work_items.test.ts
@@ -1,19 +1,18 @@
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
 import { Pool } from 'pg';
 import { runMigrate } from './helpers/migrate.js';
+import { createTestPool, truncateAllTables } from './helpers/db.js';
 
 describe('Work items core model', () => {
   let pool: Pool;
 
   beforeAll(async () => {
     runMigrate('up');
-    pool = new Pool({
-      host: process.env.PGHOST || 'localhost',
-      port: parseInt(process.env.PGPORT || '5432'),
-      user: process.env.PGUSER || 'clawdbot',
-      password: process.env.PGPASSWORD || 'clawdbot',
-      database: process.env.PGDATABASE || 'clawdbot',
-    });
+    pool = createTestPool();
+  });
+
+  beforeEach(async () => {
+    await truncateAllTables(pool);
   });
 
   afterAll(async () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,8 +5,9 @@ export default defineConfig({
     globals: true,
     testTimeout: 30000,
 
-    // All tests currently share one local Postgres database.
-    // Disable parallelism so migration reset/apply steps don't race.
+    // Tests share one local Postgres database with per-test TRUNCATE cleanup.
+    // Parallelism is disabled to avoid migration race conditions. If migrating
+    // to per-file temp databases, this could be re-enabled.
     fileParallelism: false,
   },
 });


### PR DESCRIPTION
Fixes failing tests due to duplicate key collisions by truncating DB state between tests and disabling file parallelism.