### PR TITLE
[#88] Kanban Board with drag-drop status changes

### DIFF
--- a/src/ui/components/board/board-card.tsx
+++ b/src/ui/components/board/board-card.tsx
@@ -1,0 +1,150 @@
+import * as React from 'react';
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { Clock, User, GripVertical } from 'lucide-react';
+import { cn } from '@/ui/lib/utils';
+import { Card } from '@/ui/components/ui/card';
+import { Badge } from '@/ui/components/ui/badge';
+import type { BoardItem, BoardPriority } from './types';
+
+function getPriorityVariant(priority: BoardPriority): 'default' | 'secondary' | 'destructive' | 'outline' {
+  switch (priority) {
+    case 'urgent':
+      return 'destructive';
+    case 'high':
+      return 'default';
+    case 'medium':
+      return 'secondary';
+    case 'low':
+      return 'outline';
+  }
+}
+
+function getPriorityLabel(priority: BoardPriority): string {
+  return priority.charAt(0).toUpperCase() + priority.slice(1);
+}
+
+function formatEstimate(minutes: number | undefined): string | null {
+  if (!minutes) return null;
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  const mins = minutes % 60;
+  return mins > 0 ? `${hours}h ${mins}m` : `${hours}h`;
+}
+
+export interface BoardCardProps {
+  item: BoardItem;
+  onClick?: (item: BoardItem) => void;
+  isDragging?: boolean;
+  className?: string;
+}
+
+export function BoardCard({ item, onClick, isDragging, className }: BoardCardProps) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging: isSortableDragging,
+  } = useSortable({
+    id: item.id,
+    data: {
+      type: 'card',
+      item,
+    },
+  });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  const dragging = isDragging || isSortableDragging;
+  const estimate = formatEstimate(item.estimateMinutes);
+
+  return (
+    <Card
+      ref={setNodeRef}
+      style={style}
+      data-testid="board-card"
+      className={cn(
+        'cursor-pointer p-3 transition-all',
+        'hover:border-primary/50 hover:shadow-sm',
+        dragging && 'opacity-50 rotate-2 scale-105 shadow-lg',
+        className
+      )}
+      onClick={() => onClick?.(item)}
+    >
+      <div className="space-y-2">
+        {/* Drag handle and title */}
+        <div className="flex items-start gap-2">
+          <div
+            {...attributes}
+            {...listeners}
+            className="mt-0.5 cursor-grab text-muted-foreground opacity-0 transition-opacity hover:opacity-100 group-hover:opacity-100"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <GripVertical className="size-4" />
+          </div>
+          <h4 className="flex-1 text-sm font-medium leading-tight">{item.title}</h4>
+        </div>
+
+        {/* Metadata row */}
+        <div className="flex items-center justify-between gap-2">
+          <Badge variant={getPriorityVariant(item.priority)} className="text-xs">
+            {getPriorityLabel(item.priority)}
+          </Badge>
+
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            {estimate && (
+              <span className="flex items-center gap-1">
+                <Clock className="size-3" />
+                {estimate}
+              </span>
+            )}
+            {item.assignee && (
+              <span className="flex items-center gap-1" title={item.assignee}>
+                {item.assigneeAvatar ? (
+                  <img
+                    src={item.assigneeAvatar}
+                    alt={item.assignee}
+                    className="size-5 rounded-full"
+                  />
+                ) : (
+                  <div className="flex size-5 items-center justify-center rounded-full bg-muted text-xs font-medium">
+                    {item.assignee.charAt(0).toUpperCase()}
+                  </div>
+                )}
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+// Simplified card for drag overlay (no sortable context)
+export function BoardCardOverlay({ item }: { item: BoardItem }) {
+  const estimate = formatEstimate(item.estimateMinutes);
+
+  return (
+    <Card className="w-64 rotate-2 p-3 shadow-xl ring-2 ring-primary">
+      <div className="space-y-2">
+        <h4 className="text-sm font-medium leading-tight">{item.title}</h4>
+        <div className="flex items-center justify-between gap-2">
+          <Badge variant={getPriorityVariant(item.priority)} className="text-xs">
+            {getPriorityLabel(item.priority)}
+          </Badge>
+          {estimate && (
+            <span className="flex items-center gap-1 text-xs text-muted-foreground">
+              <Clock className="size-3" />
+              {estimate}
+            </span>
+          )}
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/src/ui/components/board/board-column.tsx
+++ b/src/ui/components/board/board-column.tsx
@@ -1,0 +1,107 @@
+import * as React from 'react';
+import { useDroppable } from '@dnd-kit/core';
+import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
+import { Plus } from 'lucide-react';
+import { cn } from '@/ui/lib/utils';
+import { Button } from '@/ui/components/ui/button';
+import { ScrollArea } from '@/ui/components/ui/scroll-area';
+import { BoardCard } from './board-card';
+import type { BoardColumn as ColumnType, BoardItem, BoardStatus } from './types';
+
+function getStatusColor(status: BoardStatus): string {
+  switch (status) {
+    case 'not_started':
+      return 'bg-muted-foreground/30';
+    case 'in_progress':
+      return 'bg-blue-500';
+    case 'blocked':
+      return 'bg-red-500';
+    case 'done':
+      return 'bg-green-500';
+  }
+}
+
+export interface BoardColumnProps {
+  column: ColumnType;
+  onItemClick?: (item: BoardItem) => void;
+  onAddItem?: (status: BoardStatus) => void;
+  isOver?: boolean;
+  className?: string;
+}
+
+export function BoardColumn({
+  column,
+  onItemClick,
+  onAddItem,
+  isOver,
+  className,
+}: BoardColumnProps) {
+  const { setNodeRef, isOver: isDroppableOver } = useDroppable({
+    id: column.id,
+    data: {
+      type: 'column',
+      status: column.id,
+    },
+  });
+
+  const itemIds = column.items.map((item) => item.id);
+  const highlighted = isOver || isDroppableOver;
+
+  return (
+    <div
+      ref={setNodeRef}
+      data-testid="board-column"
+      className={cn(
+        'flex h-full w-72 shrink-0 flex-col rounded-lg border bg-muted/30',
+        highlighted && 'ring-2 ring-primary ring-offset-2',
+        className
+      )}
+    >
+      {/* Column header */}
+      <div className="flex items-center justify-between border-b px-3 py-2">
+        <div className="flex items-center gap-2">
+          <div className={cn('size-2 rounded-full', getStatusColor(column.id))} />
+          <h3 className="text-sm font-medium">{column.title}</h3>
+          <span className="rounded-full bg-muted px-1.5 text-xs font-medium">
+            {column.items.length}
+          </span>
+        </div>
+        {onAddItem && (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="size-6"
+            onClick={() => onAddItem(column.id)}
+          >
+            <Plus className="size-4" />
+            <span className="sr-only">Add item</span>
+          </Button>
+        )}
+      </div>
+
+      {/* Column content */}
+      <ScrollArea className="flex-1">
+        <div className="space-y-2 p-2">
+          <SortableContext items={itemIds} strategy={verticalListSortingStrategy}>
+            {column.items.map((item) => (
+              <BoardCard key={item.id} item={item} onClick={onItemClick} />
+            ))}
+          </SortableContext>
+
+          {column.items.length === 0 && (
+            <div
+              className={cn(
+                'flex h-24 items-center justify-center rounded-md border-2 border-dashed',
+                highlighted ? 'border-primary bg-primary/5' : 'border-muted-foreground/20'
+              )}
+            >
+              <p className="text-xs text-muted-foreground">
+                {highlighted ? 'Drop here' : 'No items'}
+              </p>
+            </div>
+          )}
+        </div>
+      </ScrollArea>
+    </div>
+  );
+}

--- a/src/ui/components/board/index.ts
+++ b/src/ui/components/board/index.ts
@@ -1,0 +1,16 @@
+export { KanbanBoard } from './kanban-board';
+export type { KanbanBoardProps, ViewMode } from './kanban-board';
+
+export { BoardColumn } from './board-column';
+export type { BoardColumnProps } from './board-column';
+
+export { BoardCard, BoardCardOverlay } from './board-card';
+export type { BoardCardProps } from './board-card';
+
+export type {
+  BoardItem,
+  BoardStatus,
+  BoardPriority,
+  BoardColumn as BoardColumnType,
+  BoardState,
+} from './types';

--- a/src/ui/components/board/kanban-board.tsx
+++ b/src/ui/components/board/kanban-board.tsx
@@ -1,0 +1,215 @@
+import * as React from 'react';
+import { useCallback, useMemo, useState } from 'react';
+import {
+  DndContext,
+  DragEndEvent,
+  DragOverEvent,
+  DragOverlay,
+  DragStartEvent,
+  KeyboardSensor,
+  PointerSensor,
+  closestCorners,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import { sortableKeyboardCoordinates } from '@dnd-kit/sortable';
+import { LayoutGrid, List } from 'lucide-react';
+import { cn } from '@/ui/lib/utils';
+import { Button } from '@/ui/components/ui/button';
+import { ScrollArea, ScrollBar } from '@/ui/components/ui/scroll-area';
+import { BoardColumn } from './board-column';
+import { BoardCardOverlay } from './board-card';
+import type { BoardItem, BoardStatus, BoardColumn as ColumnType } from './types';
+
+const DEFAULT_COLUMNS: ColumnType[] = [
+  { id: 'not_started', title: 'To Do', items: [] },
+  { id: 'in_progress', title: 'In Progress', items: [] },
+  { id: 'blocked', title: 'Blocked', items: [] },
+  { id: 'done', title: 'Done', items: [] },
+];
+
+function groupItemsByStatus(items: BoardItem[]): ColumnType[] {
+  const columns = DEFAULT_COLUMNS.map((col) => ({
+    ...col,
+    items: items.filter((item) => item.status === col.id),
+  }));
+  return columns;
+}
+
+export type ViewMode = 'board' | 'list';
+
+export interface KanbanBoardProps {
+  items: BoardItem[];
+  onItemsChange?: (items: BoardItem[]) => void;
+  onItemClick?: (item: BoardItem) => void;
+  onAddItem?: (status: BoardStatus) => void;
+  viewMode?: ViewMode;
+  onViewModeChange?: (mode: ViewMode) => void;
+  className?: string;
+}
+
+export function KanbanBoard({
+  items,
+  onItemsChange,
+  onItemClick,
+  onAddItem,
+  viewMode = 'board',
+  onViewModeChange,
+  className,
+}: KanbanBoardProps) {
+  const [activeItem, setActiveItem] = useState<BoardItem | null>(null);
+  const [overColumn, setOverColumn] = useState<BoardStatus | null>(null);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: {
+        distance: 8,
+      },
+    }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
+  );
+
+  const columns = useMemo(() => groupItemsByStatus(items), [items]);
+
+  const handleDragStart = useCallback((event: DragStartEvent) => {
+    const { active } = event;
+    const item = items.find((i) => i.id === active.id);
+    if (item) {
+      setActiveItem(item);
+    }
+  }, [items]);
+
+  const handleDragOver = useCallback((event: DragOverEvent) => {
+    const { over } = event;
+    if (!over) {
+      setOverColumn(null);
+      return;
+    }
+
+    // Check if over a column
+    if (over.data.current?.type === 'column') {
+      setOverColumn(over.id as BoardStatus);
+    } else if (over.data.current?.type === 'card') {
+      // Find which column the card is in
+      const cardItem = over.data.current.item as BoardItem;
+      setOverColumn(cardItem.status);
+    }
+  }, []);
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      setActiveItem(null);
+      setOverColumn(null);
+
+      if (!over) return;
+
+      const activeId = active.id as string;
+      let newStatus: BoardStatus | null = null;
+
+      // Determine the target status
+      if (over.data.current?.type === 'column') {
+        newStatus = over.id as BoardStatus;
+      } else if (over.data.current?.type === 'card') {
+        const overItem = over.data.current.item as BoardItem;
+        newStatus = overItem.status;
+      }
+
+      if (!newStatus) return;
+
+      // Find the item and update its status if changed
+      const itemIndex = items.findIndex((i) => i.id === activeId);
+      if (itemIndex === -1) return;
+
+      const item = items[itemIndex];
+      if (item.status === newStatus) return; // No change
+
+      // Optimistic update
+      const newItems = items.map((i) =>
+        i.id === activeId ? { ...i, status: newStatus! } : i
+      );
+      onItemsChange?.(newItems);
+    },
+    [items, onItemsChange]
+  );
+
+  const handleDragCancel = useCallback(() => {
+    setActiveItem(null);
+    setOverColumn(null);
+  }, []);
+
+  return (
+    <div className={cn('flex h-full flex-col', className)}>
+      {/* View mode toggle */}
+      {onViewModeChange && (
+        <div className="flex items-center justify-end gap-1 border-b p-2">
+          <Button
+            variant={viewMode === 'board' ? 'secondary' : 'ghost'}
+            size="sm"
+            onClick={() => onViewModeChange('board')}
+          >
+            <LayoutGrid className="mr-1 size-4" />
+            Board
+          </Button>
+          <Button
+            variant={viewMode === 'list' ? 'secondary' : 'ghost'}
+            size="sm"
+            onClick={() => onViewModeChange('list')}
+          >
+            <List className="mr-1 size-4" />
+            List
+          </Button>
+        </div>
+      )}
+
+      {/* Board */}
+      <ScrollArea className="flex-1">
+        <div className="flex gap-4 p-4">
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCorners}
+            onDragStart={handleDragStart}
+            onDragOver={handleDragOver}
+            onDragEnd={handleDragEnd}
+            onDragCancel={handleDragCancel}
+          >
+            {columns.map((column) => (
+              <BoardColumn
+                key={column.id}
+                column={column}
+                onItemClick={onItemClick}
+                onAddItem={onAddItem}
+                isOver={overColumn === column.id}
+              />
+            ))}
+            <DragOverlay>
+              {activeItem && <BoardCardOverlay item={activeItem} />}
+            </DragOverlay>
+          </DndContext>
+        </div>
+        <ScrollBar orientation="horizontal" />
+      </ScrollArea>
+
+      {/* Empty state */}
+      {items.length === 0 && (
+        <div className="absolute inset-0 flex items-center justify-center">
+          <div className="text-center">
+            <p className="text-muted-foreground">No items on this board</p>
+            {onAddItem && (
+              <Button
+                variant="outline"
+                size="sm"
+                className="mt-4"
+                onClick={() => onAddItem('not_started')}
+              >
+                Add first item
+              </Button>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/ui/components/board/types.ts
+++ b/src/ui/components/board/types.ts
@@ -1,0 +1,23 @@
+export type BoardStatus = 'not_started' | 'in_progress' | 'blocked' | 'done';
+
+export type BoardPriority = 'urgent' | 'high' | 'medium' | 'low';
+
+export interface BoardItem {
+  id: string;
+  title: string;
+  status: BoardStatus;
+  priority: BoardPriority;
+  estimateMinutes?: number;
+  assignee?: string;
+  assigneeAvatar?: string;
+}
+
+export interface BoardColumn {
+  id: BoardStatus;
+  title: string;
+  items: BoardItem[];
+}
+
+export interface BoardState {
+  columns: BoardColumn[];
+}

--- a/tests/ui/kanban-board.test.tsx
+++ b/tests/ui/kanban-board.test.tsx
@@ -1,0 +1,205 @@
+/**
+ * @vitest-environment jsdom
+ */
+import * as React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import {
+  KanbanBoard,
+  BoardCard,
+  BoardColumn,
+  type BoardItem,
+  type BoardColumnType,
+} from '@/ui/components/board';
+
+const mockItems: BoardItem[] = [
+  { id: '1', title: 'Task A', status: 'not_started', priority: 'high' },
+  { id: '2', title: 'Task B', status: 'in_progress', priority: 'medium', estimateMinutes: 60 },
+  { id: '3', title: 'Task C', status: 'in_progress', priority: 'urgent', assignee: 'Alice' },
+  { id: '4', title: 'Task D', status: 'done', priority: 'low' },
+];
+
+describe('BoardCard', () => {
+  const item: BoardItem = {
+    id: '1',
+    title: 'Test Task',
+    status: 'not_started',
+    priority: 'high',
+    estimateMinutes: 120,
+    assignee: 'John',
+  };
+
+  it('renders card title', () => {
+    render(<BoardCard item={item} />);
+    expect(screen.getByText('Test Task')).toBeInTheDocument();
+  });
+
+  it('shows priority badge', () => {
+    render(<BoardCard item={item} />);
+    expect(screen.getByText('High')).toBeInTheDocument();
+  });
+
+  it('shows estimate when provided', () => {
+    render(<BoardCard item={item} />);
+    expect(screen.getByText('2h')).toBeInTheDocument();
+  });
+
+  it('shows assignee initial when no avatar', () => {
+    render(<BoardCard item={item} />);
+    expect(screen.getByText('J')).toBeInTheDocument();
+  });
+
+  it('calls onClick when clicked', () => {
+    const onClick = vi.fn();
+    render(<BoardCard item={item} onClick={onClick} />);
+
+    fireEvent.click(screen.getByTestId('board-card'));
+    expect(onClick).toHaveBeenCalledWith(item);
+  });
+
+  it('applies dragging styles', () => {
+    const { container } = render(<BoardCard item={item} isDragging />);
+    const card = container.querySelector('[data-testid="board-card"]');
+    expect(card?.className).toContain('opacity-50');
+  });
+});
+
+describe('BoardColumn', () => {
+  const column: BoardColumnType = {
+    id: 'in_progress',
+    title: 'In Progress',
+    items: [
+      { id: '1', title: 'Task 1', status: 'in_progress', priority: 'high' },
+      { id: '2', title: 'Task 2', status: 'in_progress', priority: 'medium' },
+    ],
+  };
+
+  it('renders column title', () => {
+    render(<BoardColumn column={column} />);
+    expect(screen.getByText('In Progress')).toBeInTheDocument();
+  });
+
+  it('shows item count', () => {
+    render(<BoardColumn column={column} />);
+    expect(screen.getByText('2')).toBeInTheDocument();
+  });
+
+  it('renders all items', () => {
+    render(<BoardColumn column={column} />);
+    expect(screen.getByText('Task 1')).toBeInTheDocument();
+    expect(screen.getByText('Task 2')).toBeInTheDocument();
+  });
+
+  it('shows add button when onAddItem is provided', () => {
+    const onAddItem = vi.fn();
+    render(<BoardColumn column={column} onAddItem={onAddItem} />);
+
+    const addButton = screen.getByText('Add item');
+    expect(addButton).toBeInTheDocument();
+  });
+
+  it('calls onAddItem with status when add clicked', () => {
+    const onAddItem = vi.fn();
+    const { container } = render(<BoardColumn column={column} onAddItem={onAddItem} />);
+
+    // Find the add button by sr-only text
+    const addButton = container.querySelector('[aria-label="Add item"]')
+      ?? screen.getByText('Add item').closest('button');
+    fireEvent.click(addButton!);
+
+    expect(onAddItem).toHaveBeenCalledWith('in_progress');
+  });
+
+  it('shows empty state when no items', () => {
+    const emptyColumn: BoardColumnType = { id: 'blocked', title: 'Blocked', items: [] };
+    render(<BoardColumn column={emptyColumn} />);
+
+    expect(screen.getByText('No items')).toBeInTheDocument();
+  });
+
+  it('shows drop zone highlight when isOver', () => {
+    const emptyColumn: BoardColumnType = { id: 'blocked', title: 'Blocked', items: [] };
+    const { container } = render(<BoardColumn column={emptyColumn} isOver />);
+
+    // Should show "Drop here" text
+    expect(screen.getByText('Drop here')).toBeInTheDocument();
+  });
+});
+
+describe('KanbanBoard', () => {
+  it('renders all columns', () => {
+    render(<KanbanBoard items={mockItems} />);
+
+    expect(screen.getByText('To Do')).toBeInTheDocument();
+    expect(screen.getByText('In Progress')).toBeInTheDocument();
+    expect(screen.getByText('Blocked')).toBeInTheDocument();
+    expect(screen.getByText('Done')).toBeInTheDocument();
+  });
+
+  it('groups items by status', () => {
+    render(<KanbanBoard items={mockItems} />);
+
+    // Task A is in 'not_started' (To Do)
+    expect(screen.getByText('Task A')).toBeInTheDocument();
+    // Task B and C are in 'in_progress'
+    expect(screen.getByText('Task B')).toBeInTheDocument();
+    expect(screen.getByText('Task C')).toBeInTheDocument();
+    // Task D is in 'done'
+    expect(screen.getByText('Task D')).toBeInTheDocument();
+  });
+
+  it('shows column counts', () => {
+    render(<KanbanBoard items={mockItems} />);
+
+    // Check counts appear (To Do: 1, In Progress: 2, Done: 1, Blocked: 0)
+    const columns = screen.getAllByTestId('board-column');
+    expect(columns).toHaveLength(4);
+  });
+
+  it('shows view mode toggle when onViewModeChange provided', () => {
+    const onViewModeChange = vi.fn();
+    render(<KanbanBoard items={mockItems} onViewModeChange={onViewModeChange} />);
+
+    expect(screen.getByText('Board')).toBeInTheDocument();
+    expect(screen.getByText('List')).toBeInTheDocument();
+  });
+
+  it('calls onViewModeChange when toggle clicked', () => {
+    const onViewModeChange = vi.fn();
+    render(
+      <KanbanBoard
+        items={mockItems}
+        viewMode="board"
+        onViewModeChange={onViewModeChange}
+      />
+    );
+
+    fireEvent.click(screen.getByText('List'));
+    expect(onViewModeChange).toHaveBeenCalledWith('list');
+  });
+
+  it('calls onItemClick when card is clicked', () => {
+    const onItemClick = vi.fn();
+    render(<KanbanBoard items={mockItems} onItemClick={onItemClick} />);
+
+    fireEvent.click(screen.getByText('Task A'));
+    expect(onItemClick).toHaveBeenCalledWith(mockItems[0]);
+  });
+
+  it('passes onAddItem to columns', () => {
+    const onAddItem = vi.fn();
+    const { container } = render(<KanbanBoard items={[]} onAddItem={onAddItem} />);
+
+    // Should have 4 add buttons (one per column)
+    const addButtons = container.querySelectorAll('[class*="size-6"]');
+    expect(addButtons.length).toBeGreaterThan(0);
+  });
+
+  it('shows empty state when no items and onAddItem provided', () => {
+    const onAddItem = vi.fn();
+    render(<KanbanBoard items={[]} onAddItem={onAddItem} />);
+
+    expect(screen.getByText('No items on this board')).toBeInTheDocument();
+    expect(screen.getByText('Add first item')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
Implements the Kanban Board view for Issue #88, part of the Frontend Redesign epic (#80).

### Components
- **BoardCard**: Draggable issue card showing title, priority badge, estimate time, and assignee avatar/initial
- **BoardColumn**: Droppable column with status color indicator, item count badge, and add button
- **KanbanBoard**: Full board container with DnD context, view mode toggle, and empty state

### Features Implemented
- [x] Columns for each status (To Do, In Progress, Blocked, Done)
- [x] Drag-drop cards between columns to change status
- [x] Card shows: title, priority badge, estimate, assignee avatar
- [x] Visual feedback during drag (rotation, shadow, overlay)
- [x] Optimistic status update via callback
- [x] Toggle between List and Board view
- [x] Column item counts
- [x] Quick add issue button per column

### Technical Implementation
- Uses dnd-kit with `closestCorners` collision detection for multi-column support
- Pointer sensor with 8px activation distance to prevent accidental drags
- Keyboard sensor with sortable coordinates for accessibility
- DragOverlay with styled card for visual feedback
- Horizontal scroll area for mobile support

### Deferred to API Issues
- Persist status change to backend (#111)

## Test Plan
- [x] 21 kanban board tests pass
- [x] Full test suite passes (187 tests)
- [x] Cards render with all metadata
- [x] View mode toggle works
- [x] DnD context properly configured

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)