### PR TITLE
[#48] Improve Postmark error handling and fix .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,7 +21,9 @@ POSTGRES_DB=clawdbot
 
 # Optional: Postmark email (magic links)
 # If unset, the app will still work but will return the login URL in non-production only.
-# POSTMARK_TOKEN=...
+# Can use either POSTMARK_TRANSACTIONAL_TOKEN directly or POSTMARK_TRANSACTIONAL_TOKEN_FILE
+# POSTMARK_TRANSACTIONAL_TOKEN=your-token-here
+# POSTMARK_TRANSACTIONAL_TOKEN_FILE=/path/to/token/file
 # POSTMARK_FROM=Projects <projects@execdesk.ai>
-# POSTMARK_REPLY_TO=quasar@execdesk.ai>
+# POSTMARK_REPLY_TO=quasar@execdesk.ai
 # POSTMARK_MESSAGE_STREAM=outbound

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -368,7 +368,11 @@ export function buildServer(options: ProjectsApiOptions = {}): FastifyInstance {
     const baseUrl = process.env.PUBLIC_BASE_URL || 'http://localhost:3000';
     const loginUrl = `${baseUrl}/api/auth/consume?token=${token}`;
 
-    const { delivered } = await sendMagicLinkEmail({ toEmail: email, loginUrl });
+    const { delivered, error } = await sendMagicLinkEmail({ toEmail: email, loginUrl });
+
+    if (!delivered) {
+      console.warn(`[Auth] Magic link email not delivered to ${email}${error ? `: ${error}` : ''}`);
+    }
 
     // Only return the URL when email delivery isn't configured (or in non-production).
     // This prevents leaking a login token to whoever can see the response in production.

--- a/src/email/magicLink.ts
+++ b/src/email/magicLink.ts
@@ -8,14 +8,17 @@ export type SendMagicLinkArgs = {
   loginUrl: string;
 };
 
-export async function sendMagicLinkEmail(args: SendMagicLinkArgs): Promise<{ delivered: boolean }> {
+export async function sendMagicLinkEmail(args: SendMagicLinkArgs): Promise<{ delivered: boolean; error?: string }> {
   // Avoid sending real email during unit tests unless explicitly enabled.
   if (process.env.NODE_ENV === 'test' && process.env.POSTMARK_ENABLE_TEST_SEND !== '1') {
     return { delivered: false };
   }
 
   const token = await getPostmarkTransactionalToken();
-  if (!token) return { delivered: false };
+  if (!token) {
+    console.warn('[Postmark] No transactional token configured - email will not be sent');
+    return { delivered: false, error: 'no_token' };
+  }
 
   const subject = 'Your ExecDesk dashboard login link';
   const textBody = `Use this link to sign in (valid for 15 minutes):\n\n${args.loginUrl}\n\nIf you did not request this, you can ignore this email.`;
@@ -28,17 +31,23 @@ export async function sendMagicLinkEmail(args: SendMagicLinkArgs): Promise<{ del
   </body>
 </html>`;
 
-  await sendPostmarkEmail(token, {
-    From: process.env.POSTMARK_FROM || DEFAULT_FROM,
-    To: args.toEmail,
-    Subject: subject,
-    TextBody: textBody,
-    HtmlBody: htmlBody,
-    ReplyTo: process.env.POSTMARK_REPLY_TO || DEFAULT_REPLY_TO,
-    MessageStream: process.env.POSTMARK_MESSAGE_STREAM || 'outbound',
-  });
-
-  return { delivered: true };
+  try {
+    await sendPostmarkEmail(token, {
+      From: process.env.POSTMARK_FROM || DEFAULT_FROM,
+      To: args.toEmail,
+      Subject: subject,
+      TextBody: textBody,
+      HtmlBody: htmlBody,
+      ReplyTo: process.env.POSTMARK_REPLY_TO || DEFAULT_REPLY_TO,
+      MessageStream: process.env.POSTMARK_MESSAGE_STREAM || 'outbound',
+    });
+    console.log(`[Postmark] Magic link email sent to ${args.toEmail}`);
+    return { delivered: true };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`[Postmark] Failed to send magic link email to ${args.toEmail}: ${message}`);
+    return { delivered: false, error: message };
+  }
 }
 
 function escapeHtmlAttr(s: string): string {


### PR DESCRIPTION
## Summary
Code changes for production hardening (Issue #48):

- **Fix `.env.example`**: 
  - Changed `POSTMARK_TOKEN` to `POSTMARK_TRANSACTIONAL_TOKEN` (correct env var name)
  - Fixed typo `POSTMARK_REPLY_TO=quasar@execdesk.ai>` → `quasar@execdesk.ai` (removed extra `>`)
  - Added `POSTMARK_TRANSACTIONAL_TOKEN_FILE` option documentation

- **Improve Postmark error handling**:
  - Wrapped `sendPostmarkEmail` in try/catch to prevent request crashes
  - Added explicit console logging for success/failure
  - Return error reason in response for debugging

## What this PR does NOT do (infrastructure tasks)
The following tasks in Issue #48 are infrastructure/deployment work, not code changes:
- Postgres bind mount setup (already configured in `docker-compose.prod.yml`)
- Password rotation
- User seeding (script exists at `scripts/seed-user.ts`)
- End-to-end verification

## Test plan
- [x] All 620 tests pass
- [x] Logging visible in test output for email delivery status
- [x] Postmark failures no longer crash the auth request

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)