### PR TITLE
[#230] Configure GitHub Secrets for embedding API integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,17 @@ jobs:
           docker compose -f .devcontainer/docker-compose.devcontainer.yml exec -T -u root workspace bash -lc "chown -R vscode:vscode /workspaces/clawdbot-projects"
 
       - name: Install deps + run tests
+        env:
+          VOYAGERAI_API_KEY: ${{ secrets.VOYAGERAI_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
         run: |
           docker compose -f .devcontainer/docker-compose.devcontainer.yml exec -T workspace bash -lc "cd /workspaces/clawdbot-projects && pnpm install --frozen-lockfile"
-          docker compose -f .devcontainer/docker-compose.devcontainer.yml exec -T workspace bash -lc "cd /workspaces/clawdbot-projects && pnpm -s test"
+          docker compose -f .devcontainer/docker-compose.devcontainer.yml exec -T \
+            -e VOYAGERAI_API_KEY \
+            -e OPENAI_API_KEY \
+            -e GEMINI_API_KEY \
+            workspace bash -lc "cd /workspaces/clawdbot-projects && pnpm -s test"
 
       - name: Shutdown
         if: always()


### PR DESCRIPTION
## Summary
- Add VOYAGERAI_API_KEY, OPENAI_API_KEY, and GEMINI_API_KEY GitHub repository secrets
- Update CI workflow to pass these secrets to the devcontainer during test execution

## Changes
- `.github/workflows/ci.yml`: Configure env variables and pass them to docker exec command

## Test plan
- [x] Verified locally: all 847 tests pass
- [x] Verified locally: build (typecheck) passes
- [x] Verified secrets are configured via `gh secret list`
- [ ] CI workflow runs successfully with secrets available

Closes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)