### PR TITLE
[#102] Add Mark as Read endpoints for activity feed

### DIFF
--- a/migrations/020_activity_read_at.down.sql
+++ b/migrations/020_activity_read_at.down.sql
@@ -1,0 +1,4 @@
+-- Migration 020 down: Remove read_at column
+
+DROP INDEX IF EXISTS work_item_activity_read_at_idx;
+ALTER TABLE work_item_activity DROP COLUMN IF EXISTS read_at;

--- a/migrations/020_activity_read_at.up.sql
+++ b/migrations/020_activity_read_at.up.sql
@@ -1,0 +1,10 @@
+-- Migration 020: Add read_at column to work_item_activity (issue #102)
+-- Allows tracking when activity items have been read
+
+ALTER TABLE work_item_activity
+ADD COLUMN IF NOT EXISTS read_at timestamptz DEFAULT NULL;
+
+-- Index for efficient queries on unread items
+CREATE INDEX IF NOT EXISTS work_item_activity_read_at_idx ON work_item_activity(read_at);
+
+COMMENT ON COLUMN work_item_activity.read_at IS 'Timestamp when the activity item was marked as read, NULL if unread';


### PR DESCRIPTION
## Summary
- Add `POST /api/activity/:id/read` - marks a single activity item as read (returns 204)
- Add `POST /api/activity/read-all` - marks all unread activity as read (returns `{ marked: count }`)
- Add migration 020 to add `read_at` column to `work_item_activity` table
- Include `read_at` field in GET /api/activity responses

## Test plan
- [x] All 615 tests pass
- [x] New tests verify single item can be marked as read
- [x] New tests verify 404 for non-existent activity
- [x] New tests verify idempotent behavior (can mark already-read items)
- [x] New tests verify read-all marks all items and returns count
- [x] New tests verify read-all only counts unread items

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)