### PR TITLE
[#60] Load .env into devcontainer workspace

### DIFF
--- a/.devcontainer/docker-compose.devcontainer.yml
+++ b/.devcontainer/docker-compose.devcontainer.yml
@@ -4,7 +4,8 @@ services:
       context: ..
       dockerfile: .devcontainer/Dockerfile
     env_file:
-      - ../.env
+      - path: ../.env
+        required: false
     volumes:
       - ..:/workspaces/clawdbot-projects:cached
       - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
Closes #60.

Loads ../.env into the devcontainer workspace service so tokens are available inside the container.

Tested:
- docker compose -f .devcontainer/docker-compose.devcontainer.yml up -d --force-recreate workspace
- verified GITHUB_TOKEN + GITHUB_TOKEN_TROY present in workspace env