### PR TITLE
[#219] Implement agent context bootstrap endpoint

### DIFF
--- a/src/api/bootstrap/index.ts
+++ b/src/api/bootstrap/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Bootstrap module exports.
+ * Part of Epic #199, Issue #219
+ */
+
+export * from './types.ts';
+export * from './service.ts';

--- a/src/api/bootstrap/service.ts
+++ b/src/api/bootstrap/service.ts
@@ -1,0 +1,398 @@
+/**
+ * Agent context bootstrap service.
+ * Part of Epic #199, Issue #219
+ */
+
+import type { Pool } from 'pg';
+import type {
+  BootstrapResponse,
+  BootstrapOptions,
+  BootstrapUser,
+  BootstrapPreference,
+  BootstrapProject,
+  BootstrapReminder,
+  BootstrapActivity,
+  BootstrapContact,
+  BootstrapStats,
+  BootstrapSection,
+} from './types.ts';
+import { BOOTSTRAP_SECTIONS } from './types.ts';
+
+/**
+ * Determines which sections to include based on options.
+ */
+function getSectionsToFetch(options: BootstrapOptions): Set<BootstrapSection> {
+  const sections = new Set<BootstrapSection>(BOOTSTRAP_SECTIONS);
+
+  if (options.include && options.include.length > 0) {
+    // If include is specified, only include those sections
+    sections.clear();
+    for (const section of options.include) {
+      if (BOOTSTRAP_SECTIONS.includes(section as BootstrapSection)) {
+        sections.add(section as BootstrapSection);
+      }
+    }
+  }
+
+  if (options.exclude) {
+    for (const section of options.exclude) {
+      sections.delete(section as BootstrapSection);
+    }
+  }
+
+  return sections;
+}
+
+/**
+ * Fetches user settings.
+ */
+async function fetchUser(pool: Pool, userEmail: string): Promise<BootstrapUser | null> {
+  const result = await pool.query(
+    `SELECT theme, default_view, default_project_id::text,
+            sidebar_collapsed, show_completed_items, items_per_page,
+            email_notifications, email_digest_frequency, timezone
+     FROM user_setting
+     WHERE email = $1`,
+    [userEmail]
+  );
+
+  if (result.rows.length === 0) {
+    return {
+      email: userEmail,
+      settings: {},
+    };
+  }
+
+  const row = result.rows[0] as Record<string, unknown>;
+  const settings: Record<string, unknown> = {};
+
+  // Map all available settings
+  for (const [key, value] of Object.entries(row)) {
+    if (value !== null) {
+      settings[key] = value;
+    }
+  }
+
+  return {
+    email: userEmail,
+    timezone: row.timezone as string | undefined,
+    settings,
+  };
+}
+
+/**
+ * Fetches user preferences (preference-type memories).
+ */
+async function fetchPreferences(
+  pool: Pool,
+  userEmail: string,
+  limit: number
+): Promise<BootstrapPreference[]> {
+  const result = await pool.query(
+    `SELECT id::text, memory_type as type, title, content, importance, created_at
+     FROM memory
+     WHERE user_email = $1
+       AND memory_type IN ('preference', 'fact')
+       AND (expires_at IS NULL OR expires_at > NOW())
+       AND superseded_by IS NULL
+     ORDER BY importance DESC, created_at DESC
+     LIMIT $2`,
+    [userEmail, limit]
+  );
+
+  return result.rows.map((row) => {
+    const r = row as {
+      id: string;
+      type: string;
+      title: string;
+      content: string;
+      importance: number;
+      created_at: string;
+    };
+    return {
+      id: r.id,
+      type: r.type,
+      title: r.title,
+      content: r.content,
+      importance: r.importance,
+      createdAt: new Date(r.created_at),
+    };
+  });
+}
+
+/**
+ * Fetches active projects.
+ */
+async function fetchActiveProjects(
+  pool: Pool,
+  limit: number
+): Promise<BootstrapProject[]> {
+  const result = await pool.query(
+    `SELECT id::text, title, status, work_item_kind::text as kind, updated_at
+     FROM work_item
+     WHERE work_item_kind::text IN ('project', 'epic', 'initiative')
+       AND status NOT IN ('completed', 'cancelled', 'archived')
+     ORDER BY updated_at DESC
+     LIMIT $1`,
+    [limit]
+  );
+
+  return result.rows.map((row) => {
+    const r = row as {
+      id: string;
+      title: string;
+      status: string;
+      kind: string;
+      updated_at: string;
+    };
+    return {
+      id: r.id,
+      title: r.title,
+      status: r.status,
+      kind: r.kind,
+      updatedAt: new Date(r.updated_at),
+    };
+  });
+}
+
+/**
+ * Fetches pending reminders (work items with not_before in the future).
+ */
+async function fetchPendingReminders(
+  pool: Pool,
+  limit: number
+): Promise<BootstrapReminder[]> {
+  const result = await pool.query(
+    `SELECT id::text, title, description, not_before, work_item_kind::text as kind
+     FROM work_item
+     WHERE not_before IS NOT NULL
+       AND not_before > NOW()
+       AND status NOT IN ('completed', 'cancelled', 'archived')
+     ORDER BY not_before ASC
+     LIMIT $1`,
+    [limit]
+  );
+
+  return result.rows.map((row) => {
+    const r = row as {
+      id: string;
+      title: string;
+      description: string | null;
+      not_before: string;
+      kind: string;
+    };
+    return {
+      id: r.id,
+      title: r.title,
+      description: r.description ?? undefined,
+      notBefore: new Date(r.not_before),
+      kind: r.kind,
+    };
+  });
+}
+
+/**
+ * Fetches recent activity.
+ */
+async function fetchRecentActivity(
+  pool: Pool,
+  limit: number
+): Promise<BootstrapActivity[]> {
+  // Activity is tracked in the activity table if it exists
+  // For now, we'll use work_item changes as a proxy
+  const result = await pool.query(
+    `SELECT
+       'work_item:updated' as type,
+       id::text as entity_id,
+       title as entity_title,
+       updated_at as timestamp
+     FROM work_item
+     WHERE updated_at > NOW() - INTERVAL '7 days'
+     ORDER BY updated_at DESC
+     LIMIT $1`,
+    [limit]
+  );
+
+  return result.rows.map((row) => {
+    const r = row as {
+      type: string;
+      entity_id: string;
+      entity_title: string;
+      timestamp: string;
+    };
+    return {
+      type: r.type,
+      entityId: r.entity_id,
+      entityTitle: r.entity_title,
+      timestamp: new Date(r.timestamp),
+    };
+  });
+}
+
+/**
+ * Fetches unread message count.
+ *
+ * For now, we count inbound messages from the last 24 hours as "unread".
+ * A proper read/unread tracking system would require a new column or table.
+ */
+async function fetchUnreadMessages(pool: Pool): Promise<number> {
+  // Count recent inbound messages that don't have a work_item_communication entry
+  // (i.e., haven't been acted upon)
+  const result = await pool.query(
+    `SELECT COUNT(*) as count
+     FROM external_message em
+     WHERE em.direction = 'inbound'
+       AND em.received_at > NOW() - INTERVAL '24 hours'
+       AND NOT EXISTS (
+         SELECT 1 FROM work_item_communication wic
+         WHERE wic.message_id = em.id
+       )`
+  );
+
+  return parseInt((result.rows[0] as { count: string }).count, 10);
+}
+
+/**
+ * Fetches key contacts.
+ */
+async function fetchKeyContacts(
+  pool: Pool,
+  limit: number
+): Promise<BootstrapContact[]> {
+  const result = await pool.query(
+    `SELECT
+       c.id::text,
+       c.display_name,
+       (SELECT MAX(em.received_at)
+        FROM external_message em
+        JOIN external_thread et ON et.id = em.thread_id
+        JOIN contact_endpoint ce ON ce.id = et.endpoint_id
+        WHERE ce.contact_id = c.id
+       ) as last_contact,
+       (SELECT COUNT(*) FROM contact_endpoint WHERE contact_id = c.id) as endpoint_count
+     FROM contact c
+     ORDER BY last_contact DESC NULLS LAST
+     LIMIT $1`,
+    [limit]
+  );
+
+  return result.rows.map((row) => {
+    const r = row as {
+      id: string;
+      display_name: string;
+      last_contact: string | null;
+      endpoint_count: string;
+    };
+    return {
+      id: r.id,
+      displayName: r.display_name,
+      lastContact: r.last_contact ? new Date(r.last_contact) : undefined,
+      endpointCount: parseInt(r.endpoint_count, 10),
+    };
+  });
+}
+
+/**
+ * Fetches statistics.
+ */
+async function fetchStats(pool: Pool): Promise<BootstrapStats> {
+  const result = await pool.query(`
+    SELECT
+      (SELECT COUNT(*) FROM work_item WHERE status NOT IN ('completed', 'cancelled', 'archived')) as open_items,
+      (SELECT COUNT(*) FROM work_item
+       WHERE not_after IS NOT NULL
+         AND not_after::date = CURRENT_DATE
+         AND status NOT IN ('completed', 'cancelled', 'archived')) as due_today,
+      (SELECT COUNT(*) FROM work_item
+       WHERE not_after IS NOT NULL
+         AND not_after < NOW()
+         AND status NOT IN ('completed', 'cancelled', 'archived')) as overdue,
+      (SELECT COUNT(*) FROM work_item WHERE work_item_kind::text = 'project') as total_projects,
+      (SELECT COUNT(*) FROM memory) as total_memories,
+      (SELECT COUNT(*) FROM contact) as total_contacts
+  `);
+
+  const row = result.rows[0] as {
+    open_items: string;
+    due_today: string;
+    overdue: string;
+    total_projects: string;
+    total_memories: string;
+    total_contacts: string;
+  };
+
+  return {
+    openItems: parseInt(row.open_items, 10),
+    dueToday: parseInt(row.due_today, 10),
+    overdue: parseInt(row.overdue, 10),
+    totalProjects: parseInt(row.total_projects, 10),
+    totalMemories: parseInt(row.total_memories, 10),
+    totalContacts: parseInt(row.total_contacts, 10),
+  };
+}
+
+/**
+ * Fetches the bootstrap context for an agent session.
+ */
+export async function getBootstrapContext(
+  pool: Pool,
+  options: BootstrapOptions = {}
+): Promise<BootstrapResponse> {
+  const sections = getSectionsToFetch(options);
+  const limits = {
+    preferences: options.limit?.preferences ?? 10,
+    projects: options.limit?.projects ?? 5,
+    reminders: options.limit?.reminders ?? 10,
+    activity: options.limit?.activity ?? 20,
+    contacts: options.limit?.contacts ?? 10,
+  };
+
+  const userEmail = options.userEmail ?? '';
+
+  // Execute queries in parallel for performance
+  const [
+    user,
+    preferences,
+    activeProjects,
+    pendingReminders,
+    recentActivity,
+    unreadMessages,
+    keyContacts,
+    stats,
+  ] = await Promise.all([
+    sections.has('user') && userEmail ? fetchUser(pool, userEmail) : Promise.resolve(null),
+    sections.has('preferences') && userEmail
+      ? fetchPreferences(pool, userEmail, limits.preferences)
+      : Promise.resolve([]),
+    sections.has('projects') ? fetchActiveProjects(pool, limits.projects) : Promise.resolve([]),
+    sections.has('reminders') ? fetchPendingReminders(pool, limits.reminders) : Promise.resolve([]),
+    sections.has('activity') ? fetchRecentActivity(pool, limits.activity) : Promise.resolve([]),
+    sections.has('messages') ? fetchUnreadMessages(pool) : Promise.resolve(0),
+    sections.has('contacts') ? fetchKeyContacts(pool, limits.contacts) : Promise.resolve([]),
+    sections.has('stats') ? fetchStats(pool) : Promise.resolve({
+      openItems: 0,
+      dueToday: 0,
+      overdue: 0,
+      totalProjects: 0,
+      totalMemories: 0,
+      totalContacts: 0,
+    }),
+  ]);
+
+  const generatedAt = new Date();
+  // Suggest refresh in 5 minutes
+  const nextRefreshHint = new Date(generatedAt.getTime() + 5 * 60 * 1000);
+
+  return {
+    user,
+    preferences,
+    activeProjects,
+    pendingReminders,
+    recentActivity,
+    unreadMessages,
+    keyContacts,
+    stats,
+    generatedAt,
+    nextRefreshHint,
+  };
+}

--- a/src/api/bootstrap/types.ts
+++ b/src/api/bootstrap/types.ts
@@ -1,0 +1,107 @@
+/**
+ * Types for the agent context bootstrap API.
+ * Part of Epic #199, Issue #219
+ */
+
+/** User information for bootstrap context */
+export interface BootstrapUser {
+  email: string;
+  timezone?: string;
+  settings: Record<string, unknown>;
+}
+
+/** User preference memory */
+export interface BootstrapPreference {
+  id: string;
+  type: string;
+  title: string;
+  content: string;
+  importance: number;
+  createdAt: Date;
+}
+
+/** Active project summary */
+export interface BootstrapProject {
+  id: string;
+  title: string;
+  status: string;
+  kind: string;
+  updatedAt: Date;
+}
+
+/** Pending reminder */
+export interface BootstrapReminder {
+  id: string;
+  title: string;
+  description?: string;
+  notBefore: Date;
+  kind: string;
+}
+
+/** Recent activity entry */
+export interface BootstrapActivity {
+  type: string;
+  entityId: string;
+  entityTitle?: string;
+  timestamp: Date;
+}
+
+/** Key contact summary */
+export interface BootstrapContact {
+  id: string;
+  displayName: string;
+  lastContact?: Date;
+  endpointCount: number;
+}
+
+/** Bootstrap statistics */
+export interface BootstrapStats {
+  openItems: number;
+  dueToday: number;
+  overdue: number;
+  totalProjects: number;
+  totalMemories: number;
+  totalContacts: number;
+}
+
+/** Full bootstrap response */
+export interface BootstrapResponse {
+  user: BootstrapUser | null;
+  preferences: BootstrapPreference[];
+  activeProjects: BootstrapProject[];
+  pendingReminders: BootstrapReminder[];
+  recentActivity: BootstrapActivity[];
+  unreadMessages: number;
+  keyContacts: BootstrapContact[];
+  stats: BootstrapStats;
+  generatedAt: Date;
+  nextRefreshHint: Date;
+}
+
+/** Options for bootstrap request */
+export interface BootstrapOptions {
+  userEmail?: string;
+  include?: string[];
+  exclude?: string[];
+  limit?: {
+    preferences?: number;
+    projects?: number;
+    reminders?: number;
+    activity?: number;
+    contacts?: number;
+  };
+}
+
+/** Available bootstrap sections */
+export const BOOTSTRAP_SECTIONS = [
+  'user',
+  'preferences',
+  'projects',
+  'reminders',
+  'activity',
+  'messages',
+  'contacts',
+  'stats',
+] as const;
+
+export type BootstrapSection = typeof BOOTSTRAP_SECTIONS[number];

--- a/tests/bootstrap_api.test.ts
+++ b/tests/bootstrap_api.test.ts
@@ -1,0 +1,298 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { Pool } from 'pg';
+import { buildServer } from '../src/api/server.ts';
+import { runMigrate } from './helpers/migrate.js';
+import { createTestPool, truncateAllTables } from './helpers/db.js';
+
+describe('Agent Bootstrap API (Issue #219)', () => {
+  const app = buildServer();
+  let pool: Pool;
+
+  beforeAll(async () => {
+    await runMigrate('up');
+    pool = createTestPool();
+    await app.ready();
+  });
+
+  beforeEach(async () => {
+    await truncateAllTables(pool);
+  });
+
+  afterAll(async () => {
+    await app.close();
+    await pool.end();
+  });
+
+  describe('GET /api/bootstrap', () => {
+    it('returns bootstrap context with all sections', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/bootstrap',
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+
+      expect(body.generatedAt).toBeDefined();
+      expect(body.nextRefreshHint).toBeDefined();
+      expect(body.preferences).toBeDefined();
+      expect(body.activeProjects).toBeDefined();
+      expect(body.pendingReminders).toBeDefined();
+      expect(body.recentActivity).toBeDefined();
+      expect(body.keyContacts).toBeDefined();
+      expect(body.stats).toBeDefined();
+    });
+
+    it('returns user preferences when user_email is provided', async () => {
+      // Create a preference memory
+      await pool.query(
+        `INSERT INTO memory (user_email, title, content, memory_type, importance)
+         VALUES ('test@example.com', 'Dark Mode', 'User prefers dark mode', 'preference', 8)`
+      );
+
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/bootstrap?user_email=test@example.com',
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+
+      expect(body.user.email).toBe('test@example.com');
+      expect(body.preferences.length).toBe(1);
+      expect(body.preferences[0].title).toBe('Dark Mode');
+      expect(body.preferences[0].importance).toBe(8);
+    });
+
+    it('returns active projects', async () => {
+      await pool.query(
+        `INSERT INTO work_item (title, work_item_kind, status)
+         VALUES ('Active Project', 'project', 'in_progress'),
+                ('Completed Project', 'project', 'completed')`
+      );
+
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/bootstrap',
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+
+      expect(body.activeProjects.length).toBe(1);
+      expect(body.activeProjects[0].title).toBe('Active Project');
+      expect(body.activeProjects[0].status).toBe('in_progress');
+    });
+
+    it('returns pending reminders', async () => {
+      const futureDate = new Date(Date.now() + 3600000); // 1 hour from now
+
+      await pool.query(
+        `INSERT INTO work_item (title, work_item_kind, status, not_before)
+         VALUES ('Future Reminder', 'issue', 'open', $1)`,
+        [futureDate]
+      );
+
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/bootstrap',
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+
+      expect(body.pendingReminders.length).toBe(1);
+      expect(body.pendingReminders[0].title).toBe('Future Reminder');
+    });
+
+    it('returns key contacts', async () => {
+      await pool.query(
+        `INSERT INTO contact (display_name)
+         VALUES ('John Doe'), ('Jane Smith')`
+      );
+
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/bootstrap',
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+
+      expect(body.keyContacts.length).toBe(2);
+    });
+
+    it('returns statistics', async () => {
+      // Create some work items
+      await pool.query(
+        `INSERT INTO work_item (title, work_item_kind, status)
+         VALUES ('Open Issue', 'issue', 'open'),
+                ('Completed Issue', 'issue', 'completed')`
+      );
+
+      // Create a contact
+      await pool.query(
+        `INSERT INTO contact (display_name)
+         VALUES ('Test Contact')`
+      );
+
+      // Create a memory
+      await pool.query(
+        `INSERT INTO memory (title, content, memory_type)
+         VALUES ('Test Memory', 'Content', 'note')`
+      );
+
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/bootstrap',
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+
+      expect(body.stats.openItems).toBe(1);
+      expect(body.stats.totalContacts).toBe(1);
+      expect(body.stats.totalMemories).toBe(1);
+    });
+
+    it('filters sections with include parameter', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/bootstrap?include=stats,projects',
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+
+      // Should have stats and projects
+      expect(body.stats).toBeDefined();
+      expect(body.activeProjects).toBeDefined();
+
+      // Other sections should be empty (not fetched)
+      expect(body.preferences).toEqual([]);
+      expect(body.pendingReminders).toEqual([]);
+      expect(body.keyContacts).toEqual([]);
+    });
+
+    it('excludes sections with exclude parameter', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/bootstrap?exclude=activity,messages',
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+
+      // Excluded sections should be empty/zero
+      expect(body.recentActivity).toEqual([]);
+      expect(body.unreadMessages).toBe(0);
+
+      // Other sections should still be present
+      expect(body.stats).toBeDefined();
+      expect(body.activeProjects).toBeDefined();
+    });
+
+    it('returns unread message count', async () => {
+      // Create contact and endpoint first
+      const contactResult = await pool.query(
+        `INSERT INTO contact (display_name)
+         VALUES ('Sender')
+         RETURNING id`
+      );
+      const contactId = contactResult.rows[0].id;
+
+      const endpointResult = await pool.query(
+        `INSERT INTO contact_endpoint (contact_id, endpoint_type, endpoint_value, normalized_value)
+         VALUES ($1, 'phone', '+15551234567', '+15551234567')
+         RETURNING id`,
+        [contactId]
+      );
+      const endpointId = endpointResult.rows[0].id;
+
+      // Create thread with required fields
+      const threadResult = await pool.query(
+        `INSERT INTO external_thread (endpoint_id, channel, external_thread_key)
+         VALUES ($1, 'phone', 'thread-123')
+         RETURNING id`,
+        [endpointId]
+      );
+      const threadId = threadResult.rows[0].id;
+
+      // Create inbound messages (within 24 hours = unread)
+      await pool.query(
+        `INSERT INTO external_message (thread_id, external_message_key, direction, body, received_at)
+         VALUES ($1, 'msg1', 'inbound', 'Hello', NOW()),
+                ($1, 'msg2', 'inbound', 'World', NOW())`,
+        [threadId]
+      );
+
+      // Create a work item and link one message to it (making it "read"/actioned)
+      const workItemResult = await pool.query(
+        `INSERT INTO work_item (title, work_item_kind, status)
+         VALUES ('Reply to message', 'issue', 'open')
+         RETURNING id`
+      );
+      const workItemId = workItemResult.rows[0].id;
+
+      const messageResult = await pool.query(
+        `SELECT id FROM external_message WHERE external_message_key = 'msg1'`
+      );
+      const messageId = messageResult.rows[0].id;
+
+      await pool.query(
+        `INSERT INTO work_item_communication (work_item_id, thread_id, message_id, action)
+         VALUES ($1, $2, $3, 'reply_required')`,
+        [workItemId, threadId, messageId]
+      );
+
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/bootstrap',
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+
+      // msg1 is linked to work_item_communication (actioned), msg2 is not
+      expect(body.unreadMessages).toBe(1);
+    });
+
+    it('returns recent activity', async () => {
+      // Create a work item that was updated recently
+      await pool.query(
+        `INSERT INTO work_item (title, work_item_kind, status, updated_at)
+         VALUES ('Recent Work', 'issue', 'open', NOW())`
+      );
+
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/bootstrap',
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+
+      expect(body.recentActivity.length).toBeGreaterThan(0);
+      expect(body.recentActivity[0].entityTitle).toBe('Recent Work');
+    });
+
+    it('returns user settings when available', async () => {
+      await pool.query(
+        `INSERT INTO user_setting (email, theme, timezone)
+         VALUES ('test@example.com', 'dark', 'Australia/Sydney')`
+      );
+
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/bootstrap?user_email=test@example.com',
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+
+      expect(body.user.email).toBe('test@example.com');
+      expect(body.user.timezone).toBe('Australia/Sydney');
+      expect(body.user.settings.theme).toBe('dark');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements the agent context bootstrap endpoint that returns everything needed to start an agent session in a single call:

- **User settings**: Theme, timezone, display preferences from `user_setting` table
- **User preferences**: High-importance memories (preference/fact type) for personalization
- **Active projects**: Work items with project/epic/initiative kind that are in_progress
- **Pending reminders**: Work items with future `not_before` dates
- **Recent activity**: Work item changes from last 7 days
- **Unread messages**: Inbound messages not yet linked to work items
- **Key contacts**: Contacts ordered by last contact time
- **Statistics**: Open items, due today, overdue counts

### Section Filtering

Clients can request only the sections they need:
- `?include=stats,projects` - Only include specified sections
- `?exclude=activity,messages` - Exclude specified sections

### Context Freshness

Response includes:
- `generatedAt` - When the bootstrap context was generated
- `nextRefreshHint` - Suggested refresh time (5 minutes)

## Test plan

- [x] Returns bootstrap context with all sections
- [x] Returns user preferences when user_email is provided
- [x] Returns active projects
- [x] Returns pending reminders
- [x] Returns key contacts
- [x] Returns statistics
- [x] Filters sections with include parameter
- [x] Excludes sections with exclude parameter
- [x] Returns unread message count
- [x] Returns recent activity
- [x] Returns user settings when available

All 1087 tests pass.

Closes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)