### PR TITLE
[#108] Add Todos CRUD endpoints for work items

### DIFF
--- a/migrations/017_work_item_todo.down.sql
+++ b/migrations/017_work_item_todo.down.sql
@@ -1,0 +1,4 @@
+-- Rollback for work item todo table
+-- Issue #108
+
+DROP TABLE IF EXISTS work_item_todo;

--- a/migrations/017_work_item_todo.up.sql
+++ b/migrations/017_work_item_todo.up.sql
@@ -1,0 +1,17 @@
+-- Work Item Todo table for checklists/todos attached to work items
+-- Issue #108
+
+CREATE TABLE IF NOT EXISTS work_item_todo (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  work_item_id uuid NOT NULL REFERENCES work_item(id) ON DELETE CASCADE,
+  text text NOT NULL,
+  completed boolean NOT NULL DEFAULT false,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  completed_at timestamptz
+);
+
+-- Index for efficient lookup by work item
+CREATE INDEX idx_work_item_todo_work_item_id ON work_item_todo(work_item_id);
+
+-- Index for filtering by completion status
+CREATE INDEX idx_work_item_todo_completed ON work_item_todo(completed);

--- a/tests/todos_api.test.ts
+++ b/tests/todos_api.test.ts
@@ -1,0 +1,269 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { Pool } from 'pg';
+import { runMigrate } from './helpers/migrate.js';
+import { createTestPool, truncateAllTables } from './helpers/db.js';
+import { buildServer } from '../src/api/server.js';
+
+describe('Todos API (issue #108)', () => {
+  const app = buildServer();
+  let pool: Pool;
+  let workItemId: string;
+
+  beforeAll(async () => {
+    await runMigrate('up');
+    pool = createTestPool();
+    await app.ready();
+  });
+
+  beforeEach(async () => {
+    await truncateAllTables(pool);
+
+    // Create a work item for todos to attach to
+    const created = await app.inject({
+      method: 'POST',
+      url: '/api/work-items',
+      payload: { title: 'Work item with todos' },
+    });
+    workItemId = (created.json() as { id: string }).id;
+  });
+
+  afterAll(async () => {
+    await app.close();
+    await pool.end();
+  });
+
+  describe('GET /api/work-items/:id/todos', () => {
+    it('returns empty array when no todos exist', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: `/api/work-items/${workItemId}/todos`,
+      });
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toEqual({ todos: [] });
+    });
+
+    it('returns 404 for non-existent work item', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/work-items/00000000-0000-0000-0000-000000000000/todos',
+      });
+      expect(res.statusCode).toBe(404);
+      expect(res.json()).toEqual({ error: 'not found' });
+    });
+
+    it('returns todos ordered by creation date', async () => {
+      // Create multiple todos
+      await app.inject({
+        method: 'POST',
+        url: `/api/work-items/${workItemId}/todos`,
+        payload: { text: 'First todo' },
+      });
+      await app.inject({
+        method: 'POST',
+        url: `/api/work-items/${workItemId}/todos`,
+        payload: { text: 'Second todo' },
+      });
+
+      const res = await app.inject({
+        method: 'GET',
+        url: `/api/work-items/${workItemId}/todos`,
+      });
+      expect(res.statusCode).toBe(200);
+
+      const body = res.json() as { todos: Array<{ text: string }> };
+      expect(body.todos.length).toBe(2);
+      expect(body.todos[0].text).toBe('First todo');
+      expect(body.todos[1].text).toBe('Second todo');
+    });
+  });
+
+  describe('POST /api/work-items/:id/todos', () => {
+    it('creates a new todo', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: `/api/work-items/${workItemId}/todos`,
+        payload: { text: 'New todo item' },
+      });
+      expect(res.statusCode).toBe(201);
+
+      const body = res.json() as {
+        id: string;
+        text: string;
+        completed: boolean;
+        createdAt: string;
+        completedAt: string | null;
+      };
+      expect(body.id).toMatch(/^[0-9a-f-]{36}$/i);
+      expect(body.text).toBe('New todo item');
+      expect(body.completed).toBe(false);
+      expect(body.completedAt).toBeNull();
+      expect(body.createdAt).toBeDefined();
+    });
+
+    it('returns 400 when text is missing', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: `/api/work-items/${workItemId}/todos`,
+        payload: {},
+      });
+      expect(res.statusCode).toBe(400);
+      expect(res.json()).toEqual({ error: 'text is required' });
+    });
+
+    it('returns 400 when text is empty', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: `/api/work-items/${workItemId}/todos`,
+        payload: { text: '   ' },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(res.json()).toEqual({ error: 'text is required' });
+    });
+
+    it('returns 404 for non-existent work item', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/work-items/00000000-0000-0000-0000-000000000000/todos',
+        payload: { text: 'Todo for missing item' },
+      });
+      expect(res.statusCode).toBe(404);
+      expect(res.json()).toEqual({ error: 'not found' });
+    });
+  });
+
+  describe('PATCH /api/work-items/:id/todos/:todoId', () => {
+    let todoId: string;
+
+    beforeEach(async () => {
+      const created = await app.inject({
+        method: 'POST',
+        url: `/api/work-items/${workItemId}/todos`,
+        payload: { text: 'Original text' },
+      });
+      todoId = (created.json() as { id: string }).id;
+    });
+
+    it('updates todo text', async () => {
+      const res = await app.inject({
+        method: 'PATCH',
+        url: `/api/work-items/${workItemId}/todos/${todoId}`,
+        payload: { text: 'Updated text' },
+      });
+      expect(res.statusCode).toBe(200);
+
+      const body = res.json() as { text: string };
+      expect(body.text).toBe('Updated text');
+    });
+
+    it('marks todo as completed and sets completedAt', async () => {
+      const res = await app.inject({
+        method: 'PATCH',
+        url: `/api/work-items/${workItemId}/todos/${todoId}`,
+        payload: { completed: true },
+      });
+      expect(res.statusCode).toBe(200);
+
+      const body = res.json() as { completed: boolean; completedAt: string | null };
+      expect(body.completed).toBe(true);
+      expect(body.completedAt).not.toBeNull();
+    });
+
+    it('marks todo as incomplete and clears completedAt', async () => {
+      // First mark as complete
+      await app.inject({
+        method: 'PATCH',
+        url: `/api/work-items/${workItemId}/todos/${todoId}`,
+        payload: { completed: true },
+      });
+
+      // Then mark as incomplete
+      const res = await app.inject({
+        method: 'PATCH',
+        url: `/api/work-items/${workItemId}/todos/${todoId}`,
+        payload: { completed: false },
+      });
+      expect(res.statusCode).toBe(200);
+
+      const body = res.json() as { completed: boolean; completedAt: string | null };
+      expect(body.completed).toBe(false);
+      expect(body.completedAt).toBeNull();
+    });
+
+    it('returns 404 for non-existent todo', async () => {
+      const res = await app.inject({
+        method: 'PATCH',
+        url: `/api/work-items/${workItemId}/todos/00000000-0000-0000-0000-000000000000`,
+        payload: { text: 'Updated' },
+      });
+      expect(res.statusCode).toBe(404);
+      expect(res.json()).toEqual({ error: 'not found' });
+    });
+
+    it('returns 404 for non-existent work item', async () => {
+      const res = await app.inject({
+        method: 'PATCH',
+        url: `/api/work-items/00000000-0000-0000-0000-000000000000/todos/${todoId}`,
+        payload: { text: 'Updated' },
+      });
+      expect(res.statusCode).toBe(404);
+      expect(res.json()).toEqual({ error: 'not found' });
+    });
+
+    it('returns 400 when no update fields provided', async () => {
+      const res = await app.inject({
+        method: 'PATCH',
+        url: `/api/work-items/${workItemId}/todos/${todoId}`,
+        payload: {},
+      });
+      expect(res.statusCode).toBe(400);
+      expect(res.json()).toEqual({ error: 'at least one field is required' });
+    });
+  });
+
+  describe('DELETE /api/work-items/:id/todos/:todoId', () => {
+    let todoId: string;
+
+    beforeEach(async () => {
+      const created = await app.inject({
+        method: 'POST',
+        url: `/api/work-items/${workItemId}/todos`,
+        payload: { text: 'Todo to delete' },
+      });
+      todoId = (created.json() as { id: string }).id;
+    });
+
+    it('deletes a todo', async () => {
+      const res = await app.inject({
+        method: 'DELETE',
+        url: `/api/work-items/${workItemId}/todos/${todoId}`,
+      });
+      expect(res.statusCode).toBe(204);
+
+      // Verify it's deleted
+      const list = await app.inject({
+        method: 'GET',
+        url: `/api/work-items/${workItemId}/todos`,
+      });
+      const body = list.json() as { todos: Array<{ id: string }> };
+      expect(body.todos.find(t => t.id === todoId)).toBeUndefined();
+    });
+
+    it('returns 404 for non-existent todo', async () => {
+      const res = await app.inject({
+        method: 'DELETE',
+        url: `/api/work-items/${workItemId}/todos/00000000-0000-0000-0000-000000000000`,
+      });
+      expect(res.statusCode).toBe(404);
+      expect(res.json()).toEqual({ error: 'not found' });
+    });
+
+    it('returns 404 for non-existent work item', async () => {
+      const res = await app.inject({
+        method: 'DELETE',
+        url: `/api/work-items/00000000-0000-0000-0000-000000000000/todos/${todoId}`,
+      });
+      expect(res.statusCode).toBe(404);
+      expect(res.json()).toEqual({ error: 'not found' });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Create `work_item_todo` table with migration (017)
- Implement full CRUD endpoints for work item todos:
  - `GET /api/work-items/:id/todos` - List todos for a work item
  - `POST /api/work-items/:id/todos` - Create a new todo
  - `PATCH /api/work-items/:id/todos/:todoId` - Update text and/or completed status
  - `DELETE /api/work-items/:id/todos/:todoId` - Delete a todo
- Track completion timestamps (`completedAt` automatically set/cleared on toggle)
- Add comprehensive test coverage (16 tests)

## Test plan
- [x] Run `pnpm test tests/todos_api.test.ts` - all 16 tests pass
- [x] Run full test suite `pnpm test` - all 500 tests pass
- [x] Verify migration creates table correctly

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)