### PR TITLE
[#104] Add PATCH /api/work-items/:id/reorder endpoint

### DIFF
--- a/migrations/018_work_item_sort_order.down.sql
+++ b/migrations/018_work_item_sort_order.down.sql
@@ -1,0 +1,5 @@
+-- Rollback for sort_order column
+-- Issue #104
+
+DROP INDEX IF EXISTS idx_work_item_parent_sort_order;
+ALTER TABLE work_item DROP COLUMN IF EXISTS sort_order;

--- a/migrations/018_work_item_sort_order.up.sql
+++ b/migrations/018_work_item_sort_order.up.sql
@@ -1,0 +1,31 @@
+-- Add sort_order column for reordering work items within same parent
+-- Issue #104
+
+-- Add sort_order column with default based on creation time
+ALTER TABLE work_item
+  ADD COLUMN IF NOT EXISTS sort_order integer;
+
+-- Initialize sort_order based on created_at for existing items
+-- Items with same parent get sequential sort_order
+UPDATE work_item wi
+SET sort_order = subq.row_num
+FROM (
+  SELECT id, ROW_NUMBER() OVER (
+    PARTITION BY parent_work_item_id
+    ORDER BY created_at ASC
+  ) as row_num
+  FROM work_item
+) subq
+WHERE wi.id = subq.id;
+
+-- Make sort_order NOT NULL after initialization
+ALTER TABLE work_item
+  ALTER COLUMN sort_order SET NOT NULL;
+
+-- Default for new items: use timestamp to avoid conflicts
+ALTER TABLE work_item
+  ALTER COLUMN sort_order SET DEFAULT EXTRACT(EPOCH FROM now())::integer;
+
+-- Index for efficient sibling ordering
+CREATE INDEX IF NOT EXISTS idx_work_item_parent_sort_order
+  ON work_item(parent_work_item_id, sort_order);

--- a/tests/work_item_reorder_api.test.ts
+++ b/tests/work_item_reorder_api.test.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { Pool } from 'pg';
+import { runMigrate } from './helpers/migrate.js';
+import { createTestPool, truncateAllTables } from './helpers/db.js';
+import { buildServer } from '../src/api/server.js';
+
+describe('Work Item Reorder API (issue #104)', () => {
+  const app = buildServer();
+  let pool: Pool;
+  let parentId: string;
+  let childIds: string[];
+
+  beforeAll(async () => {
+    await runMigrate('up');
+    pool = createTestPool();
+    await app.ready();
+  });
+
+  beforeEach(async () => {
+    await truncateAllTables(pool);
+    childIds = [];
+
+    // Create parent initiative (top-level)
+    const parent = await app.inject({
+      method: 'POST',
+      url: '/api/work-items',
+      payload: { title: 'Parent Initiative', kind: 'initiative' },
+    });
+    parentId = (parent.json() as { id: string }).id;
+
+    // Create 4 child epics under the initiative
+    for (const name of ['A', 'B', 'C', 'D']) {
+      const child = await app.inject({
+        method: 'POST',
+        url: '/api/work-items',
+        payload: { title: `Epic ${name}`, kind: 'epic', parentId },
+      });
+      childIds.push((child.json() as { id: string }).id);
+    }
+  });
+
+  afterAll(async () => {
+    await app.close();
+    await pool.end();
+  });
+
+  async function getSiblingOrder(): Promise<string[]> {
+    const result = await pool.query(
+      `SELECT id::text as id FROM work_item
+       WHERE parent_work_item_id = $1
+       ORDER BY sort_order ASC`,
+      [parentId]
+    );
+    return result.rows.map((r: { id: string }) => r.id);
+  }
+
+  describe('PATCH /api/work-items/:id/reorder', () => {
+    it('moves item to first position when afterId is null', async () => {
+      // Move D to first (after null = beginning)
+      const res = await app.inject({
+        method: 'PATCH',
+        url: `/api/work-items/${childIds[3]}/reorder`,
+        payload: { afterId: null },
+      });
+      expect(res.statusCode).toBe(200);
+      expect(res.json().ok).toBe(true);
+
+      const order = await getSiblingOrder();
+      expect(order[0]).toBe(childIds[3]); // D first
+      expect(order[1]).toBe(childIds[0]); // A second
+    });
+
+    it('moves item to last position when beforeId is null', async () => {
+      // Move A to last (before null = end)
+      const res = await app.inject({
+        method: 'PATCH',
+        url: `/api/work-items/${childIds[0]}/reorder`,
+        payload: { beforeId: null },
+      });
+      expect(res.statusCode).toBe(200);
+
+      const order = await getSiblingOrder();
+      expect(order[3]).toBe(childIds[0]); // A last
+    });
+
+    it('moves item after a specific sibling', async () => {
+      // First normalize the sort_orders to have gaps
+      for (let i = 0; i < childIds.length; i++) {
+        await pool.query('UPDATE work_item SET sort_order = $1 WHERE id = $2', [
+          (i + 1) * 1000,
+          childIds[i],
+        ]);
+      }
+
+      // Move D after A (A, D, B, C)
+      const res = await app.inject({
+        method: 'PATCH',
+        url: `/api/work-items/${childIds[3]}/reorder`,
+        payload: { afterId: childIds[0] },
+      });
+      expect(res.statusCode).toBe(200);
+
+      const order = await getSiblingOrder();
+      expect(order[0]).toBe(childIds[0]); // A
+      expect(order[1]).toBe(childIds[3]); // D
+      expect(order[2]).toBe(childIds[1]); // B
+      expect(order[3]).toBe(childIds[2]); // C
+    });
+
+    it('moves item before a specific sibling', async () => {
+      // First normalize the sort_orders to have gaps
+      for (let i = 0; i < childIds.length; i++) {
+        await pool.query('UPDATE work_item SET sort_order = $1 WHERE id = $2', [
+          (i + 1) * 1000,
+          childIds[i],
+        ]);
+      }
+
+      // Move D before B (A, D, B, C)
+      const res = await app.inject({
+        method: 'PATCH',
+        url: `/api/work-items/${childIds[3]}/reorder`,
+        payload: { beforeId: childIds[1] },
+      });
+      expect(res.statusCode).toBe(200);
+
+      const order = await getSiblingOrder();
+      expect(order[0]).toBe(childIds[0]); // A
+      expect(order[1]).toBe(childIds[3]); // D
+      expect(order[2]).toBe(childIds[1]); // B
+      expect(order[3]).toBe(childIds[2]); // C
+    });
+
+    it('returns 400 when neither afterId nor beforeId provided', async () => {
+      const res = await app.inject({
+        method: 'PATCH',
+        url: `/api/work-items/${childIds[0]}/reorder`,
+        payload: {},
+      });
+      expect(res.statusCode).toBe(400);
+      expect(res.json()).toEqual({ error: 'afterId or beforeId is required' });
+    });
+
+    it('returns 400 when both afterId and beforeId provided', async () => {
+      const res = await app.inject({
+        method: 'PATCH',
+        url: `/api/work-items/${childIds[0]}/reorder`,
+        payload: { afterId: childIds[1], beforeId: childIds[2] },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(res.json()).toEqual({ error: 'provide only one of afterId or beforeId' });
+    });
+
+    it('returns 404 for non-existent work item', async () => {
+      const res = await app.inject({
+        method: 'PATCH',
+        url: '/api/work-items/00000000-0000-0000-0000-000000000000/reorder',
+        payload: { afterId: null },
+      });
+      expect(res.statusCode).toBe(404);
+      expect(res.json()).toEqual({ error: 'not found' });
+    });
+
+    it('returns 400 when target is not a sibling', async () => {
+      // Create another initiative with its own child
+      const otherParent = await app.inject({
+        method: 'POST',
+        url: '/api/work-items',
+        payload: { title: 'Other Initiative', kind: 'initiative' },
+      });
+      const otherParentId = (otherParent.json() as { id: string }).id;
+
+      const otherChild = await app.inject({
+        method: 'POST',
+        url: '/api/work-items',
+        payload: { title: 'Other Epic', kind: 'epic', parentId: otherParentId },
+      });
+      const otherChildId = (otherChild.json() as { id: string }).id;
+
+      // Try to reorder relative to non-sibling
+      const res = await app.inject({
+        method: 'PATCH',
+        url: `/api/work-items/${childIds[0]}/reorder`,
+        payload: { afterId: otherChildId },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(res.json()).toEqual({ error: 'target must be a sibling' });
+    });
+
+    it('returns 400 when target does not exist', async () => {
+      const res = await app.inject({
+        method: 'PATCH',
+        url: `/api/work-items/${childIds[0]}/reorder`,
+        payload: { afterId: '00000000-0000-0000-0000-000000000000' },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(res.json()).toEqual({ error: 'target not found' });
+    });
+
+    it('handles reordering to same position (no-op)', async () => {
+      // First normalize the sort_orders to have gaps
+      for (let i = 0; i < childIds.length; i++) {
+        await pool.query('UPDATE work_item SET sort_order = $1 WHERE id = $2', [
+          (i + 1) * 1000,
+          childIds[i],
+        ]);
+      }
+
+      // Move B after A (it's already there)
+      const res = await app.inject({
+        method: 'PATCH',
+        url: `/api/work-items/${childIds[1]}/reorder`,
+        payload: { afterId: childIds[0] },
+      });
+      expect(res.statusCode).toBe(200);
+
+      const order = await getSiblingOrder();
+      expect(order).toEqual(childIds); // Order unchanged
+    });
+
+    it('handles reordering top-level items (null parent)', async () => {
+      // Create another top-level initiative
+      const init2 = await app.inject({
+        method: 'POST',
+        url: '/api/work-items',
+        payload: { title: 'Second Initiative', kind: 'initiative' },
+      });
+      const init2Id = (init2.json() as { id: string }).id;
+
+      // Move second initiative before first
+      const res = await app.inject({
+        method: 'PATCH',
+        url: `/api/work-items/${init2Id}/reorder`,
+        payload: { beforeId: parentId },
+      });
+      expect(res.statusCode).toBe(200);
+
+      // Verify order of top-level items
+      const result = await pool.query(
+        `SELECT id::text as id FROM work_item
+         WHERE parent_work_item_id IS NULL
+         ORDER BY sort_order ASC`
+      );
+      const topLevelOrder = result.rows.map((r: { id: string }) => r.id);
+      expect(topLevelOrder[0]).toBe(init2Id);
+      expect(topLevelOrder[1]).toBe(parentId);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `sort_order` column to `work_item` table (migration 018)
- Implement `PATCH /api/work-items/:id/reorder` endpoint
- Support `afterId` (null = first position) and `beforeId` (null = last position)
- Validate target is a sibling (same parent)
- Auto-normalize sort_orders when integer gaps run out
- Handle race conditions with `FOR UPDATE` locking

## Test plan
- [x] Run `pnpm test tests/work_item_reorder_api.test.ts` - all 11 tests pass
- [x] Run full test suite `pnpm test` - all 522 tests pass

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)