### PR TITLE
[#53] Support re-parenting work items

### DIFF
--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -614,8 +614,13 @@ export function buildServer(options: ProjectsApiOptions = {}): FastifyInstance {
         parentId,
       ]
     );
-    await pool.end();
 
+    if (result.rows.length === 0) {
+      await pool.end();
+      return reply.code(404).send({ error: 'not found' });
+    }
+
+    await pool.end();
     return reply.send(result.rows[0]);
   });
 


### PR DESCRIPTION
Issue: #53 https://github.com/troykelly/clawdbot-projects/issues/53
Epic: #50 https://github.com/troykelly/clawdbot-projects/issues/50

Changes:
- Add support for updating work_item.parent_id via PUT /api/work-items/:id (with hierarchy validation)
- Add tests for re-parenting semantics

Local tests:
- corepack pnpm -s test

