### PR TITLE
[#73] Disable devcontainer UID remapping

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,5 +6,5 @@
   "shutdownAction": "stopCompose",
   "remoteUser": "vscode",
   "postCreateCommand": "bash .devcontainer/postCreate.sh",
-  "updateRemoteUserUID": true
+  "updateRemoteUserUID": false
 }


### PR DESCRIPTION
Fixes #73.\n\nDisables updateRemoteUserUID to avoid UID/GID mutation issues in restricted environments and when host user UID != 1000.