### PR TITLE
[#91] Memory items management components

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-separator": "^1.1.8",
     "@radix-ui/react-slot": "^1.2.4",
+    "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@types/pg": "^8.16.0",
     "class-variance-authority": "^0.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.2.4
         version: 1.2.4(@types/react@19.2.10)(react@19.2.4)
+      '@radix-ui/react-tabs':
+        specifier: ^1.1.13
+        version: 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-tooltip':
         specifier: ^1.2.8
         version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -804,6 +807,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-tabs@1.1.13':
+    resolution: {integrity: sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-tooltip@1.2.8':
@@ -2766,6 +2782,22 @@ snapshots:
       react: 19.2.4
     optionalDependencies:
       '@types/react': 19.2.10
+
+  '@radix-ui/react-tabs@1.1.13(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.10)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.10)(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.10)(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.10)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.10
+      '@types/react-dom': 19.2.3(@types/react@19.2.10)
 
   '@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:

--- a/src/ui/components/memory/index.ts
+++ b/src/ui/components/memory/index.ts
@@ -1,0 +1,20 @@
+export { MemoryCard } from './memory-card';
+export type { MemoryCardProps } from './memory-card';
+
+export { MemoryList } from './memory-list';
+export type { MemoryListProps } from './memory-list';
+
+export { MemoryEditor } from './memory-editor';
+export type { MemoryEditorProps } from './memory-editor';
+
+export { MemoryDetailSheet } from './memory-detail-sheet';
+export type { MemoryDetailSheetProps } from './memory-detail-sheet';
+
+export { ItemMemories } from './item-memories';
+export type { ItemMemoriesProps } from './item-memories';
+
+export type {
+  MemoryItem,
+  MemoryFilter,
+  MemoryFormData,
+} from './types';

--- a/src/ui/components/memory/item-memories.tsx
+++ b/src/ui/components/memory/item-memories.tsx
@@ -1,0 +1,92 @@
+import * as React from 'react';
+import { Plus, FileText, Link2 } from 'lucide-react';
+import { cn } from '@/ui/lib/utils';
+import { Button } from '@/ui/components/ui/button';
+import { Badge } from '@/ui/components/ui/badge';
+import { MemoryCard } from './memory-card';
+import type { MemoryItem } from './types';
+
+export interface ItemMemoriesProps {
+  memories: MemoryItem[];
+  onMemoryClick?: (memory: MemoryItem) => void;
+  onAddMemory?: () => void;
+  onLinkMemory?: () => void;
+  onEditMemory?: (memory: MemoryItem) => void;
+  onDeleteMemory?: (memory: MemoryItem) => void;
+  className?: string;
+}
+
+export function ItemMemories({
+  memories,
+  onMemoryClick,
+  onAddMemory,
+  onLinkMemory,
+  onEditMemory,
+  onDeleteMemory,
+  className,
+}: ItemMemoriesProps) {
+  return (
+    <div className={cn('space-y-4', className)}>
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <h3 className="text-sm font-medium">Memories</h3>
+          <Badge variant="secondary" className="text-xs">
+            {memories.length}
+          </Badge>
+        </div>
+
+        <div className="flex gap-1">
+          {onLinkMemory && (
+            <Button variant="ghost" size="sm" onClick={onLinkMemory}>
+              <Link2 className="mr-1 size-3" />
+              Link
+            </Button>
+          )}
+          {onAddMemory && (
+            <Button variant="ghost" size="sm" onClick={onAddMemory}>
+              <Plus className="mr-1 size-3" />
+              Add
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {/* Memory list */}
+      {memories.length > 0 ? (
+        <div className="grid gap-2 sm:grid-cols-2">
+          {memories.map((memory) => (
+            <MemoryCard
+              key={memory.id}
+              memory={memory}
+              onClick={onMemoryClick}
+              onEdit={onEditMemory}
+              onDelete={onDeleteMemory}
+            />
+          ))}
+        </div>
+      ) : (
+        <div className="rounded-lg border border-dashed p-6 text-center">
+          <FileText className="mx-auto size-8 text-muted-foreground/50" />
+          <p className="mt-2 text-sm text-muted-foreground">No memories attached</p>
+          {(onAddMemory || onLinkMemory) && (
+            <div className="mt-3 flex justify-center gap-2">
+              {onAddMemory && (
+                <Button variant="outline" size="sm" onClick={onAddMemory}>
+                  <Plus className="mr-1 size-3" />
+                  Create new
+                </Button>
+              )}
+              {onLinkMemory && (
+                <Button variant="outline" size="sm" onClick={onLinkMemory}>
+                  <Link2 className="mr-1 size-3" />
+                  Link existing
+                </Button>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/ui/components/memory/memory-card.tsx
+++ b/src/ui/components/memory/memory-card.tsx
@@ -1,0 +1,130 @@
+import * as React from 'react';
+import { FileText, Folder, Target, Layers, MoreVertical, Pencil, Trash2 } from 'lucide-react';
+import { cn } from '@/ui/lib/utils';
+import { Badge } from '@/ui/components/ui/badge';
+import { Button } from '@/ui/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/ui/components/ui/dropdown-menu';
+import type { MemoryItem } from './types';
+
+function getLinkedItemIcon(kind: MemoryItem['linkedItemKind']) {
+  switch (kind) {
+    case 'project':
+      return <Folder className="size-3" />;
+    case 'initiative':
+      return <Target className="size-3" />;
+    case 'epic':
+      return <Layers className="size-3" />;
+    case 'issue':
+      return <FileText className="size-3" />;
+    default:
+      return null;
+  }
+}
+
+export interface MemoryCardProps {
+  memory: MemoryItem;
+  onClick?: (memory: MemoryItem) => void;
+  onEdit?: (memory: MemoryItem) => void;
+  onDelete?: (memory: MemoryItem) => void;
+  className?: string;
+}
+
+export function MemoryCard({
+  memory,
+  onClick,
+  onEdit,
+  onDelete,
+  className,
+}: MemoryCardProps) {
+  const preview = memory.content.slice(0, 150) + (memory.content.length > 150 ? '...' : '');
+
+  return (
+    <div
+      data-testid="memory-card"
+      className={cn(
+        'group relative rounded-lg border bg-card p-4 transition-colors hover:bg-accent/50',
+        onClick && 'cursor-pointer',
+        className
+      )}
+      onClick={() => onClick?.(memory)}
+    >
+      {/* Header */}
+      <div className="flex items-start justify-between gap-2">
+        <h3 className="font-medium leading-tight">{memory.title}</h3>
+
+        {(onEdit || onDelete) && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="size-6 opacity-0 group-hover:opacity-100"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <MoreVertical className="size-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              {onEdit && (
+                <DropdownMenuItem
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onEdit(memory);
+                  }}
+                >
+                  <Pencil className="mr-2 size-4" />
+                  Edit
+                </DropdownMenuItem>
+              )}
+              {onDelete && (
+                <DropdownMenuItem
+                  className="text-destructive focus:text-destructive"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onDelete(memory);
+                  }}
+                >
+                  <Trash2 className="mr-2 size-4" />
+                  Delete
+                </DropdownMenuItem>
+              )}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
+      </div>
+
+      {/* Preview */}
+      <p className="mt-2 text-sm text-muted-foreground line-clamp-2">{preview}</p>
+
+      {/* Footer */}
+      <div className="mt-3 flex items-center justify-between text-xs text-muted-foreground">
+        <div className="flex items-center gap-2">
+          {memory.linkedItemKind && memory.linkedItemTitle && (
+            <span className="flex items-center gap-1">
+              {getLinkedItemIcon(memory.linkedItemKind)}
+              <span className="truncate max-w-[120px]">{memory.linkedItemTitle}</span>
+            </span>
+          )}
+        </div>
+
+        <span>{memory.updatedAt.toLocaleDateString()}</span>
+      </div>
+
+      {/* Tags */}
+      {memory.tags && memory.tags.length > 0 && (
+        <div className="mt-2 flex flex-wrap gap-1">
+          {memory.tags.map((tag) => (
+            <Badge key={tag} variant="secondary" className="text-xs">
+              {tag}
+            </Badge>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/ui/components/memory/memory-detail-sheet.tsx
+++ b/src/ui/components/memory/memory-detail-sheet.tsx
@@ -1,0 +1,189 @@
+import * as React from 'react';
+import {
+  Folder,
+  Target,
+  Layers,
+  FileText,
+  Pencil,
+  Trash2,
+  Calendar,
+  Tag,
+} from 'lucide-react';
+import { cn } from '@/ui/lib/utils';
+import { Button } from '@/ui/components/ui/button';
+import { Badge } from '@/ui/components/ui/badge';
+import { ScrollArea } from '@/ui/components/ui/scroll-area';
+import { Separator } from '@/ui/components/ui/separator';
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from '@/ui/components/ui/sheet';
+import type { MemoryItem } from './types';
+
+function getLinkedItemIcon(kind: MemoryItem['linkedItemKind']) {
+  switch (kind) {
+    case 'project':
+      return <Folder className="size-4" />;
+    case 'initiative':
+      return <Target className="size-4" />;
+    case 'epic':
+      return <Layers className="size-4" />;
+    case 'issue':
+      return <FileText className="size-4" />;
+    default:
+      return null;
+  }
+}
+
+export interface MemoryDetailSheetProps {
+  memory: MemoryItem | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onEdit?: (memory: MemoryItem) => void;
+  onDelete?: (memory: MemoryItem) => void;
+  onLinkedItemClick?: (memory: MemoryItem) => void;
+}
+
+export function MemoryDetailSheet({
+  memory,
+  open,
+  onOpenChange,
+  onEdit,
+  onDelete,
+  onLinkedItemClick,
+}: MemoryDetailSheetProps) {
+  if (!memory) return null;
+
+  // Simple markdown rendering for display
+  const renderContent = (text: string) => {
+    return text.split('\n').map((line, i) => {
+      // Headers
+      if (line.startsWith('### ')) {
+        return <h3 key={i} className="text-lg font-semibold mt-4 mb-2">{line.slice(4)}</h3>;
+      }
+      if (line.startsWith('## ')) {
+        return <h2 key={i} className="text-xl font-semibold mt-4 mb-2">{line.slice(3)}</h2>;
+      }
+      if (line.startsWith('# ')) {
+        return <h1 key={i} className="text-2xl font-bold mt-4 mb-2">{line.slice(2)}</h1>;
+      }
+
+      // List items
+      if (line.startsWith('- ') || line.startsWith('* ')) {
+        return <li key={i} className="ml-4">{line.slice(2)}</li>;
+      }
+
+      // Numbered list
+      if (/^\d+\. /.test(line)) {
+        return <li key={i} className="ml-4 list-decimal">{line.replace(/^\d+\. /, '')}</li>;
+      }
+
+      // Empty line
+      if (!line.trim()) {
+        return <br key={i} />;
+      }
+
+      // Regular paragraph
+      return <p key={i} className="my-1">{line}</p>;
+    });
+  };
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent className="w-96 sm:max-w-md">
+        <SheetHeader>
+          <SheetTitle className="sr-only">Memory Details</SheetTitle>
+        </SheetHeader>
+
+        <ScrollArea className="h-full">
+          <div className="space-y-6 pb-6">
+            {/* Title */}
+            <div>
+              <h2 className="text-xl font-semibold">{memory.title}</h2>
+            </div>
+
+            {/* Actions */}
+            <div className="flex gap-2">
+              {onEdit && (
+                <Button variant="outline" size="sm" onClick={() => onEdit(memory)}>
+                  <Pencil className="mr-1 size-3" />
+                  Edit
+                </Button>
+              )}
+              {onDelete && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="text-destructive hover:text-destructive"
+                  onClick={() => onDelete(memory)}
+                >
+                  <Trash2 className="mr-1 size-3" />
+                  Delete
+                </Button>
+              )}
+            </div>
+
+            <Separator />
+
+            {/* Meta info */}
+            <div className="space-y-3 text-sm">
+              {memory.linkedItemKind && memory.linkedItemTitle && (
+                <button
+                  className="flex items-center gap-2 text-left hover:text-primary"
+                  onClick={() => onLinkedItemClick?.(memory)}
+                >
+                  <span className="text-muted-foreground">
+                    {getLinkedItemIcon(memory.linkedItemKind)}
+                  </span>
+                  <span>Linked to: {memory.linkedItemTitle}</span>
+                </button>
+              )}
+
+              <div className="flex items-center gap-2 text-muted-foreground">
+                <Calendar className="size-4" />
+                <span>Created: {memory.createdAt.toLocaleDateString()}</span>
+              </div>
+
+              <div className="flex items-center gap-2 text-muted-foreground">
+                <Calendar className="size-4" />
+                <span>Updated: {memory.updatedAt.toLocaleDateString()}</span>
+              </div>
+            </div>
+
+            {/* Tags */}
+            {memory.tags && memory.tags.length > 0 && (
+              <>
+                <Separator />
+                <div className="space-y-2">
+                  <div className="flex items-center gap-2 text-sm font-medium">
+                    <Tag className="size-4" />
+                    Tags
+                  </div>
+                  <div className="flex flex-wrap gap-1">
+                    {memory.tags.map((tag) => (
+                      <Badge key={tag} variant="secondary">
+                        {tag}
+                      </Badge>
+                    ))}
+                  </div>
+                </div>
+              </>
+            )}
+
+            <Separator />
+
+            {/* Content */}
+            <div className="space-y-2">
+              <h3 className="text-sm font-medium">Content</h3>
+              <div className="prose prose-sm dark:prose-invert max-w-none">
+                {renderContent(memory.content)}
+              </div>
+            </div>
+          </div>
+        </ScrollArea>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/src/ui/components/memory/memory-editor.tsx
+++ b/src/ui/components/memory/memory-editor.tsx
@@ -1,0 +1,315 @@
+import * as React from 'react';
+import { useState, useCallback } from 'react';
+import { Bold, Italic, List, ListOrdered, Link2, Code, Eye, Edit3 } from 'lucide-react';
+import { cn } from '@/ui/lib/utils';
+import { Button } from '@/ui/components/ui/button';
+import { Input } from '@/ui/components/ui/input';
+import { Textarea } from '@/ui/components/ui/textarea';
+import { Badge } from '@/ui/components/ui/badge';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/ui/components/ui/dialog';
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from '@/ui/components/ui/tabs';
+import type { MemoryItem, MemoryFormData } from './types';
+
+export interface MemoryEditorProps {
+  memory?: MemoryItem;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (data: MemoryFormData) => void;
+  className?: string;
+}
+
+export function MemoryEditor({
+  memory,
+  open,
+  onOpenChange,
+  onSubmit,
+  className,
+}: MemoryEditorProps) {
+  const [title, setTitle] = useState(memory?.title ?? '');
+  const [content, setContent] = useState(memory?.content ?? '');
+  const [tagInput, setTagInput] = useState('');
+  const [tags, setTags] = useState<string[]>(memory?.tags ?? []);
+  const [activeTab, setActiveTab] = useState<'edit' | 'preview'>('edit');
+
+  const textareaRef = React.useRef<HTMLTextAreaElement>(null);
+
+  const insertMarkdown = useCallback((before: string, after: string = '') => {
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+
+    const start = textarea.selectionStart;
+    const end = textarea.selectionEnd;
+    const selected = content.slice(start, end);
+
+    const newContent =
+      content.slice(0, start) +
+      before +
+      (selected || 'text') +
+      after +
+      content.slice(end);
+
+    setContent(newContent);
+
+    // Restore focus and selection
+    setTimeout(() => {
+      textarea.focus();
+      const newStart = start + before.length;
+      const newEnd = newStart + (selected || 'text').length;
+      textarea.setSelectionRange(newStart, newEnd);
+    }, 0);
+  }, [content]);
+
+  const handleAddTag = () => {
+    const tag = tagInput.trim();
+    if (tag && !tags.includes(tag)) {
+      setTags([...tags, tag]);
+      setTagInput('');
+    }
+  };
+
+  const handleRemoveTag = (tagToRemove: string) => {
+    setTags(tags.filter((t) => t !== tagToRemove));
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSubmit({
+      title: title.trim(),
+      content: content.trim(),
+      tags: tags.length > 0 ? tags : undefined,
+    });
+  };
+
+  const isValid = title.trim() && content.trim();
+
+  // Simple markdown to HTML conversion for preview
+  const renderPreview = (text: string) => {
+    return text
+      .split('\n')
+      .map((line, i) => {
+        // Headers
+        if (line.startsWith('### ')) {
+          return <h3 key={i} className="text-lg font-semibold mt-4 mb-2">{line.slice(4)}</h3>;
+        }
+        if (line.startsWith('## ')) {
+          return <h2 key={i} className="text-xl font-semibold mt-4 mb-2">{line.slice(3)}</h2>;
+        }
+        if (line.startsWith('# ')) {
+          return <h1 key={i} className="text-2xl font-bold mt-4 mb-2">{line.slice(2)}</h1>;
+        }
+
+        // List items
+        if (line.startsWith('- ') || line.startsWith('* ')) {
+          return <li key={i} className="ml-4">{line.slice(2)}</li>;
+        }
+
+        // Numbered list
+        if (/^\d+\. /.test(line)) {
+          return <li key={i} className="ml-4 list-decimal">{line.replace(/^\d+\. /, '')}</li>;
+        }
+
+        // Empty line
+        if (!line.trim()) {
+          return <br key={i} />;
+        }
+
+        // Regular paragraph
+        return <p key={i} className="my-1">{line}</p>;
+      });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className={cn('sm:max-w-2xl', className)}>
+        <DialogHeader>
+          <DialogTitle>{memory ? 'Edit Memory' : 'Create Memory'}</DialogTitle>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {/* Title */}
+          <div className="space-y-2">
+            <label htmlFor="memory-title" className="text-sm font-medium">
+              Title <span className="text-destructive">*</span>
+            </label>
+            <Input
+              id="memory-title"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="Memory title"
+              required
+            />
+          </div>
+
+          {/* Content with tabs */}
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <label className="text-sm font-medium">
+                Content <span className="text-destructive">*</span>
+              </label>
+            </div>
+
+            <Tabs value={activeTab} onValueChange={(v) => setActiveTab(v as 'edit' | 'preview')}>
+              <div className="flex items-center justify-between">
+                {/* Toolbar */}
+                <div className="flex gap-1">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="size-8"
+                    onClick={() => insertMarkdown('**', '**')}
+                    title="Bold"
+                  >
+                    <Bold className="size-4" />
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="size-8"
+                    onClick={() => insertMarkdown('*', '*')}
+                    title="Italic"
+                  >
+                    <Italic className="size-4" />
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="size-8"
+                    onClick={() => insertMarkdown('- ')}
+                    title="Bullet list"
+                  >
+                    <List className="size-4" />
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="size-8"
+                    onClick={() => insertMarkdown('1. ')}
+                    title="Numbered list"
+                  >
+                    <ListOrdered className="size-4" />
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="size-8"
+                    onClick={() => insertMarkdown('[', '](url)')}
+                    title="Link"
+                  >
+                    <Link2 className="size-4" />
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="size-8"
+                    onClick={() => insertMarkdown('`', '`')}
+                    title="Code"
+                  >
+                    <Code className="size-4" />
+                  </Button>
+                </div>
+
+                <TabsList>
+                  <TabsTrigger value="edit" className="gap-1">
+                    <Edit3 className="size-3" />
+                    Edit
+                  </TabsTrigger>
+                  <TabsTrigger value="preview" className="gap-1">
+                    <Eye className="size-3" />
+                    Preview
+                  </TabsTrigger>
+                </TabsList>
+              </div>
+
+              <TabsContent value="edit" className="mt-2">
+                <Textarea
+                  ref={textareaRef}
+                  value={content}
+                  onChange={(e) => setContent(e.target.value)}
+                  placeholder="Write your memory content here... (Markdown supported)"
+                  className="min-h-[200px] font-mono text-sm"
+                  required
+                />
+              </TabsContent>
+
+              <TabsContent value="preview" className="mt-2">
+                <div className="min-h-[200px] rounded-md border bg-muted/30 p-4 text-sm">
+                  {content ? (
+                    <div className="prose prose-sm dark:prose-invert max-w-none">
+                      {renderPreview(content)}
+                    </div>
+                  ) : (
+                    <p className="text-muted-foreground">Nothing to preview</p>
+                  )}
+                </div>
+              </TabsContent>
+            </Tabs>
+          </div>
+
+          {/* Tags */}
+          <div className="space-y-2">
+            <label htmlFor="memory-tags" className="text-sm font-medium">
+              Tags
+            </label>
+            <div className="flex gap-2">
+              <Input
+                id="memory-tags"
+                value={tagInput}
+                onChange={(e) => setTagInput(e.target.value)}
+                placeholder="Add a tag"
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault();
+                    handleAddTag();
+                  }
+                }}
+              />
+              <Button type="button" variant="outline" onClick={handleAddTag}>
+                Add
+              </Button>
+            </div>
+            {tags.length > 0 && (
+              <div className="flex flex-wrap gap-1 mt-2">
+                {tags.map((tag) => (
+                  <Badge
+                    key={tag}
+                    variant="secondary"
+                    className="cursor-pointer"
+                    onClick={() => handleRemoveTag(tag)}
+                  >
+                    {tag} ×
+                  </Badge>
+                ))}
+              </div>
+            )}
+          </div>
+
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={!isValid}>
+              {memory ? 'Save Changes' : 'Create Memory'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/ui/components/memory/memory-list.tsx
+++ b/src/ui/components/memory/memory-list.tsx
@@ -1,0 +1,133 @@
+import * as React from 'react';
+import { useState, useMemo } from 'react';
+import { Search, Plus, FileText } from 'lucide-react';
+import { cn } from '@/ui/lib/utils';
+import { Button } from '@/ui/components/ui/button';
+import { Input } from '@/ui/components/ui/input';
+import { ScrollArea } from '@/ui/components/ui/scroll-area';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/ui/components/ui/select';
+import { MemoryCard } from './memory-card';
+import type { MemoryItem, MemoryFilter } from './types';
+
+export interface MemoryListProps {
+  memories: MemoryItem[];
+  onMemoryClick?: (memory: MemoryItem) => void;
+  onAddMemory?: () => void;
+  onEditMemory?: (memory: MemoryItem) => void;
+  onDeleteMemory?: (memory: MemoryItem) => void;
+  className?: string;
+}
+
+export function MemoryList({
+  memories,
+  onMemoryClick,
+  onAddMemory,
+  onEditMemory,
+  onDeleteMemory,
+  className,
+}: MemoryListProps) {
+  const [filter, setFilter] = useState<MemoryFilter>({});
+
+  const filteredMemories = useMemo(() => {
+    let result = memories;
+
+    if (filter.search?.trim()) {
+      const query = filter.search.toLowerCase();
+      result = result.filter(
+        (m) =>
+          m.title.toLowerCase().includes(query) ||
+          m.content.toLowerCase().includes(query) ||
+          m.tags?.some((t) => t.toLowerCase().includes(query))
+      );
+    }
+
+    if (filter.linkedItemKind) {
+      result = result.filter((m) => m.linkedItemKind === filter.linkedItemKind);
+    }
+
+    return result;
+  }, [memories, filter]);
+
+  return (
+    <div className={cn('flex h-full flex-col', className)}>
+      {/* Header */}
+      <div className="flex items-center justify-between border-b p-4">
+        <h2 className="text-lg font-semibold">Memory Items</h2>
+        {onAddMemory && (
+          <Button size="sm" onClick={onAddMemory}>
+            <Plus className="mr-1 size-4" />
+            Add Memory
+          </Button>
+        )}
+      </div>
+
+      {/* Filters */}
+      <div className="flex gap-2 border-b p-4">
+        <div className="relative flex-1">
+          <Search className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            value={filter.search ?? ''}
+            onChange={(e) => setFilter((prev) => ({ ...prev, search: e.target.value }))}
+            placeholder="Search memories..."
+            className="pl-9"
+          />
+        </div>
+        <Select
+          value={filter.linkedItemKind ?? 'all'}
+          onValueChange={(v) =>
+            setFilter((prev) => ({
+              ...prev,
+              linkedItemKind: v === 'all' ? undefined : (v as MemoryFilter['linkedItemKind']),
+            }))
+          }
+        >
+          <SelectTrigger className="w-[140px]">
+            <SelectValue placeholder="All types" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All types</SelectItem>
+            <SelectItem value="project">Projects</SelectItem>
+            <SelectItem value="initiative">Initiatives</SelectItem>
+            <SelectItem value="epic">Epics</SelectItem>
+            <SelectItem value="issue">Issues</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* List */}
+      <ScrollArea className="flex-1">
+        <div className="grid gap-3 p-4 sm:grid-cols-2 lg:grid-cols-3">
+          {filteredMemories.map((memory) => (
+            <MemoryCard
+              key={memory.id}
+              memory={memory}
+              onClick={onMemoryClick}
+              onEdit={onEditMemory}
+              onDelete={onDeleteMemory}
+            />
+          ))}
+
+          {filteredMemories.length === 0 && (
+            <div className="col-span-full py-12 text-center">
+              <FileText className="mx-auto size-12 text-muted-foreground/50" />
+              <p className="mt-4 text-muted-foreground">
+                {filter.search || filter.linkedItemKind ? 'No memories found' : 'No memories yet'}
+              </p>
+              {!filter.search && !filter.linkedItemKind && onAddMemory && (
+                <Button variant="outline" size="sm" className="mt-4" onClick={onAddMemory}>
+                  Create your first memory
+                </Button>
+              )}
+            </div>
+          )}
+        </div>
+      </ScrollArea>
+    </div>
+  );
+}

--- a/src/ui/components/memory/types.ts
+++ b/src/ui/components/memory/types.ts
@@ -1,0 +1,23 @@
+export interface MemoryItem {
+  id: string;
+  title: string;
+  content: string;
+  linkedItemId?: string;
+  linkedItemTitle?: string;
+  linkedItemKind?: 'project' | 'initiative' | 'epic' | 'issue';
+  tags?: string[];
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface MemoryFilter {
+  search?: string;
+  linkedItemKind?: 'project' | 'initiative' | 'epic' | 'issue';
+  tags?: string[];
+}
+
+export interface MemoryFormData {
+  title: string;
+  content: string;
+  tags?: string[];
+}

--- a/src/ui/components/ui/tabs.tsx
+++ b/src/ui/components/ui/tabs.tsx
@@ -1,0 +1,89 @@
+import * as React from "react"
+import * as TabsPrimitive from "@radix-ui/react-tabs"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/ui/lib/utils"
+
+function Tabs({
+  className,
+  orientation = "horizontal",
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Root>) {
+  return (
+    <TabsPrimitive.Root
+      data-slot="tabs"
+      data-orientation={orientation}
+      orientation={orientation}
+      className={cn(
+        "group/tabs flex gap-2 data-[orientation=horizontal]:flex-col",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+const tabsListVariants = cva(
+  "rounded-lg p-[3px] group-data-[orientation=horizontal]/tabs:h-9 data-[variant=line]:rounded-none group/tabs-list text-muted-foreground inline-flex w-fit items-center justify-center group-data-[orientation=vertical]/tabs:h-fit group-data-[orientation=vertical]/tabs:flex-col",
+  {
+    variants: {
+      variant: {
+        default: "bg-muted",
+        line: "gap-1 bg-transparent",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function TabsList({
+  className,
+  variant = "default",
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.List> &
+  VariantProps<typeof tabsListVariants>) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      data-variant={variant}
+      className={cn(tabsListVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+function TabsTrigger({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+  return (
+    <TabsPrimitive.Trigger
+      data-slot="tabs-trigger"
+      className={cn(
+        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring text-foreground/60 hover:text-foreground dark:text-muted-foreground dark:hover:text-foreground relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-all group-data-[orientation=vertical]/tabs:w-full group-data-[orientation=vertical]/tabs:justify-start focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 group-data-[variant=default]/tabs-list:data-[state=active]:shadow-sm group-data-[variant=line]/tabs-list:data-[state=active]:shadow-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:border-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent",
+        "data-[state=active]:bg-background dark:data-[state=active]:text-foreground dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 data-[state=active]:text-foreground",
+        "after:bg-foreground after:absolute after:opacity-0 after:transition-opacity group-data-[orientation=horizontal]/tabs:after:inset-x-0 group-data-[orientation=horizontal]/tabs:after:bottom-[-5px] group-data-[orientation=horizontal]/tabs:after:h-0.5 group-data-[orientation=vertical]/tabs:after:inset-y-0 group-data-[orientation=vertical]/tabs:after:-right-1 group-data-[orientation=vertical]/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-[state=active]:after:opacity-100",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TabsContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Content>) {
+  return (
+    <TabsPrimitive.Content
+      data-slot="tabs-content"
+      className={cn("flex-1 outline-none", className)}
+      {...props}
+    />
+  )
+}
+
+export { Tabs, TabsList, TabsTrigger, TabsContent, tabsListVariants }

--- a/tests/setup-ui.ts
+++ b/tests/setup-ui.ts
@@ -1,1 +1,19 @@
 import '@testing-library/jest-dom/vitest';
+
+// Only apply DOM mocks when running in jsdom environment
+if (typeof Element !== 'undefined') {
+  // Mock scrollIntoView for Radix UI components
+  Element.prototype.scrollIntoView = () => {};
+
+  // Mock hasPointerCapture for Radix UI
+  Element.prototype.hasPointerCapture = () => false;
+}
+
+// Mock ResizeObserver (needed for Radix UI in jsdom)
+if (typeof global.ResizeObserver === 'undefined') {
+  global.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+}

--- a/tests/ui/memory.test.tsx
+++ b/tests/ui/memory.test.tsx
@@ -1,0 +1,366 @@
+/**
+ * @vitest-environment jsdom
+ */
+import * as React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import {
+  MemoryCard,
+  MemoryList,
+  MemoryEditor,
+  MemoryDetailSheet,
+  ItemMemories,
+  type MemoryItem,
+} from '@/ui/components/memory';
+
+const mockMemory: MemoryItem = {
+  id: '1',
+  title: 'Project Architecture Notes',
+  content: '# Overview\n\nThis project uses a monorepo structure with:\n- Frontend in React\n- Backend in Node.js',
+  linkedItemId: 'proj-1',
+  linkedItemTitle: 'Main Project',
+  linkedItemKind: 'project',
+  tags: ['architecture', 'documentation'],
+  createdAt: new Date('2024-01-15'),
+  updatedAt: new Date('2024-01-20'),
+};
+
+const mockMemories: MemoryItem[] = [
+  mockMemory,
+  {
+    id: '2',
+    title: 'API Design Decisions',
+    content: 'We decided to use REST for external APIs and GraphQL for internal.',
+    linkedItemId: 'epic-1',
+    linkedItemTitle: 'API Epic',
+    linkedItemKind: 'epic',
+    tags: ['api', 'design'],
+    createdAt: new Date('2024-01-10'),
+    updatedAt: new Date('2024-01-12'),
+  },
+  {
+    id: '3',
+    title: 'Meeting Notes - Sprint Planning',
+    content: 'Key decisions from the sprint planning meeting.',
+    createdAt: new Date('2024-01-18'),
+    updatedAt: new Date('2024-01-18'),
+  },
+];
+
+describe('MemoryCard', () => {
+  it('renders memory title', () => {
+    render(<MemoryCard memory={mockMemory} />);
+
+    expect(screen.getByText('Project Architecture Notes')).toBeInTheDocument();
+  });
+
+  it('renders content preview', () => {
+    render(<MemoryCard memory={mockMemory} />);
+
+    expect(screen.getByText(/This project uses a monorepo structure/)).toBeInTheDocument();
+  });
+
+  it('shows linked item info', () => {
+    render(<MemoryCard memory={mockMemory} />);
+
+    expect(screen.getByText('Main Project')).toBeInTheDocument();
+  });
+
+  it('shows tags', () => {
+    render(<MemoryCard memory={mockMemory} />);
+
+    expect(screen.getByText('architecture')).toBeInTheDocument();
+    expect(screen.getByText('documentation')).toBeInTheDocument();
+  });
+
+  it('calls onClick when clicked', () => {
+    const onClick = vi.fn();
+    render(<MemoryCard memory={mockMemory} onClick={onClick} />);
+
+    fireEvent.click(screen.getByTestId('memory-card'));
+    expect(onClick).toHaveBeenCalledWith(mockMemory);
+  });
+
+  it('shows edit/delete menu when handlers provided', () => {
+    const onEdit = vi.fn();
+    const onDelete = vi.fn();
+    render(<MemoryCard memory={mockMemory} onEdit={onEdit} onDelete={onDelete} />);
+
+    // Menu trigger should exist
+    const menuButton = screen.getByRole('button');
+    expect(menuButton).toBeInTheDocument();
+  });
+});
+
+describe('MemoryList', () => {
+  it('renders all memories', () => {
+    render(<MemoryList memories={mockMemories} />);
+
+    expect(screen.getByText('Project Architecture Notes')).toBeInTheDocument();
+    expect(screen.getByText('API Design Decisions')).toBeInTheDocument();
+    expect(screen.getByText('Meeting Notes - Sprint Planning')).toBeInTheDocument();
+  });
+
+  it('filters by search query', () => {
+    render(<MemoryList memories={mockMemories} />);
+
+    const searchInput = screen.getByPlaceholderText('Search memories...');
+    fireEvent.change(searchInput, { target: { value: 'API' } });
+
+    expect(screen.queryByText('Project Architecture Notes')).not.toBeInTheDocument();
+    expect(screen.getByText('API Design Decisions')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no memories', () => {
+    render(<MemoryList memories={[]} />);
+
+    expect(screen.getByText('No memories yet')).toBeInTheDocument();
+  });
+
+  it('shows no results message when search has no matches', () => {
+    render(<MemoryList memories={mockMemories} />);
+
+    const searchInput = screen.getByPlaceholderText('Search memories...');
+    fireEvent.change(searchInput, { target: { value: 'xyz' } });
+
+    expect(screen.getByText('No memories found')).toBeInTheDocument();
+  });
+
+  it('shows add button when onAddMemory provided', () => {
+    const onAddMemory = vi.fn();
+    render(<MemoryList memories={mockMemories} onAddMemory={onAddMemory} />);
+
+    expect(screen.getByText('Add Memory')).toBeInTheDocument();
+  });
+
+  it('filters by linked item type', () => {
+    render(<MemoryList memories={mockMemories} />);
+
+    // Open the select
+    const selectTrigger = screen.getByRole('combobox');
+    fireEvent.click(selectTrigger);
+
+    // Select "Projects"
+    fireEvent.click(screen.getByText('Projects'));
+
+    // Only project memories should show
+    expect(screen.getByText('Project Architecture Notes')).toBeInTheDocument();
+    expect(screen.queryByText('API Design Decisions')).not.toBeInTheDocument();
+  });
+});
+
+describe('MemoryEditor', () => {
+  it('renders form fields', () => {
+    render(
+      <MemoryEditor
+        open={true}
+        onOpenChange={() => {}}
+        onSubmit={() => {}}
+      />
+    );
+
+    expect(screen.getByLabelText(/Title/)).toBeInTheDocument();
+    expect(screen.getByText('Content')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/Write your memory content/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Tags/)).toBeInTheDocument();
+  });
+
+  it('pre-fills form when editing', () => {
+    render(
+      <MemoryEditor
+        memory={mockMemory}
+        open={true}
+        onOpenChange={() => {}}
+        onSubmit={() => {}}
+      />
+    );
+
+    expect(screen.getByDisplayValue('Project Architecture Notes')).toBeInTheDocument();
+  });
+
+  it('submits form data', () => {
+    const onSubmit = vi.fn();
+    render(
+      <MemoryEditor
+        open={true}
+        onOpenChange={() => {}}
+        onSubmit={onSubmit}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText(/Title/), { target: { value: 'Test Memory' } });
+    fireEvent.change(screen.getByPlaceholderText(/Write your memory content/), {
+      target: { value: 'Test content' },
+    });
+
+    const submitButton = screen.getByRole('button', { name: 'Create Memory' });
+    fireEvent.click(submitButton);
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Test Memory',
+        content: 'Test content',
+      })
+    );
+  });
+
+  it('disables submit when required fields empty', () => {
+    render(
+      <MemoryEditor
+        open={true}
+        onOpenChange={() => {}}
+        onSubmit={() => {}}
+      />
+    );
+
+    const submitButton = screen.getByRole('button', { name: 'Create Memory' });
+    expect(submitButton).toBeDisabled();
+  });
+
+  it('allows adding and removing tags', () => {
+    render(
+      <MemoryEditor
+        open={true}
+        onOpenChange={() => {}}
+        onSubmit={() => {}}
+      />
+    );
+
+    const tagInput = screen.getByPlaceholderText('Add a tag');
+    fireEvent.change(tagInput, { target: { value: 'test-tag' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+
+    expect(screen.getByText('test-tag ×')).toBeInTheDocument();
+
+    // Click to remove
+    fireEvent.click(screen.getByText('test-tag ×'));
+    expect(screen.queryByText('test-tag ×')).not.toBeInTheDocument();
+  });
+
+  it('has edit and preview tabs', () => {
+    render(
+      <MemoryEditor
+        open={true}
+        onOpenChange={() => {}}
+        onSubmit={() => {}}
+      />
+    );
+
+    expect(screen.getByRole('tab', { name: /Edit/i })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /Preview/i })).toBeInTheDocument();
+  });
+});
+
+describe('MemoryDetailSheet', () => {
+  it('renders memory title and content', () => {
+    render(
+      <MemoryDetailSheet
+        memory={mockMemory}
+        open={true}
+        onOpenChange={() => {}}
+      />
+    );
+
+    expect(screen.getByText('Project Architecture Notes')).toBeInTheDocument();
+    expect(screen.getByText(/This project uses a monorepo structure/)).toBeInTheDocument();
+  });
+
+  it('shows linked item', () => {
+    render(
+      <MemoryDetailSheet
+        memory={mockMemory}
+        open={true}
+        onOpenChange={() => {}}
+      />
+    );
+
+    expect(screen.getByText(/Linked to: Main Project/)).toBeInTheDocument();
+  });
+
+  it('shows tags', () => {
+    render(
+      <MemoryDetailSheet
+        memory={mockMemory}
+        open={true}
+        onOpenChange={() => {}}
+      />
+    );
+
+    expect(screen.getByText('architecture')).toBeInTheDocument();
+    expect(screen.getByText('documentation')).toBeInTheDocument();
+  });
+
+  it('calls onEdit when edit clicked', () => {
+    const onEdit = vi.fn();
+    render(
+      <MemoryDetailSheet
+        memory={mockMemory}
+        open={true}
+        onOpenChange={() => {}}
+        onEdit={onEdit}
+      />
+    );
+
+    fireEvent.click(screen.getByText('Edit'));
+    expect(onEdit).toHaveBeenCalledWith(mockMemory);
+  });
+
+  it('calls onLinkedItemClick when linked item clicked', () => {
+    const onLinkedItemClick = vi.fn();
+    render(
+      <MemoryDetailSheet
+        memory={mockMemory}
+        open={true}
+        onOpenChange={() => {}}
+        onLinkedItemClick={onLinkedItemClick}
+      />
+    );
+
+    fireEvent.click(screen.getByText(/Linked to: Main Project/));
+    expect(onLinkedItemClick).toHaveBeenCalledWith(mockMemory);
+  });
+});
+
+describe('ItemMemories', () => {
+  it('renders all attached memories', () => {
+    render(<ItemMemories memories={mockMemories.slice(0, 2)} />);
+
+    expect(screen.getByText('Project Architecture Notes')).toBeInTheDocument();
+    expect(screen.getByText('API Design Decisions')).toBeInTheDocument();
+  });
+
+  it('shows memory count badge', () => {
+    render(<ItemMemories memories={mockMemories.slice(0, 2)} />);
+
+    expect(screen.getByText('2')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no memories', () => {
+    render(<ItemMemories memories={[]} />);
+
+    expect(screen.getByText('No memories attached')).toBeInTheDocument();
+  });
+
+  it('shows add and link buttons when handlers provided', () => {
+    const onAddMemory = vi.fn();
+    const onLinkMemory = vi.fn();
+    render(
+      <ItemMemories
+        memories={[]}
+        onAddMemory={onAddMemory}
+        onLinkMemory={onLinkMemory}
+      />
+    );
+
+    expect(screen.getByText('Create new')).toBeInTheDocument();
+    expect(screen.getByText('Link existing')).toBeInTheDocument();
+  });
+
+  it('calls onMemoryClick when memory clicked', () => {
+    const onMemoryClick = vi.fn();
+    render(<ItemMemories memories={mockMemories.slice(0, 1)} onMemoryClick={onMemoryClick} />);
+
+    fireEvent.click(screen.getByTestId('memory-card'));
+    expect(onMemoryClick).toHaveBeenCalledWith(mockMemories[0]);
+  });
+});


### PR DESCRIPTION
## Summary
- MemoryCard: Display card with title, content preview, linked item info, and tags
- MemoryList: Searchable grid with type filter and empty states
- MemoryEditor: Dialog with markdown toolbar, edit/preview tabs, and tag management
- MemoryDetailSheet: Slide-out panel for viewing full memory content with rendered markdown
- ItemMemories: Component for showing memories attached to a specific work item

## Components Added
- `shadcn/ui` Tabs component for edit/preview functionality
- DOM mocks in test setup for Radix UI components

## Test Plan
- [x] 28 tests passing for all memory components
- [x] Full test suite passing (258 tests)

## API Issues Created
- #120 - GET /api/memory endpoint
- #121 - POST/PUT/DELETE /api/memory CRUD endpoints
- #122 - Memory-WorkItem linking endpoints

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)