### PR TITLE
[#226] Add thread history API for agent conversation context

### DIFF
--- a/src/api/threads/index.ts
+++ b/src/api/threads/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Threads module exports.
+ * Part of Epic #199, Issue #226
+ */
+
+export * from './types.js';
+export * from './service.js';

--- a/src/api/threads/service.ts
+++ b/src/api/threads/service.ts
@@ -1,0 +1,288 @@
+/**
+ * Thread history service.
+ * Part of Epic #199, Issue #226
+ */
+
+import type { Pool } from 'pg';
+import type {
+  ThreadInfo,
+  ThreadMessage,
+  RelatedWorkItem,
+  ContactMemory,
+  ThreadHistoryResponse,
+  ThreadHistoryOptions,
+} from './types.js';
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+
+/**
+ * Fetch thread information by ID.
+ */
+async function fetchThreadInfo(
+  pool: Pool,
+  threadId: string
+): Promise<ThreadInfo | null> {
+  const result = await pool.query(
+    `SELECT
+       et.id::text as id,
+       et.channel::text as channel,
+       et.external_thread_key as "externalThreadKey",
+       et.created_at as "createdAt",
+       et.updated_at as "updatedAt",
+       c.id::text as "contactId",
+       c.display_name as "displayName",
+       c.notes
+     FROM external_thread et
+     JOIN contact_endpoint ce ON ce.id = et.endpoint_id
+     JOIN contact c ON c.id = ce.contact_id
+     WHERE et.id = $1`,
+    [threadId]
+  );
+
+  if (result.rows.length === 0) {
+    return null;
+  }
+
+  const row = result.rows[0] as {
+    id: string;
+    channel: string;
+    externalThreadKey: string;
+    createdAt: string;
+    updatedAt: string;
+    contactId: string;
+    displayName: string;
+    notes: string | null;
+  };
+
+  return {
+    id: row.id,
+    channel: row.channel,
+    externalThreadKey: row.externalThreadKey,
+    contact: {
+      id: row.contactId,
+      displayName: row.displayName,
+      notes: row.notes || undefined,
+    },
+    createdAt: new Date(row.createdAt),
+    updatedAt: new Date(row.updatedAt),
+  };
+}
+
+/**
+ * Fetch messages for a thread with pagination.
+ */
+async function fetchMessages(
+  pool: Pool,
+  threadId: string,
+  options: ThreadHistoryOptions
+): Promise<{ messages: ThreadMessage[]; hasMore: boolean }> {
+  const limit = Math.min(options.limit || DEFAULT_LIMIT, MAX_LIMIT);
+  const params: (string | number | Date)[] = [threadId, limit + 1];
+  const conditions: string[] = ['em.thread_id = $1'];
+  let paramIndex = 3;
+
+  if (options.before) {
+    conditions.push(`em.received_at < $${paramIndex}`);
+    params.push(options.before);
+    paramIndex++;
+  }
+
+  if (options.after) {
+    conditions.push(`em.received_at > $${paramIndex}`);
+    params.push(options.after);
+    paramIndex++;
+  }
+
+  const whereClause = conditions.join(' AND ');
+
+  const result = await pool.query(
+    `SELECT
+       em.id::text as id,
+       em.direction::text as direction,
+       em.body,
+       em.subject,
+       em.from_address as "fromAddress",
+       em.received_at as "receivedAt",
+       em.created_at as "createdAt"
+     FROM external_message em
+     WHERE ${whereClause}
+     ORDER BY em.received_at DESC
+     LIMIT $2`,
+    params
+  );
+
+  const hasMore = result.rows.length > limit;
+  const messages = result.rows.slice(0, limit).map((row) => {
+    const r = row as {
+      id: string;
+      direction: string;
+      body: string | null;
+      subject: string | null;
+      fromAddress: string | null;
+      receivedAt: string;
+      createdAt: string;
+    };
+    return {
+      id: r.id,
+      direction: r.direction as 'inbound' | 'outbound',
+      body: r.body,
+      subject: r.subject || undefined,
+      fromAddress: r.fromAddress || undefined,
+      receivedAt: new Date(r.receivedAt),
+      createdAt: new Date(r.createdAt),
+    };
+  });
+
+  // Reverse to get chronological order (oldest first)
+  messages.reverse();
+
+  return { messages, hasMore };
+}
+
+/**
+ * Fetch work items related to a thread.
+ */
+async function fetchRelatedWorkItems(
+  pool: Pool,
+  threadId: string
+): Promise<RelatedWorkItem[]> {
+  const result = await pool.query(
+    `SELECT
+       wi.id::text as id,
+       wi.title,
+       wi.status,
+       wi.work_item_kind::text as "workItemKind",
+       wi.not_before as "notBefore",
+       wi.not_after as "notAfter"
+     FROM work_item wi
+     JOIN work_item_communication wic ON wic.work_item_id = wi.id
+     WHERE wic.thread_id = $1
+     ORDER BY wi.updated_at DESC
+     LIMIT 20`,
+    [threadId]
+  );
+
+  return result.rows.map((row) => {
+    const r = row as {
+      id: string;
+      title: string;
+      status: string;
+      workItemKind: string;
+      notBefore: string | null;
+      notAfter: string | null;
+    };
+    return {
+      id: r.id,
+      title: r.title,
+      status: r.status,
+      workItemKind: r.workItemKind,
+      notBefore: r.notBefore ? new Date(r.notBefore) : undefined,
+      notAfter: r.notAfter ? new Date(r.notAfter) : undefined,
+    };
+  });
+}
+
+/**
+ * Fetch memories related to the contact.
+ */
+async function fetchContactMemories(
+  pool: Pool,
+  contactId: string
+): Promise<ContactMemory[]> {
+  const result = await pool.query(
+    `SELECT
+       m.id::text as id,
+       m.memory_type as "memoryType",
+       m.title,
+       m.content,
+       m.importance
+     FROM memory m
+     WHERE m.contact_id = $1
+       AND (m.expires_at IS NULL OR m.expires_at > NOW())
+       AND m.superseded_by IS NULL
+     ORDER BY m.importance DESC, m.created_at DESC
+     LIMIT 10`,
+    [contactId]
+  );
+
+  return result.rows.map((row) => {
+    const r = row as {
+      id: string;
+      memoryType: string;
+      title: string;
+      content: string;
+      importance: number;
+    };
+    return {
+      id: r.id,
+      memoryType: r.memoryType,
+      title: r.title,
+      content: r.content,
+      importance: r.importance,
+    };
+  });
+}
+
+/**
+ * Get thread history with messages, related work items, and contact memories.
+ */
+export async function getThreadHistory(
+  pool: Pool,
+  threadId: string,
+  options: ThreadHistoryOptions = {}
+): Promise<ThreadHistoryResponse | null> {
+  // Fetch thread info first
+  const thread = await fetchThreadInfo(pool, threadId);
+
+  if (!thread) {
+    return null;
+  }
+
+  // Fetch messages
+  const { messages, hasMore } = await fetchMessages(pool, threadId, options);
+
+  // Fetch related work items (default: include)
+  const relatedWorkItems =
+    options.includeWorkItems !== false
+      ? await fetchRelatedWorkItems(pool, threadId)
+      : [];
+
+  // Fetch contact memories (default: include)
+  const contactMemories =
+    options.includeMemories !== false
+      ? await fetchContactMemories(pool, thread.contact.id)
+      : [];
+
+  // Build pagination info
+  const pagination: ThreadHistoryResponse['pagination'] = {
+    hasMore,
+  };
+
+  if (messages.length > 0) {
+    pagination.oldestTimestamp = messages[0].receivedAt.toISOString();
+    pagination.newestTimestamp = messages[messages.length - 1].receivedAt.toISOString();
+  }
+
+  return {
+    thread,
+    messages,
+    relatedWorkItems,
+    contactMemories,
+    pagination,
+  };
+}
+
+/**
+ * Check if a thread exists.
+ */
+export async function threadExists(
+  pool: Pool,
+  threadId: string
+): Promise<boolean> {
+  const result = await pool.query(
+    `SELECT 1 FROM external_thread WHERE id = $1`,
+    [threadId]
+  );
+  return result.rows.length > 0;
+}

--- a/src/api/threads/types.ts
+++ b/src/api/threads/types.ts
@@ -1,0 +1,66 @@
+/**
+ * Types for thread history API.
+ * Part of Epic #199, Issue #226
+ */
+
+export interface ThreadContact {
+  id: string;
+  displayName: string;
+  notes?: string;
+}
+
+export interface ThreadInfo {
+  id: string;
+  channel: string;
+  externalThreadKey: string;
+  contact: ThreadContact;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface ThreadMessage {
+  id: string;
+  direction: 'inbound' | 'outbound';
+  body: string | null;
+  subject?: string;
+  fromAddress?: string;
+  receivedAt: Date;
+  createdAt: Date;
+}
+
+export interface RelatedWorkItem {
+  id: string;
+  title: string;
+  status: string;
+  workItemKind: string;
+  notBefore?: Date;
+  notAfter?: Date;
+}
+
+export interface ContactMemory {
+  id: string;
+  memoryType: string;
+  title: string;
+  content: string;
+  importance: number;
+}
+
+export interface ThreadHistoryResponse {
+  thread: ThreadInfo;
+  messages: ThreadMessage[];
+  relatedWorkItems: RelatedWorkItem[];
+  contactMemories: ContactMemory[];
+  pagination: {
+    hasMore: boolean;
+    oldestTimestamp?: string;
+    newestTimestamp?: string;
+  };
+}
+
+export interface ThreadHistoryOptions {
+  limit?: number;
+  before?: Date;
+  after?: Date;
+  includeWorkItems?: boolean;
+  includeMemories?: boolean;
+}

--- a/tests/thread_history_api.test.ts
+++ b/tests/thread_history_api.test.ts
@@ -1,0 +1,372 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { Pool } from 'pg';
+import { buildServer } from '../src/api/server.ts';
+import { runMigrate } from './helpers/migrate.js';
+import { createTestPool, truncateAllTables } from './helpers/db.js';
+
+describe('Thread History API (Issue #226)', () => {
+  const app = buildServer();
+  let pool: Pool;
+
+  beforeAll(async () => {
+    await runMigrate('up');
+    pool = createTestPool();
+    await app.ready();
+  });
+
+  beforeEach(async () => {
+    await truncateAllTables(pool);
+  });
+
+  afterAll(async () => {
+    await app.close();
+    await pool.end();
+  });
+
+  async function createTestThread() {
+    // Create contact
+    const contactResult = await pool.query(
+      `INSERT INTO contact (display_name, notes)
+       VALUES ('John Smith', 'Friend from work')
+       RETURNING id::text as id`
+    );
+    const contactId = contactResult.rows[0].id as string;
+
+    // Create endpoint
+    const endpointResult = await pool.query(
+      `INSERT INTO contact_endpoint (contact_id, endpoint_type, endpoint_value, normalized_value)
+       VALUES ($1, 'phone', '+15551234567', '+15551234567')
+       RETURNING id::text as id`,
+      [contactId]
+    );
+    const endpointId = endpointResult.rows[0].id as string;
+
+    // Create thread
+    const threadResult = await pool.query(
+      `INSERT INTO external_thread (endpoint_id, channel, external_thread_key)
+       VALUES ($1, 'phone', 'thread-123')
+       RETURNING id::text as id`,
+      [endpointId]
+    );
+    const threadId = threadResult.rows[0].id as string;
+
+    return { contactId, endpointId, threadId };
+  }
+
+  describe('GET /api/threads/:id/history', () => {
+    it('returns thread info with contact details', async () => {
+      const { threadId } = await createTestThread();
+
+      const res = await app.inject({
+        method: 'GET',
+        url: `/api/threads/${threadId}/history`,
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+
+      expect(body.thread).toBeDefined();
+      expect(body.thread.id).toBe(threadId);
+      expect(body.thread.channel).toBe('phone');
+      expect(body.thread.contact.displayName).toBe('John Smith');
+      expect(body.thread.contact.notes).toBe('Friend from work');
+    });
+
+    it('returns 404 for non-existent thread', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/threads/00000000-0000-0000-0000-000000000000/history',
+      });
+
+      expect(res.statusCode).toBe(404);
+      expect(res.json().error).toBe('Thread not found');
+    });
+
+    it('returns messages in chronological order', async () => {
+      const { threadId } = await createTestThread();
+
+      // Create messages
+      await pool.query(
+        `INSERT INTO external_message (thread_id, external_message_key, direction, body, received_at)
+         VALUES ($1, 'msg1', 'inbound', 'Hello', NOW() - interval '2 hours'),
+                ($1, 'msg2', 'outbound', 'Hi there!', NOW() - interval '1 hour'),
+                ($1, 'msg3', 'inbound', 'How are you?', NOW())`,
+        [threadId]
+      );
+
+      const res = await app.inject({
+        method: 'GET',
+        url: `/api/threads/${threadId}/history`,
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+
+      expect(body.messages.length).toBe(3);
+      expect(body.messages[0].body).toBe('Hello');
+      expect(body.messages[0].direction).toBe('inbound');
+      expect(body.messages[1].body).toBe('Hi there!');
+      expect(body.messages[1].direction).toBe('outbound');
+      expect(body.messages[2].body).toBe('How are you?');
+    });
+
+    it('respects limit parameter', async () => {
+      const { threadId } = await createTestThread();
+
+      // Create 5 messages
+      for (let i = 0; i < 5; i++) {
+        await pool.query(
+          `INSERT INTO external_message (thread_id, external_message_key, direction, body, received_at)
+           VALUES ($1, $2, 'inbound', $3, NOW() - interval '${5 - i} hours')`,
+          [threadId, `msg${i}`, `Message ${i}`]
+        );
+      }
+
+      const res = await app.inject({
+        method: 'GET',
+        url: `/api/threads/${threadId}/history?limit=3`,
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+
+      expect(body.messages.length).toBe(3);
+      expect(body.pagination.hasMore).toBe(true);
+    });
+
+    it('returns related work items', async () => {
+      const { threadId } = await createTestThread();
+
+      // Create message
+      const msgResult = await pool.query(
+        `INSERT INTO external_message (thread_id, external_message_key, direction, body)
+         VALUES ($1, 'msg1', 'inbound', 'Can we reschedule?')
+         RETURNING id::text as id`,
+        [threadId]
+      );
+      const messageId = msgResult.rows[0].id as string;
+
+      // Create work item linked to thread
+      const wiResult = await pool.query(
+        `INSERT INTO work_item (title, work_item_kind, status, not_before)
+         VALUES ('Lunch with John', 'issue', 'open', NOW() + interval '1 day')
+         RETURNING id::text as id`
+      );
+      const workItemId = wiResult.rows[0].id as string;
+
+      await pool.query(
+        `INSERT INTO work_item_communication (work_item_id, thread_id, message_id, action)
+         VALUES ($1, $2, $3, 'reply_required')`,
+        [workItemId, threadId, messageId]
+      );
+
+      const res = await app.inject({
+        method: 'GET',
+        url: `/api/threads/${threadId}/history`,
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+
+      expect(body.relatedWorkItems.length).toBe(1);
+      expect(body.relatedWorkItems[0].title).toBe('Lunch with John');
+      expect(body.relatedWorkItems[0].status).toBe('open');
+      expect(body.relatedWorkItems[0].notBefore).toBeDefined();
+    });
+
+    it('returns contact memories', async () => {
+      const { threadId, contactId } = await createTestThread();
+
+      // Create a memory for the contact
+      await pool.query(
+        `INSERT INTO memory (title, content, memory_type, contact_id, importance)
+         VALUES ('Scheduling preference', 'Prefers afternoon meetings', 'preference', $1, 8)`,
+        [contactId]
+      );
+
+      const res = await app.inject({
+        method: 'GET',
+        url: `/api/threads/${threadId}/history`,
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+
+      expect(body.contactMemories.length).toBe(1);
+      expect(body.contactMemories[0].title).toBe('Scheduling preference');
+      expect(body.contactMemories[0].memoryType).toBe('preference');
+      expect(body.contactMemories[0].importance).toBe(8);
+    });
+
+    it('excludes work items when include_work_items=false', async () => {
+      const { threadId } = await createTestThread();
+
+      const res = await app.inject({
+        method: 'GET',
+        url: `/api/threads/${threadId}/history?include_work_items=false`,
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+
+      expect(body.relatedWorkItems).toEqual([]);
+    });
+
+    it('excludes memories when include_memories=false', async () => {
+      const { threadId, contactId } = await createTestThread();
+
+      await pool.query(
+        `INSERT INTO memory (title, content, memory_type, contact_id)
+         VALUES ('Test memory', 'Content', 'note', $1)`,
+        [contactId]
+      );
+
+      const res = await app.inject({
+        method: 'GET',
+        url: `/api/threads/${threadId}/history?include_memories=false`,
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+
+      expect(body.contactMemories).toEqual([]);
+    });
+
+    it('supports before pagination', async () => {
+      const { threadId } = await createTestThread();
+
+      // Create messages at different times
+      await pool.query(
+        `INSERT INTO external_message (thread_id, external_message_key, direction, body, received_at)
+         VALUES ($1, 'msg1', 'inbound', 'First', '2026-01-01T10:00:00Z'),
+                ($1, 'msg2', 'inbound', 'Second', '2026-01-01T11:00:00Z'),
+                ($1, 'msg3', 'inbound', 'Third', '2026-01-01T12:00:00Z')`,
+        [threadId]
+      );
+
+      const res = await app.inject({
+        method: 'GET',
+        url: `/api/threads/${threadId}/history?before=2026-01-01T12:00:00Z`,
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+
+      expect(body.messages.length).toBe(2);
+      expect(body.messages[0].body).toBe('First');
+      expect(body.messages[1].body).toBe('Second');
+    });
+
+    it('supports after pagination', async () => {
+      const { threadId } = await createTestThread();
+
+      // Create messages at different times
+      await pool.query(
+        `INSERT INTO external_message (thread_id, external_message_key, direction, body, received_at)
+         VALUES ($1, 'msg1', 'inbound', 'First', '2026-01-01T10:00:00Z'),
+                ($1, 'msg2', 'inbound', 'Second', '2026-01-01T11:00:00Z'),
+                ($1, 'msg3', 'inbound', 'Third', '2026-01-01T12:00:00Z')`,
+        [threadId]
+      );
+
+      const res = await app.inject({
+        method: 'GET',
+        url: `/api/threads/${threadId}/history?after=2026-01-01T10:00:00Z`,
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+
+      expect(body.messages.length).toBe(2);
+      expect(body.messages[0].body).toBe('Second');
+      expect(body.messages[1].body).toBe('Third');
+    });
+
+    it('returns pagination metadata', async () => {
+      const { threadId } = await createTestThread();
+
+      await pool.query(
+        `INSERT INTO external_message (thread_id, external_message_key, direction, body, received_at)
+         VALUES ($1, 'msg1', 'inbound', 'Message', NOW())`,
+        [threadId]
+      );
+
+      const res = await app.inject({
+        method: 'GET',
+        url: `/api/threads/${threadId}/history`,
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+
+      expect(body.pagination).toBeDefined();
+      expect(body.pagination.hasMore).toBe(false);
+      expect(body.pagination.oldestTimestamp).toBeDefined();
+      expect(body.pagination.newestTimestamp).toBeDefined();
+    });
+
+    it('includes email-specific fields when present', async () => {
+      // Create contact with email endpoint
+      const contactResult = await pool.query(
+        `INSERT INTO contact (display_name)
+         VALUES ('Email User')
+         RETURNING id::text as id`
+      );
+      const contactId = contactResult.rows[0].id as string;
+
+      const endpointResult = await pool.query(
+        `INSERT INTO contact_endpoint (contact_id, endpoint_type, endpoint_value, normalized_value)
+         VALUES ($1, 'email', 'user@example.com', 'user@example.com')
+         RETURNING id::text as id`,
+        [contactId]
+      );
+      const endpointId = endpointResult.rows[0].id as string;
+
+      const threadResult = await pool.query(
+        `INSERT INTO external_thread (endpoint_id, channel, external_thread_key)
+         VALUES ($1, 'email', 'email-thread-123')
+         RETURNING id::text as id`,
+        [endpointId]
+      );
+      const threadId = threadResult.rows[0].id as string;
+
+      // Create email message with subject
+      await pool.query(
+        `INSERT INTO external_message (thread_id, external_message_key, direction, body, subject, from_address)
+         VALUES ($1, 'email1', 'inbound', 'Email body', 'Meeting Request', 'user@example.com')`,
+        [threadId]
+      );
+
+      const res = await app.inject({
+        method: 'GET',
+        url: `/api/threads/${threadId}/history`,
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+
+      expect(body.messages.length).toBe(1);
+      expect(body.messages[0].subject).toBe('Meeting Request');
+      expect(body.messages[0].fromAddress).toBe('user@example.com');
+    });
+  });
+
+  describe('API Capabilities', () => {
+    it('includes threads capability in /api/capabilities', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/capabilities',
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+
+      const threadsCapability = body.capabilities.find(
+        (c: { name: string }) => c.name === 'threads'
+      );
+
+      expect(threadsCapability).toBeDefined();
+      expect(threadsCapability.endpoints[0].path).toBe('/api/threads/:id/history');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements the thread history API for agent conversation context. When an SMS or email arrives, OpenClaw agents can fetch the conversation thread history to understand context and respond appropriately.

### API Endpoint

`GET /api/threads/:id/history`

Returns:
- **thread**: Thread info (id, channel, external_thread_key, contact details)
- **messages**: Messages in chronological order (oldest first)
- **relatedWorkItems**: Work items linked via `work_item_communication`
- **contactMemories**: Relevant memories about the contact
- **pagination**: hasMore, oldestTimestamp, newestTimestamp

### Query Parameters

| Parameter | Description |
|-----------|-------------|
| `limit` | Max messages (default 50, max 200) |
| `before` | Get messages before timestamp (ISO 8601) |
| `after` | Get messages after timestamp (ISO 8601) |
| `include_work_items` | Include related work items (default true) |
| `include_memories` | Include contact memories (default true) |

### Example Response

```json
{
  "thread": {
    "id": "uuid",
    "channel": "phone",
    "contact": {
      "id": "uuid",
      "displayName": "John Smith",
      "notes": "Friend from work"
    }
  },
  "messages": [
    {
      "id": "uuid",
      "direction": "inbound",
      "body": "Can we reschedule lunch?",
      "receivedAt": "2026-02-02T10:30:00Z"
    }
  ],
  "relatedWorkItems": [...],
  "contactMemories": [...],
  "pagination": { "hasMore": false, ... }
}
```

### Use Case

1. SMS arrives: "Can we move it to Friday?"
2. Agent fetches `/api/threads/:id/history`
3. Sees previous messages + linked work item "Lunch with John"
4. Agent responds: "Sure, I'll move lunch with John to Friday"

## Test plan

- [x] Returns thread info with contact details
- [x] Returns 404 for non-existent thread
- [x] Returns messages in chronological order
- [x] Respects limit parameter
- [x] Returns related work items
- [x] Returns contact memories
- [x] Excludes work items when include_work_items=false
- [x] Excludes memories when include_memories=false
- [x] Supports before pagination
- [x] Supports after pagination
- [x] Returns pagination metadata
- [x] Includes email-specific fields when present
- [x] Adds threads capability to /api/capabilities

All 1121 tests pass.

Closes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)