### PR TITLE
[#222] Implement reminder firing hook for not_before dates

### DIFF
--- a/migrations/029_reminder_firing_hook.down.sql
+++ b/migrations/029_reminder_firing_hook.down.sql
@@ -1,0 +1,8 @@
+-- Issue #222: Rollback reminder firing hook
+
+-- Remove the pg_cron job
+SELECT cron.unschedule('internal_reminder_enqueue')
+WHERE EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'internal_reminder_enqueue');
+
+-- Drop the function
+DROP FUNCTION IF EXISTS enqueue_due_reminders();

--- a/migrations/029_reminder_firing_hook.up.sql
+++ b/migrations/029_reminder_firing_hook.up.sql
@@ -1,0 +1,48 @@
+-- Issue #222: Reminder firing hook for not_before dates
+-- Complements the nudge system (not_after) with reminder support (not_before)
+
+-- Reminder enqueuer: work items whose not_before has been reached.
+-- Similar to enqueue_due_nudges but for reminders.
+CREATE OR REPLACE FUNCTION enqueue_due_reminders()
+RETURNS integer
+LANGUAGE sql
+AS $$
+  WITH candidates AS (
+    SELECT wi.id,
+           wi.not_before
+      FROM work_item wi
+     WHERE wi.not_before IS NOT NULL
+       AND wi.not_before <= now()
+       AND wi.status NOT IN ('completed', 'cancelled', 'archived', 'done')
+  ),
+  inserted AS (
+    INSERT INTO internal_job (kind, run_at, payload, idempotency_key)
+    SELECT 'reminder.work_item.not_before',
+           now(),
+           jsonb_build_object(
+             'work_item_id', c.id::text,
+             'not_before', c.not_before
+           ),
+           'work_item_not_before:' || c.id::text || ':' || to_char(c.not_before, 'YYYY-MM-DD')
+      FROM candidates c
+    ON CONFLICT (kind, idempotency_key) DO NOTHING
+    RETURNING 1
+  )
+  SELECT count(*)::int FROM inserted;
+$$;
+
+-- Register a pg_cron job to periodically enqueue reminders.
+-- Runs every minute to catch reminders quickly.
+-- Idempotent: only creates the cron entry if it does not exist.
+DO $do$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'internal_reminder_enqueue') THEN
+    PERFORM cron.schedule(
+      'internal_reminder_enqueue',
+      '*/1 * * * *',
+      $cmd$SELECT enqueue_due_reminders();$cmd$
+    );
+  END IF;
+END $do$;
+
+COMMENT ON FUNCTION enqueue_due_reminders() IS 'Enqueues internal jobs for work items whose not_before date has been reached';

--- a/src/api/jobs/index.ts
+++ b/src/api/jobs/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Jobs module exports.
+ * Part of Issue #222.
+ */
+
+export * from './types.js';
+export * from './processor.js';

--- a/src/api/jobs/processor.ts
+++ b/src/api/jobs/processor.ts
@@ -1,0 +1,309 @@
+/**
+ * Internal job processor.
+ * Processes jobs from internal_job table and dispatches actions.
+ * Part of Issue #222.
+ */
+
+import type { Pool } from 'pg';
+import type {
+  InternalJob,
+  JobProcessorResult,
+  JobProcessorStats,
+  JobHandler,
+} from './types.js';
+import { enqueueWebhook } from '../webhooks/dispatcher.js';
+import {
+  buildReminderDuePayload,
+  buildDeadlineApproachingPayload,
+  getWebhookDestination,
+} from '../webhooks/payloads.js';
+
+const LOCK_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+const MAX_RETRIES = 5;
+
+/**
+ * Generate a unique worker ID for locking.
+ */
+function getWorkerId(): string {
+  return `job-worker-${process.pid}-${Date.now()}`;
+}
+
+/**
+ * Claim pending jobs for processing.
+ */
+export async function claimJobs(
+  pool: Pool,
+  workerId: string,
+  limit: number = 10
+): Promise<InternalJob[]> {
+  const result = await pool.query(
+    `SELECT
+       id::text as id,
+       kind,
+       run_at as "runAt",
+       payload,
+       attempts,
+       last_error as "lastError",
+       locked_at as "lockedAt",
+       locked_by as "lockedBy",
+       completed_at as "completedAt",
+       idempotency_key as "idempotencyKey",
+       created_at as "createdAt",
+       updated_at as "updatedAt"
+     FROM internal_job_claim($1, $2)`,
+    [workerId, limit]
+  );
+
+  return result.rows as InternalJob[];
+}
+
+/**
+ * Mark a job as completed.
+ */
+export async function completeJob(
+  pool: Pool,
+  jobId: string
+): Promise<void> {
+  await pool.query(`SELECT internal_job_complete($1)`, [jobId]);
+}
+
+/**
+ * Mark a job as failed with retry.
+ */
+export async function failJob(
+  pool: Pool,
+  jobId: string,
+  error: string,
+  retrySeconds: number = 60
+): Promise<void> {
+  await pool.query(`SELECT internal_job_fail($1, $2, $3)`, [
+    jobId,
+    error,
+    retrySeconds,
+  ]);
+}
+
+/**
+ * Handle reminder.work_item.not_before job.
+ * Fetches work item details and enqueues a webhook.
+ */
+async function handleReminderJob(
+  pool: Pool,
+  job: InternalJob
+): Promise<JobProcessorResult> {
+  const workItemId = job.payload.work_item_id as string;
+  const notBefore = new Date(job.payload.not_before as string);
+
+  // Fetch work item details
+  const workItemResult = await pool.query(
+    `SELECT
+       id::text as id,
+       title,
+       description,
+       work_item_kind::text as kind,
+       status
+     FROM work_item
+     WHERE id = $1`,
+    [workItemId]
+  );
+
+  if (workItemResult.rows.length === 0) {
+    return {
+      success: false,
+      error: `Work item ${workItemId} not found`,
+    };
+  }
+
+  const workItem = workItemResult.rows[0] as {
+    id: string;
+    title: string;
+    description: string | null;
+    kind: string;
+    status: string;
+  };
+
+  // Skip if already completed
+  if (['completed', 'cancelled', 'archived', 'done'].includes(workItem.status)) {
+    return { success: true }; // Silently skip completed items
+  }
+
+  // Build the webhook payload
+  const payload = buildReminderDuePayload({
+    workItemId: workItem.id,
+    workItemTitle: workItem.title,
+    workItemDescription: workItem.description || undefined,
+    workItemKind: workItem.kind,
+    notBefore,
+  });
+
+  const destination = getWebhookDestination('reminder_due');
+  const idempotencyKey = `reminder:${workItemId}:${notBefore.toISOString().split('T')[0]}`;
+
+  // Enqueue the webhook
+  await enqueueWebhook(pool, 'reminder.work_item.not_before', destination, payload, {
+    idempotencyKey,
+  });
+
+  return { success: true };
+}
+
+/**
+ * Handle nudge.work_item.not_after job.
+ * Fetches work item details and enqueues a webhook.
+ */
+async function handleNudgeJob(
+  pool: Pool,
+  job: InternalJob
+): Promise<JobProcessorResult> {
+  const workItemId = job.payload.work_item_id as string;
+  const notAfter = new Date(job.payload.not_after as string);
+
+  // Fetch work item details
+  const workItemResult = await pool.query(
+    `SELECT
+       id::text as id,
+       title,
+       work_item_kind::text as kind,
+       status
+     FROM work_item
+     WHERE id = $1`,
+    [workItemId]
+  );
+
+  if (workItemResult.rows.length === 0) {
+    return {
+      success: false,
+      error: `Work item ${workItemId} not found`,
+    };
+  }
+
+  const workItem = workItemResult.rows[0] as {
+    id: string;
+    title: string;
+    kind: string;
+    status: string;
+  };
+
+  // Skip if already completed
+  if (['completed', 'cancelled', 'archived', 'done'].includes(workItem.status)) {
+    return { success: true };
+  }
+
+  // Calculate hours remaining
+  const hoursRemaining = Math.max(
+    0,
+    Math.round((notAfter.getTime() - Date.now()) / (1000 * 60 * 60))
+  );
+
+  // Build the webhook payload
+  const payload = buildDeadlineApproachingPayload({
+    workItemId: workItem.id,
+    workItemTitle: workItem.title,
+    workItemKind: workItem.kind,
+    notAfter,
+    hoursRemaining,
+  });
+
+  const destination = getWebhookDestination('deadline_approaching');
+  const idempotencyKey = `nudge:${workItemId}:${notAfter.toISOString().split('T')[0]}`;
+
+  // Enqueue the webhook
+  await enqueueWebhook(pool, 'nudge.work_item.not_after', destination, payload, {
+    idempotencyKey,
+  });
+
+  return { success: true };
+}
+
+/**
+ * Get handler for a job kind.
+ */
+function getJobHandler(
+  pool: Pool,
+  kind: string
+): ((job: InternalJob) => Promise<JobProcessorResult>) | null {
+  switch (kind) {
+    case 'reminder.work_item.not_before':
+      return (job) => handleReminderJob(pool, job);
+    case 'nudge.work_item.not_after':
+      return (job) => handleNudgeJob(pool, job);
+    default:
+      return null;
+  }
+}
+
+/**
+ * Process pending internal jobs.
+ */
+export async function processJobs(
+  pool: Pool,
+  limit: number = 10
+): Promise<JobProcessorStats> {
+  const workerId = getWorkerId();
+  const jobs = await claimJobs(pool, workerId, limit);
+
+  const stats: JobProcessorStats = {
+    processed: 0,
+    succeeded: 0,
+    failed: 0,
+    skipped: 0,
+  };
+
+  for (const job of jobs) {
+    stats.processed++;
+
+    const handler = getJobHandler(pool, job.kind);
+
+    if (!handler) {
+      console.warn(`[Jobs] Unknown job kind: ${job.kind}`);
+      await failJob(pool, job.id, `Unknown job kind: ${job.kind}`);
+      stats.failed++;
+      continue;
+    }
+
+    try {
+      const result = await handler(job);
+
+      if (result.success) {
+        await completeJob(pool, job.id);
+        stats.succeeded++;
+        console.log(`[Jobs] Completed ${job.kind} job ${job.id}`);
+      } else {
+        const retrySeconds = Math.pow(2, job.attempts) * 60; // Exponential backoff
+        await failJob(pool, job.id, result.error || 'Unknown error', retrySeconds);
+        stats.failed++;
+        console.warn(`[Jobs] Failed ${job.kind} job ${job.id}: ${result.error}`);
+      }
+    } catch (error) {
+      const err = error as Error;
+      const retrySeconds = Math.pow(2, job.attempts) * 60;
+      await failJob(pool, job.id, err.message, retrySeconds);
+      stats.failed++;
+      console.error(`[Jobs] Error processing ${job.kind} job ${job.id}:`, err);
+    }
+  }
+
+  return stats;
+}
+
+/**
+ * Get pending job count by kind.
+ */
+export async function getPendingJobCounts(
+  pool: Pool
+): Promise<Record<string, number>> {
+  const result = await pool.query(
+    `SELECT kind, COUNT(*) as count
+     FROM internal_job
+     WHERE completed_at IS NULL
+     GROUP BY kind`
+  );
+
+  const counts: Record<string, number> = {};
+  for (const row of result.rows) {
+    const r = row as { kind: string; count: string };
+    counts[r.kind] = parseInt(r.count, 10);
+  }
+
+  return counts;
+}

--- a/src/api/jobs/types.ts
+++ b/src/api/jobs/types.ts
@@ -1,0 +1,35 @@
+/**
+ * Types for internal job processing.
+ * Part of Issue #222.
+ */
+
+export interface InternalJob {
+  id: string;
+  kind: string;
+  runAt: Date;
+  payload: Record<string, unknown>;
+  attempts: number;
+  lastError: string | null;
+  lockedAt: Date | null;
+  lockedBy: string | null;
+  completedAt: Date | null;
+  idempotencyKey: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface JobProcessorResult {
+  success: boolean;
+  error?: string;
+}
+
+export interface JobProcessorStats {
+  processed: number;
+  succeeded: number;
+  failed: number;
+  skipped: number;
+}
+
+export type JobHandler = (
+  job: InternalJob
+) => Promise<JobProcessorResult>;

--- a/tests/jobs/processor.test.ts
+++ b/tests/jobs/processor.test.ts
@@ -1,0 +1,282 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import { Pool } from 'pg';
+import { runMigrate } from '../helpers/migrate.js';
+import { createTestPool, truncateAllTables } from '../helpers/db.js';
+import {
+  claimJobs,
+  completeJob,
+  failJob,
+  processJobs,
+  getPendingJobCounts,
+} from '../../src/api/jobs/processor.js';
+
+// Set up OpenClaw config for webhook tests
+vi.stubEnv('OPENCLAW_GATEWAY_URL', 'https://test-gateway.openclaw.ai');
+vi.stubEnv('OPENCLAW_HOOK_TOKEN', 'test-hook-token');
+
+describe('Job processor (Issue #222)', () => {
+  let pool: Pool;
+
+  beforeAll(async () => {
+    await runMigrate('up');
+    pool = createTestPool();
+  });
+
+  beforeEach(async () => {
+    await truncateAllTables(pool);
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  describe('claimJobs', () => {
+    it('claims available jobs', async () => {
+      // Insert a job that's due
+      await pool.query(
+        `INSERT INTO internal_job (kind, run_at, payload)
+         VALUES ('test.job', now(), '{"test": true}'::jsonb)`
+      );
+
+      const jobs = await claimJobs(pool, 'test-worker', 10);
+
+      expect(jobs.length).toBe(1);
+      expect(jobs[0].kind).toBe('test.job');
+      expect(jobs[0].payload).toEqual({ test: true });
+    });
+
+    it('does not claim future jobs', async () => {
+      await pool.query(
+        `INSERT INTO internal_job (kind, run_at, payload)
+         VALUES ('test.job', now() + interval '1 hour', '{"test": true}'::jsonb)`
+      );
+
+      const jobs = await claimJobs(pool, 'test-worker', 10);
+
+      expect(jobs.length).toBe(0);
+    });
+
+    it('does not claim completed jobs', async () => {
+      await pool.query(
+        `INSERT INTO internal_job (kind, run_at, payload, completed_at)
+         VALUES ('test.job', now(), '{"test": true}'::jsonb, now())`
+      );
+
+      const jobs = await claimJobs(pool, 'test-worker', 10);
+
+      expect(jobs.length).toBe(0);
+    });
+
+    it('respects limit parameter', async () => {
+      for (let i = 0; i < 5; i++) {
+        await pool.query(
+          `INSERT INTO internal_job (kind, run_at, payload)
+           VALUES ('test.job', now(), '{"index": ${i}}'::jsonb)`
+        );
+      }
+
+      const jobs = await claimJobs(pool, 'test-worker', 2);
+
+      expect(jobs.length).toBe(2);
+    });
+  });
+
+  describe('completeJob', () => {
+    it('marks a job as completed', async () => {
+      const result = await pool.query(
+        `INSERT INTO internal_job (kind, run_at, payload)
+         VALUES ('test.job', now(), '{}'::jsonb)
+         RETURNING id::text as id`
+      );
+      const jobId = result.rows[0].id as string;
+
+      await completeJob(pool, jobId);
+
+      const job = await pool.query(
+        `SELECT completed_at FROM internal_job WHERE id = $1`,
+        [jobId]
+      );
+
+      expect(job.rows[0].completed_at).not.toBeNull();
+    });
+  });
+
+  describe('failJob', () => {
+    it('records error and schedules retry', async () => {
+      const result = await pool.query(
+        `INSERT INTO internal_job (kind, run_at, payload)
+         VALUES ('test.job', now(), '{}'::jsonb)
+         RETURNING id::text as id`
+      );
+      const jobId = result.rows[0].id as string;
+
+      await failJob(pool, jobId, 'Test error', 60);
+
+      const job = await pool.query(
+        `SELECT attempts, last_error, (run_at > now()) as scheduled_future
+         FROM internal_job WHERE id = $1`,
+        [jobId]
+      );
+
+      expect(job.rows[0].attempts).toBe(1);
+      expect(job.rows[0].last_error).toBe('Test error');
+      expect(job.rows[0].scheduled_future).toBe(true);
+    });
+  });
+
+  describe('processJobs', () => {
+    it('processes reminder.work_item.not_before jobs', async () => {
+      // Create a work item
+      const wi = await pool.query(
+        `INSERT INTO work_item (title, not_before, status, work_item_kind)
+         VALUES ('Call mom', now() - interval '1 hour', 'open', 'issue')
+         RETURNING id::text as id`
+      );
+      const workItemId = wi.rows[0].id as string;
+
+      // Create a reminder job
+      await pool.query(
+        `INSERT INTO internal_job (kind, run_at, payload)
+         VALUES ('reminder.work_item.not_before', now(), $1)`,
+        [JSON.stringify({ work_item_id: workItemId, not_before: new Date().toISOString() })]
+      );
+
+      // Process jobs
+      const stats = await processJobs(pool, 10);
+
+      expect(stats.processed).toBe(1);
+      expect(stats.succeeded).toBe(1);
+      expect(stats.failed).toBe(0);
+
+      // Verify webhook was enqueued
+      const webhooks = await pool.query(
+        `SELECT kind, destination, body
+         FROM webhook_outbox
+         WHERE kind = 'reminder.work_item.not_before'`
+      );
+
+      expect(webhooks.rows.length).toBe(1);
+      expect(webhooks.rows[0].destination).toBe('/hooks/agent');
+      expect(webhooks.rows[0].body.context.work_item_id).toBe(workItemId);
+    });
+
+    it('processes nudge.work_item.not_after jobs', async () => {
+      // Create a work item
+      const wi = await pool.query(
+        `INSERT INTO work_item (title, not_after, status, work_item_kind)
+         VALUES ('Deadline soon', now() + interval '2 hours', 'open', 'issue')
+         RETURNING id::text as id`
+      );
+      const workItemId = wi.rows[0].id as string;
+
+      // Create a nudge job
+      await pool.query(
+        `INSERT INTO internal_job (kind, run_at, payload)
+         VALUES ('nudge.work_item.not_after', now(), $1)`,
+        [JSON.stringify({ work_item_id: workItemId, not_after: new Date().toISOString() })]
+      );
+
+      // Process jobs
+      const stats = await processJobs(pool, 10);
+
+      expect(stats.processed).toBe(1);
+      expect(stats.succeeded).toBe(1);
+
+      // Verify webhook was enqueued
+      const webhooks = await pool.query(
+        `SELECT kind, destination
+         FROM webhook_outbox
+         WHERE kind = 'nudge.work_item.not_after'`
+      );
+
+      expect(webhooks.rows.length).toBe(1);
+      expect(webhooks.rows[0].destination).toBe('/hooks/wake');
+    });
+
+    it('skips completed work items', async () => {
+      // Create a completed work item
+      const wi = await pool.query(
+        `INSERT INTO work_item (title, not_before, status, work_item_kind)
+         VALUES ('Done task', now() - interval '1 hour', 'completed', 'issue')
+         RETURNING id::text as id`
+      );
+      const workItemId = wi.rows[0].id as string;
+
+      // Create a reminder job
+      await pool.query(
+        `INSERT INTO internal_job (kind, run_at, payload)
+         VALUES ('reminder.work_item.not_before', now(), $1)`,
+        [JSON.stringify({ work_item_id: workItemId, not_before: new Date().toISOString() })]
+      );
+
+      // Process jobs
+      const stats = await processJobs(pool, 10);
+
+      expect(stats.processed).toBe(1);
+      expect(stats.succeeded).toBe(1); // Skipped silently counts as success
+
+      // Verify no webhook was enqueued
+      const webhooks = await pool.query(
+        `SELECT COUNT(*) as count FROM webhook_outbox`
+      );
+
+      expect(parseInt(webhooks.rows[0].count as string, 10)).toBe(0);
+    });
+
+    it('fails unknown job kinds', async () => {
+      await pool.query(
+        `INSERT INTO internal_job (kind, run_at, payload)
+         VALUES ('unknown.job.kind', now(), '{}'::jsonb)`
+      );
+
+      const stats = await processJobs(pool, 10);
+
+      expect(stats.processed).toBe(1);
+      expect(stats.failed).toBe(1);
+    });
+
+    it('handles missing work items gracefully', async () => {
+      // Create a job referencing a non-existent work item
+      await pool.query(
+        `INSERT INTO internal_job (kind, run_at, payload)
+         VALUES ('reminder.work_item.not_before', now(), $1)`,
+        [JSON.stringify({
+          work_item_id: '00000000-0000-0000-0000-000000000000',
+          not_before: new Date().toISOString()
+        })]
+      );
+
+      const stats = await processJobs(pool, 10);
+
+      expect(stats.processed).toBe(1);
+      expect(stats.failed).toBe(1);
+    });
+  });
+
+  describe('getPendingJobCounts', () => {
+    it('returns counts by job kind', async () => {
+      await pool.query(
+        `INSERT INTO internal_job (kind, run_at, payload)
+         VALUES ('reminder.work_item.not_before', now(), '{}'),
+                ('reminder.work_item.not_before', now(), '{}'),
+                ('nudge.work_item.not_after', now(), '{}')`
+      );
+
+      const counts = await getPendingJobCounts(pool);
+
+      expect(counts['reminder.work_item.not_before']).toBe(2);
+      expect(counts['nudge.work_item.not_after']).toBe(1);
+    });
+
+    it('excludes completed jobs', async () => {
+      await pool.query(
+        `INSERT INTO internal_job (kind, run_at, payload, completed_at)
+         VALUES ('reminder.work_item.not_before', now(), '{}', now())`
+      );
+
+      const counts = await getPendingJobCounts(pool);
+
+      expect(counts['reminder.work_item.not_before']).toBeUndefined();
+    });
+  });
+});

--- a/tests/reminder_firing.test.ts
+++ b/tests/reminder_firing.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { Pool } from 'pg';
+import { runMigrate } from './helpers/migrate.js';
+import { createTestPool, truncateAllTables } from './helpers/db.js';
+
+describe('Reminder firing hook (Issue #222)', () => {
+  let pool: Pool;
+
+  beforeAll(async () => {
+    await runMigrate('up');
+    pool = createTestPool();
+  });
+
+  beforeEach(async () => {
+    await truncateAllTables(pool);
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  describe('enqueue_due_reminders()', () => {
+    it('enqueues a reminder job when not_before is reached', async () => {
+      // Create a work item with not_before in the past (reminder due)
+      const wi = await pool.query(
+        `INSERT INTO work_item (title, not_before, status)
+         VALUES ($1, now() - interval '1 hour', 'open')
+         RETURNING id::text as id`,
+        ['Call mom']
+      );
+      const workItemId = wi.rows[0].id as string;
+
+      // Run the enqueue function
+      await pool.query(`SELECT enqueue_due_reminders()`);
+
+      // Verify job was created
+      const jobs = await pool.query(
+        `SELECT kind, payload->>'work_item_id' as work_item_id
+           FROM internal_job
+          WHERE kind = 'reminder.work_item.not_before'`
+      );
+
+      expect(jobs.rows).toEqual([
+        {
+          kind: 'reminder.work_item.not_before',
+          work_item_id: workItemId,
+        },
+      ]);
+    });
+
+    it('is idempotent - only one job per work item per day', async () => {
+      // Create a work item with not_before in the past
+      await pool.query(
+        `INSERT INTO work_item (title, not_before, status)
+         VALUES ($1, now() - interval '1 hour', 'open')`,
+        ['Call mom']
+      );
+
+      // Run the enqueue function twice
+      await pool.query(`SELECT enqueue_due_reminders()`);
+      await pool.query(`SELECT enqueue_due_reminders()`);
+
+      // Verify only one job was created
+      const jobs = await pool.query(
+        `SELECT COUNT(*) as count
+           FROM internal_job
+          WHERE kind = 'reminder.work_item.not_before'`
+      );
+
+      expect(parseInt(jobs.rows[0].count as string, 10)).toBe(1);
+    });
+
+    it('does not enqueue for future not_before dates', async () => {
+      // Create a work item with not_before in the future
+      await pool.query(
+        `INSERT INTO work_item (title, not_before, status)
+         VALUES ($1, now() + interval '1 hour', 'open')`,
+        ['Future reminder']
+      );
+
+      // Run the enqueue function
+      await pool.query(`SELECT enqueue_due_reminders()`);
+
+      // Verify no jobs were created
+      const jobs = await pool.query(
+        `SELECT COUNT(*) as count
+           FROM internal_job
+          WHERE kind = 'reminder.work_item.not_before'`
+      );
+
+      expect(parseInt(jobs.rows[0].count as string, 10)).toBe(0);
+    });
+
+    it('does not enqueue for completed work items', async () => {
+      // Create a completed work item with not_before in the past
+      await pool.query(
+        `INSERT INTO work_item (title, not_before, status)
+         VALUES ($1, now() - interval '1 hour', 'completed')`,
+        ['Done task']
+      );
+
+      // Run the enqueue function
+      await pool.query(`SELECT enqueue_due_reminders()`);
+
+      // Verify no jobs were created
+      const jobs = await pool.query(
+        `SELECT COUNT(*) as count
+           FROM internal_job
+          WHERE kind = 'reminder.work_item.not_before'`
+      );
+
+      expect(parseInt(jobs.rows[0].count as string, 10)).toBe(0);
+    });
+
+    it('does not enqueue for cancelled work items', async () => {
+      await pool.query(
+        `INSERT INTO work_item (title, not_before, status)
+         VALUES ($1, now() - interval '1 hour', 'cancelled')`,
+        ['Cancelled task']
+      );
+
+      await pool.query(`SELECT enqueue_due_reminders()`);
+
+      const jobs = await pool.query(
+        `SELECT COUNT(*) as count
+           FROM internal_job
+          WHERE kind = 'reminder.work_item.not_before'`
+      );
+
+      expect(parseInt(jobs.rows[0].count as string, 10)).toBe(0);
+    });
+
+    it('does not enqueue for archived work items', async () => {
+      await pool.query(
+        `INSERT INTO work_item (title, not_before, status)
+         VALUES ($1, now() - interval '1 hour', 'archived')`,
+        ['Archived task']
+      );
+
+      await pool.query(`SELECT enqueue_due_reminders()`);
+
+      const jobs = await pool.query(
+        `SELECT COUNT(*) as count
+           FROM internal_job
+          WHERE kind = 'reminder.work_item.not_before'`
+      );
+
+      expect(parseInt(jobs.rows[0].count as string, 10)).toBe(0);
+    });
+
+    it('includes not_before timestamp in payload', async () => {
+      const notBefore = new Date();
+      notBefore.setHours(notBefore.getHours() - 1);
+
+      await pool.query(
+        `INSERT INTO work_item (title, not_before, status)
+         VALUES ($1, $2, 'open')`,
+        ['Call mom', notBefore]
+      );
+
+      await pool.query(`SELECT enqueue_due_reminders()`);
+
+      const jobs = await pool.query(
+        `SELECT payload->>'not_before' as not_before
+           FROM internal_job
+          WHERE kind = 'reminder.work_item.not_before'`
+      );
+
+      expect(jobs.rows.length).toBe(1);
+      expect(jobs.rows[0].not_before).toBeDefined();
+    });
+  });
+
+  describe('pg_cron job', () => {
+    it('registers a pg_cron job for enqueuing reminders', async () => {
+      const job = await pool.query(
+        `SELECT jobname, schedule, command
+           FROM cron.job
+          WHERE jobname = 'internal_reminder_enqueue'
+          LIMIT 1`
+      );
+
+      expect(job.rows.length).toBe(1);
+      expect(job.rows[0].schedule).toContain('*');
+      expect(job.rows[0].command).toContain('enqueue_due_reminders');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements the reminder firing hook for `not_before` dates, allowing pgcron to detect when reminders are due and dispatch webhooks to OpenClaw.

### Database Migration (029)

- `enqueue_due_reminders()` function that checks work items where `not_before <= now()`
- Creates internal jobs with kind `reminder.work_item.not_before`
- Idempotent via idempotency key (one reminder per work item per day)
- Skips completed/cancelled/archived work items
- pgcron job scheduled every minute

### Job Processor

New `src/api/jobs/` module:
- `claimJobs()` - Claims pending jobs using advisory locks
- `completeJob()` / `failJob()` - Mark jobs as complete or failed with retry
- `processJobs()` - Main processor that handles:
  - `reminder.work_item.not_before` - Reminder due events
  - `nudge.work_item.not_after` - Deadline approaching events
- Enqueues webhooks to `webhook_outbox` for dispatch to OpenClaw

### Example Flow

1. User: "Remind me to call mom tomorrow at 2pm"
2. Agent creates work_item with `not_before: 2026-02-03T14:00:00Z`
3. At 2pm, pgcron runs `enqueue_due_reminders()`
4. Job processor picks up job and enqueues webhook
5. Webhook dispatcher sends to OpenClaw `/hooks/agent`
6. OpenClaw agent messages user

## Test plan

- [x] enqueue_due_reminders() creates jobs for due reminders
- [x] Idempotent - only one job per work item per day
- [x] Does not enqueue for future not_before dates
- [x] Does not enqueue for completed/cancelled/archived items
- [x] Includes not_before timestamp in payload
- [x] pgcron job registered correctly
- [x] Job processor claims available jobs
- [x] Job processor respects limit
- [x] completeJob marks job as completed
- [x] failJob records error and schedules retry
- [x] Processes reminder jobs and enqueues webhooks
- [x] Processes nudge jobs and enqueues webhooks
- [x] Skips completed work items gracefully
- [x] Fails unknown job kinds
- [x] Handles missing work items gracefully
- [x] getPendingJobCounts returns counts by kind

All 1108 tests pass.

Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)