### PR TITLE
[#109] Add attachments and dependencies to work item detail

### DIFF
--- a/tests/enhanced_work_item_detail.test.ts
+++ b/tests/enhanced_work_item_detail.test.ts
@@ -111,16 +111,25 @@ describe('Enhanced Work Item Detail', () => {
 
       expect(res.statusCode).toBe(200);
       const body = res.json() as {
-        dependencies: {
-          blocks: Array<{ id: string; title: string }>;
-          blocked_by: Array<{ id: string; title: string }>;
-        };
+        dependencies: Array<{
+          id: string;
+          title: string;
+          kind: string;
+          status: string;
+          direction: 'blocks' | 'blocked_by';
+        }>;
       };
       expect(body.dependencies).toBeDefined();
-      expect(body.dependencies.blocks.length).toBe(1);
-      expect(body.dependencies.blocks[0].title).toBe('Blocking Task');
-      expect(body.dependencies.blocked_by.length).toBe(1);
-      expect(body.dependencies.blocked_by[0].title).toBe('Prerequisite Task');
+      expect(Array.isArray(body.dependencies)).toBe(true);
+
+      // Find dependencies by direction
+      const blocks = body.dependencies.filter((d) => d.direction === 'blocks');
+      const blockedBy = body.dependencies.filter((d) => d.direction === 'blocked_by');
+
+      expect(blocks.length).toBe(1);
+      expect(blocks[0].title).toBe('Blocking Task');
+      expect(blockedBy.length).toBe(1);
+      expect(blockedBy[0].title).toBe('Prerequisite Task');
     });
 
     it('returns parent information', async () => {

--- a/tests/work_item_attachments_api.test.ts
+++ b/tests/work_item_attachments_api.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { Pool } from 'pg';
+import { runMigrate } from './helpers/migrate.js';
+import { createTestPool, truncateAllTables } from './helpers/db.js';
+import { buildServer } from '../src/api/server.js';
+
+describe('Work Item Attachments and Dependencies API (issue #109)', () => {
+  const app = buildServer();
+  let pool: Pool;
+  let workItemId: string;
+  let contactId: string;
+
+  beforeAll(async () => {
+    await runMigrate('up');
+    pool = createTestPool();
+    await app.ready();
+  });
+
+  beforeEach(async () => {
+    await truncateAllTables(pool);
+
+    // Create a work item
+    const wi = await app.inject({
+      method: 'POST',
+      url: '/api/work-items',
+      payload: { title: 'Test Project', kind: 'project' },
+    });
+    workItemId = (wi.json() as { id: string }).id;
+
+    // Create a contact
+    const contact = await app.inject({
+      method: 'POST',
+      url: '/api/contacts',
+      payload: { displayName: 'John Doe' },
+    });
+    contactId = (contact.json() as { id: string }).id;
+  });
+
+  afterAll(async () => {
+    await app.close();
+    await pool.end();
+  });
+
+  describe('GET /api/work-items/:id with attachments', () => {
+    it('returns empty attachments array when no attachments exist', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: `/api/work-items/${workItemId}`,
+      });
+      expect(res.statusCode).toBe(200);
+
+      const body = res.json() as { attachments: unknown[] };
+      expect(body.attachments).toEqual([]);
+    });
+
+    it('returns linked memories as attachments', async () => {
+      // Create a memory
+      const memory = await app.inject({
+        method: 'POST',
+        url: `/api/work-items/${workItemId}/memories`,
+        payload: { title: 'Important Note', content: 'Content here', type: 'note' },
+      });
+      const memoryId = (memory.json() as { id: string }).id;
+
+      const res = await app.inject({
+        method: 'GET',
+        url: `/api/work-items/${workItemId}`,
+      });
+      expect(res.statusCode).toBe(200);
+
+      const body = res.json() as {
+        attachments: Array<{
+          id: string;
+          type: string;
+          title: string;
+          subtitle?: string;
+          linkedAt: string;
+        }>;
+      };
+      expect(body.attachments.length).toBe(1);
+      expect(body.attachments[0].id).toBe(memoryId);
+      expect(body.attachments[0].type).toBe('memory');
+      expect(body.attachments[0].title).toBe('Important Note');
+    });
+
+    it('returns linked contacts as attachments', async () => {
+      // Link a contact
+      await app.inject({
+        method: 'POST',
+        url: `/api/work-items/${workItemId}/contacts`,
+        payload: { contactId, relationship: 'owner' },
+      });
+
+      const res = await app.inject({
+        method: 'GET',
+        url: `/api/work-items/${workItemId}`,
+      });
+      expect(res.statusCode).toBe(200);
+
+      const body = res.json() as {
+        attachments: Array<{
+          id: string;
+          type: string;
+          title: string;
+          subtitle?: string;
+        }>;
+      };
+      expect(body.attachments.length).toBe(1);
+      expect(body.attachments[0].id).toBe(contactId);
+      expect(body.attachments[0].type).toBe('contact');
+      expect(body.attachments[0].title).toBe('John Doe');
+      expect(body.attachments[0].subtitle).toBe('owner');
+    });
+
+    it('returns multiple attachment types', async () => {
+      // Create a memory
+      await app.inject({
+        method: 'POST',
+        url: `/api/work-items/${workItemId}/memories`,
+        payload: { title: 'Memory 1', content: 'Content', type: 'note' },
+      });
+
+      // Link a contact
+      await app.inject({
+        method: 'POST',
+        url: `/api/work-items/${workItemId}/contacts`,
+        payload: { contactId, relationship: 'assignee' },
+      });
+
+      const res = await app.inject({
+        method: 'GET',
+        url: `/api/work-items/${workItemId}`,
+      });
+      expect(res.statusCode).toBe(200);
+
+      const body = res.json() as {
+        attachments: Array<{ type: string }>;
+      };
+      expect(body.attachments.length).toBe(2);
+      const types = body.attachments.map((a) => a.type);
+      expect(types).toContain('memory');
+      expect(types).toContain('contact');
+    });
+  });
+
+  describe('GET /api/work-items/:id with dependencies', () => {
+    let blockedWorkItemId: string;
+    let blockingWorkItemId: string;
+
+    beforeEach(async () => {
+      // Create an initiative under the project
+      const init1 = await app.inject({
+        method: 'POST',
+        url: '/api/work-items',
+        payload: { title: 'Initiative 1', kind: 'initiative', parentId: workItemId },
+      });
+      blockedWorkItemId = (init1.json() as { id: string }).id;
+
+      const init2 = await app.inject({
+        method: 'POST',
+        url: '/api/work-items',
+        payload: { title: 'Initiative 2', kind: 'initiative', parentId: workItemId },
+      });
+      blockingWorkItemId = (init2.json() as { id: string }).id;
+    });
+
+    it('returns dependencies with kind and status', async () => {
+      // Create a dependency: blockedWorkItemId depends on blockingWorkItemId
+      await pool.query(
+        `INSERT INTO work_item_dependency (work_item_id, depends_on_work_item_id, kind)
+         VALUES ($1, $2, 'depends_on')`,
+        [blockedWorkItemId, blockingWorkItemId]
+      );
+
+      const res = await app.inject({
+        method: 'GET',
+        url: `/api/work-items/${blockedWorkItemId}`,
+      });
+      expect(res.statusCode).toBe(200);
+
+      const body = res.json() as {
+        dependencies: Array<{
+          id: string;
+          title: string;
+          kind: string;
+          status: string;
+          direction: string;
+        }>;
+      };
+
+      expect(body.dependencies.length).toBe(1);
+      const dep = body.dependencies[0];
+      expect(dep.id).toBe(blockingWorkItemId);
+      expect(dep.title).toBe('Initiative 2');
+      expect(dep.kind).toBe('initiative');
+      expect(dep.status).toBe('open');
+      expect(dep.direction).toBe('blocked_by');
+    });
+
+    it('returns dependencies in both directions', async () => {
+      // blockedWorkItemId depends on blockingWorkItemId
+      await pool.query(
+        `INSERT INTO work_item_dependency (work_item_id, depends_on_work_item_id, kind)
+         VALUES ($1, $2, 'depends_on')`,
+        [blockedWorkItemId, blockingWorkItemId]
+      );
+
+      // Check from the blocking item's perspective
+      const res = await app.inject({
+        method: 'GET',
+        url: `/api/work-items/${blockingWorkItemId}`,
+      });
+      expect(res.statusCode).toBe(200);
+
+      const body = res.json() as {
+        dependencies: Array<{ direction: string }>;
+      };
+
+      expect(body.dependencies.length).toBe(1);
+      expect(body.dependencies[0].direction).toBe('blocks');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Extend GET /api/work-items/:id endpoint to return `attachments` array (memories and contacts)
- Change dependencies format from nested `{blocks, blocked_by}` to flat array with `direction` field
- Each dependency now includes `kind` and `status` fields
- Update existing test to match new API format

## Test plan
- [x] All 603 tests pass
- [x] New tests verify attachments array includes memories and contacts
- [x] New tests verify dependencies include kind, status, and direction fields
- [x] Updated existing enhanced_work_item_detail.test.ts to use new format

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)