### PR TITLE
[#209] Redesign memory system for flexible scoping and agent attribution

### DIFF
--- a/migrations/028_unified_memory.down.sql
+++ b/migrations/028_unified_memory.down.sql
@@ -1,0 +1,29 @@
+-- Migration 028: Unified Memory System - Rollback
+-- Part of Epic #199, Issue #209
+
+-- Restore foreign key constraints to reference work_item_memory
+ALTER TABLE memory_relationship DROP CONSTRAINT IF EXISTS memory_relationship_memory_id_fkey;
+ALTER TABLE memory_relationship DROP CONSTRAINT IF EXISTS memory_relationship_related_memory_id_fkey;
+ALTER TABLE memory_relationship
+  ADD CONSTRAINT memory_relationship_memory_id_fkey
+  FOREIGN KEY (memory_id) REFERENCES work_item_memory(id) ON DELETE CASCADE;
+ALTER TABLE memory_relationship
+  ADD CONSTRAINT memory_relationship_related_memory_id_fkey
+  FOREIGN KEY (related_memory_id) REFERENCES work_item_memory(id) ON DELETE CASCADE;
+
+ALTER TABLE memory_contact DROP CONSTRAINT IF EXISTS memory_contact_memory_id_fkey;
+ALTER TABLE memory_contact
+  ADD CONSTRAINT memory_contact_memory_id_fkey
+  FOREIGN KEY (memory_id) REFERENCES work_item_memory(id) ON DELETE CASCADE;
+
+-- Drop triggers and functions
+DROP TRIGGER IF EXISTS memory_updated_at_trigger ON memory;
+DROP TRIGGER IF EXISTS memory_search_vector_trigger ON memory;
+DROP FUNCTION IF EXISTS update_memory_updated_at();
+DROP FUNCTION IF EXISTS memory_search_vector_update();
+
+-- Drop the unified memory table
+DROP TABLE IF EXISTS memory CASCADE;
+
+-- Note: memory_type enum values 'preference' and 'fact' cannot be removed
+-- This is a PostgreSQL limitation - enum values cannot be removed

--- a/migrations/028_unified_memory.up.sql
+++ b/migrations/028_unified_memory.up.sql
@@ -1,0 +1,164 @@
+-- Migration 028: Unified Memory System
+-- Part of Epic #199, Issue #209
+-- Redesigns memory system for flexible scoping and agent attribution
+
+-- Extend memory_type enum with new types
+DO $$ BEGIN
+  ALTER TYPE memory_type ADD VALUE 'preference' BEFORE 'note';
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
+  ALTER TYPE memory_type ADD VALUE 'fact' BEFORE 'note';
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- Create new unified memory table with flexible scoping
+CREATE TABLE IF NOT EXISTS memory (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+
+  -- Flexible scoping (all nullable - at least one scope should be set)
+  user_email text,           -- User this memory belongs to (global scope)
+  work_item_id uuid REFERENCES work_item(id) ON DELETE SET NULL,
+  contact_id uuid REFERENCES contact(id) ON DELETE SET NULL,
+
+  -- Content
+  title text NOT NULL,
+  content text NOT NULL,
+  memory_type memory_type NOT NULL DEFAULT 'note',
+
+  -- Embeddings for semantic search (1024 dimensions to match work_item_memory)
+  embedding vector(1024),
+  embedding_model text,
+  embedding_provider text,
+  embedding_status text DEFAULT 'pending' CHECK (embedding_status IN ('complete', 'pending', 'failed')),
+
+  -- Attribution
+  created_by_agent text,     -- Which agent created this? (e.g., "openclaw-pi")
+  created_by_human boolean DEFAULT false,
+  source_url text,           -- External reference if applicable
+
+  -- Importance and validity
+  importance integer DEFAULT 5 CHECK (importance BETWEEN 1 AND 10),
+  confidence float DEFAULT 1.0 CHECK (confidence BETWEEN 0 AND 1),
+  expires_at timestamptz,    -- For temporary context
+  superseded_by uuid,        -- Points to newer memory that replaces this
+
+  -- Full-text search
+  search_vector tsvector,
+
+  -- Timestamps
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Add foreign key for superseded_by after table creation
+ALTER TABLE memory
+  ADD CONSTRAINT fk_memory_superseded_by
+  FOREIGN KEY (superseded_by) REFERENCES memory(id) ON DELETE SET NULL;
+
+-- Indexes for flexible scoping
+CREATE INDEX idx_memory_user_email ON memory(user_email) WHERE user_email IS NOT NULL;
+CREATE INDEX idx_memory_work_item_id ON memory(work_item_id) WHERE work_item_id IS NOT NULL;
+CREATE INDEX idx_memory_contact_id ON memory(contact_id) WHERE contact_id IS NOT NULL;
+CREATE INDEX idx_memory_type ON memory(memory_type);
+CREATE INDEX idx_memory_created_by_agent ON memory(created_by_agent) WHERE created_by_agent IS NOT NULL;
+CREATE INDEX idx_memory_expires_at ON memory(expires_at) WHERE expires_at IS NOT NULL;
+CREATE INDEX idx_memory_superseded_by ON memory(superseded_by) WHERE superseded_by IS NOT NULL;
+CREATE INDEX idx_memory_created_at ON memory(created_at DESC);
+
+-- Index for semantic search (using different name to avoid conflict with work_item_memory index)
+CREATE INDEX idx_unified_memory_embedding ON memory USING hnsw (embedding vector_cosine_ops) WHERE embedding IS NOT NULL;
+
+-- Index for finding memories by embedding status (for backfill operations)
+CREATE INDEX idx_unified_memory_embedding_status ON memory(embedding_status) WHERE embedding_status != 'complete';
+
+-- Index for full-text search
+CREATE INDEX idx_memory_search_vector ON memory USING gin(search_vector);
+
+-- Trigger to update search_vector
+CREATE OR REPLACE FUNCTION memory_search_vector_update()
+RETURNS trigger AS $$
+BEGIN
+  NEW.search_vector :=
+    setweight(to_tsvector('english', coalesce(NEW.title, '')), 'A') ||
+    setweight(to_tsvector('english', coalesce(NEW.content, '')), 'B');
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER memory_search_vector_trigger
+  BEFORE INSERT OR UPDATE ON memory
+  FOR EACH ROW EXECUTE FUNCTION memory_search_vector_update();
+
+-- Trigger to update updated_at
+CREATE OR REPLACE FUNCTION update_memory_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER memory_updated_at_trigger
+  BEFORE UPDATE ON memory
+  FOR EACH ROW EXECUTE FUNCTION update_memory_updated_at();
+
+-- Migrate data from work_item_memory to memory
+INSERT INTO memory (
+  id,
+  work_item_id,
+  title,
+  content,
+  memory_type,
+  embedding,
+  embedding_model,
+  embedding_provider,
+  embedding_status,
+  created_at,
+  updated_at
+)
+SELECT
+  id,
+  work_item_id,
+  title,
+  content,
+  memory_type,
+  embedding,
+  embedding_model,
+  embedding_provider,
+  embedding_status,
+  created_at,
+  updated_at
+FROM work_item_memory
+ON CONFLICT (id) DO NOTHING;
+
+-- Update memory_relationship to reference new memory table
+-- First drop existing constraints
+ALTER TABLE memory_relationship DROP CONSTRAINT IF EXISTS memory_relationship_memory_id_fkey;
+ALTER TABLE memory_relationship DROP CONSTRAINT IF EXISTS memory_relationship_related_memory_id_fkey;
+
+-- Add new constraints referencing memory table
+ALTER TABLE memory_relationship
+  ADD CONSTRAINT memory_relationship_memory_id_fkey
+  FOREIGN KEY (memory_id) REFERENCES memory(id) ON DELETE CASCADE;
+ALTER TABLE memory_relationship
+  ADD CONSTRAINT memory_relationship_related_memory_id_fkey
+  FOREIGN KEY (related_memory_id) REFERENCES memory(id) ON DELETE CASCADE;
+
+-- Update memory_contact to reference new memory table
+ALTER TABLE memory_contact DROP CONSTRAINT IF EXISTS memory_contact_memory_id_fkey;
+ALTER TABLE memory_contact
+  ADD CONSTRAINT memory_contact_memory_id_fkey
+  FOREIGN KEY (memory_id) REFERENCES memory(id) ON DELETE CASCADE;
+
+-- Add comments for documentation
+COMMENT ON TABLE memory IS 'Unified memory store with flexible scoping (global, work_item, contact, or combinations)';
+COMMENT ON COLUMN memory.user_email IS 'Owner of this memory. When set alone, memory is global scope.';
+COMMENT ON COLUMN memory.work_item_id IS 'Optional work item scope. Can be combined with user_email.';
+COMMENT ON COLUMN memory.contact_id IS 'Optional contact scope. Can be combined with user_email and/or work_item_id.';
+COMMENT ON COLUMN memory.created_by_agent IS 'Agent ID that created this memory (e.g., openclaw-pi)';
+COMMENT ON COLUMN memory.importance IS 'Importance score 1-10, higher = more important for retrieval';
+COMMENT ON COLUMN memory.confidence IS 'Confidence score 0-1, lower = uncertain/unverified';
+COMMENT ON COLUMN memory.expires_at IS 'When set, memory auto-expires and should be cleaned up';
+COMMENT ON COLUMN memory.superseded_by IS 'When set, points to newer memory that replaces this one';

--- a/src/api/embeddings/memory-integration.ts
+++ b/src/api/embeddings/memory-integration.ts
@@ -46,7 +46,7 @@ export async function generateMemoryEmbedding(
   if (!embeddingService.isConfigured()) {
     // Mark as pending - can be backfilled later
     await pool.query(
-      `UPDATE work_item_memory SET embedding_status = 'pending' WHERE id = $1`,
+      `UPDATE memory SET embedding_status = 'pending' WHERE id = $1`,
       [memoryId]
     );
     return 'pending';
@@ -57,7 +57,7 @@ export async function generateMemoryEmbedding(
 
     if (!result) {
       await pool.query(
-        `UPDATE work_item_memory SET embedding_status = 'pending' WHERE id = $1`,
+        `UPDATE memory SET embedding_status = 'pending' WHERE id = $1`,
         [memoryId]
       );
       return 'pending';
@@ -65,7 +65,7 @@ export async function generateMemoryEmbedding(
 
     // Store embedding in database
     await pool.query(
-      `UPDATE work_item_memory
+      `UPDATE memory
        SET embedding = $1::vector,
            embedding_model = $2,
            embedding_provider = $3,
@@ -92,7 +92,7 @@ export async function generateMemoryEmbedding(
 
     // Mark as failed
     await pool.query(
-      `UPDATE work_item_memory SET embedding_status = 'failed' WHERE id = $1`,
+      `UPDATE memory SET embedding_status = 'failed' WHERE id = $1`,
       [memoryId]
     );
 
@@ -197,7 +197,7 @@ export async function searchMemoriesSemantic(
          m.embedding_provider,
          m.embedding_model,
          1 - (m.embedding <=> $${embeddingParamIndex}::vector) as similarity
-       FROM work_item_memory m
+       FROM memory m
        ${fullWhereClause}
        ORDER BY m.embedding <=> $${embeddingParamIndex}::vector
        LIMIT $${limitParamIndex} OFFSET $${offsetParamIndex}`,
@@ -238,7 +238,7 @@ export async function searchMemoriesSemantic(
        m.embedding_provider,
        m.embedding_model,
        0.5 as similarity
-     FROM work_item_memory m
+     FROM memory m
      ${fullWhereClause}
      ORDER BY m.updated_at DESC
      LIMIT $${limitParamIndex} OFFSET $${offsetParamIndex}`,
@@ -282,7 +282,7 @@ export async function backfillMemoryEmbeddings(
 
   const result = await pool.query(
     `SELECT id::text as id, title, content
-     FROM work_item_memory
+     FROM memory
      WHERE ${condition}
      ORDER BY created_at ASC
      LIMIT $1`,

--- a/src/api/memory/index.ts
+++ b/src/api/memory/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Memory module exports.
+ * Part of Epic #199, Issue #209
+ */
+
+export * from './types.ts';
+export * from './service.ts';

--- a/src/api/memory/service.ts
+++ b/src/api/memory/service.ts
@@ -1,0 +1,555 @@
+/**
+ * Memory service for the unified memory system.
+ * Part of Epic #199, Issue #209
+ */
+
+import type { Pool } from 'pg';
+import type {
+  MemoryEntry,
+  CreateMemoryInput,
+  UpdateMemoryInput,
+  ListMemoriesOptions,
+  ListMemoriesResult,
+  SearchMemoriesOptions,
+  MemorySearchResult,
+  MemoryType,
+} from './types.ts';
+
+/** Valid memory types for validation */
+const VALID_MEMORY_TYPES: MemoryType[] = [
+  'preference',
+  'fact',
+  'note',
+  'decision',
+  'context',
+  'reference',
+];
+
+/**
+ * Maps database row to MemoryEntry
+ */
+function mapRowToMemory(row: Record<string, unknown>): MemoryEntry {
+  return {
+    id: row.id as string,
+    userEmail: row.user_email as string | null,
+    workItemId: row.work_item_id as string | null,
+    contactId: row.contact_id as string | null,
+    title: row.title as string,
+    content: row.content as string,
+    memoryType: row.memory_type as MemoryType,
+    createdByAgent: row.created_by_agent as string | null,
+    createdByHuman: (row.created_by_human as boolean) ?? false,
+    sourceUrl: row.source_url as string | null,
+    importance: row.importance as number,
+    confidence: row.confidence as number,
+    expiresAt: row.expires_at ? new Date(row.expires_at as string) : null,
+    supersededBy: row.superseded_by as string | null,
+    embeddingStatus: row.embedding_status as 'pending' | 'complete' | 'failed',
+    createdAt: new Date(row.created_at as string),
+    updatedAt: new Date(row.updated_at as string),
+  };
+}
+
+/**
+ * Validates a memory type.
+ */
+export function isValidMemoryType(type: string): type is MemoryType {
+  return VALID_MEMORY_TYPES.includes(type as MemoryType);
+}
+
+/**
+ * Creates a new memory.
+ */
+export async function createMemory(
+  pool: Pool,
+  input: CreateMemoryInput
+): Promise<MemoryEntry> {
+  const memoryType = input.memoryType ?? 'note';
+
+  if (!isValidMemoryType(memoryType)) {
+    throw new Error(`Invalid memory type: ${memoryType}. Valid types are: ${VALID_MEMORY_TYPES.join(', ')}`);
+  }
+
+  // At least one scope should be set
+  if (!input.userEmail && !input.workItemId && !input.contactId) {
+    // Default to requiring at least some scope for organization
+    // For now, allow completely unscoped memories but log a warning
+    console.warn('[Memory] Creating memory without scope - consider adding userEmail, workItemId, or contactId');
+  }
+
+  const result = await pool.query(
+    `INSERT INTO memory (
+      user_email, work_item_id, contact_id,
+      title, content, memory_type,
+      created_by_agent, created_by_human, source_url,
+      importance, confidence, expires_at
+    ) VALUES ($1, $2, $3, $4, $5, $6::memory_type, $7, $8, $9, $10, $11, $12)
+    RETURNING
+      id::text, user_email, work_item_id::text, contact_id::text,
+      title, content, memory_type::text,
+      created_by_agent, created_by_human, source_url,
+      importance, confidence, expires_at, superseded_by::text,
+      embedding_status, created_at, updated_at`,
+    [
+      input.userEmail ?? null,
+      input.workItemId ?? null,
+      input.contactId ?? null,
+      input.title,
+      input.content,
+      memoryType,
+      input.createdByAgent ?? null,
+      input.createdByHuman ?? false,
+      input.sourceUrl ?? null,
+      input.importance ?? 5,
+      input.confidence ?? 1.0,
+      input.expiresAt ?? null,
+    ]
+  );
+
+  return mapRowToMemory(result.rows[0] as Record<string, unknown>);
+}
+
+/**
+ * Gets a memory by ID.
+ */
+export async function getMemory(
+  pool: Pool,
+  id: string
+): Promise<MemoryEntry | null> {
+  const result = await pool.query(
+    `SELECT
+      id::text, user_email, work_item_id::text, contact_id::text,
+      title, content, memory_type::text,
+      created_by_agent, created_by_human, source_url,
+      importance, confidence, expires_at, superseded_by::text,
+      embedding_status, created_at, updated_at
+    FROM memory
+    WHERE id = $1`,
+    [id]
+  );
+
+  if (result.rows.length === 0) {
+    return null;
+  }
+
+  return mapRowToMemory(result.rows[0] as Record<string, unknown>);
+}
+
+/**
+ * Updates a memory.
+ */
+export async function updateMemory(
+  pool: Pool,
+  id: string,
+  input: UpdateMemoryInput
+): Promise<MemoryEntry | null> {
+  const updates: string[] = [];
+  const params: unknown[] = [];
+  let paramIndex = 1;
+
+  if (input.title !== undefined) {
+    updates.push(`title = $${paramIndex}`);
+    params.push(input.title);
+    paramIndex++;
+  }
+
+  if (input.content !== undefined) {
+    updates.push(`content = $${paramIndex}`);
+    params.push(input.content);
+    paramIndex++;
+    // Reset embedding status when content changes
+    updates.push(`embedding_status = 'pending'`);
+  }
+
+  if (input.memoryType !== undefined) {
+    if (!isValidMemoryType(input.memoryType)) {
+      throw new Error(`Invalid memory type: ${input.memoryType}`);
+    }
+    updates.push(`memory_type = $${paramIndex}::memory_type`);
+    params.push(input.memoryType);
+    paramIndex++;
+  }
+
+  if (input.importance !== undefined) {
+    if (input.importance < 1 || input.importance > 10) {
+      throw new Error('Importance must be between 1 and 10');
+    }
+    updates.push(`importance = $${paramIndex}`);
+    params.push(input.importance);
+    paramIndex++;
+  }
+
+  if (input.confidence !== undefined) {
+    if (input.confidence < 0 || input.confidence > 1) {
+      throw new Error('Confidence must be between 0 and 1');
+    }
+    updates.push(`confidence = $${paramIndex}`);
+    params.push(input.confidence);
+    paramIndex++;
+  }
+
+  if (input.expiresAt !== undefined) {
+    updates.push(`expires_at = $${paramIndex}`);
+    params.push(input.expiresAt);
+    paramIndex++;
+  }
+
+  if (input.supersededBy !== undefined) {
+    updates.push(`superseded_by = $${paramIndex}`);
+    params.push(input.supersededBy);
+    paramIndex++;
+  }
+
+  if (updates.length === 0) {
+    return getMemory(pool, id);
+  }
+
+  params.push(id);
+
+  const result = await pool.query(
+    `UPDATE memory SET ${updates.join(', ')}, updated_at = NOW()
+    WHERE id = $${paramIndex}
+    RETURNING
+      id::text, user_email, work_item_id::text, contact_id::text,
+      title, content, memory_type::text,
+      created_by_agent, created_by_human, source_url,
+      importance, confidence, expires_at, superseded_by::text,
+      embedding_status, created_at, updated_at`,
+    params
+  );
+
+  if (result.rows.length === 0) {
+    return null;
+  }
+
+  return mapRowToMemory(result.rows[0] as Record<string, unknown>);
+}
+
+/**
+ * Deletes a memory.
+ */
+export async function deleteMemory(pool: Pool, id: string): Promise<boolean> {
+  const result = await pool.query(
+    'DELETE FROM memory WHERE id = $1 RETURNING id',
+    [id]
+  );
+  return result.rows.length > 0;
+}
+
+/**
+ * Lists memories with flexible filtering.
+ */
+export async function listMemories(
+  pool: Pool,
+  options: ListMemoriesOptions = {}
+): Promise<ListMemoriesResult> {
+  const conditions: string[] = [];
+  const params: unknown[] = [];
+  let paramIndex = 1;
+
+  // Scope filters
+  if (options.userEmail !== undefined) {
+    conditions.push(`user_email = $${paramIndex}`);
+    params.push(options.userEmail);
+    paramIndex++;
+  }
+
+  if (options.workItemId !== undefined) {
+    conditions.push(`work_item_id = $${paramIndex}`);
+    params.push(options.workItemId);
+    paramIndex++;
+  }
+
+  if (options.contactId !== undefined) {
+    conditions.push(`contact_id = $${paramIndex}`);
+    params.push(options.contactId);
+    paramIndex++;
+  }
+
+  // Type filter
+  if (options.memoryType !== undefined) {
+    conditions.push(`memory_type = $${paramIndex}::memory_type`);
+    params.push(options.memoryType);
+    paramIndex++;
+  }
+
+  // Exclude expired unless requested
+  if (!options.includeExpired) {
+    conditions.push(`(expires_at IS NULL OR expires_at > NOW())`);
+  }
+
+  // Exclude superseded unless requested
+  if (!options.includeSuperseded) {
+    conditions.push(`superseded_by IS NULL`);
+  }
+
+  const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+
+  // Get total count
+  const countResult = await pool.query(
+    `SELECT COUNT(*) as total FROM memory ${whereClause}`,
+    params
+  );
+  const total = parseInt((countResult.rows[0] as { total: string }).total, 10);
+
+  // Get paginated results
+  const limit = Math.min(options.limit ?? 50, 100);
+  const offset = options.offset ?? 0;
+
+  params.push(limit, offset);
+
+  const result = await pool.query(
+    `SELECT
+      id::text, user_email, work_item_id::text, contact_id::text,
+      title, content, memory_type::text,
+      created_by_agent, created_by_human, source_url,
+      importance, confidence, expires_at, superseded_by::text,
+      embedding_status, created_at, updated_at
+    FROM memory
+    ${whereClause}
+    ORDER BY importance DESC, created_at DESC
+    LIMIT $${paramIndex} OFFSET $${paramIndex + 1}`,
+    params
+  );
+
+  return {
+    memories: result.rows.map((row) => mapRowToMemory(row as Record<string, unknown>)),
+    total,
+  };
+}
+
+/**
+ * Gets global memories for a user (no work_item_id or contact_id).
+ */
+export async function getGlobalMemories(
+  pool: Pool,
+  userEmail: string,
+  options: { memoryType?: MemoryType; limit?: number; offset?: number } = {}
+): Promise<ListMemoriesResult> {
+  const conditions: string[] = [
+    'user_email = $1',
+    'work_item_id IS NULL',
+    'contact_id IS NULL',
+    '(expires_at IS NULL OR expires_at > NOW())',
+    'superseded_by IS NULL',
+  ];
+  const params: unknown[] = [userEmail];
+  let paramIndex = 2;
+
+  if (options.memoryType !== undefined) {
+    conditions.push(`memory_type = $${paramIndex}::memory_type`);
+    params.push(options.memoryType);
+    paramIndex++;
+  }
+
+  const whereClause = `WHERE ${conditions.join(' AND ')}`;
+
+  // Get total count
+  const countResult = await pool.query(
+    `SELECT COUNT(*) as total FROM memory ${whereClause}`,
+    params
+  );
+  const total = parseInt((countResult.rows[0] as { total: string }).total, 10);
+
+  // Get paginated results
+  const limit = Math.min(options.limit ?? 50, 100);
+  const offset = options.offset ?? 0;
+
+  params.push(limit, offset);
+
+  const result = await pool.query(
+    `SELECT
+      id::text, user_email, work_item_id::text, contact_id::text,
+      title, content, memory_type::text,
+      created_by_agent, created_by_human, source_url,
+      importance, confidence, expires_at, superseded_by::text,
+      embedding_status, created_at, updated_at
+    FROM memory
+    ${whereClause}
+    ORDER BY importance DESC, created_at DESC
+    LIMIT $${paramIndex} OFFSET $${paramIndex + 1}`,
+    params
+  );
+
+  return {
+    memories: result.rows.map((row) => mapRowToMemory(row as Record<string, unknown>)),
+    total,
+  };
+}
+
+/**
+ * Supersedes a memory with a new one.
+ */
+export async function supersedeMemory(
+  pool: Pool,
+  oldMemoryId: string,
+  newMemoryInput: CreateMemoryInput
+): Promise<MemoryEntry> {
+  // Create the new memory
+  const newMemory = await createMemory(pool, newMemoryInput);
+
+  // Mark the old memory as superseded
+  await pool.query(
+    'UPDATE memory SET superseded_by = $1, updated_at = NOW() WHERE id = $2',
+    [newMemory.id, oldMemoryId]
+  );
+
+  return newMemory;
+}
+
+/**
+ * Cleans up expired memories.
+ */
+export async function cleanupExpiredMemories(pool: Pool): Promise<number> {
+  const result = await pool.query(
+    `DELETE FROM memory
+     WHERE expires_at IS NOT NULL AND expires_at < NOW()
+     RETURNING id`
+  );
+  return result.rows.length;
+}
+
+/**
+ * Searches memories semantically using embeddings or falls back to text search.
+ */
+export async function searchMemories(
+  pool: Pool,
+  query: string,
+  options: SearchMemoriesOptions = {}
+): Promise<MemorySearchResult> {
+  const limit = Math.min(options.limit ?? 20, 100);
+  const offset = options.offset ?? 0;
+  const minSimilarity = options.minSimilarity ?? 0.3;
+
+  // Try semantic search first
+  try {
+    const { embeddingService } = await import('../embeddings/index.ts');
+
+    if (embeddingService.isConfigured()) {
+      const embeddingResult = await embeddingService.embed(query);
+
+      if (embeddingResult) {
+        const queryEmbedding = embeddingResult.embedding;
+        // Build semantic search conditions with proper indexing
+        // $1 = embedding, $2 = minSimilarity, then filter params, then limit/offset
+        const semanticConditions: string[] = [
+          '(expires_at IS NULL OR expires_at > NOW())',
+          'superseded_by IS NULL',
+        ];
+        const semanticParams: unknown[] = [];
+        let semanticIdx = 3; // Start after embedding and minSimilarity
+
+        if (options.userEmail !== undefined) {
+          semanticConditions.push(`user_email = $${semanticIdx}`);
+          semanticParams.push(options.userEmail);
+          semanticIdx++;
+        }
+        if (options.workItemId !== undefined) {
+          semanticConditions.push(`work_item_id = $${semanticIdx}`);
+          semanticParams.push(options.workItemId);
+          semanticIdx++;
+        }
+        if (options.contactId !== undefined) {
+          semanticConditions.push(`contact_id = $${semanticIdx}`);
+          semanticParams.push(options.contactId);
+          semanticIdx++;
+        }
+        if (options.memoryType !== undefined) {
+          semanticConditions.push(`memory_type = $${semanticIdx}::memory_type`);
+          semanticParams.push(options.memoryType);
+          semanticIdx++;
+        }
+
+        const embeddingStr = `[${queryEmbedding.join(',')}]`;
+        const allParams = [embeddingStr, minSimilarity, ...semanticParams, limit, offset];
+        const whereClause = semanticConditions.length > 0 ? `AND ${semanticConditions.join(' AND ')}` : '';
+
+        const result = await pool.query(
+          `SELECT
+            id::text, user_email, work_item_id::text, contact_id::text,
+            title, content, memory_type::text,
+            created_by_agent, created_by_human, source_url,
+            importance, confidence, expires_at, superseded_by::text,
+            embedding_status, created_at, updated_at,
+            1 - (embedding <=> $1::vector) as similarity
+          FROM memory
+          WHERE embedding IS NOT NULL
+            AND 1 - (embedding <=> $1::vector) >= $2
+            ${whereClause}
+          ORDER BY similarity DESC, importance DESC
+          LIMIT $${semanticIdx} OFFSET $${semanticIdx + 1}`,
+          allParams
+        );
+
+        return {
+          results: result.rows.map((row) => ({
+            ...mapRowToMemory(row as Record<string, unknown>),
+            similarity: parseFloat(row.similarity as string),
+          })),
+          searchType: 'semantic',
+          queryEmbeddingProvider: embeddingResult.provider,
+        };
+      }
+    }
+  } catch (error) {
+    console.warn('[Memory] Semantic search failed, falling back to text search:', error);
+  }
+
+  // Fall back to text search
+  // Build text search conditions with proper indexing
+  // $1 = query text, then filter params, then limit/offset
+  const textConditions: string[] = [
+    '(expires_at IS NULL OR expires_at > NOW())',
+    'superseded_by IS NULL',
+  ];
+  const textParams: unknown[] = [query];
+  let textIdx = 2; // Start after query
+
+  if (options.userEmail !== undefined) {
+    textConditions.push(`user_email = $${textIdx}`);
+    textParams.push(options.userEmail);
+    textIdx++;
+  }
+  if (options.workItemId !== undefined) {
+    textConditions.push(`work_item_id = $${textIdx}`);
+    textParams.push(options.workItemId);
+    textIdx++;
+  }
+  if (options.contactId !== undefined) {
+    textConditions.push(`contact_id = $${textIdx}`);
+    textParams.push(options.contactId);
+    textIdx++;
+  }
+  if (options.memoryType !== undefined) {
+    textConditions.push(`memory_type = $${textIdx}::memory_type`);
+    textParams.push(options.memoryType);
+    textIdx++;
+  }
+
+  textParams.push(limit, offset);
+  const whereClause = textConditions.length > 0 ? `AND ${textConditions.join(' AND ')}` : '';
+
+  const result = await pool.query(
+    `SELECT
+      id::text, user_email, work_item_id::text, contact_id::text,
+      title, content, memory_type::text,
+      created_by_agent, created_by_human, source_url,
+      importance, confidence, expires_at, superseded_by::text,
+      embedding_status, created_at, updated_at,
+      ts_rank(search_vector, websearch_to_tsquery('english', $1)) as similarity
+    FROM memory
+    WHERE search_vector @@ websearch_to_tsquery('english', $1)
+      ${whereClause}
+    ORDER BY similarity DESC, importance DESC
+    LIMIT $${textIdx} OFFSET $${textIdx + 1}`,
+    textParams
+  );
+
+  return {
+    results: result.rows.map((row) => ({
+      ...mapRowToMemory(row as Record<string, unknown>),
+      similarity: parseFloat(row.similarity as string),
+    })),
+    searchType: 'text',
+  };
+}

--- a/src/api/memory/types.ts
+++ b/src/api/memory/types.ts
@@ -1,0 +1,109 @@
+/**
+ * Memory types for the unified memory system.
+ * Part of Epic #199, Issue #209
+ */
+
+/** Valid memory types */
+export type MemoryType = 'preference' | 'fact' | 'note' | 'decision' | 'context' | 'reference';
+
+/** Memory scoping options */
+export interface MemoryScope {
+  /** User email for global scope */
+  userEmail?: string;
+  /** Work item ID for work item scope */
+  workItemId?: string;
+  /** Contact ID for contact scope */
+  contactId?: string;
+}
+
+/** Attribution metadata for a memory */
+export interface MemoryAttribution {
+  /** Agent that created this memory */
+  createdByAgent?: string;
+  /** Whether created by a human (vs agent) */
+  createdByHuman?: boolean;
+  /** Source URL for external references */
+  sourceUrl?: string;
+}
+
+/** Lifecycle metadata for a memory */
+export interface MemoryLifecycle {
+  /** Importance score 1-10 */
+  importance?: number;
+  /** Confidence score 0-1 */
+  confidence?: number;
+  /** When the memory expires (for temporary context) */
+  expiresAt?: Date;
+  /** ID of memory that supersedes this one */
+  supersededBy?: string;
+}
+
+/** Input for creating a new memory */
+export interface CreateMemoryInput extends MemoryScope, MemoryAttribution, MemoryLifecycle {
+  title: string;
+  content: string;
+  memoryType?: MemoryType;
+}
+
+/** Input for updating a memory */
+export interface UpdateMemoryInput {
+  title?: string;
+  content?: string;
+  memoryType?: MemoryType;
+  importance?: number;
+  confidence?: number;
+  expiresAt?: Date | null;
+  supersededBy?: string | null;
+}
+
+/** A memory entry from the database */
+export interface MemoryEntry {
+  id: string;
+  userEmail: string | null;
+  workItemId: string | null;
+  contactId: string | null;
+  title: string;
+  content: string;
+  memoryType: MemoryType;
+  createdByAgent: string | null;
+  createdByHuman: boolean;
+  sourceUrl: string | null;
+  importance: number;
+  confidence: number;
+  expiresAt: Date | null;
+  supersededBy: string | null;
+  embeddingStatus: 'pending' | 'complete' | 'failed';
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/** Query options for listing memories */
+export interface ListMemoriesOptions extends MemoryScope {
+  status?: 'pending' | 'dispatched' | 'failed';
+  memoryType?: MemoryType;
+  includeExpired?: boolean;
+  includeSuperseded?: boolean;
+  limit?: number;
+  offset?: number;
+}
+
+/** Result of listing memories */
+export interface ListMemoriesResult {
+  memories: MemoryEntry[];
+  total: number;
+}
+
+/** Result of semantic memory search */
+export interface MemorySearchResult {
+  results: Array<MemoryEntry & { similarity: number }>;
+  searchType: 'semantic' | 'text';
+  queryEmbeddingProvider?: string;
+}
+
+/** Options for semantic search */
+export interface SearchMemoriesOptions extends MemoryScope {
+  memoryType?: MemoryType;
+  limit?: number;
+  offset?: number;
+  minSimilarity?: number;
+}

--- a/src/api/search/service.ts
+++ b/src/api/search/service.ts
@@ -160,7 +160,7 @@ async function searchMemoriesText(
        memory_type::text as memory_type,
        work_item_id::text as work_item_id,
        ts_rank(search_vector, plainto_tsquery('english', $1)) as rank
-     FROM work_item_memory
+     FROM memory
      WHERE ${conditions.join(' AND ')}
      ORDER BY rank DESC
      LIMIT $${paramIndex} OFFSET $${paramIndex + 1}`,
@@ -265,7 +265,7 @@ async function searchMemoriesSemantic(
        memory_type::text as memory_type,
        work_item_id::text as work_item_id,
        1 - (embedding <=> $1::vector) as similarity
-     FROM work_item_memory
+     FROM memory
      WHERE ${conditions.join(' AND ')}
      ORDER BY embedding <=> $1::vector
      LIMIT $${paramIndex} OFFSET $${paramIndex + 1}`,
@@ -527,7 +527,7 @@ export async function countSearchResults(
 
   // Count memories
   const memoryCount = await pool.query(
-    `SELECT COUNT(*) FROM work_item_memory
+    `SELECT COUNT(*) FROM memory
      WHERE search_vector @@ plainto_tsquery('english', $1) ${workItemWhere}`,
     params
   );

--- a/tests/embeddings/memory-integration.test.ts
+++ b/tests/embeddings/memory-integration.test.ts
@@ -44,7 +44,7 @@ describe('Memory Embedding Integration', () => {
 
       // Create a memory
       const memory = await pool.query(
-        `INSERT INTO work_item_memory (work_item_id, title, content, memory_type)
+        `INSERT INTO memory (work_item_id, title, content, memory_type)
          VALUES ($1, 'User Preference', 'User prefers dark mode', 'note')
          RETURNING id::text as id`,
         [workItemId]
@@ -63,7 +63,7 @@ describe('Memory Embedding Integration', () => {
       // Verify embedding was stored
       const result = await pool.query(
         `SELECT embedding_status, embedding_provider, embedding_model, embedding
-         FROM work_item_memory WHERE id = $1`,
+         FROM memory WHERE id = $1`,
         [memoryId]
       );
 
@@ -96,7 +96,7 @@ describe('Memory Embedding Integration', () => {
 
         // Create a memory
         const memory = await pool.query(
-          `INSERT INTO work_item_memory (work_item_id, title, content, memory_type)
+          `INSERT INTO memory (work_item_id, title, content, memory_type)
            VALUES ($1, 'Test Memory', 'Test content', 'note')
            RETURNING id::text as id`,
           [workItemId]
@@ -110,7 +110,7 @@ describe('Memory Embedding Integration', () => {
 
         // Verify status was updated
         const result = await pool.query(
-          `SELECT embedding_status FROM work_item_memory WHERE id = $1`,
+          `SELECT embedding_status FROM memory WHERE id = $1`,
           [memoryId]
         );
         expect((result.rows[0] as { embedding_status: string }).embedding_status).toBe('pending');
@@ -143,7 +143,7 @@ describe('Memory Embedding Integration', () => {
 
       for (const mem of memories) {
         const result = await pool.query(
-          `INSERT INTO work_item_memory (work_item_id, title, content, memory_type)
+          `INSERT INTO memory (work_item_id, title, content, memory_type)
            VALUES ($1, $2, $3, 'note')
            RETURNING id::text as id`,
           [workItemId, mem.title, mem.content]
@@ -183,7 +183,7 @@ describe('Memory Embedding Integration', () => {
 
         // Create a memory (no embedding)
         await pool.query(
-          `INSERT INTO work_item_memory (work_item_id, title, content, memory_type)
+          `INSERT INTO memory (work_item_id, title, content, memory_type)
            VALUES ($1, 'Test Memory with Keyword', 'Contains the keyword searchterm', 'note')`,
           [workItemId]
         );
@@ -216,7 +216,7 @@ describe('Memory Embedding Integration', () => {
 
       // Create memories without embeddings
       await pool.query(
-        `INSERT INTO work_item_memory (work_item_id, title, content, memory_type, embedding_status)
+        `INSERT INTO memory (work_item_id, title, content, memory_type, embedding_status)
          VALUES ($1, 'Memory 1', 'Content 1', 'note', 'pending'),
                 ($1, 'Memory 2', 'Content 2', 'note', 'pending')`,
         [workItemId]
@@ -231,7 +231,7 @@ describe('Memory Embedding Integration', () => {
 
       // Verify embeddings were created
       const memories = await pool.query(
-        `SELECT embedding_status FROM work_item_memory WHERE work_item_id = $1`,
+        `SELECT embedding_status FROM memory WHERE work_item_id = $1`,
         [workItemId]
       );
       for (const row of memories.rows as Array<{ embedding_status: string }>) {

--- a/tests/helpers/db.ts
+++ b/tests/helpers/db.ts
@@ -57,6 +57,7 @@ const APPLICATION_TABLES = [
   'webhook_outbox',
   'internal_job',
   // Parents
+  'memory',
   'work_item_memory',
   'work_item',
   'contact',

--- a/tests/memory/service.test.ts
+++ b/tests/memory/service.test.ts
@@ -1,0 +1,532 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { Pool } from 'pg';
+import { runMigrate } from '../helpers/migrate.js';
+import { createTestPool, truncateAllTables } from '../helpers/db.js';
+import {
+  createMemory,
+  getMemory,
+  updateMemory,
+  deleteMemory,
+  listMemories,
+  getGlobalMemories,
+  supersedeMemory,
+  cleanupExpiredMemories,
+  searchMemories,
+  isValidMemoryType,
+} from '../../src/api/memory/index.ts';
+
+describe('Memory Service', () => {
+  let pool: Pool;
+
+  beforeAll(async () => {
+    await runMigrate('up');
+    pool = createTestPool();
+  });
+
+  beforeEach(async () => {
+    await truncateAllTables(pool);
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  describe('isValidMemoryType', () => {
+    it('returns true for valid memory types', () => {
+      expect(isValidMemoryType('preference')).toBe(true);
+      expect(isValidMemoryType('fact')).toBe(true);
+      expect(isValidMemoryType('note')).toBe(true);
+      expect(isValidMemoryType('decision')).toBe(true);
+      expect(isValidMemoryType('context')).toBe(true);
+      expect(isValidMemoryType('reference')).toBe(true);
+    });
+
+    it('returns false for invalid memory types', () => {
+      expect(isValidMemoryType('invalid')).toBe(false);
+      expect(isValidMemoryType('')).toBe(false);
+      expect(isValidMemoryType('PREFERENCE')).toBe(false);
+    });
+  });
+
+  describe('createMemory', () => {
+    it('creates a global memory with user email only', async () => {
+      const memory = await createMemory(pool, {
+        userEmail: 'test@example.com',
+        title: 'Test preference',
+        content: 'User prefers dark mode',
+        memoryType: 'preference',
+      });
+
+      expect(memory.id).toBeDefined();
+      expect(memory.userEmail).toBe('test@example.com');
+      expect(memory.workItemId).toBeNull();
+      expect(memory.contactId).toBeNull();
+      expect(memory.title).toBe('Test preference');
+      expect(memory.content).toBe('User prefers dark mode');
+      expect(memory.memoryType).toBe('preference');
+      expect(memory.importance).toBe(5);
+      expect(memory.confidence).toBe(1.0);
+      expect(memory.embeddingStatus).toBe('pending');
+    });
+
+    it('creates a memory with work item scope', async () => {
+      // First create a work item
+      const workItemResult = await pool.query(
+        `INSERT INTO work_item (title, work_item_kind, status)
+         VALUES ('Test Project', 'project', 'open')
+         RETURNING id::text as id`
+      );
+      const workItemId = (workItemResult.rows[0] as { id: string }).id;
+
+      const memory = await createMemory(pool, {
+        userEmail: 'test@example.com',
+        workItemId,
+        title: 'Tech decision',
+        content: 'Chose PostgreSQL for ACID compliance',
+        memoryType: 'decision',
+      });
+
+      expect(memory.workItemId).toBe(workItemId);
+      expect(memory.memoryType).toBe('decision');
+    });
+
+    it('creates a memory with contact scope', async () => {
+      // First create a contact
+      const contactResult = await pool.query(
+        `INSERT INTO contact (display_name)
+         VALUES ('John Doe')
+         RETURNING id::text as id`
+      );
+      const contactId = (contactResult.rows[0] as { id: string }).id;
+
+      const memory = await createMemory(pool, {
+        userEmail: 'test@example.com',
+        contactId,
+        title: 'Contact preference',
+        content: 'John prefers email communication',
+        memoryType: 'fact',
+      });
+
+      expect(memory.contactId).toBe(contactId);
+      expect(memory.memoryType).toBe('fact');
+    });
+
+    it('creates a memory with full attribution', async () => {
+      const memory = await createMemory(pool, {
+        userEmail: 'test@example.com',
+        title: 'Agent note',
+        content: 'User mentioned they like pizza',
+        memoryType: 'fact',
+        createdByAgent: 'openclaw-pi',
+        sourceUrl: 'https://example.com/conversation/123',
+      });
+
+      expect(memory.createdByAgent).toBe('openclaw-pi');
+      expect(memory.createdByHuman).toBe(false);
+      expect(memory.sourceUrl).toBe('https://example.com/conversation/123');
+    });
+
+    it('creates a memory with custom importance and confidence', async () => {
+      const memory = await createMemory(pool, {
+        userEmail: 'test@example.com',
+        title: 'Important fact',
+        content: 'User is allergic to peanuts',
+        memoryType: 'fact',
+        importance: 10,
+        confidence: 0.95,
+      });
+
+      expect(memory.importance).toBe(10);
+      expect(memory.confidence).toBe(0.95);
+    });
+
+    it('creates a memory with expiry', async () => {
+      const expiresAt = new Date(Date.now() + 3600000); // 1 hour from now
+
+      const memory = await createMemory(pool, {
+        userEmail: 'test@example.com',
+        title: 'Temporary context',
+        content: 'Currently in a meeting',
+        memoryType: 'context',
+        expiresAt,
+      });
+
+      expect(memory.expiresAt).toBeDefined();
+      expect(Math.abs(memory.expiresAt!.getTime() - expiresAt.getTime())).toBeLessThan(1000);
+    });
+
+    it('throws on invalid memory type', async () => {
+      await expect(
+        createMemory(pool, {
+          userEmail: 'test@example.com',
+          title: 'Test',
+          content: 'Test',
+          memoryType: 'invalid' as any,
+        })
+      ).rejects.toThrow('Invalid memory type');
+    });
+  });
+
+  describe('getMemory', () => {
+    it('returns a memory by ID', async () => {
+      const created = await createMemory(pool, {
+        userEmail: 'test@example.com',
+        title: 'Test memory',
+        content: 'Test content',
+      });
+
+      const retrieved = await getMemory(pool, created.id);
+
+      expect(retrieved).not.toBeNull();
+      expect(retrieved!.id).toBe(created.id);
+      expect(retrieved!.title).toBe('Test memory');
+    });
+
+    it('returns null for non-existent memory', async () => {
+      const result = await getMemory(pool, '00000000-0000-0000-0000-000000000000');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('updateMemory', () => {
+    it('updates memory title and content', async () => {
+      const created = await createMemory(pool, {
+        userEmail: 'test@example.com',
+        title: 'Original title',
+        content: 'Original content',
+      });
+
+      const updated = await updateMemory(pool, created.id, {
+        title: 'Updated title',
+        content: 'Updated content',
+      });
+
+      expect(updated!.title).toBe('Updated title');
+      expect(updated!.content).toBe('Updated content');
+      expect(updated!.embeddingStatus).toBe('pending'); // Reset on content change
+    });
+
+    it('updates memory type', async () => {
+      const created = await createMemory(pool, {
+        userEmail: 'test@example.com',
+        title: 'Test',
+        content: 'Test',
+        memoryType: 'note',
+      });
+
+      const updated = await updateMemory(pool, created.id, {
+        memoryType: 'decision',
+      });
+
+      expect(updated!.memoryType).toBe('decision');
+    });
+
+    it('updates importance and confidence', async () => {
+      const created = await createMemory(pool, {
+        userEmail: 'test@example.com',
+        title: 'Test',
+        content: 'Test',
+      });
+
+      const updated = await updateMemory(pool, created.id, {
+        importance: 9,
+        confidence: 0.8,
+      });
+
+      expect(updated!.importance).toBe(9);
+      expect(updated!.confidence).toBe(0.8);
+    });
+
+    it('returns null for non-existent memory', async () => {
+      const result = await updateMemory(pool, '00000000-0000-0000-0000-000000000000', {
+        title: 'New title',
+      });
+      expect(result).toBeNull();
+    });
+
+    it('throws on invalid importance', async () => {
+      const created = await createMemory(pool, {
+        userEmail: 'test@example.com',
+        title: 'Test',
+        content: 'Test',
+      });
+
+      await expect(
+        updateMemory(pool, created.id, { importance: 11 })
+      ).rejects.toThrow('Importance must be between 1 and 10');
+    });
+
+    it('throws on invalid confidence', async () => {
+      const created = await createMemory(pool, {
+        userEmail: 'test@example.com',
+        title: 'Test',
+        content: 'Test',
+      });
+
+      await expect(
+        updateMemory(pool, created.id, { confidence: 1.5 })
+      ).rejects.toThrow('Confidence must be between 0 and 1');
+    });
+  });
+
+  describe('deleteMemory', () => {
+    it('deletes a memory', async () => {
+      const created = await createMemory(pool, {
+        userEmail: 'test@example.com',
+        title: 'To be deleted',
+        content: 'Test',
+      });
+
+      const deleted = await deleteMemory(pool, created.id);
+      expect(deleted).toBe(true);
+
+      const retrieved = await getMemory(pool, created.id);
+      expect(retrieved).toBeNull();
+    });
+
+    it('returns false for non-existent memory', async () => {
+      const result = await deleteMemory(pool, '00000000-0000-0000-0000-000000000000');
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('listMemories', () => {
+    it('lists all memories', async () => {
+      await createMemory(pool, { userEmail: 'test@example.com', title: 'Memory 1', content: 'Content 1' });
+      await createMemory(pool, { userEmail: 'test@example.com', title: 'Memory 2', content: 'Content 2' });
+
+      const result = await listMemories(pool);
+
+      expect(result.memories.length).toBe(2);
+      expect(result.total).toBe(2);
+    });
+
+    it('filters by user email', async () => {
+      await createMemory(pool, { userEmail: 'user1@example.com', title: 'Memory 1', content: 'Content 1' });
+      await createMemory(pool, { userEmail: 'user2@example.com', title: 'Memory 2', content: 'Content 2' });
+
+      const result = await listMemories(pool, { userEmail: 'user1@example.com' });
+
+      expect(result.memories.length).toBe(1);
+      expect(result.memories[0].userEmail).toBe('user1@example.com');
+    });
+
+    it('filters by memory type', async () => {
+      await createMemory(pool, { userEmail: 'test@example.com', title: 'Pref', content: 'C1', memoryType: 'preference' });
+      await createMemory(pool, { userEmail: 'test@example.com', title: 'Fact', content: 'C2', memoryType: 'fact' });
+
+      const result = await listMemories(pool, { memoryType: 'preference' });
+
+      expect(result.memories.length).toBe(1);
+      expect(result.memories[0].memoryType).toBe('preference');
+    });
+
+    it('excludes expired memories by default', async () => {
+      await createMemory(pool, {
+        userEmail: 'test@example.com',
+        title: 'Active',
+        content: 'Not expired',
+      });
+
+      // Create expired memory by directly setting past date
+      await pool.query(
+        `INSERT INTO memory (user_email, title, content, memory_type, expires_at)
+         VALUES ($1, $2, $3, 'note', NOW() - INTERVAL '1 hour')`,
+        ['test@example.com', 'Expired', 'Already expired']
+      );
+
+      const result = await listMemories(pool);
+
+      expect(result.memories.length).toBe(1);
+      expect(result.memories[0].title).toBe('Active');
+    });
+
+    it('includes expired memories when requested', async () => {
+      await createMemory(pool, { userEmail: 'test@example.com', title: 'Active', content: 'Not expired' });
+
+      await pool.query(
+        `INSERT INTO memory (user_email, title, content, memory_type, expires_at)
+         VALUES ($1, $2, $3, 'note', NOW() - INTERVAL '1 hour')`,
+        ['test@example.com', 'Expired', 'Already expired']
+      );
+
+      const result = await listMemories(pool, { includeExpired: true });
+
+      expect(result.memories.length).toBe(2);
+    });
+
+    it('respects pagination', async () => {
+      for (let i = 0; i < 5; i++) {
+        await createMemory(pool, { userEmail: 'test@example.com', title: `Memory ${i}`, content: 'C' });
+      }
+
+      const result = await listMemories(pool, { limit: 2, offset: 1 });
+
+      expect(result.memories.length).toBe(2);
+      expect(result.total).toBe(5);
+    });
+  });
+
+  describe('getGlobalMemories', () => {
+    it('returns only global memories for a user', async () => {
+      // Global memory (no work_item_id or contact_id)
+      await createMemory(pool, {
+        userEmail: 'test@example.com',
+        title: 'Global preference',
+        content: 'Dark mode',
+        memoryType: 'preference',
+      });
+
+      // Work item scoped memory
+      const workItemResult = await pool.query(
+        `INSERT INTO work_item (title, work_item_kind, status)
+         VALUES ('Test', 'project', 'open')
+         RETURNING id::text as id`
+      );
+      await createMemory(pool, {
+        userEmail: 'test@example.com',
+        workItemId: (workItemResult.rows[0] as { id: string }).id,
+        title: 'Work item memory',
+        content: 'Scoped to work item',
+      });
+
+      const result = await getGlobalMemories(pool, 'test@example.com');
+
+      expect(result.memories.length).toBe(1);
+      expect(result.memories[0].title).toBe('Global preference');
+    });
+  });
+
+  describe('supersedeMemory', () => {
+    it('creates new memory and marks old as superseded', async () => {
+      const oldMemory = await createMemory(pool, {
+        userEmail: 'test@example.com',
+        title: 'Old fact',
+        content: 'Outdated information',
+        memoryType: 'fact',
+      });
+
+      const newMemory = await supersedeMemory(pool, oldMemory.id, {
+        userEmail: 'test@example.com',
+        title: 'New fact',
+        content: 'Updated information',
+        memoryType: 'fact',
+      });
+
+      expect(newMemory.id).not.toBe(oldMemory.id);
+
+      // Check old memory is marked as superseded
+      const oldUpdated = await getMemory(pool, oldMemory.id);
+      expect(oldUpdated!.supersededBy).toBe(newMemory.id);
+    });
+  });
+
+  describe('cleanupExpiredMemories', () => {
+    it('deletes expired memories', async () => {
+      // Create active memory
+      await createMemory(pool, {
+        userEmail: 'test@example.com',
+        title: 'Active',
+        content: 'Still valid',
+      });
+
+      // Create expired memory
+      await pool.query(
+        `INSERT INTO memory (user_email, title, content, memory_type, expires_at)
+         VALUES ($1, $2, $3, 'note', NOW() - INTERVAL '1 hour')`,
+        ['test@example.com', 'Expired', 'Should be deleted']
+      );
+
+      const deleted = await cleanupExpiredMemories(pool);
+
+      expect(deleted).toBe(1);
+
+      const remaining = await listMemories(pool, { includeExpired: true });
+      expect(remaining.total).toBe(1);
+      expect(remaining.memories[0].title).toBe('Active');
+    });
+  });
+
+  describe('searchMemories', () => {
+    it('searches memories using semantic search when embeddings configured', async () => {
+      // Create memories with embeddings populated
+      const memory = await createMemory(pool, {
+        userEmail: 'test@example.com',
+        title: 'Pizza preference',
+        content: 'User loves pepperoni pizza',
+        memoryType: 'preference',
+      });
+
+      await createMemory(pool, {
+        userEmail: 'test@example.com',
+        title: 'Coffee preference',
+        content: 'User drinks black coffee',
+        memoryType: 'preference',
+      });
+
+      // Manually populate an embedding for the pizza memory for testing
+      // Using a dummy embedding vector of correct dimension (1024)
+      const dummyEmbedding = new Array(1024).fill(0.1);
+      await pool.query(
+        `UPDATE memory SET embedding = $1::vector, embedding_status = 'complete' WHERE id = $2`,
+        [`[${dummyEmbedding.join(',')}]`, memory.id]
+      );
+
+      const result = await searchMemories(pool, 'pizza');
+
+      // Should use semantic search since embeddings are configured
+      expect(result.searchType).toBe('semantic');
+      // May or may not find results depending on similarity threshold
+    });
+
+    it('falls back to text search when no embeddings match', async () => {
+      // Create memories without populating embeddings
+      await createMemory(pool, {
+        userEmail: 'test@example.com',
+        title: 'Pizza preference',
+        content: 'User loves pepperoni pizza',
+        memoryType: 'preference',
+      });
+
+      // With no embeddings populated, semantic search returns empty and we fall through
+      // Actually with voyageai configured, it tries semantic first
+      // The test just needs to verify search works
+      const result = await searchMemories(pool, 'pizza');
+
+      // Should still complete without error
+      expect(result.searchType).toBeDefined();
+    });
+
+    it('filters search by memory type', async () => {
+      const pref = await createMemory(pool, {
+        userEmail: 'test@example.com',
+        title: 'Pizza preference',
+        content: 'User loves pizza',
+        memoryType: 'preference',
+      });
+
+      const fact = await createMemory(pool, {
+        userEmail: 'test@example.com',
+        title: 'Pizza fact',
+        content: 'Pizza originated in Italy',
+        memoryType: 'fact',
+      });
+
+      // Populate embeddings for both
+      const dummyEmbedding = new Array(1024).fill(0.1);
+      await pool.query(
+        `UPDATE memory SET embedding = $1::vector, embedding_status = 'complete' WHERE id = ANY($2::uuid[])`,
+        [`[${dummyEmbedding.join(',')}]`, [pref.id, fact.id]]
+      );
+
+      const result = await searchMemories(pool, 'pizza', { memoryType: 'preference' });
+
+      // Should filter to preference type only
+      if (result.results.length > 0) {
+        expect(result.results[0].memoryType).toBe('preference');
+      }
+      // At minimum, verify no facts are returned
+      expect(result.results.every(r => r.memoryType !== 'fact')).toBe(true);
+    });
+  });
+});

--- a/tests/memory_crud_api.test.ts
+++ b/tests/memory_crud_api.test.ts
@@ -255,7 +255,7 @@ describe('Memory CRUD API (issue #121)', () => {
 
       // Verify deletion
       const check = await pool.query(
-        'SELECT 1 FROM work_item_memory WHERE id = $1',
+        'SELECT 1 FROM memory WHERE id = $1',
         [memoryId]
       );
       expect(check.rows.length).toBe(0);

--- a/tests/memory_items_detail.test.ts
+++ b/tests/memory_items_detail.test.ts
@@ -39,7 +39,7 @@ describe('Memory Items in Work Item Detail', () => {
 
       // Create some memories
       await pool.query(
-        `INSERT INTO work_item_memory (work_item_id, title, content, memory_type)
+        `INSERT INTO memory (work_item_id, title, content, memory_type)
          VALUES ($1, 'Decision Note', 'We decided to use TypeScript', 'decision'),
                 ($1, 'Context Info', 'This is background information', 'context')`,
         [itemId]
@@ -141,7 +141,7 @@ describe('Memory Items in Work Item Detail', () => {
       const itemId = (item.rows[0] as { id: string }).id;
 
       const memory = await pool.query(
-        `INSERT INTO work_item_memory (work_item_id, title, content, memory_type)
+        `INSERT INTO memory (work_item_id, title, content, memory_type)
          VALUES ($1, 'Original Title', 'Original content', 'note')
          RETURNING id::text as id`,
         [itemId]
@@ -184,7 +184,7 @@ describe('Memory Items in Work Item Detail', () => {
       const itemId = (item.rows[0] as { id: string }).id;
 
       const memory = await pool.query(
-        `INSERT INTO work_item_memory (work_item_id, title, content, memory_type)
+        `INSERT INTO memory (work_item_id, title, content, memory_type)
          VALUES ($1, 'To Delete', 'Delete me', 'note')
          RETURNING id::text as id`,
         [itemId]

--- a/tests/memory_relationships_api.test.ts
+++ b/tests/memory_relationships_api.test.ts
@@ -49,7 +49,7 @@ describe('Memory Relationships API', () => {
     content: string
   ): Promise<string> {
     const result = await pool.query(
-      `INSERT INTO work_item_memory (work_item_id, title, content, memory_type)
+      `INSERT INTO memory (work_item_id, title, content, memory_type)
        VALUES ($1, $2, $3, 'note')
        RETURNING id::text as id`,
       [workItemId, title, content]

--- a/tests/memory_search_api.test.ts
+++ b/tests/memory_search_api.test.ts
@@ -53,7 +53,7 @@ describe('Memory Search API', () => {
 
       // Create a memory
       await pool.query(
-        `INSERT INTO work_item_memory (work_item_id, title, content, memory_type)
+        `INSERT INTO memory (work_item_id, title, content, memory_type)
          VALUES ($1, 'Test Memory', 'Some content', 'note')`,
         [workItemId]
       );
@@ -144,7 +144,7 @@ describe('Memory Search API', () => {
 
       // Create memory
       const memory = await pool.query(
-        `INSERT INTO work_item_memory (work_item_id, title, content, memory_type, embedding_status)
+        `INSERT INTO memory (work_item_id, title, content, memory_type, embedding_status)
          VALUES ($1, 'Original Title', 'Original content', 'note', 'complete')
          RETURNING id::text as id`,
         [workItemId]
@@ -181,7 +181,7 @@ describe('Memory Search API', () => {
 
       // Create memories without embeddings
       await pool.query(
-        `INSERT INTO work_item_memory (work_item_id, title, content, memory_type, embedding_status)
+        `INSERT INTO memory (work_item_id, title, content, memory_type, embedding_status)
          VALUES ($1, 'Memory 1', 'Content 1', 'note', 'pending'),
                 ($1, 'Memory 2', 'Content 2', 'note', 'pending')`,
         [workItemId]

--- a/tests/unified_memory_api.test.ts
+++ b/tests/unified_memory_api.test.ts
@@ -1,0 +1,340 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { Pool } from 'pg';
+import { buildServer } from '../src/api/server.ts';
+import { runMigrate } from './helpers/migrate.js';
+import { createTestPool, truncateAllTables } from './helpers/db.js';
+
+describe('Unified Memory API (Issue #209)', () => {
+  const app = buildServer();
+  let pool: Pool;
+
+  beforeAll(async () => {
+    await runMigrate('up');
+    pool = createTestPool();
+    await app.ready();
+  });
+
+  beforeEach(async () => {
+    await truncateAllTables(pool);
+  });
+
+  afterAll(async () => {
+    await app.close();
+    await pool.end();
+  });
+
+  describe('POST /api/memories/unified', () => {
+    it('creates a global memory with user email only', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/memories/unified',
+        payload: {
+          title: 'User preference',
+          content: 'User prefers dark mode',
+          memory_type: 'preference',
+          user_email: 'test@example.com',
+        },
+      });
+
+      expect(res.statusCode).toBe(201);
+      const body = res.json();
+      expect(body.id).toBeDefined();
+      expect(body.userEmail).toBe('test@example.com');
+      expect(body.workItemId).toBeNull();
+      expect(body.contactId).toBeNull();
+      expect(body.memoryType).toBe('preference');
+    });
+
+    it('creates memory with work item scope', async () => {
+      // Create a work item first
+      const wiResult = await pool.query(
+        `INSERT INTO work_item (title, work_item_kind, status)
+         VALUES ('Test Project', 'project', 'open')
+         RETURNING id::text as id`
+      );
+      const workItemId = (wiResult.rows[0] as { id: string }).id;
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/memories/unified',
+        payload: {
+          title: 'Tech decision',
+          content: 'Chose PostgreSQL for ACID compliance',
+          memory_type: 'decision',
+          user_email: 'test@example.com',
+          work_item_id: workItemId,
+        },
+      });
+
+      expect(res.statusCode).toBe(201);
+      const body = res.json();
+      expect(body.workItemId).toBe(workItemId);
+    });
+
+    it('creates memory with contact scope', async () => {
+      // Create a contact first
+      const contactResult = await pool.query(
+        `INSERT INTO contact (display_name)
+         VALUES ('John Doe')
+         RETURNING id::text as id`
+      );
+      const contactId = (contactResult.rows[0] as { id: string }).id;
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/memories/unified',
+        payload: {
+          title: 'Contact preference',
+          content: 'John prefers email',
+          memory_type: 'fact',
+          user_email: 'test@example.com',
+          contact_id: contactId,
+        },
+      });
+
+      expect(res.statusCode).toBe(201);
+      const body = res.json();
+      expect(body.contactId).toBe(contactId);
+    });
+
+    it('creates memory with agent attribution', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/memories/unified',
+        payload: {
+          title: 'Agent note',
+          content: 'User mentioned liking pizza',
+          memory_type: 'fact',
+          created_by_agent: 'openclaw-pi',
+          source_url: 'https://example.com/conv/123',
+        },
+      });
+
+      expect(res.statusCode).toBe(201);
+      const body = res.json();
+      expect(body.createdByAgent).toBe('openclaw-pi');
+      expect(body.sourceUrl).toBe('https://example.com/conv/123');
+    });
+
+    it('creates memory with importance and confidence', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/memories/unified',
+        payload: {
+          title: 'Important fact',
+          content: 'User is allergic to peanuts',
+          memory_type: 'fact',
+          importance: 10,
+          confidence: 0.95,
+        },
+      });
+
+      expect(res.statusCode).toBe(201);
+      const body = res.json();
+      expect(body.importance).toBe(10);
+      expect(body.confidence).toBe(0.95);
+    });
+
+    it('returns 400 for invalid memory type', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/memories/unified',
+        payload: {
+          title: 'Test',
+          content: 'Test',
+          memory_type: 'invalid',
+        },
+      });
+
+      expect(res.statusCode).toBe(400);
+      expect(res.json().error).toContain('Invalid memory_type');
+    });
+
+    it('returns 400 when title is missing', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/memories/unified',
+        payload: {
+          content: 'Test',
+        },
+      });
+
+      expect(res.statusCode).toBe(400);
+      expect(res.json().error).toContain('title');
+    });
+  });
+
+  describe('GET /api/memories/unified', () => {
+    it('lists all memories', async () => {
+      await pool.query(
+        `INSERT INTO memory (title, content, memory_type, user_email)
+         VALUES ('Memory 1', 'Content 1', 'note', 'user1@example.com'),
+                ('Memory 2', 'Content 2', 'fact', 'user2@example.com')`
+      );
+
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/memories/unified',
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.memories.length).toBe(2);
+      expect(body.total).toBe(2);
+    });
+
+    it('filters by user email', async () => {
+      await pool.query(
+        `INSERT INTO memory (title, content, memory_type, user_email)
+         VALUES ('Memory 1', 'Content 1', 'note', 'user1@example.com'),
+                ('Memory 2', 'Content 2', 'note', 'user2@example.com')`
+      );
+
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/memories/unified?user_email=user1@example.com',
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.memories.length).toBe(1);
+      expect(body.memories[0].userEmail).toBe('user1@example.com');
+    });
+
+    it('filters by memory type', async () => {
+      await pool.query(
+        `INSERT INTO memory (title, content, memory_type)
+         VALUES ('Pref', 'Content 1', 'preference'),
+                ('Fact', 'Content 2', 'fact')`
+      );
+
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/memories/unified?memory_type=preference',
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.memories.length).toBe(1);
+      expect(body.memories[0].memoryType).toBe('preference');
+    });
+  });
+
+  describe('GET /api/memories/global', () => {
+    it('returns only global memories for a user', async () => {
+      // Create a work item
+      const wiResult = await pool.query(
+        `INSERT INTO work_item (title, work_item_kind, status)
+         VALUES ('Test', 'project', 'open')
+         RETURNING id::text as id`
+      );
+      const workItemId = (wiResult.rows[0] as { id: string }).id;
+
+      // Create global and work item scoped memories
+      await pool.query(
+        `INSERT INTO memory (title, content, memory_type, user_email)
+         VALUES ('Global', 'Content', 'preference', 'test@example.com')`
+      );
+      await pool.query(
+        `INSERT INTO memory (title, content, memory_type, user_email, work_item_id)
+         VALUES ('Scoped', 'Content', 'note', 'test@example.com', $1)`,
+        [workItemId]
+      );
+
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/memories/global?user_email=test@example.com',
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.memories.length).toBe(1);
+      expect(body.memories[0].title).toBe('Global');
+    });
+
+    it('returns 400 when user_email is missing', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/memories/global',
+      });
+
+      expect(res.statusCode).toBe(400);
+      expect(res.json().error).toContain('user_email');
+    });
+  });
+
+  describe('POST /api/memories/:id/supersede', () => {
+    it('supersedes a memory with a new one', async () => {
+      // Create original memory
+      const result = await pool.query(
+        `INSERT INTO memory (title, content, memory_type, user_email, importance)
+         VALUES ('Old fact', 'Outdated info', 'fact', 'test@example.com', 5)
+         RETURNING id::text as id`
+      );
+      const oldId = (result.rows[0] as { id: string }).id;
+
+      const res = await app.inject({
+        method: 'POST',
+        url: `/api/memories/${oldId}/supersede`,
+        payload: {
+          title: 'New fact',
+          content: 'Updated information',
+          importance: 8,
+        },
+      });
+
+      expect(res.statusCode).toBe(201);
+      const body = res.json();
+      expect(body.newMemory.title).toBe('New fact');
+      expect(body.newMemory.importance).toBe(8);
+      expect(body.supersededId).toBe(oldId);
+
+      // Verify old memory is marked superseded
+      const oldMemory = await pool.query(
+        `SELECT superseded_by::text FROM memory WHERE id = $1`,
+        [oldId]
+      );
+      expect(oldMemory.rows[0].superseded_by).toBe(body.newMemory.id);
+    });
+
+    it('returns 404 for non-existent memory', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/memories/00000000-0000-0000-0000-000000000000/supersede',
+        payload: {
+          title: 'New',
+          content: 'Content',
+        },
+      });
+
+      expect(res.statusCode).toBe(404);
+    });
+  });
+
+  describe('DELETE /api/memories/cleanup-expired', () => {
+    it('deletes expired memories', async () => {
+      // Create active and expired memories
+      await pool.query(
+        `INSERT INTO memory (title, content, memory_type)
+         VALUES ('Active', 'Content', 'note')`
+      );
+      await pool.query(
+        `INSERT INTO memory (title, content, memory_type, expires_at)
+         VALUES ('Expired', 'Content', 'note', NOW() - INTERVAL '1 hour')`
+      );
+
+      const res = await app.inject({
+        method: 'DELETE',
+        url: '/api/memories/cleanup-expired',
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.deleted).toBe(1);
+
+      // Verify only active remains
+      const remaining = await pool.query('SELECT COUNT(*) as count FROM memory');
+      expect(parseInt((remaining.rows[0] as { count: string }).count, 10)).toBe(1);
+    });
+  });
+});

--- a/tests/unified_search_api.test.ts
+++ b/tests/unified_search_api.test.ts
@@ -60,7 +60,7 @@ describe('Unified Search API', () => {
     content: string
   ): Promise<string> {
     const result = await pool.query(
-      `INSERT INTO work_item_memory (work_item_id, title, content, memory_type)
+      `INSERT INTO memory (work_item_id, title, content, memory_type)
        VALUES ($1, $2, $3, 'note')
        RETURNING id::text as id`,
       [workItemId, title, content]


### PR DESCRIPTION
## Summary

- Implements unified memory system with flexible scoping (global, work_item, contact, or combinations)
- Adds agent attribution for tracking which agent or human created each memory
- Adds lifecycle management with importance, confidence, expiry, and superseding
- Migrates existing data from work_item_memory to new unified memory table

## Implementation Details

### New Unified Memory Table
- **user_email**: Global scope for user preferences
- **work_item_id**: Work item scope for project context
- **contact_id**: Contact scope for relationship information
- All scopes can be combined (e.g., memory about a contact in a project context)

### Attribution Fields
- **created_by_agent**: Track which OpenClaw agent created the memory (e.g., "openclaw-pi")
- **created_by_human**: Boolean to distinguish human vs agent entries
- **source_url**: External reference URL for memory origin

### Lifecycle Management
- **importance** (1-10): Priority for retrieval, higher = more important
- **confidence** (0-1): Certainty level, lower = uncertain/unverified
- **expires_at**: For temporary context that should auto-expire
- **superseded_by**: Points to newer memory that replaces this one

### New API Endpoints
- `GET /api/memories/global?user_email=...` - List global memories for a user
- `POST /api/memories/unified` - Create memory with flexible scoping
- `GET /api/memories/unified?user_email=...&work_item_id=...&contact_id=...` - List with filters
- `POST /api/memories/:id/supersede` - Create new memory that supersedes an existing one
- `DELETE /api/memories/cleanup-expired` - Clean up expired memories

### Migration Path
- New migration 028 creates `memory` table and migrates data from `work_item_memory`
- Foreign keys in `memory_relationship` and `memory_contact` updated to reference `memory`
- All existing API endpoints updated to use `memory` table
- `work_item_id` uses `ON DELETE SET NULL` so memories persist when work items are deleted

## Test Plan
- [x] Memory service tests - 31 tests (types, CRUD, search, supersede, cleanup)
- [x] Unified memory API tests - 15 tests (all new endpoints)
- [x] Updated existing tests to use new memory table
- [x] All 1076 tests pass

Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)