### PR TITLE
feat: scheduling estimates + rollups + next-action query (#28)

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -23,6 +23,32 @@ Adds to `work_item`:
 - `task_type` (`work_item_task_type` enum: `general|coding|admin|ops|research|meeting`)
 - `not_before` / `not_after` scheduling window with check constraint (`not_before <= not_after` when both are set)
 
+### Estimates + hierarchy (Issue #28)
+
+Adds to `work_item`:
+
+- `estimate_minutes` (int, nullable)
+- `actual_minutes` (int, nullable)
+- `work_item_kind` (`work_item_kind` enum: `project|initiative|epic|issue`, default `issue`)
+- `parent_work_item_id` (self-referential FK for hierarchy, nullable)
+
+Constraints:
+
+- `estimate_minutes` and `actual_minutes` must be between 0 and 525,600 minutes when set.
+- `parent_work_item_id` may not reference the same row.
+
+Rollup views (include descendants):
+
+- `work_item_rollup_project`
+- `work_item_rollup_initiative`
+- `work_item_rollup_epic`
+- `work_item_rollup_issue`
+
+Next-actionable query:
+
+- `work_item_next_actionable_at(as_of timestamptz)` function
+- `work_item_next_actionable` view (invokes the function with `now()`)
+
 ## Contacts (Issue #9)
 
 - `contact`

--- a/migrations/010_scheduling_estimates_rollups.down.sql
+++ b/migrations/010_scheduling_estimates_rollups.down.sql
@@ -1,0 +1,23 @@
+-- Issue #28: Scheduling estimates, hierarchy rollups, next-actionable query (rollback)
+
+DROP VIEW IF EXISTS work_item_next_actionable;
+DROP FUNCTION IF EXISTS work_item_next_actionable_at(timestamptz);
+DROP VIEW IF EXISTS work_item_rollup_issue;
+DROP VIEW IF EXISTS work_item_rollup_epic;
+DROP VIEW IF EXISTS work_item_rollup_initiative;
+DROP VIEW IF EXISTS work_item_rollup_project;
+DROP VIEW IF EXISTS work_item_descendants;
+
+ALTER TABLE work_item DROP CONSTRAINT IF EXISTS work_item_parent_not_self_check;
+ALTER TABLE work_item DROP CONSTRAINT IF EXISTS work_item_estimate_minutes_check;
+ALTER TABLE work_item DROP CONSTRAINT IF EXISTS work_item_actual_minutes_check;
+
+DROP INDEX IF EXISTS work_item_parent_idx;
+DROP INDEX IF EXISTS work_item_kind_idx;
+
+ALTER TABLE work_item DROP COLUMN IF EXISTS parent_work_item_id;
+ALTER TABLE work_item DROP COLUMN IF EXISTS work_item_kind;
+ALTER TABLE work_item DROP COLUMN IF EXISTS estimate_minutes;
+ALTER TABLE work_item DROP COLUMN IF EXISTS actual_minutes;
+
+DROP TYPE IF EXISTS work_item_kind;

--- a/migrations/010_scheduling_estimates_rollups.up.sql
+++ b/migrations/010_scheduling_estimates_rollups.up.sql
@@ -1,0 +1,162 @@
+-- Issue #28: Scheduling estimates, hierarchy rollups, next-actionable query
+
+DO $$ BEGIN
+  CREATE TYPE work_item_kind AS ENUM ('project', 'initiative', 'epic', 'issue');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+ALTER TABLE work_item
+  ADD COLUMN IF NOT EXISTS work_item_kind work_item_kind NOT NULL DEFAULT 'issue';
+
+ALTER TABLE work_item
+  ADD COLUMN IF NOT EXISTS parent_work_item_id uuid REFERENCES work_item(id) ON DELETE SET NULL;
+
+ALTER TABLE work_item
+  ADD COLUMN IF NOT EXISTS estimate_minutes integer;
+
+ALTER TABLE work_item
+  ADD COLUMN IF NOT EXISTS actual_minutes integer;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'work_item_parent_not_self_check'
+      AND conrelid = 'work_item'::regclass
+  ) THEN
+    ALTER TABLE work_item
+      ADD CONSTRAINT work_item_parent_not_self_check
+      CHECK (parent_work_item_id IS NULL OR parent_work_item_id <> id);
+  END IF;
+END $$;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'work_item_estimate_minutes_check'
+      AND conrelid = 'work_item'::regclass
+  ) THEN
+    ALTER TABLE work_item
+      ADD CONSTRAINT work_item_estimate_minutes_check
+      CHECK (estimate_minutes IS NULL OR (estimate_minutes >= 0 AND estimate_minutes <= 525600));
+  END IF;
+END $$;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'work_item_actual_minutes_check'
+      AND conrelid = 'work_item'::regclass
+  ) THEN
+    ALTER TABLE work_item
+      ADD CONSTRAINT work_item_actual_minutes_check
+      CHECK (actual_minutes IS NULL OR (actual_minutes >= 0 AND actual_minutes <= 525600));
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS work_item_parent_idx ON work_item(parent_work_item_id);
+CREATE INDEX IF NOT EXISTS work_item_kind_idx ON work_item(work_item_kind);
+
+CREATE OR REPLACE VIEW work_item_descendants AS
+WITH RECURSIVE tree AS (
+  SELECT wi.id as root_id, wi.id as descendant_id
+    FROM work_item wi
+  UNION ALL
+  SELECT t.root_id, child.id as descendant_id
+    FROM tree t
+    JOIN work_item child ON child.parent_work_item_id = t.descendant_id
+)
+SELECT root_id, descendant_id
+  FROM tree;
+
+CREATE OR REPLACE VIEW work_item_rollup_project AS
+SELECT root.id as work_item_id,
+       root.title as title,
+       SUM(COALESCE(wi.estimate_minutes, 0))::int as total_estimate_minutes,
+       SUM(COALESCE(wi.actual_minutes, 0))::int as total_actual_minutes
+  FROM work_item_descendants d
+  JOIN work_item root ON root.id = d.root_id
+  JOIN work_item wi ON wi.id = d.descendant_id
+ WHERE root.work_item_kind = 'project'
+ GROUP BY root.id, root.title;
+
+CREATE OR REPLACE VIEW work_item_rollup_initiative AS
+SELECT root.id as work_item_id,
+       root.title as title,
+       SUM(COALESCE(wi.estimate_minutes, 0))::int as total_estimate_minutes,
+       SUM(COALESCE(wi.actual_minutes, 0))::int as total_actual_minutes
+  FROM work_item_descendants d
+  JOIN work_item root ON root.id = d.root_id
+  JOIN work_item wi ON wi.id = d.descendant_id
+ WHERE root.work_item_kind = 'initiative'
+ GROUP BY root.id, root.title;
+
+CREATE OR REPLACE VIEW work_item_rollup_epic AS
+SELECT root.id as work_item_id,
+       root.title as title,
+       SUM(COALESCE(wi.estimate_minutes, 0))::int as total_estimate_minutes,
+       SUM(COALESCE(wi.actual_minutes, 0))::int as total_actual_minutes
+  FROM work_item_descendants d
+  JOIN work_item root ON root.id = d.root_id
+  JOIN work_item wi ON wi.id = d.descendant_id
+ WHERE root.work_item_kind = 'epic'
+ GROUP BY root.id, root.title;
+
+CREATE OR REPLACE VIEW work_item_rollup_issue AS
+SELECT root.id as work_item_id,
+       root.title as title,
+       SUM(COALESCE(wi.estimate_minutes, 0))::int as total_estimate_minutes,
+       SUM(COALESCE(wi.actual_minutes, 0))::int as total_actual_minutes
+  FROM work_item_descendants d
+  JOIN work_item root ON root.id = d.root_id
+  JOIN work_item wi ON wi.id = d.descendant_id
+ WHERE root.work_item_kind = 'issue'
+ GROUP BY root.id, root.title;
+
+CREATE OR REPLACE FUNCTION work_item_next_actionable_at(as_of timestamptz DEFAULT now())
+RETURNS TABLE (
+  id uuid,
+  title text,
+  status text,
+  priority work_item_priority,
+  task_type work_item_task_type,
+  not_before timestamptz,
+  not_after timestamptz,
+  estimate_minutes integer,
+  actual_minutes integer
+)
+LANGUAGE sql
+STABLE
+AS $$
+  SELECT wi.id,
+         wi.title,
+         wi.status,
+         wi.priority,
+         wi.task_type,
+         wi.not_before,
+         wi.not_after,
+         wi.estimate_minutes,
+         wi.actual_minutes
+    FROM work_item wi
+   WHERE lower(wi.status) NOT IN ('done', 'completed', 'closed')
+     AND (wi.not_before IS NULL OR wi.not_before <= as_of)
+     AND (wi.not_after IS NULL OR wi.not_after >= as_of)
+     AND NOT EXISTS (
+       SELECT 1
+         FROM work_item_dependency dep
+         JOIN work_item blocker ON blocker.id = dep.depends_on_work_item_id
+        WHERE dep.work_item_id = wi.id
+          AND lower(blocker.status) NOT IN ('done', 'completed', 'closed')
+     )
+   ORDER BY wi.priority ASC,
+            COALESCE(wi.not_after, 'infinity'::timestamptz) ASC,
+            COALESCE(wi.not_before, 'infinity'::timestamptz) ASC,
+            wi.created_at ASC;
+$$;
+
+CREATE OR REPLACE VIEW work_item_next_actionable AS
+SELECT *
+  FROM work_item_next_actionable_at(now());

--- a/tests/work_item_estimates_rollups.test.ts
+++ b/tests/work_item_estimates_rollups.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { Pool } from 'pg';
+import { runMigrate } from './helpers/migrate.js';
+import { createTestPool, truncateAllTables } from './helpers/db.js';
+
+describe('Work item estimates, rollups, and next-actionable query', () => {
+  let pool: Pool;
+
+  beforeAll(async () => {
+    await runMigrate('up');
+    pool = createTestPool();
+  });
+
+  beforeEach(async () => {
+    await truncateAllTables(pool);
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  it('enforces estimate/actual minute constraints', async () => {
+    const ok = await pool.query(
+      `INSERT INTO work_item (title, estimate_minutes, actual_minutes)
+       VALUES ('Estimate ok', 120, 45)
+       RETURNING estimate_minutes, actual_minutes`
+    );
+    expect(ok.rows[0].estimate_minutes).toBe(120);
+    expect(ok.rows[0].actual_minutes).toBe(45);
+
+    await expect(
+      pool.query(
+        `INSERT INTO work_item (title, estimate_minutes)
+         VALUES ('Estimate negative', -5)`
+      )
+    ).rejects.toThrow(/work_item/);
+
+    await expect(
+      pool.query(
+        `INSERT INTO work_item (title, actual_minutes)
+         VALUES ('Actual negative', -3)`
+      )
+    ).rejects.toThrow(/work_item/);
+
+    await expect(
+      pool.query(
+        `INSERT INTO work_item (title, estimate_minutes)
+         VALUES ('Estimate too big', 600000)`
+      )
+    ).rejects.toThrow(/work_item/);
+
+    await expect(
+      pool.query(
+        `INSERT INTO work_item (title, actual_minutes)
+         VALUES ('Actual too big', 600000)`
+      )
+    ).rejects.toThrow(/work_item/);
+  });
+
+  it('rolls up estimates/actuals across the hierarchy', async () => {
+    const project = await pool.query(
+      `INSERT INTO work_item (title, work_item_kind, estimate_minutes, actual_minutes)
+       VALUES ('Project', 'project', 10, 5)
+       RETURNING id`
+    );
+    const initiative = await pool.query(
+      `INSERT INTO work_item (title, work_item_kind, parent_work_item_id, estimate_minutes, actual_minutes)
+       VALUES ('Initiative', 'initiative', $1, 20, NULL)
+       RETURNING id`,
+      [project.rows[0].id]
+    );
+    const epic = await pool.query(
+      `INSERT INTO work_item (title, work_item_kind, parent_work_item_id, estimate_minutes, actual_minutes)
+       VALUES ('Epic', 'epic', $1, 30, 12)
+       RETURNING id`,
+      [initiative.rows[0].id]
+    );
+    const issueA = await pool.query(
+      `INSERT INTO work_item (title, work_item_kind, parent_work_item_id, estimate_minutes, actual_minutes)
+       VALUES ('Issue A', 'issue', $1, 40, 40)
+       RETURNING id`,
+      [epic.rows[0].id]
+    );
+    const issueB = await pool.query(
+      `INSERT INTO work_item (title, work_item_kind, parent_work_item_id, estimate_minutes, actual_minutes)
+       VALUES ('Issue B', 'issue', $1, 5, 2)
+       RETURNING id`,
+      [epic.rows[0].id]
+    );
+
+    const projectRollup = await pool.query(
+      `SELECT total_estimate_minutes, total_actual_minutes
+         FROM work_item_rollup_project
+        WHERE work_item_id = $1`,
+      [project.rows[0].id]
+    );
+    expect(projectRollup.rows[0].total_estimate_minutes).toBe(105);
+    expect(projectRollup.rows[0].total_actual_minutes).toBe(59);
+
+    const initiativeRollup = await pool.query(
+      `SELECT total_estimate_minutes, total_actual_minutes
+         FROM work_item_rollup_initiative
+        WHERE work_item_id = $1`,
+      [initiative.rows[0].id]
+    );
+    expect(initiativeRollup.rows[0].total_estimate_minutes).toBe(95);
+    expect(initiativeRollup.rows[0].total_actual_minutes).toBe(54);
+
+    const epicRollup = await pool.query(
+      `SELECT total_estimate_minutes, total_actual_minutes
+         FROM work_item_rollup_epic
+        WHERE work_item_id = $1`,
+      [epic.rows[0].id]
+    );
+    expect(epicRollup.rows[0].total_estimate_minutes).toBe(75);
+    expect(epicRollup.rows[0].total_actual_minutes).toBe(54);
+
+    const issueRollup = await pool.query(
+      `SELECT total_estimate_minutes, total_actual_minutes
+         FROM work_item_rollup_issue
+        WHERE work_item_id = $1`,
+      [issueA.rows[0].id]
+    );
+    expect(issueRollup.rows[0].total_estimate_minutes).toBe(40);
+    expect(issueRollup.rows[0].total_actual_minutes).toBe(40);
+
+    const issueRollupB = await pool.query(
+      `SELECT total_estimate_minutes, total_actual_minutes
+         FROM work_item_rollup_issue
+        WHERE work_item_id = $1`,
+      [issueB.rows[0].id]
+    );
+    expect(issueRollupB.rows[0].total_estimate_minutes).toBe(5);
+    expect(issueRollupB.rows[0].total_actual_minutes).toBe(2);
+  });
+
+  it('filters next-actionable items with deterministic ordering', async () => {
+    const asOf = '2025-01-01 12:00:00+00';
+
+    const done = await pool.query(
+      `INSERT INTO work_item (title, status, priority)
+       VALUES ('Done item', 'done', 'P1')
+       RETURNING id`
+    );
+    const blocked = await pool.query(
+      `INSERT INTO work_item (title, status, priority)
+       VALUES ('Blocked item', 'open', 'P0')
+       RETURNING id`
+    );
+    const blocker = await pool.query(
+      `INSERT INTO work_item (title, status, priority)
+       VALUES ('Blocker item', 'open', 'P2')
+       RETURNING id`
+    );
+    await pool.query(
+      `INSERT INTO work_item_dependency (work_item_id, depends_on_work_item_id, kind)
+       VALUES ($1, $2, 'depends_on')`,
+      [blocked.rows[0].id, blocker.rows[0].id]
+    );
+
+    await pool.query(
+      `INSERT INTO work_item (title, status, priority, not_before)
+       VALUES ('Future item', 'open', 'P1', $1::timestamptz)`,
+      ['2025-02-01 00:00:00+00']
+    );
+    await pool.query(
+      `INSERT INTO work_item (title, status, priority, not_after)
+       VALUES ('Expired item', 'open', 'P1', $1::timestamptz)`,
+      ['2024-12-31 00:00:00+00']
+    );
+
+    const actionableA = await pool.query(
+      `INSERT INTO work_item (title, status, priority, not_after)
+       VALUES ('Actionable P0', 'open', 'P0', $1::timestamptz)
+       RETURNING id`,
+      ['2025-01-03 00:00:00+00']
+    );
+    const actionableB = await pool.query(
+      `INSERT INTO work_item (title, status, priority, not_after)
+       VALUES ('Actionable P1', 'open', 'P1', $1::timestamptz)
+       RETURNING id`,
+      ['2025-01-02 00:00:00+00']
+    );
+    const actionableC = await pool.query(
+      `INSERT INTO work_item (title, status, priority, not_after)
+       VALUES ('Actionable P1 later', 'open', 'P1', $1::timestamptz)
+       RETURNING id`,
+      ['2025-01-05 00:00:00+00']
+    );
+
+    const result = await pool.query(
+      `SELECT id::text as id, title, priority::text as priority
+         FROM work_item_next_actionable_at($1::timestamptz)`,
+      [asOf]
+    );
+
+    const ids = result.rows.map((row) => row.id);
+    expect(ids).toEqual([
+      actionableA.rows[0].id,
+      actionableB.rows[0].id,
+      actionableC.rows[0].id,
+      blocker.rows[0].id,
+    ]);
+
+    const titles = result.rows.map((row) => row.title);
+    expect(titles).toEqual(['Actionable P0', 'Actionable P1', 'Actionable P1 later', 'Blocker item']);
+
+    // sanity checks for excluded items
+    expect(ids).not.toContain(done.rows[0].id);
+    expect(ids).not.toContain(blocked.rows[0].id);
+  });
+});


### PR DESCRIPTION
Implements #28.

Changes:
- Adds to work_item:
  - estimate_minutes (nullable)
  - actual_minutes (nullable)
  - work_item_kind enum (project|initiative|epic|issue, default issue)
  - parent_work_item_id (self-FK, nullable)
- Adds constraints for minutes (0..525600) and parent != self
- Adds rollup views (include descendants):
  - work_item_rollup_project / _initiative / _epic / _issue
- Adds next-actionable function/view:
  - work_item_next_actionable_at(as_of timestamptz)
  - work_item_next_actionable
- Updates docs/schema.md

How to test (devcontainer):
- devcontainer up
- pnpm test
