### PR TITLE
[#208] Enhance contact schema for OpenClaw agent context

### DIFF
--- a/migrations/030_contact_schema_enhancement.down.sql
+++ b/migrations/030_contact_schema_enhancement.down.sql
@@ -1,0 +1,30 @@
+-- Issue #208: Rollback contact schema enhancement
+
+-- Drop triggers
+DROP TRIGGER IF EXISTS external_message_update_contact_last_contact ON external_message;
+DROP TRIGGER IF EXISTS contact_external_identity_update_contact ON contact_external_identity;
+
+-- Drop functions
+DROP FUNCTION IF EXISTS update_contact_last_contact_date();
+DROP FUNCTION IF EXISTS update_contact_on_identity_change();
+
+-- Drop external identity table
+DROP TABLE IF EXISTS contact_external_identity;
+
+-- Drop columns from contact table
+ALTER TABLE contact
+  DROP COLUMN IF EXISTS organization,
+  DROP COLUMN IF EXISTS job_title,
+  DROP COLUMN IF EXISTS timezone,
+  DROP COLUMN IF EXISTS birthday,
+  DROP COLUMN IF EXISTS photo_url,
+  DROP COLUMN IF EXISTS preferred_endpoint_id,
+  DROP COLUMN IF EXISTS pronouns,
+  DROP COLUMN IF EXISTS language,
+  DROP COLUMN IF EXISTS relationship_type,
+  DROP COLUMN IF EXISTS relationship_notes,
+  DROP COLUMN IF EXISTS first_contact_date,
+  DROP COLUMN IF EXISTS last_contact_date;
+
+-- Drop index (automatically dropped with column)
+DROP INDEX IF EXISTS idx_contact_last_contact_date;

--- a/migrations/030_contact_schema_enhancement.up.sql
+++ b/migrations/030_contact_schema_enhancement.up.sql
@@ -1,0 +1,90 @@
+-- Issue #208: Enhance contact schema for OpenClaw agent context
+
+-- Add new metadata columns to contact table
+ALTER TABLE contact
+  ADD COLUMN IF NOT EXISTS organization text,
+  ADD COLUMN IF NOT EXISTS job_title text,
+  ADD COLUMN IF NOT EXISTS timezone text,
+  ADD COLUMN IF NOT EXISTS birthday date,
+  ADD COLUMN IF NOT EXISTS photo_url text,
+  ADD COLUMN IF NOT EXISTS preferred_endpoint_id uuid REFERENCES contact_endpoint(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS pronouns text,
+  ADD COLUMN IF NOT EXISTS language text DEFAULT 'en',
+  ADD COLUMN IF NOT EXISTS relationship_type text,
+  ADD COLUMN IF NOT EXISTS relationship_notes text,
+  ADD COLUMN IF NOT EXISTS first_contact_date timestamptz,
+  ADD COLUMN IF NOT EXISTS last_contact_date timestamptz;
+
+-- Create index for last_contact_date queries
+CREATE INDEX IF NOT EXISTS idx_contact_last_contact_date ON contact(last_contact_date);
+
+-- Create external identity linking table
+CREATE TABLE IF NOT EXISTS contact_external_identity (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  contact_id uuid NOT NULL REFERENCES contact(id) ON DELETE CASCADE,
+  provider text NOT NULL CHECK (provider IN ('microsoft', 'google', 'linkedin', 'github')),
+  external_id text NOT NULL,
+  sync_status text NOT NULL DEFAULT 'pending' CHECK (sync_status IN ('pending', 'synced', 'error')),
+  synced_at timestamptz,
+  sync_cursor text,
+  sync_error text,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+
+  -- Unique per provider-contact and per provider-external_id
+  CONSTRAINT contact_external_identity_unique UNIQUE (contact_id, provider),
+  CONSTRAINT contact_external_identity_provider_id UNIQUE (provider, external_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_contact_external_identity_contact_id ON contact_external_identity(contact_id);
+CREATE INDEX IF NOT EXISTS idx_contact_external_identity_provider ON contact_external_identity(provider);
+CREATE INDEX IF NOT EXISTS idx_contact_external_identity_sync_status ON contact_external_identity(sync_status);
+
+-- Trigger to update contact's updated_at when external identity changes
+CREATE OR REPLACE FUNCTION update_contact_on_identity_change()
+RETURNS TRIGGER AS $$
+BEGIN
+  UPDATE contact SET updated_at = now() WHERE id = NEW.contact_id;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER contact_external_identity_update_contact
+  AFTER INSERT OR UPDATE ON contact_external_identity
+  FOR EACH ROW
+  EXECUTE FUNCTION update_contact_on_identity_change();
+
+-- Function to auto-update last_contact_date when messages arrive
+CREATE OR REPLACE FUNCTION update_contact_last_contact_date()
+RETURNS TRIGGER AS $$
+BEGIN
+  -- Update the contact's last_contact_date via the thread's endpoint
+  UPDATE contact c
+  SET last_contact_date = GREATEST(COALESCE(c.last_contact_date, '1970-01-01'::timestamptz), NEW.received_at),
+      updated_at = now()
+  FROM external_thread et
+  JOIN contact_endpoint ce ON ce.id = et.endpoint_id
+  WHERE et.id = NEW.thread_id
+    AND ce.contact_id = c.id;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Trigger to auto-update last_contact_date on new messages
+DROP TRIGGER IF EXISTS external_message_update_contact_last_contact ON external_message;
+CREATE TRIGGER external_message_update_contact_last_contact
+  AFTER INSERT ON external_message
+  FOR EACH ROW
+  EXECUTE FUNCTION update_contact_last_contact_date();
+
+-- Comments
+COMMENT ON COLUMN contact.organization IS 'Company or organization the contact belongs to';
+COMMENT ON COLUMN contact.job_title IS 'Job title or role';
+COMMENT ON COLUMN contact.timezone IS 'IANA timezone name (e.g., America/New_York)';
+COMMENT ON COLUMN contact.preferred_endpoint_id IS 'Preferred communication endpoint';
+COMMENT ON COLUMN contact.relationship_type IS 'How user knows this contact (friend, family, colleague, client, vendor)';
+COMMENT ON COLUMN contact.last_contact_date IS 'Auto-updated when messages are received';
+
+COMMENT ON TABLE contact_external_identity IS 'Links contacts to external identity providers (M365, Google, etc.)';

--- a/tests/contact_schema_enhancement.test.ts
+++ b/tests/contact_schema_enhancement.test.ts
@@ -1,0 +1,459 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { Pool } from 'pg';
+import { runMigrate } from './helpers/migrate.js';
+import { createTestPool, truncateAllTables } from './helpers/db.js';
+
+describe('Contact Schema Enhancement (Issue #208)', () => {
+  let pool: Pool;
+
+  beforeAll(async () => {
+    await runMigrate('up');
+    pool = createTestPool();
+  });
+
+  beforeEach(async () => {
+    await truncateAllTables(pool);
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  describe('New contact metadata columns', () => {
+    it('supports organization and job_title fields', async () => {
+      const result = await pool.query(
+        `INSERT INTO contact (display_name, organization, job_title)
+         VALUES ('John Smith', 'Acme Corp', 'CTO')
+         RETURNING id::text as id, display_name, organization, job_title`
+      );
+
+      expect(result.rows[0].display_name).toBe('John Smith');
+      expect(result.rows[0].organization).toBe('Acme Corp');
+      expect(result.rows[0].job_title).toBe('CTO');
+    });
+
+    it('supports timezone field with IANA timezone names', async () => {
+      const result = await pool.query(
+        `INSERT INTO contact (display_name, timezone)
+         VALUES ('Jane Doe', 'Australia/Sydney')
+         RETURNING timezone`
+      );
+
+      expect(result.rows[0].timezone).toBe('Australia/Sydney');
+    });
+
+    it('supports birthday field', async () => {
+      const result = await pool.query(
+        `INSERT INTO contact (display_name, birthday)
+         VALUES ('Birthday Person', '1990-05-15')
+         RETURNING birthday`
+      );
+
+      const birthday = new Date(result.rows[0].birthday);
+      expect(birthday.getMonth()).toBe(4); // May (0-indexed)
+      expect(birthday.getDate()).toBe(15);
+    });
+
+    it('supports pronouns and language fields', async () => {
+      const result = await pool.query(
+        `INSERT INTO contact (display_name, pronouns, language)
+         VALUES ('Alex', 'they/them', 'es')
+         RETURNING pronouns, language`
+      );
+
+      expect(result.rows[0].pronouns).toBe('they/them');
+      expect(result.rows[0].language).toBe('es');
+    });
+
+    it('defaults language to en', async () => {
+      const result = await pool.query(
+        `INSERT INTO contact (display_name)
+         VALUES ('Default Lang')
+         RETURNING language`
+      );
+
+      expect(result.rows[0].language).toBe('en');
+    });
+
+    it('supports relationship_type and relationship_notes', async () => {
+      const result = await pool.query(
+        `INSERT INTO contact (display_name, relationship_type, relationship_notes)
+         VALUES ('Client Contact', 'client', 'Met at TechCrunch 2025')
+         RETURNING relationship_type, relationship_notes`
+      );
+
+      expect(result.rows[0].relationship_type).toBe('client');
+      expect(result.rows[0].relationship_notes).toBe('Met at TechCrunch 2025');
+    });
+
+    it('supports first_contact_date', async () => {
+      const result = await pool.query(
+        `INSERT INTO contact (display_name, first_contact_date)
+         VALUES ('First Contact', '2025-01-15T10:00:00Z')
+         RETURNING first_contact_date`
+      );
+
+      expect(result.rows[0].first_contact_date).toBeDefined();
+    });
+
+    it('supports photo_url', async () => {
+      const result = await pool.query(
+        `INSERT INTO contact (display_name, photo_url)
+         VALUES ('Photo Contact', 'https://example.com/photo.jpg')
+         RETURNING photo_url`
+      );
+
+      expect(result.rows[0].photo_url).toBe('https://example.com/photo.jpg');
+    });
+  });
+
+  describe('Preferred endpoint reference', () => {
+    it('can link to a preferred contact endpoint', async () => {
+      // Create contact
+      const contactResult = await pool.query(
+        `INSERT INTO contact (display_name)
+         VALUES ('Multi Endpoint')
+         RETURNING id::text as id`
+      );
+      const contactId = contactResult.rows[0].id;
+
+      // Create endpoints
+      const emailResult = await pool.query(
+        `INSERT INTO contact_endpoint (contact_id, endpoint_type, endpoint_value, normalized_value)
+         VALUES ($1, 'email', 'test@example.com', 'test@example.com')
+         RETURNING id::text as id`,
+        [contactId]
+      );
+      const emailId = emailResult.rows[0].id;
+
+      // Set as preferred
+      await pool.query(
+        `UPDATE contact SET preferred_endpoint_id = $1 WHERE id = $2`,
+        [emailId, contactId]
+      );
+
+      const result = await pool.query(
+        `SELECT preferred_endpoint_id::text FROM contact WHERE id = $1`,
+        [contactId]
+      );
+
+      expect(result.rows[0].preferred_endpoint_id).toBe(emailId);
+    });
+
+    it('nullifies preferred_endpoint_id when endpoint is deleted', async () => {
+      const contactResult = await pool.query(
+        `INSERT INTO contact (display_name)
+         VALUES ('Endpoint Delete Test')
+         RETURNING id::text as id`
+      );
+      const contactId = contactResult.rows[0].id;
+
+      const endpointResult = await pool.query(
+        `INSERT INTO contact_endpoint (contact_id, endpoint_type, endpoint_value, normalized_value)
+         VALUES ($1, 'email', 'delete@example.com', 'delete@example.com')
+         RETURNING id::text as id`,
+        [contactId]
+      );
+      const endpointId = endpointResult.rows[0].id;
+
+      await pool.query(
+        `UPDATE contact SET preferred_endpoint_id = $1 WHERE id = $2`,
+        [endpointId, contactId]
+      );
+
+      // Delete the endpoint
+      await pool.query(`DELETE FROM contact_endpoint WHERE id = $1`, [endpointId]);
+
+      // Check that preferred_endpoint_id is now null
+      const result = await pool.query(
+        `SELECT preferred_endpoint_id FROM contact WHERE id = $1`,
+        [contactId]
+      );
+
+      expect(result.rows[0].preferred_endpoint_id).toBeNull();
+    });
+  });
+
+  describe('External identity linking', () => {
+    it('creates external identity record', async () => {
+      const contactResult = await pool.query(
+        `INSERT INTO contact (display_name)
+         VALUES ('Synced Contact')
+         RETURNING id::text as id`
+      );
+      const contactId = contactResult.rows[0].id;
+
+      const result = await pool.query(
+        `INSERT INTO contact_external_identity
+           (contact_id, provider, external_id, sync_status, synced_at)
+         VALUES ($1, 'microsoft', 'ms-123', 'synced', NOW())
+         RETURNING provider, external_id, sync_status`,
+        [contactId]
+      );
+
+      expect(result.rows[0].provider).toBe('microsoft');
+      expect(result.rows[0].external_id).toBe('ms-123');
+      expect(result.rows[0].sync_status).toBe('synced');
+    });
+
+    it('enforces unique contact per provider', async () => {
+      const contactResult = await pool.query(
+        `INSERT INTO contact (display_name)
+         VALUES ('Unique Provider Test')
+         RETURNING id::text as id`
+      );
+      const contactId = contactResult.rows[0].id;
+
+      await pool.query(
+        `INSERT INTO contact_external_identity (contact_id, provider, external_id)
+         VALUES ($1, 'google', 'google-123')`,
+        [contactId]
+      );
+
+      // Should fail on duplicate
+      await expect(
+        pool.query(
+          `INSERT INTO contact_external_identity (contact_id, provider, external_id)
+           VALUES ($1, 'google', 'google-456')`,
+          [contactId]
+        )
+      ).rejects.toThrow(/duplicate/i);
+    });
+
+    it('enforces unique external_id per provider', async () => {
+      const contact1 = await pool.query(
+        `INSERT INTO contact (display_name) VALUES ('Contact 1') RETURNING id::text as id`
+      );
+      const contact2 = await pool.query(
+        `INSERT INTO contact (display_name) VALUES ('Contact 2') RETURNING id::text as id`
+      );
+
+      await pool.query(
+        `INSERT INTO contact_external_identity (contact_id, provider, external_id)
+         VALUES ($1, 'microsoft', 'same-id')`,
+        [contact1.rows[0].id]
+      );
+
+      await expect(
+        pool.query(
+          `INSERT INTO contact_external_identity (contact_id, provider, external_id)
+           VALUES ($1, 'microsoft', 'same-id')`,
+          [contact2.rows[0].id]
+        )
+      ).rejects.toThrow(/duplicate/i);
+    });
+
+    it('supports multiple providers per contact', async () => {
+      const contactResult = await pool.query(
+        `INSERT INTO contact (display_name)
+         VALUES ('Multi Provider')
+         RETURNING id::text as id`
+      );
+      const contactId = contactResult.rows[0].id;
+
+      await pool.query(
+        `INSERT INTO contact_external_identity (contact_id, provider, external_id)
+         VALUES ($1, 'microsoft', 'ms-id'),
+                ($1, 'google', 'google-id')`,
+        [contactId]
+      );
+
+      const result = await pool.query(
+        `SELECT provider FROM contact_external_identity WHERE contact_id = $1 ORDER BY provider`,
+        [contactId]
+      );
+
+      expect(result.rows).toHaveLength(2);
+      expect(result.rows[0].provider).toBe('google');
+      expect(result.rows[1].provider).toBe('microsoft');
+    });
+
+    it('validates provider values', async () => {
+      const contactResult = await pool.query(
+        `INSERT INTO contact (display_name)
+         VALUES ('Provider Check')
+         RETURNING id::text as id`
+      );
+      const contactId = contactResult.rows[0].id;
+
+      await expect(
+        pool.query(
+          `INSERT INTO contact_external_identity (contact_id, provider, external_id)
+           VALUES ($1, 'invalid_provider', 'id-123')`,
+          [contactId]
+        )
+      ).rejects.toThrow(/check/i);
+    });
+
+    it('validates sync_status values', async () => {
+      const contactResult = await pool.query(
+        `INSERT INTO contact (display_name)
+         VALUES ('Status Check')
+         RETURNING id::text as id`
+      );
+      const contactId = contactResult.rows[0].id;
+
+      await expect(
+        pool.query(
+          `INSERT INTO contact_external_identity (contact_id, provider, external_id, sync_status)
+           VALUES ($1, 'microsoft', 'id-123', 'invalid_status')`,
+          [contactId]
+        )
+      ).rejects.toThrow(/check/i);
+    });
+
+    it('cascades delete when contact is deleted', async () => {
+      const contactResult = await pool.query(
+        `INSERT INTO contact (display_name)
+         VALUES ('Cascade Delete')
+         RETURNING id::text as id`
+      );
+      const contactId = contactResult.rows[0].id;
+
+      await pool.query(
+        `INSERT INTO contact_external_identity (contact_id, provider, external_id)
+         VALUES ($1, 'microsoft', 'cascade-test')`,
+        [contactId]
+      );
+
+      // Delete contact
+      await pool.query(`DELETE FROM contact WHERE id = $1`, [contactId]);
+
+      // External identity should be deleted
+      const result = await pool.query(
+        `SELECT COUNT(*) as count FROM contact_external_identity WHERE contact_id = $1`,
+        [contactId]
+      );
+
+      expect(parseInt(result.rows[0].count, 10)).toBe(0);
+    });
+  });
+
+  describe('Auto-update last_contact_date', () => {
+    it('updates last_contact_date when message is received', async () => {
+      // Create contact with endpoint and thread
+      const contactResult = await pool.query(
+        `INSERT INTO contact (display_name)
+         VALUES ('Message Test')
+         RETURNING id::text as id`
+      );
+      const contactId = contactResult.rows[0].id;
+
+      const endpointResult = await pool.query(
+        `INSERT INTO contact_endpoint (contact_id, endpoint_type, endpoint_value, normalized_value)
+         VALUES ($1, 'phone', '+15551234567', '+15551234567')
+         RETURNING id::text as id`,
+        [contactId]
+      );
+      const endpointId = endpointResult.rows[0].id;
+
+      const threadResult = await pool.query(
+        `INSERT INTO external_thread (endpoint_id, channel, external_thread_key)
+         VALUES ($1, 'phone', 'thread-auto-update')
+         RETURNING id::text as id`,
+        [endpointId]
+      );
+      const threadId = threadResult.rows[0].id;
+
+      // Initially null
+      const beforeResult = await pool.query(
+        `SELECT last_contact_date FROM contact WHERE id = $1`,
+        [contactId]
+      );
+      expect(beforeResult.rows[0].last_contact_date).toBeNull();
+
+      // Insert message
+      const messageTime = new Date('2026-02-01T15:00:00Z');
+      await pool.query(
+        `INSERT INTO external_message (thread_id, external_message_key, direction, body, received_at)
+         VALUES ($1, 'msg-trigger', 'inbound', 'Hello', $2)`,
+        [threadId, messageTime]
+      );
+
+      // Check last_contact_date was updated
+      const afterResult = await pool.query(
+        `SELECT last_contact_date FROM contact WHERE id = $1`,
+        [contactId]
+      );
+
+      expect(afterResult.rows[0].last_contact_date).not.toBeNull();
+      const lastContact = new Date(afterResult.rows[0].last_contact_date);
+      expect(lastContact.toISOString()).toBe(messageTime.toISOString());
+    });
+
+    it('keeps the most recent last_contact_date', async () => {
+      const contactResult = await pool.query(
+        `INSERT INTO contact (display_name, last_contact_date)
+         VALUES ('Newer Date Test', '2026-02-10T10:00:00Z')
+         RETURNING id::text as id`
+      );
+      const contactId = contactResult.rows[0].id;
+
+      const endpointResult = await pool.query(
+        `INSERT INTO contact_endpoint (contact_id, endpoint_type, endpoint_value, normalized_value)
+         VALUES ($1, 'phone', '+15559999999', '+15559999999')
+         RETURNING id::text as id`,
+        [contactId]
+      );
+      const endpointId = endpointResult.rows[0].id;
+
+      const threadResult = await pool.query(
+        `INSERT INTO external_thread (endpoint_id, channel, external_thread_key)
+         VALUES ($1, 'phone', 'thread-newer')
+         RETURNING id::text as id`,
+        [endpointId]
+      );
+      const threadId = threadResult.rows[0].id;
+
+      // Insert an older message - should NOT update last_contact_date
+      await pool.query(
+        `INSERT INTO external_message (thread_id, external_message_key, direction, body, received_at)
+         VALUES ($1, 'older-msg', 'inbound', 'Older', '2026-02-05T10:00:00Z')`,
+        [threadId]
+      );
+
+      const result = await pool.query(
+        `SELECT last_contact_date FROM contact WHERE id = $1`,
+        [contactId]
+      );
+
+      // Should still be the original date (Feb 10), not the older message date (Feb 5)
+      const lastContact = new Date(result.rows[0].last_contact_date);
+      expect(lastContact.getDate()).toBe(10);
+    });
+  });
+
+  describe('Contact memories via memory table', () => {
+    it('can link memories to contacts', async () => {
+      const contactResult = await pool.query(
+        `INSERT INTO contact (display_name)
+         VALUES ('Memory Contact')
+         RETURNING id::text as id`
+      );
+      const contactId = contactResult.rows[0].id;
+
+      // Create memory linked to contact
+      const memoryResult = await pool.query(
+        `INSERT INTO memory (title, content, memory_type, contact_id, importance)
+         VALUES ('Preference', 'Prefers email over phone', 'preference', $1, 8)
+         RETURNING id::text as id, contact_id::text`,
+        [contactId]
+      );
+
+      expect(memoryResult.rows[0].contact_id).toBe(contactId);
+
+      // Query memories for contact
+      const memories = await pool.query(
+        `SELECT title, content, memory_type
+         FROM memory
+         WHERE contact_id = $1
+         ORDER BY created_at`,
+        [contactId]
+      );
+
+      expect(memories.rows).toHaveLength(1);
+      expect(memories.rows[0].title).toBe('Preference');
+      expect(memories.rows[0].memory_type).toBe('preference');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Enhances the contact schema to provide OpenClaw agents with rich context about people, including professional info, relationship data, external identity linking, and auto-tracked communication history.

### New Contact Metadata Columns

| Column | Type | Description |
|--------|------|-------------|
| `organization` | text | Company/employer name |
| `job_title` | text | Role/title |
| `timezone` | text | IANA timezone (e.g., "Australia/Sydney") |
| `birthday` | date | Birthday (optional) |
| `photo_url` | text | Profile photo URL |
| `preferred_endpoint_id` | uuid | FK to preferred contact_endpoint |
| `pronouns` | text | Pronouns (he/she/they) |
| `language` | text | Preferred language (default: 'en') |
| `relationship_type` | text | How user knows them (friend, family, client) |
| `relationship_notes` | text | Free-form relationship context |
| `first_contact_date` | timestamptz | When first communicated |
| `last_contact_date` | timestamptz | Most recent communication (auto-updated) |

### External Identity Linking

New `contact_external_identity` table for M365/Google sync:

```sql
contact_external_identity (
  contact_id uuid,
  provider text CHECK (provider IN ('microsoft', 'google', 'linkedin', 'github')),
  external_id text,
  sync_status text CHECK (sync_status IN ('pending', 'synced', 'error')),
  synced_at timestamptz,
  sync_cursor text,
  sync_error text,
  metadata jsonb
)
```

Constraints:
- One external ID per provider per contact
- Unique external_id per provider (prevents duplicates)

### Auto-Update Last Contact Date

Trigger on `external_message` INSERT automatically updates `contact.last_contact_date`:
- Finds contact via thread → endpoint → contact chain
- Uses GREATEST to only update if message is newer than existing date

### Contact Memories

Memories can be linked to contacts via `memory.contact_id` (added in migration 028):

```sql
INSERT INTO memory (title, content, memory_type, contact_id, importance)
VALUES ('Preference', 'Prefers email over phone', 'preference', $1, 8);
```

## Test plan

- [x] Supports organization and job_title fields
- [x] Supports timezone with IANA names
- [x] Supports birthday, pronouns, language
- [x] Defaults language to 'en'
- [x] Supports relationship_type and relationship_notes
- [x] Can link to preferred endpoint
- [x] Nullifies preferred_endpoint_id when endpoint deleted
- [x] Creates external identity records
- [x] Enforces unique contact per provider
- [x] Enforces unique external_id per provider
- [x] Supports multiple providers per contact
- [x] Validates provider and sync_status values
- [x] Cascades delete when contact deleted
- [x] Auto-updates last_contact_date on message
- [x] Keeps most recent last_contact_date
- [x] Can link memories to contacts

All 1141 tests pass.

Closes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)