### PR TITLE
chore: allow devcontainer UID remap (fix permissions flips)

### DIFF
--- a/.devcontainer/docker-compose.devcontainer.yml
+++ b/.devcontainer/docker-compose.devcontainer.yml
@@ -3,7 +3,6 @@ services:
     build:
       context: ..
       dockerfile: .devcontainer/Dockerfile
-    user: vscode
     env_file:
       - path: ../.env
         required: false


### PR DESCRIPTION
Removes the hard-coded `user: vscode` from .devcontainer/docker-compose.devcontainer.yml so devcontainer's `updateRemoteUserUID: true` can remap the `vscode` user to the host UID.

This prevents bind-mount writes from showing up as `operations:operations` on the host (and breaking `.git/index.lock` and Vite/Vitest temp dirs).

Verification (local): devcontainer up remapped `vscode` to uid 1001 and `pnpm -s test` passed.