### PR TITLE
[#92] Email and calendar event display components

### DIFF
--- a/src/ui/components/communications/calendar-event-card.tsx
+++ b/src/ui/components/communications/calendar-event-card.tsx
@@ -1,0 +1,164 @@
+import * as React from 'react';
+import {
+  Calendar,
+  Clock,
+  MapPin,
+  Users,
+  Video,
+  MoreVertical,
+  Unlink,
+} from 'lucide-react';
+import { cn } from '@/ui/lib/utils';
+import { Button } from '@/ui/components/ui/button';
+import { Badge } from '@/ui/components/ui/badge';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/ui/components/ui/dropdown-menu';
+import type { LinkedCalendarEvent } from './types';
+
+export interface CalendarEventCardProps {
+  event: LinkedCalendarEvent;
+  onClick?: (event: LinkedCalendarEvent) => void;
+  onUnlink?: (event: LinkedCalendarEvent) => void;
+  className?: string;
+}
+
+export function CalendarEventCard({
+  event,
+  onClick,
+  onUnlink,
+  className,
+}: CalendarEventCardProps) {
+  const isPast = event.endTime < new Date();
+  const isToday = isSameDay(event.startTime, new Date());
+
+  return (
+    <div
+      data-testid="calendar-event-card"
+      className={cn(
+        'group flex items-start gap-3 rounded-lg border bg-card p-3 transition-colors hover:bg-accent/50',
+        onClick && 'cursor-pointer',
+        isPast && 'opacity-60',
+        className
+      )}
+      onClick={() => onClick?.(event)}
+    >
+      {/* Date box */}
+      <div
+        className={cn(
+          'flex size-12 shrink-0 flex-col items-center justify-center rounded-lg',
+          isToday ? 'bg-primary text-primary-foreground' : 'bg-muted'
+        )}
+      >
+        <span className="text-[10px] font-medium uppercase">
+          {event.startTime.toLocaleDateString([], { weekday: 'short' })}
+        </span>
+        <span className="text-lg font-bold">{event.startTime.getDate()}</span>
+      </div>
+
+      {/* Content */}
+      <div className="min-w-0 flex-1">
+        <div className="flex items-start justify-between gap-2">
+          <h4 className="font-medium leading-tight">{event.title}</h4>
+
+          {onUnlink && (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="size-6 opacity-0 group-hover:opacity-100"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  <MoreVertical className="size-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem
+                  className="text-destructive focus:text-destructive"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onUnlink(event);
+                  }}
+                >
+                  <Unlink className="mr-2 size-4" />
+                  Unlink
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
+        </div>
+
+        {/* Time */}
+        <div className="mt-1 flex items-center gap-1 text-xs text-muted-foreground">
+          <Clock className="size-3" />
+          <span>
+            {event.isAllDay
+              ? 'All day'
+              : `${formatTime(event.startTime)} - ${formatTime(event.endTime)}`}
+          </span>
+        </div>
+
+        {/* Location */}
+        {event.location && (
+          <div className="mt-1 flex items-center gap-1 text-xs text-muted-foreground">
+            <MapPin className="size-3" />
+            <span className="truncate">{event.location}</span>
+          </div>
+        )}
+
+        {/* Meeting link */}
+        {event.meetingLink && (
+          <div className="mt-1 flex items-center gap-1 text-xs text-primary">
+            <Video className="size-3" />
+            <span>Video meeting</span>
+          </div>
+        )}
+
+        {/* Attendees */}
+        {event.attendees.length > 0 && (
+          <div className="mt-2 flex items-center gap-2">
+            <Users className="size-3 text-muted-foreground" />
+            <div className="flex items-center gap-1">
+              {event.attendees.slice(0, 3).map((attendee, i) => (
+                <Badge
+                  key={attendee.email}
+                  variant={
+                    attendee.status === 'accepted'
+                      ? 'default'
+                      : attendee.status === 'declined'
+                        ? 'destructive'
+                        : 'secondary'
+                  }
+                  className="text-[10px] px-1.5 py-0"
+                >
+                  {attendee.name.split(' ')[0]}
+                </Badge>
+              ))}
+              {event.attendees.length > 3 && (
+                <span className="text-xs text-muted-foreground">
+                  +{event.attendees.length - 3}
+                </span>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function formatTime(date: Date): string {
+  return date.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+}
+
+function isSameDay(d1: Date, d2: Date): boolean {
+  return (
+    d1.getFullYear() === d2.getFullYear() &&
+    d1.getMonth() === d2.getMonth() &&
+    d1.getDate() === d2.getDate()
+  );
+}

--- a/src/ui/components/communications/calendar-event-detail-sheet.tsx
+++ b/src/ui/components/communications/calendar-event-detail-sheet.tsx
@@ -1,0 +1,217 @@
+import * as React from 'react';
+import {
+  Calendar,
+  Clock,
+  MapPin,
+  Users,
+  Video,
+  User,
+  Unlink,
+  FileText,
+  Check,
+  X,
+  HelpCircle,
+} from 'lucide-react';
+import { cn } from '@/ui/lib/utils';
+import { Button } from '@/ui/components/ui/button';
+import { Badge } from '@/ui/components/ui/badge';
+import { ScrollArea } from '@/ui/components/ui/scroll-area';
+import { Separator } from '@/ui/components/ui/separator';
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from '@/ui/components/ui/sheet';
+import type { LinkedCalendarEvent, CalendarAttendee } from './types';
+
+function getStatusIcon(status: CalendarAttendee['status']) {
+  switch (status) {
+    case 'accepted':
+      return <Check className="size-3 text-green-600" />;
+    case 'declined':
+      return <X className="size-3 text-red-600" />;
+    case 'tentative':
+      return <HelpCircle className="size-3 text-yellow-600" />;
+    default:
+      return null;
+  }
+}
+
+export interface CalendarEventDetailSheetProps {
+  event: LinkedCalendarEvent | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onUnlink?: (event: LinkedCalendarEvent) => void;
+  onJoinMeeting?: (event: LinkedCalendarEvent) => void;
+}
+
+export function CalendarEventDetailSheet({
+  event,
+  open,
+  onOpenChange,
+  onUnlink,
+  onJoinMeeting,
+}: CalendarEventDetailSheetProps) {
+  if (!event) return null;
+
+  const isPast = event.endTime < new Date();
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent className="w-[500px] sm:max-w-lg">
+        <SheetHeader>
+          <SheetTitle className="sr-only">Event Details</SheetTitle>
+        </SheetHeader>
+
+        <ScrollArea className="h-full">
+          <div className="space-y-4 pb-6">
+            {/* Title */}
+            <div>
+              <h2 className="text-xl font-semibold">{event.title}</h2>
+              {isPast && (
+                <Badge variant="secondary" className="mt-1">
+                  Past event
+                </Badge>
+              )}
+            </div>
+
+            {/* Actions */}
+            <div className="flex gap-2">
+              {event.meetingLink && onJoinMeeting && !isPast && (
+                <Button size="sm" onClick={() => onJoinMeeting(event)}>
+                  <Video className="mr-1 size-3" />
+                  Join meeting
+                </Button>
+              )}
+              {onUnlink && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="text-destructive hover:text-destructive"
+                  onClick={() => onUnlink(event)}
+                >
+                  <Unlink className="mr-1 size-3" />
+                  Unlink
+                </Button>
+              )}
+            </div>
+
+            <Separator />
+
+            {/* When */}
+            <div className="space-y-3 text-sm">
+              <div className="flex items-center gap-2">
+                <Calendar className="size-4 text-muted-foreground" />
+                <span>
+                  {event.startTime.toLocaleDateString([], {
+                    weekday: 'long',
+                    year: 'numeric',
+                    month: 'long',
+                    day: 'numeric',
+                  })}
+                </span>
+              </div>
+
+              <div className="flex items-center gap-2">
+                <Clock className="size-4 text-muted-foreground" />
+                <span>
+                  {event.isAllDay
+                    ? 'All day'
+                    : `${formatTime(event.startTime)} - ${formatTime(event.endTime)}`}
+                </span>
+              </div>
+
+              {/* Location */}
+              {event.location && (
+                <div className="flex items-center gap-2">
+                  <MapPin className="size-4 text-muted-foreground" />
+                  <span>{event.location}</span>
+                </div>
+              )}
+
+              {/* Meeting link */}
+              {event.meetingLink && (
+                <div className="flex items-center gap-2 text-primary">
+                  <Video className="size-4" />
+                  <a
+                    href={event.meetingLink}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="hover:underline"
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    Join video call
+                  </a>
+                </div>
+              )}
+
+              {/* Organizer */}
+              {event.organizer && (
+                <div className="flex items-center gap-2">
+                  <User className="size-4 text-muted-foreground" />
+                  <span>Organized by {event.organizer.name || event.organizer.email}</span>
+                </div>
+              )}
+            </div>
+
+            {/* Attendees */}
+            {event.attendees.length > 0 && (
+              <>
+                <Separator />
+
+                <div className="space-y-3">
+                  <div className="flex items-center gap-2 text-sm font-medium">
+                    <Users className="size-4" />
+                    Attendees ({event.attendees.length})
+                  </div>
+
+                  <div className="space-y-2">
+                    {event.attendees.map((attendee) => (
+                      <div
+                        key={attendee.email}
+                        className="flex items-center justify-between rounded-md bg-muted/50 px-3 py-2"
+                      >
+                        <div>
+                          <p className="text-sm font-medium">{attendee.name}</p>
+                          <p className="text-xs text-muted-foreground">{attendee.email}</p>
+                        </div>
+                        <div className="flex items-center gap-1">
+                          {getStatusIcon(attendee.status)}
+                          <span className="text-xs capitalize text-muted-foreground">
+                            {attendee.status}
+                          </span>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </>
+            )}
+
+            {/* Description */}
+            {event.description && (
+              <>
+                <Separator />
+
+                <div className="space-y-2">
+                  <div className="flex items-center gap-2 text-sm font-medium">
+                    <FileText className="size-4" />
+                    Description
+                  </div>
+                  <div className="prose prose-sm dark:prose-invert max-w-none">
+                    <div className="whitespace-pre-wrap">{event.description}</div>
+                  </div>
+                </div>
+              </>
+            )}
+          </div>
+        </ScrollArea>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+function formatTime(date: Date): string {
+  return date.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+}

--- a/src/ui/components/communications/email-card.tsx
+++ b/src/ui/components/communications/email-card.tsx
@@ -1,0 +1,114 @@
+import * as React from 'react';
+import { Mail, Paperclip, MoreVertical, Unlink, ExternalLink } from 'lucide-react';
+import { cn } from '@/ui/lib/utils';
+import { Button } from '@/ui/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/ui/components/ui/dropdown-menu';
+import type { LinkedEmail } from './types';
+
+export interface EmailCardProps {
+  email: LinkedEmail;
+  onClick?: (email: LinkedEmail) => void;
+  onUnlink?: (email: LinkedEmail) => void;
+  className?: string;
+}
+
+export function EmailCard({
+  email,
+  onClick,
+  onUnlink,
+  className,
+}: EmailCardProps) {
+  return (
+    <div
+      data-testid="email-card"
+      className={cn(
+        'group flex items-start gap-3 rounded-lg border bg-card p-3 transition-colors hover:bg-accent/50',
+        onClick && 'cursor-pointer',
+        !email.isRead && 'border-l-2 border-l-primary',
+        className
+      )}
+      onClick={() => onClick?.(email)}
+    >
+      {/* Icon */}
+      <div className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-full bg-primary/10">
+        <Mail className="size-4 text-primary" />
+      </div>
+
+      {/* Content */}
+      <div className="min-w-0 flex-1">
+        <div className="flex items-start justify-between gap-2">
+          <div className="min-w-0">
+            <p className={cn('truncate text-sm', !email.isRead && 'font-semibold')}>
+              {email.subject}
+            </p>
+            <p className="text-xs text-muted-foreground">
+              {email.from.name || email.from.email}
+            </p>
+          </div>
+
+          <div className="flex shrink-0 items-center gap-1">
+            {email.hasAttachments && (
+              <Paperclip className="size-3 text-muted-foreground" />
+            )}
+            <span className="text-xs text-muted-foreground">
+              {formatEmailDate(email.date)}
+            </span>
+
+            {onUnlink && (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="size-6 opacity-0 group-hover:opacity-100"
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    <MoreVertical className="size-4" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  <DropdownMenuItem
+                    className="text-destructive focus:text-destructive"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onUnlink(email);
+                    }}
+                  >
+                    <Unlink className="mr-2 size-4" />
+                    Unlink
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            )}
+          </div>
+        </div>
+
+        <p className="mt-1 line-clamp-2 text-xs text-muted-foreground">
+          {email.snippet}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function formatEmailDate(date: Date): string {
+  const now = new Date();
+  const diff = now.getTime() - date.getTime();
+  const days = Math.floor(diff / (1000 * 60 * 60 * 24));
+
+  if (days === 0) {
+    return date.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+  }
+  if (days === 1) {
+    return 'Yesterday';
+  }
+  if (days < 7) {
+    return date.toLocaleDateString([], { weekday: 'short' });
+  }
+  return date.toLocaleDateString([], { month: 'short', day: 'numeric' });
+}

--- a/src/ui/components/communications/email-detail-sheet.tsx
+++ b/src/ui/components/communications/email-detail-sheet.tsx
@@ -1,0 +1,131 @@
+import * as React from 'react';
+import {
+  Mail,
+  Paperclip,
+  Reply,
+  Forward,
+  Unlink,
+  Calendar,
+  User,
+} from 'lucide-react';
+import { cn } from '@/ui/lib/utils';
+import { Button } from '@/ui/components/ui/button';
+import { ScrollArea } from '@/ui/components/ui/scroll-area';
+import { Separator } from '@/ui/components/ui/separator';
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from '@/ui/components/ui/sheet';
+import type { LinkedEmail } from './types';
+
+export interface EmailDetailSheetProps {
+  email: LinkedEmail | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onUnlink?: (email: LinkedEmail) => void;
+}
+
+export function EmailDetailSheet({
+  email,
+  open,
+  onOpenChange,
+  onUnlink,
+}: EmailDetailSheetProps) {
+  if (!email) return null;
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent className="w-[500px] sm:max-w-lg">
+        <SheetHeader>
+          <SheetTitle className="sr-only">Email Details</SheetTitle>
+        </SheetHeader>
+
+        <ScrollArea className="h-full">
+          <div className="space-y-4 pb-6">
+            {/* Subject */}
+            <div>
+              <h2 className="text-xl font-semibold">{email.subject}</h2>
+            </div>
+
+            {/* Actions */}
+            {onUnlink && (
+              <div className="flex gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="text-destructive hover:text-destructive"
+                  onClick={() => onUnlink(email)}
+                >
+                  <Unlink className="mr-1 size-3" />
+                  Unlink
+                </Button>
+              </div>
+            )}
+
+            <Separator />
+
+            {/* Meta info */}
+            <div className="space-y-3 text-sm">
+              <div className="flex items-start gap-2">
+                <User className="mt-0.5 size-4 text-muted-foreground" />
+                <div>
+                  <p className="font-medium">{email.from.name || email.from.email}</p>
+                  {email.from.name && (
+                    <p className="text-xs text-muted-foreground">{email.from.email}</p>
+                  )}
+                </div>
+              </div>
+
+              <div className="flex items-start gap-2">
+                <Mail className="mt-0.5 size-4 text-muted-foreground" />
+                <div>
+                  <p className="text-muted-foreground">To:</p>
+                  <p>
+                    {email.to.map((r) => r.name || r.email).join(', ')}
+                  </p>
+                </div>
+              </div>
+
+              <div className="flex items-center gap-2 text-muted-foreground">
+                <Calendar className="size-4" />
+                <span>
+                  {email.date.toLocaleDateString([], {
+                    weekday: 'long',
+                    year: 'numeric',
+                    month: 'long',
+                    day: 'numeric',
+                  })}{' '}
+                  at{' '}
+                  {email.date.toLocaleTimeString([], {
+                    hour: 'numeric',
+                    minute: '2-digit',
+                  })}
+                </span>
+              </div>
+
+              {email.hasAttachments && (
+                <div className="flex items-center gap-2 text-muted-foreground">
+                  <Paperclip className="size-4" />
+                  <span>Has attachments</span>
+                </div>
+              )}
+            </div>
+
+            <Separator />
+
+            {/* Body */}
+            <div className="prose prose-sm dark:prose-invert max-w-none">
+              {email.body ? (
+                <div className="whitespace-pre-wrap">{email.body}</div>
+              ) : (
+                <p className="text-muted-foreground">{email.snippet}</p>
+              )}
+            </div>
+          </div>
+        </ScrollArea>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/src/ui/components/communications/index.ts
+++ b/src/ui/components/communications/index.ts
@@ -1,0 +1,24 @@
+export { EmailCard } from './email-card';
+export type { EmailCardProps } from './email-card';
+
+export { CalendarEventCard } from './calendar-event-card';
+export type { CalendarEventCardProps } from './calendar-event-card';
+
+export { EmailDetailSheet } from './email-detail-sheet';
+export type { EmailDetailSheetProps } from './email-detail-sheet';
+
+export { CalendarEventDetailSheet } from './calendar-event-detail-sheet';
+export type { CalendarEventDetailSheetProps } from './calendar-event-detail-sheet';
+
+export { ItemCommunications } from './item-communications';
+export type { ItemCommunicationsProps } from './item-communications';
+
+export { LinkCommunicationDialog } from './link-communication-dialog';
+export type { LinkCommunicationDialogProps } from './link-communication-dialog';
+
+export type {
+  LinkedEmail,
+  LinkedCalendarEvent,
+  CalendarAttendee,
+  CommunicationFilter,
+} from './types';

--- a/src/ui/components/communications/item-communications.tsx
+++ b/src/ui/components/communications/item-communications.tsx
@@ -1,0 +1,169 @@
+import * as React from 'react';
+import { useState } from 'react';
+import { Mail, Calendar, Plus, Link2 } from 'lucide-react';
+import { cn } from '@/ui/lib/utils';
+import { Button } from '@/ui/components/ui/button';
+import { Badge } from '@/ui/components/ui/badge';
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from '@/ui/components/ui/tabs';
+import { EmailCard } from './email-card';
+import { CalendarEventCard } from './calendar-event-card';
+import type { LinkedEmail, LinkedCalendarEvent } from './types';
+
+export interface ItemCommunicationsProps {
+  emails: LinkedEmail[];
+  calendarEvents: LinkedCalendarEvent[];
+  onEmailClick?: (email: LinkedEmail) => void;
+  onEventClick?: (event: LinkedCalendarEvent) => void;
+  onUnlinkEmail?: (email: LinkedEmail) => void;
+  onUnlinkEvent?: (event: LinkedCalendarEvent) => void;
+  onLinkEmail?: () => void;
+  onLinkEvent?: () => void;
+  className?: string;
+}
+
+export function ItemCommunications({
+  emails,
+  calendarEvents,
+  onEmailClick,
+  onEventClick,
+  onUnlinkEmail,
+  onUnlinkEvent,
+  onLinkEmail,
+  onLinkEvent,
+  className,
+}: ItemCommunicationsProps) {
+  const [activeTab, setActiveTab] = useState<'emails' | 'calendar'>('emails');
+
+  const totalCount = emails.length + calendarEvents.length;
+
+  return (
+    <div className={cn('space-y-4', className)}>
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <h3 className="text-sm font-medium">Communications</h3>
+          <Badge variant="secondary" className="text-xs">
+            {totalCount}
+          </Badge>
+        </div>
+      </div>
+
+      <Tabs value={activeTab} onValueChange={(v) => setActiveTab(v as 'emails' | 'calendar')}>
+        <div className="flex items-center justify-between">
+          <TabsList>
+            <TabsTrigger value="emails" className="gap-1">
+              <Mail className="size-3" />
+              Emails
+              {emails.length > 0 && (
+                <Badge variant="secondary" className="ml-1 text-[10px] px-1">
+                  {emails.length}
+                </Badge>
+              )}
+            </TabsTrigger>
+            <TabsTrigger value="calendar" className="gap-1">
+              <Calendar className="size-3" />
+              Calendar
+              {calendarEvents.length > 0 && (
+                <Badge variant="secondary" className="ml-1 text-[10px] px-1">
+                  {calendarEvents.length}
+                </Badge>
+              )}
+            </TabsTrigger>
+          </TabsList>
+
+          {activeTab === 'emails' && onLinkEmail && (
+            <Button variant="ghost" size="sm" onClick={onLinkEmail}>
+              <Link2 className="mr-1 size-3" />
+              Link Email
+            </Button>
+          )}
+          {activeTab === 'calendar' && onLinkEvent && (
+            <Button variant="ghost" size="sm" onClick={onLinkEvent}>
+              <Link2 className="mr-1 size-3" />
+              Link Event
+            </Button>
+          )}
+        </div>
+
+        <TabsContent value="emails" className="mt-4">
+          {emails.length > 0 ? (
+            <div className="space-y-2">
+              {emails.map((email) => (
+                <EmailCard
+                  key={email.id}
+                  email={email}
+                  onClick={onEmailClick}
+                  onUnlink={onUnlinkEmail}
+                />
+              ))}
+            </div>
+          ) : (
+            <EmptyState
+              icon={<Mail className="size-8" />}
+              message="No linked emails"
+              action={
+                onLinkEmail && (
+                  <Button variant="outline" size="sm" onClick={onLinkEmail}>
+                    <Link2 className="mr-1 size-3" />
+                    Link an email
+                  </Button>
+                )
+              }
+            />
+          )}
+        </TabsContent>
+
+        <TabsContent value="calendar" className="mt-4">
+          {calendarEvents.length > 0 ? (
+            <div className="space-y-2">
+              {calendarEvents.map((event) => (
+                <CalendarEventCard
+                  key={event.id}
+                  event={event}
+                  onClick={onEventClick}
+                  onUnlink={onUnlinkEvent}
+                />
+              ))}
+            </div>
+          ) : (
+            <EmptyState
+              icon={<Calendar className="size-8" />}
+              message="No linked calendar events"
+              action={
+                onLinkEvent && (
+                  <Button variant="outline" size="sm" onClick={onLinkEvent}>
+                    <Link2 className="mr-1 size-3" />
+                    Link an event
+                  </Button>
+                )
+              }
+            />
+          )}
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}
+
+function EmptyState({
+  icon,
+  message,
+  action,
+}: {
+  icon: React.ReactNode;
+  message: string;
+  action?: React.ReactNode;
+}) {
+  return (
+    <div className="rounded-lg border border-dashed p-6 text-center">
+      <div className="mx-auto text-muted-foreground/50">{icon}</div>
+      <p className="mt-2 text-sm text-muted-foreground">{message}</p>
+      {action && <div className="mt-3">{action}</div>}
+    </div>
+  );
+}

--- a/src/ui/components/communications/link-communication-dialog.tsx
+++ b/src/ui/components/communications/link-communication-dialog.tsx
@@ -1,0 +1,86 @@
+import * as React from 'react';
+import { useState } from 'react';
+import { Mail, Calendar } from 'lucide-react';
+import { cn } from '@/ui/lib/utils';
+import { Button } from '@/ui/components/ui/button';
+import { Input } from '@/ui/components/ui/input';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  DialogDescription,
+} from '@/ui/components/ui/dialog';
+
+export interface LinkCommunicationDialogProps {
+  type: 'email' | 'calendar';
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (id: string) => void;
+}
+
+export function LinkCommunicationDialog({
+  type,
+  open,
+  onOpenChange,
+  onSubmit,
+}: LinkCommunicationDialogProps) {
+  const [id, setId] = useState('');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (id.trim()) {
+      onSubmit(id.trim());
+      setId('');
+    }
+  };
+
+  const isEmail = type === 'email';
+  const Icon = isEmail ? Mail : Calendar;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Icon className="size-5" />
+            Link {isEmail ? 'Email' : 'Calendar Event'}
+          </DialogTitle>
+          <DialogDescription>
+            Enter the {isEmail ? 'email' : 'calendar event'} ID to link it to this work item.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <label htmlFor="communication-id" className="text-sm font-medium">
+              {isEmail ? 'Email' : 'Event'} ID
+            </label>
+            <Input
+              id="communication-id"
+              value={id}
+              onChange={(e) => setId(e.target.value)}
+              placeholder={isEmail ? 'Enter email ID...' : 'Enter event ID...'}
+              required
+            />
+            <p className="text-xs text-muted-foreground">
+              {isEmail
+                ? 'You can find the email ID in your email provider or integration settings.'
+                : 'You can find the event ID in your calendar provider or integration settings.'}
+            </p>
+          </div>
+
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={!id.trim()}>
+              Link {isEmail ? 'Email' : 'Event'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/ui/components/communications/types.ts
+++ b/src/ui/components/communications/types.ts
@@ -1,0 +1,44 @@
+export interface LinkedEmail {
+  id: string;
+  subject: string;
+  from: {
+    name: string;
+    email: string;
+  };
+  to: {
+    name: string;
+    email: string;
+  }[];
+  date: Date;
+  snippet: string;
+  body?: string;
+  hasAttachments?: boolean;
+  isRead?: boolean;
+}
+
+export interface CalendarAttendee {
+  name: string;
+  email: string;
+  status: 'accepted' | 'declined' | 'tentative' | 'pending';
+}
+
+export interface LinkedCalendarEvent {
+  id: string;
+  title: string;
+  description?: string;
+  startTime: Date;
+  endTime: Date;
+  isAllDay?: boolean;
+  location?: string;
+  attendees: CalendarAttendee[];
+  organizer?: {
+    name: string;
+    email: string;
+  };
+  meetingLink?: string;
+}
+
+export interface CommunicationFilter {
+  type?: 'email' | 'calendar';
+  search?: string;
+}

--- a/tests/ui/communications.test.tsx
+++ b/tests/ui/communications.test.tsx
@@ -1,0 +1,429 @@
+/**
+ * @vitest-environment jsdom
+ */
+import * as React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import {
+  EmailCard,
+  CalendarEventCard,
+  EmailDetailSheet,
+  CalendarEventDetailSheet,
+  ItemCommunications,
+  LinkCommunicationDialog,
+  type LinkedEmail,
+  type LinkedCalendarEvent,
+} from '@/ui/components/communications';
+
+const mockEmail: LinkedEmail = {
+  id: 'email-1',
+  subject: 'Project Update - Q1 Review',
+  from: { name: 'John Doe', email: 'john@example.com' },
+  to: [{ name: 'Jane Smith', email: 'jane@example.com' }],
+  date: new Date(),
+  snippet: 'Hi team, I wanted to share the latest project updates from our Q1 review meeting...',
+  body: 'Hi team,\n\nI wanted to share the latest project updates from our Q1 review meeting.\n\nBest,\nJohn',
+  hasAttachments: true,
+  isRead: false,
+};
+
+const mockEmails: LinkedEmail[] = [
+  mockEmail,
+  {
+    id: 'email-2',
+    subject: 'Re: Project Update',
+    from: { name: 'Jane Smith', email: 'jane@example.com' },
+    to: [{ name: 'John Doe', email: 'john@example.com' }],
+    date: new Date(Date.now() - 86400000), // Yesterday
+    snippet: 'Thanks for the update! I have a few questions...',
+    isRead: true,
+  },
+];
+
+const mockEvent: LinkedCalendarEvent = {
+  id: 'event-1',
+  title: 'Sprint Planning Meeting',
+  description: 'Weekly sprint planning and backlog grooming session.',
+  startTime: new Date(),
+  endTime: new Date(Date.now() + 3600000),
+  location: 'Conference Room A',
+  meetingLink: 'https://meet.example.com/123',
+  organizer: { name: 'Project Manager', email: 'pm@example.com' },
+  attendees: [
+    { name: 'John Doe', email: 'john@example.com', status: 'accepted' },
+    { name: 'Jane Smith', email: 'jane@example.com', status: 'tentative' },
+    { name: 'Bob Wilson', email: 'bob@example.com', status: 'pending' },
+  ],
+};
+
+const mockEvents: LinkedCalendarEvent[] = [
+  mockEvent,
+  {
+    id: 'event-2',
+    title: 'Design Review',
+    startTime: new Date(Date.now() + 86400000),
+    endTime: new Date(Date.now() + 86400000 + 3600000),
+    isAllDay: false,
+    attendees: [],
+  },
+];
+
+describe('EmailCard', () => {
+  it('renders email subject', () => {
+    render(<EmailCard email={mockEmail} />);
+
+    expect(screen.getByText('Project Update - Q1 Review')).toBeInTheDocument();
+  });
+
+  it('renders sender name', () => {
+    render(<EmailCard email={mockEmail} />);
+
+    expect(screen.getByText('John Doe')).toBeInTheDocument();
+  });
+
+  it('shows attachment indicator', () => {
+    render(<EmailCard email={mockEmail} />);
+
+    // Attachment icon should be present
+    const emailCard = screen.getByTestId('email-card');
+    expect(emailCard).toBeInTheDocument();
+  });
+
+  it('shows unread indicator for unread emails', () => {
+    render(<EmailCard email={mockEmail} />);
+
+    const card = screen.getByTestId('email-card');
+    expect(card.className).toContain('border-l-primary');
+  });
+
+  it('calls onClick when clicked', () => {
+    const onClick = vi.fn();
+    render(<EmailCard email={mockEmail} onClick={onClick} />);
+
+    fireEvent.click(screen.getByTestId('email-card'));
+    expect(onClick).toHaveBeenCalledWith(mockEmail);
+  });
+
+  it('shows unlink option when onUnlink provided', () => {
+    const onUnlink = vi.fn();
+    render(<EmailCard email={mockEmail} onUnlink={onUnlink} />);
+
+    // Menu button should exist
+    expect(screen.getByRole('button')).toBeInTheDocument();
+  });
+});
+
+describe('CalendarEventCard', () => {
+  it('renders event title', () => {
+    render(<CalendarEventCard event={mockEvent} />);
+
+    expect(screen.getByText('Sprint Planning Meeting')).toBeInTheDocument();
+  });
+
+  it('shows location', () => {
+    render(<CalendarEventCard event={mockEvent} />);
+
+    expect(screen.getByText('Conference Room A')).toBeInTheDocument();
+  });
+
+  it('shows video meeting indicator', () => {
+    render(<CalendarEventCard event={mockEvent} />);
+
+    expect(screen.getByText('Video meeting')).toBeInTheDocument();
+  });
+
+  it('shows attendee badges', () => {
+    render(<CalendarEventCard event={mockEvent} />);
+
+    expect(screen.getByText('John')).toBeInTheDocument();
+    expect(screen.getByText('Jane')).toBeInTheDocument();
+  });
+
+  it('calls onClick when clicked', () => {
+    const onClick = vi.fn();
+    render(<CalendarEventCard event={mockEvent} onClick={onClick} />);
+
+    fireEvent.click(screen.getByTestId('calendar-event-card'));
+    expect(onClick).toHaveBeenCalledWith(mockEvent);
+  });
+
+  it('shows all day indicator for all-day events', () => {
+    const allDayEvent = { ...mockEvent, isAllDay: true };
+    render(<CalendarEventCard event={allDayEvent} />);
+
+    expect(screen.getByText('All day')).toBeInTheDocument();
+  });
+});
+
+describe('EmailDetailSheet', () => {
+  it('renders email subject', () => {
+    render(
+      <EmailDetailSheet
+        email={mockEmail}
+        open={true}
+        onOpenChange={() => {}}
+      />
+    );
+
+    expect(screen.getByText('Project Update - Q1 Review')).toBeInTheDocument();
+  });
+
+  it('renders email body', () => {
+    render(
+      <EmailDetailSheet
+        email={mockEmail}
+        open={true}
+        onOpenChange={() => {}}
+      />
+    );
+
+    expect(screen.getByText(/I wanted to share the latest project updates/)).toBeInTheDocument();
+  });
+
+  it('shows sender info', () => {
+    render(
+      <EmailDetailSheet
+        email={mockEmail}
+        open={true}
+        onOpenChange={() => {}}
+      />
+    );
+
+    expect(screen.getByText('John Doe')).toBeInTheDocument();
+    expect(screen.getByText('john@example.com')).toBeInTheDocument();
+  });
+
+  it('calls onUnlink when unlink clicked', () => {
+    const onUnlink = vi.fn();
+    render(
+      <EmailDetailSheet
+        email={mockEmail}
+        open={true}
+        onOpenChange={() => {}}
+        onUnlink={onUnlink}
+      />
+    );
+
+    fireEvent.click(screen.getByText('Unlink'));
+    expect(onUnlink).toHaveBeenCalledWith(mockEmail);
+  });
+});
+
+describe('CalendarEventDetailSheet', () => {
+  it('renders event title', () => {
+    render(
+      <CalendarEventDetailSheet
+        event={mockEvent}
+        open={true}
+        onOpenChange={() => {}}
+      />
+    );
+
+    expect(screen.getByText('Sprint Planning Meeting')).toBeInTheDocument();
+  });
+
+  it('shows attendees list', () => {
+    render(
+      <CalendarEventDetailSheet
+        event={mockEvent}
+        open={true}
+        onOpenChange={() => {}}
+      />
+    );
+
+    expect(screen.getByText('John Doe')).toBeInTheDocument();
+    expect(screen.getByText('Jane Smith')).toBeInTheDocument();
+    expect(screen.getByText('Bob Wilson')).toBeInTheDocument();
+  });
+
+  it('shows attendee status', () => {
+    render(
+      <CalendarEventDetailSheet
+        event={mockEvent}
+        open={true}
+        onOpenChange={() => {}}
+      />
+    );
+
+    expect(screen.getByText('accepted')).toBeInTheDocument();
+    expect(screen.getByText('tentative')).toBeInTheDocument();
+  });
+
+  it('shows join meeting button when meeting link exists', () => {
+    const onJoinMeeting = vi.fn();
+    render(
+      <CalendarEventDetailSheet
+        event={mockEvent}
+        open={true}
+        onOpenChange={() => {}}
+        onJoinMeeting={onJoinMeeting}
+      />
+    );
+
+    fireEvent.click(screen.getByText('Join meeting'));
+    expect(onJoinMeeting).toHaveBeenCalledWith(mockEvent);
+  });
+
+  it('shows description', () => {
+    render(
+      <CalendarEventDetailSheet
+        event={mockEvent}
+        open={true}
+        onOpenChange={() => {}}
+      />
+    );
+
+    expect(screen.getByText(/Weekly sprint planning/)).toBeInTheDocument();
+  });
+});
+
+describe('ItemCommunications', () => {
+  it('renders emails and calendar tabs', () => {
+    render(
+      <ItemCommunications
+        emails={mockEmails}
+        calendarEvents={mockEvents}
+      />
+    );
+
+    expect(screen.getByRole('tab', { name: /Emails/i })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /Calendar/i })).toBeInTheDocument();
+  });
+
+  it('shows email count badge', () => {
+    render(
+      <ItemCommunications
+        emails={mockEmails}
+        calendarEvents={mockEvents}
+      />
+    );
+
+    // Total count badge
+    expect(screen.getByText('4')).toBeInTheDocument();
+  });
+
+  it('shows emails by default', () => {
+    render(
+      <ItemCommunications
+        emails={mockEmails}
+        calendarEvents={mockEvents}
+      />
+    );
+
+    expect(screen.getByText('Project Update - Q1 Review')).toBeInTheDocument();
+  });
+
+  it('has clickable calendar tab', () => {
+    const onEventClick = vi.fn();
+    render(
+      <ItemCommunications
+        emails={[]}
+        calendarEvents={mockEvents}
+        onEventClick={onEventClick}
+      />
+    );
+
+    // Calendar tab should be present and clickable
+    const calendarTab = screen.getByRole('tab', { name: /Calendar/i });
+    expect(calendarTab).toBeInTheDocument();
+    fireEvent.click(calendarTab);
+    // No errors should occur
+  });
+
+  it('shows empty state when no emails', () => {
+    render(
+      <ItemCommunications
+        emails={[]}
+        calendarEvents={mockEvents}
+      />
+    );
+
+    expect(screen.getByText('No linked emails')).toBeInTheDocument();
+  });
+
+  it('shows link email button when handler provided', () => {
+    const onLinkEmail = vi.fn();
+    render(
+      <ItemCommunications
+        emails={[]}
+        calendarEvents={[]}
+        onLinkEmail={onLinkEmail}
+      />
+    );
+
+    expect(screen.getByText('Link Email')).toBeInTheDocument();
+  });
+
+  it('calls onEmailClick when email clicked', () => {
+    const onEmailClick = vi.fn();
+    render(
+      <ItemCommunications
+        emails={mockEmails}
+        calendarEvents={[]}
+        onEmailClick={onEmailClick}
+      />
+    );
+
+    fireEvent.click(screen.getByText('Project Update - Q1 Review'));
+    expect(onEmailClick).toHaveBeenCalledWith(mockEmails[0]);
+  });
+});
+
+describe('LinkCommunicationDialog', () => {
+  it('renders email link dialog', () => {
+    render(
+      <LinkCommunicationDialog
+        type="email"
+        open={true}
+        onOpenChange={() => {}}
+        onSubmit={() => {}}
+      />
+    );
+
+    expect(screen.getByRole('heading', { name: 'Link Email' })).toBeInTheDocument();
+  });
+
+  it('renders calendar link dialog', () => {
+    render(
+      <LinkCommunicationDialog
+        type="calendar"
+        open={true}
+        onOpenChange={() => {}}
+        onSubmit={() => {}}
+      />
+    );
+
+    expect(screen.getByRole('heading', { name: 'Link Calendar Event' })).toBeInTheDocument();
+  });
+
+  it('submits with entered ID', () => {
+    const onSubmit = vi.fn();
+    render(
+      <LinkCommunicationDialog
+        type="email"
+        open={true}
+        onOpenChange={() => {}}
+        onSubmit={onSubmit}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText(/Email ID/), { target: { value: 'test-id-123' } });
+    fireEvent.click(screen.getByRole('button', { name: /Link Email/i }));
+
+    expect(onSubmit).toHaveBeenCalledWith('test-id-123');
+  });
+
+  it('disables submit when ID is empty', () => {
+    render(
+      <LinkCommunicationDialog
+        type="email"
+        open={true}
+        onOpenChange={() => {}}
+        onSubmit={() => {}}
+      />
+    );
+
+    const submitButton = screen.getByRole('button', { name: /Link Email/i });
+    expect(submitButton).toBeDisabled();
+  });
+});


### PR DESCRIPTION
## Summary
- EmailCard: Display email with subject, sender, date, snippet, attachment indicator, unread styling
- CalendarEventCard: Display event with date box, time, location, video meeting link, attendee badges
- EmailDetailSheet: Full email view with body, recipients, metadata, unlink action
- CalendarEventDetailSheet: Full event view with attendee statuses, description, join meeting button
- ItemCommunications: Tabbed component showing linked emails and calendar events per work item
- LinkCommunicationDialog: UI for manually linking emails/events by ID

## Test Plan
- [x] 32 tests passing for all communication components
- [x] Full test suite passing (290 tests)

## API Issues Created
- #124 - GET /api/work-items/:id/emails endpoint
- #125 - GET /api/work-items/:id/calendar endpoint
- #126 - POST/DELETE link/unlink endpoints

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)