### PR TITLE
[#202] Implement Twilio SMS inbound webhook

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,11 +13,18 @@
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@fastify/cookie": "^11.0.2",
+        "@fastify/formbody": "^8.0.2",
         "@fastify/static": "^9.0.0",
+        "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.15",
+        "@radix-ui/react-dropdown-menu": "^2.1.16",
+        "@radix-ui/react-popover": "^1.1.15",
         "@radix-ui/react-scroll-area": "^1.2.10",
+        "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-separator": "^1.1.8",
         "@radix-ui/react-slot": "^1.2.4",
+        "@radix-ui/react-switch": "^1.2.6",
+        "@radix-ui/react-tabs": "^1.1.13",
         "@radix-ui/react-tooltip": "^1.2.8",
         "@types/pg": "^8.16.0",
         "class-variance-authority": "^0.7.1",
@@ -25,7 +32,7 @@
         "cmdk": "^1.1.1",
         "fastify": "^5.7.2",
         "lucide-react": "^0.563.0",
-        "pg": "^8.17.2",
+        "pg": "^8.18.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "tailwind-merge": "^3.4.0"
@@ -34,13 +41,12 @@
         "@tailwindcss/vite": "^4.1.18",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
-        "@types/node": "^25.0.10",
+        "@types/node": "^25.2.0",
         "@types/react": "^19.2.10",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.1.2",
         "jsdom": "^27.4.0",
         "tailwindcss": "^4.1.18",
-        "tsx": "^4.21.0",
         "typescript": "^5.9.3",
         "vite": "^7.3.1",
         "vitest": "^4.0.18"
@@ -1144,6 +1150,26 @@
         "fast-json-stringify": "^6.0.0"
       }
     },
+    "node_modules/@fastify/formbody": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@fastify/formbody/-/formbody-8.0.2.tgz",
+      "integrity": "sha512-84v5J2KrkXzjgBpYnaNRPqwgMsmY7ZDjuj0YVuMR3NXCJRCgKEZy/taSP1wUYGn0onfxJpLyRGDLa+NMaDJtnA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-querystring": "^1.1.2",
+        "fastify-plugin": "^5.0.0"
+      }
+    },
     "node_modules/@fastify/forwarded": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@fastify/forwarded/-/forwarded-3.0.1.tgz",
@@ -1405,6 +1431,80 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-checkbox": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.3.tgz",
+      "integrity": "sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
+      "integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collection/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
@@ -1531,6 +1631,35 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-dropdown-menu": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.16.tgz",
+      "integrity": "sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-menu": "2.1.16",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-focus-guards": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
@@ -1578,6 +1707,119 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.16.tgz",
+      "integrity": "sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.15.tgz",
+      "integrity": "sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1710,6 +1952,37 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz",
+      "integrity": "sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-scroll-area": {
       "version": "1.2.10",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.10.tgz",
@@ -1737,6 +2010,67 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.2.6.tgz",
+      "integrity": "sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -1801,6 +2135,65 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-switch": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.2.6.tgz",
+      "integrity": "sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.13.tgz",
+      "integrity": "sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }
@@ -1931,6 +2324,21 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
       "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz",
+      "integrity": "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -2798,9 +3206,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.1.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.1.0.tgz",
-      "integrity": "sha512-t7frlewr6+cbx+9Ohpl0NOTKXZNV9xHRmNOvql47BFJKcEG1CxtxlPEEe+gR9uhVWM4DwhnvTF110mIL4yP9RA==",
+      "version": "25.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.0.tgz",
+      "integrity": "sha512-DZ8VwRFUNzuqJ5khrvwMXHmvPe+zGayJhr2CDNiKB1WBE1ST8Djl00D0IC4vvNmHMdj6DlbYRIaFE7WHjlDl5w==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -3690,19 +4098,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/get-tsconfig": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.1.tgz",
-      "integrity": "sha512-EoY1N2xCn44xU6750Sx7OjOIT59FkmstNc3X6y5xpz7D5cBtZRe/3pSlTkDJgqsOk3WwZPkWfonhhUJfttQo3w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "resolve-pkg-maps": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/glob": {
@@ -4808,16 +5203,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/resolve-pkg-maps": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
-      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
-      }
-    },
     "node_modules/ret": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.5.0.tgz",
@@ -5238,26 +5623,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
-    },
-    "node_modules/tsx": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
-      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "esbuild": "~0.27.0",
-        "get-tsconfig": "^4.7.5"
-      },
-      "bin": {
-        "tsx": "dist/cli.mjs"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
-      }
     },
     "node_modules/typescript": {
       "version": "5.9.3",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@fastify/cookie": "^11.0.2",
+    "@fastify/formbody": "^8.0.2",
     "@fastify/static": "^9.0.0",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@fastify/cookie':
         specifier: ^11.0.2
         version: 11.0.2
+      '@fastify/formbody':
+        specifier: ^8.0.2
+        version: 8.0.2
       '@fastify/static':
         specifier: ^9.0.0
         version: 9.0.0
@@ -464,6 +467,9 @@ packages:
 
   '@fastify/fast-json-stringify-compiler@5.0.3':
     resolution: {integrity: sha512-uik7yYHkLr6fxd8hJSZ8c+xF4WafPK+XzneQDPU+D10r5X19GW8lJcom2YijX2+qtFF1ENJlHXKFM9ouXNJYgQ==}
+
+  '@fastify/formbody@8.0.2':
+    resolution: {integrity: sha512-84v5J2KrkXzjgBpYnaNRPqwgMsmY7ZDjuj0YVuMR3NXCJRCgKEZy/taSP1wUYGn0onfxJpLyRGDLa+NMaDJtnA==}
 
   '@fastify/forwarded@3.0.1':
     resolution: {integrity: sha512-JqDochHFqXs3C3Ml3gOY58zM7OqO9ENqPo0UqAjAjH8L01fRZqwX9iLeX34//kiJubF7r2ZQHtBRU36vONbLlw==}
@@ -2446,6 +2452,11 @@ snapshots:
   '@fastify/fast-json-stringify-compiler@5.0.3':
     dependencies:
       fast-json-stringify: 6.2.0
+
+  '@fastify/formbody@8.0.2':
+    dependencies:
+      fast-querystring: 1.1.2
+      fastify-plugin: 5.1.0
 
   '@fastify/forwarded@3.0.1': {}
 

--- a/src/api/twilio/index.ts
+++ b/src/api/twilio/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Twilio SMS webhook integration.
+ * Part of Issue #202.
+ */
+
+export * from './types.js';
+export * from './phone-utils.js';
+export * from './service.js';

--- a/src/api/twilio/phone-utils.ts
+++ b/src/api/twilio/phone-utils.ts
@@ -1,0 +1,107 @@
+/**
+ * Phone number utilities for Twilio integration.
+ * Part of Issue #202.
+ */
+
+import type { E164PhoneNumber } from './types.js';
+
+/**
+ * Normalize a phone number to E.164 format.
+ * Twilio typically sends numbers in E.164 format already,
+ * but this ensures consistency and handles edge cases.
+ *
+ * @param phone - The phone number to normalize
+ * @param defaultCountryCode - Default country code if missing (e.g., '1' for US)
+ * @returns E.164 formatted number (e.g., +14155551234)
+ */
+export function normalizePhoneNumber(
+  phone: string,
+  defaultCountryCode: string = '1'
+): E164PhoneNumber {
+  // Strip all non-digit characters except leading +
+  let cleaned = phone.replace(/[^\d+]/g, '');
+
+  // If already has +, it's likely E.164
+  if (cleaned.startsWith('+')) {
+    return cleaned;
+  }
+
+  // Handle international format with leading 00 (common in Europe)
+  // e.g., 00447911123456 -> +447911123456
+  if (cleaned.startsWith('00') && cleaned.length > 10) {
+    return `+${cleaned.slice(2)}`;
+  }
+
+  // Remove any leading zeros that aren't part of international prefix
+  cleaned = cleaned.replace(/^0+/, '');
+
+  // If it looks like a US/Canada number without country code (10 digits)
+  if (cleaned.length === 10 && defaultCountryCode === '1') {
+    return `+1${cleaned}`;
+  }
+
+  // If it starts with 1 and is 11 digits (US/Canada with country code)
+  if (cleaned.length === 11 && cleaned.startsWith('1')) {
+    return `+${cleaned}`;
+  }
+
+  // If it's longer than 10 digits, it probably already has a country code
+  if (cleaned.length > 10) {
+    return `+${cleaned}`;
+  }
+
+  // Otherwise, assume the default country code is needed
+  return `+${defaultCountryCode}${cleaned}`;
+}
+
+/**
+ * Extract the phone number part without country code.
+ * Useful for display purposes.
+ *
+ * @param phone - E.164 formatted phone number
+ * @returns Phone number without country code
+ */
+export function getLocalNumber(phone: E164PhoneNumber): string {
+  // Remove + and country code (assumes US/Canada for now)
+  const digits = phone.replace(/\D/g, '');
+  if (digits.length === 11 && digits.startsWith('1')) {
+    return digits.slice(1);
+  }
+  return digits;
+}
+
+/**
+ * Format a phone number for display.
+ * Converts E.164 to a more readable format.
+ *
+ * @param phone - E.164 formatted phone number
+ * @returns Human-readable format (e.g., +1 (415) 555-1234)
+ */
+export function formatPhoneForDisplay(phone: E164PhoneNumber): string {
+  const digits = phone.replace(/\D/g, '');
+
+  // US/Canada format
+  if (digits.length === 11 && digits.startsWith('1')) {
+    const area = digits.slice(1, 4);
+    const exchange = digits.slice(4, 7);
+    const subscriber = digits.slice(7, 11);
+    return `+1 (${area}) ${exchange}-${subscriber}`;
+  }
+
+  // Default: just add + and spaces every 3 digits
+  return `+${digits.replace(/(\d{3})(?=\d)/g, '$1 ').trim()}`;
+}
+
+/**
+ * Create a unique thread key for SMS conversations.
+ * Combines both phone numbers to create a stable thread identifier.
+ *
+ * @param from - Sender phone number (E.164)
+ * @param to - Recipient phone number (E.164)
+ * @returns Thread key string
+ */
+export function createSmsThreadKey(from: E164PhoneNumber, to: E164PhoneNumber): string {
+  // Sort to ensure same thread regardless of direction
+  const [phone1, phone2] = [from, to].sort();
+  return `sms:${phone1}:${phone2}`;
+}

--- a/src/api/twilio/service.ts
+++ b/src/api/twilio/service.ts
@@ -1,0 +1,234 @@
+/**
+ * Twilio SMS webhook service.
+ * Part of Issue #202.
+ */
+
+import { Pool } from 'pg';
+import type { TwilioSmsWebhookPayload, TwilioSmsResult, E164PhoneNumber } from './types.js';
+import { normalizePhoneNumber, createSmsThreadKey } from './phone-utils.js';
+
+/**
+ * Process an inbound Twilio SMS webhook.
+ *
+ * This function:
+ * 1. Normalizes phone numbers to E.164 format
+ * 2. Creates or finds the contact/endpoint for the sender
+ * 3. Creates or finds the SMS thread
+ * 4. Stores the message with full Twilio payload
+ *
+ * @param pool - Database connection pool
+ * @param payload - Twilio webhook payload
+ * @returns Result with all created/found IDs
+ */
+export async function processTwilioSms(
+  pool: Pool,
+  payload: TwilioSmsWebhookPayload
+): Promise<TwilioSmsResult> {
+  const client = await pool.connect();
+
+  try {
+    await client.query('BEGIN');
+
+    // Normalize phone numbers (Twilio usually sends E.164 already)
+    const fromPhone: E164PhoneNumber = normalizePhoneNumber(payload.From);
+    const toPhone: E164PhoneNumber = normalizePhoneNumber(payload.To);
+
+    // Try to find an existing endpoint for the sender's phone number
+    const existingEndpoint = await client.query(
+      `SELECT ce.id::text as id, ce.contact_id::text as contact_id
+         FROM contact_endpoint ce
+        WHERE ce.endpoint_type = 'phone'
+          AND ce.normalized_value = normalize_contact_endpoint_value('phone', $1)
+        LIMIT 1`,
+      [fromPhone]
+    );
+
+    let contactId: string;
+    let endpointId: string;
+    let isNewContact = false;
+
+    if (existingEndpoint.rows.length > 0) {
+      endpointId = existingEndpoint.rows[0].id;
+      contactId = existingEndpoint.rows[0].contact_id;
+    } else {
+      // Create new contact with phone number as display name
+      // The display name can be updated later when we learn the actual name
+      const displayName = formatDisplayNameFromPayload(payload);
+      isNewContact = true;
+
+      const contact = await client.query(
+        `INSERT INTO contact (display_name)
+         VALUES ($1)
+         RETURNING id::text as id`,
+        [displayName]
+      );
+      contactId = contact.rows[0].id;
+
+      const endpoint = await client.query(
+        `INSERT INTO contact_endpoint (contact_id, endpoint_type, endpoint_value, metadata)
+         VALUES ($1, 'phone', $2, $3::jsonb)
+         RETURNING id::text as id`,
+        [
+          contactId,
+          fromPhone,
+          JSON.stringify({
+            source: 'twilio',
+            fromCity: payload.FromCity,
+            fromState: payload.FromState,
+            fromCountry: payload.FromCountry,
+          }),
+        ]
+      );
+      endpointId = endpoint.rows[0].id;
+    }
+
+    // Create or find thread for this SMS conversation
+    const threadKey = createSmsThreadKey(fromPhone, toPhone);
+
+    const thread = await client.query(
+      `INSERT INTO external_thread (endpoint_id, channel, external_thread_key, metadata)
+       VALUES ($1, 'phone', $2, $3::jsonb)
+       ON CONFLICT (channel, external_thread_key)
+       DO UPDATE SET endpoint_id = EXCLUDED.endpoint_id, updated_at = now()
+       RETURNING id::text as id`,
+      [
+        endpointId,
+        threadKey,
+        JSON.stringify({
+          fromPhone,
+          toPhone,
+          source: 'twilio',
+        }),
+      ]
+    );
+    const threadId = thread.rows[0].id;
+
+    // Insert the message with full Twilio payload
+    const message = await client.query(
+      `INSERT INTO external_message (thread_id, external_message_key, direction, body, raw, received_at)
+       VALUES ($1, $2, 'inbound', $3, $4::jsonb, now())
+       ON CONFLICT (thread_id, external_message_key)
+       DO UPDATE SET body = EXCLUDED.body, raw = EXCLUDED.raw
+       RETURNING id::text as id`,
+      [threadId, payload.MessageSid, payload.Body, JSON.stringify(payload)]
+    );
+    const messageId = message.rows[0].id;
+
+    await client.query('COMMIT');
+
+    return {
+      contactId,
+      endpointId,
+      threadId,
+      messageId,
+      isNewContact,
+    };
+  } catch (error) {
+    await client.query('ROLLBACK');
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+/**
+ * Create a display name from Twilio payload.
+ * Uses geographic info if available, otherwise the phone number.
+ */
+function formatDisplayNameFromPayload(payload: TwilioSmsWebhookPayload): string {
+  const fromPhone = normalizePhoneNumber(payload.From);
+
+  // If we have location info, include it
+  if (payload.FromCity && payload.FromState) {
+    return `${fromPhone} (${payload.FromCity}, ${payload.FromState})`;
+  }
+
+  if (payload.FromCountry) {
+    return `${fromPhone} (${payload.FromCountry})`;
+  }
+
+  return fromPhone;
+}
+
+/**
+ * Get recent SMS messages for a phone number.
+ *
+ * @param pool - Database connection pool
+ * @param phone - Phone number in E.164 format
+ * @param limit - Maximum messages to return
+ * @returns Array of message records
+ */
+export async function getRecentSmsMessages(
+  pool: Pool,
+  phone: E164PhoneNumber,
+  limit: number = 50
+): Promise<
+  Array<{
+    id: string;
+    threadId: string;
+    direction: 'inbound' | 'outbound';
+    body: string | null;
+    receivedAt: Date;
+    raw: Record<string, unknown>;
+  }>
+> {
+  const result = await pool.query(
+    `SELECT em.id::text as id,
+            em.thread_id::text as thread_id,
+            em.direction::text as direction,
+            em.body,
+            em.received_at,
+            em.raw
+       FROM external_message em
+       JOIN external_thread et ON et.id = em.thread_id
+       JOIN contact_endpoint ce ON ce.id = et.endpoint_id
+      WHERE et.channel = 'phone'
+        AND ce.normalized_value = normalize_contact_endpoint_value('phone', $1)
+      ORDER BY em.received_at DESC
+      LIMIT $2`,
+    [phone, limit]
+  );
+
+  return result.rows.map((row) => ({
+    id: row.id,
+    threadId: row.thread_id,
+    direction: row.direction,
+    body: row.body,
+    receivedAt: row.received_at,
+    raw: row.raw,
+  }));
+}
+
+/**
+ * Find contact by phone number.
+ *
+ * @param pool - Database connection pool
+ * @param phone - Phone number in E.164 format
+ * @returns Contact info or null if not found
+ */
+export async function findContactByPhone(
+  pool: Pool,
+  phone: E164PhoneNumber
+): Promise<{ contactId: string; endpointId: string; displayName: string } | null> {
+  const result = await pool.query(
+    `SELECT ce.id::text as endpoint_id,
+            c.id::text as contact_id,
+            c.display_name
+       FROM contact_endpoint ce
+       JOIN contact c ON c.id = ce.contact_id
+      WHERE ce.endpoint_type = 'phone'
+        AND ce.normalized_value = normalize_contact_endpoint_value('phone', $1)
+      LIMIT 1`,
+    [phone]
+  );
+
+  if (result.rows.length === 0) {
+    return null;
+  }
+
+  return {
+    contactId: result.rows[0].contact_id,
+    endpointId: result.rows[0].endpoint_id,
+    displayName: result.rows[0].display_name,
+  };
+}

--- a/src/api/twilio/types.ts
+++ b/src/api/twilio/types.ts
@@ -1,0 +1,64 @@
+/**
+ * Twilio webhook types.
+ * Part of Issue #202.
+ */
+
+/**
+ * Twilio SMS webhook payload (URL-encoded form data).
+ * @see https://www.twilio.com/docs/messaging/twiml#request-parameters
+ */
+export interface TwilioSmsWebhookPayload {
+  // Core message fields
+  MessageSid: string;
+  SmsSid?: string;
+  AccountSid: string;
+  MessagingServiceSid?: string;
+  From: string;
+  To: string;
+  Body: string;
+
+  // Optional media fields
+  NumMedia?: string;
+  MediaContentType0?: string;
+  MediaUrl0?: string;
+  // Can have MediaContentType1, MediaUrl1, etc. for multiple attachments
+
+  // Geographic info
+  FromCity?: string;
+  FromState?: string;
+  FromZip?: string;
+  FromCountry?: string;
+  ToCity?: string;
+  ToState?: string;
+  ToZip?: string;
+  ToCountry?: string;
+
+  // API version
+  ApiVersion?: string;
+}
+
+/**
+ * Normalized phone number in E.164 format.
+ * Always starts with + followed by country code and number.
+ */
+export type E164PhoneNumber = string;
+
+/**
+ * Result of processing a Twilio SMS webhook.
+ */
+export interface TwilioSmsResult {
+  contactId: string;
+  endpointId: string;
+  threadId: string;
+  messageId: string;
+  isNewContact: boolean;
+}
+
+/**
+ * Twilio TwiML response for SMS.
+ * Empty response means no reply.
+ */
+export interface TwilioSmsResponse {
+  // Return empty string for no TwiML response
+  twiml: string;
+}

--- a/tests/twilio/phone-utils.test.ts
+++ b/tests/twilio/phone-utils.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Tests for phone number utilities.
+ * Part of Issue #202.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  normalizePhoneNumber,
+  getLocalNumber,
+  formatPhoneForDisplay,
+  createSmsThreadKey,
+} from '../../src/api/twilio/phone-utils.ts';
+
+describe('Phone Utils', () => {
+  describe('normalizePhoneNumber', () => {
+    it('returns E.164 number unchanged', () => {
+      expect(normalizePhoneNumber('+14155551234')).toBe('+14155551234');
+    });
+
+    it('adds + to numbers starting with country code', () => {
+      expect(normalizePhoneNumber('14155551234')).toBe('+14155551234');
+    });
+
+    it('adds +1 to 10-digit US numbers', () => {
+      expect(normalizePhoneNumber('4155551234')).toBe('+14155551234');
+    });
+
+    it('strips non-digit characters', () => {
+      expect(normalizePhoneNumber('(415) 555-1234')).toBe('+14155551234');
+      expect(normalizePhoneNumber('415.555.1234')).toBe('+14155551234');
+      expect(normalizePhoneNumber('415 555 1234')).toBe('+14155551234');
+    });
+
+    it('handles international numbers with +', () => {
+      expect(normalizePhoneNumber('+447911123456')).toBe('+447911123456');
+    });
+
+    it('removes leading zeros', () => {
+      expect(normalizePhoneNumber('00447911123456')).toBe('+447911123456');
+    });
+
+    it('uses custom default country code', () => {
+      expect(normalizePhoneNumber('7911123456', '44')).toBe('+447911123456');
+    });
+  });
+
+  describe('getLocalNumber', () => {
+    it('removes +1 from US numbers', () => {
+      expect(getLocalNumber('+14155551234')).toBe('4155551234');
+    });
+
+    it('returns digits for international numbers', () => {
+      expect(getLocalNumber('+447911123456')).toBe('447911123456');
+    });
+  });
+
+  describe('formatPhoneForDisplay', () => {
+    it('formats US numbers nicely', () => {
+      expect(formatPhoneForDisplay('+14155551234')).toBe('+1 (415) 555-1234');
+    });
+
+    it('formats international numbers with spaces', () => {
+      const result = formatPhoneForDisplay('+447911123456');
+      expect(result).toBe('+447 911 123 456');
+    });
+  });
+
+  describe('createSmsThreadKey', () => {
+    it('creates consistent key regardless of direction', () => {
+      const key1 = createSmsThreadKey('+14155551234', '+14155556789');
+      const key2 = createSmsThreadKey('+14155556789', '+14155551234');
+      expect(key1).toBe(key2);
+    });
+
+    it('includes sms prefix', () => {
+      const key = createSmsThreadKey('+14155551234', '+14155556789');
+      expect(key).toMatch(/^sms:/);
+    });
+
+    it('includes both phone numbers', () => {
+      const key = createSmsThreadKey('+14155551234', '+14155556789');
+      expect(key).toContain('+14155551234');
+      expect(key).toContain('+14155556789');
+    });
+  });
+});

--- a/tests/twilio/sms-webhook.test.ts
+++ b/tests/twilio/sms-webhook.test.ts
@@ -1,0 +1,365 @@
+/**
+ * Tests for Twilio SMS webhook endpoint.
+ * Part of Issue #202.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createHmac } from 'crypto';
+import type { Pool } from 'pg';
+import { buildServer } from '../../src/api/server.ts';
+import { createTestPool, truncateAllTables } from '../helpers/db.ts';
+import type { TwilioSmsWebhookPayload } from '../../src/api/twilio/types.ts';
+
+/**
+ * Convert an object to URL-encoded form data string.
+ */
+function toUrlEncoded(data: Record<string, string | undefined>): string {
+  return Object.entries(data)
+    .filter(([, v]) => v !== undefined)
+    .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v!)}`)
+    .join('&');
+}
+
+describe('Twilio SMS Webhook', () => {
+  const originalEnv = process.env;
+  let pool: Pool;
+  let app: ReturnType<typeof buildServer>;
+
+  const authToken = 'test-twilio-auth-token-for-tests';
+
+  // Create a valid Twilio signature
+  function createTwilioSignature(
+    url: string,
+    params: Record<string, string>,
+    token: string
+  ): string {
+    const paramString = Object.keys(params)
+      .sort()
+      .reduce((acc, key) => acc + key + params[key], '');
+    const data = url + paramString;
+    return createHmac('sha1', token)
+      .update(Buffer.from(data, 'utf-8'))
+      .digest('base64');
+  }
+
+  function createTwilioPayload(overrides: Partial<TwilioSmsWebhookPayload> = {}): TwilioSmsWebhookPayload {
+    return {
+      MessageSid: `SM${Date.now()}${Math.random().toString(36).slice(2)}`,
+      AccountSid: 'ACTEST00000000000000000000000000', // Test account ID (not a real Twilio SID)
+      From: '+14155551234',
+      To: '+14155556789',
+      Body: 'Hello from test',
+      FromCity: 'San Francisco',
+      FromState: 'CA',
+      FromCountry: 'US',
+      ...overrides,
+    };
+  }
+
+  beforeEach(async () => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+    process.env.TWILIO_AUTH_TOKEN = authToken;
+    process.env.CLAWDBOT_AUTH_DISABLED = 'true'; // Disable auth for testing
+
+    pool = createTestPool();
+    await truncateAllTables(pool);
+    app = buildServer({ logger: false });
+  });
+
+  afterEach(async () => {
+    process.env = originalEnv;
+    await pool.end();
+  });
+
+  describe('POST /api/twilio/sms', () => {
+    it('returns 400 for missing required fields', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/twilio/sms',
+        payload: toUrlEncoded({ Body: 'Hello' }), // Missing MessageSid, From, To
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.json().error).toContain('Missing required fields');
+    });
+
+    it('creates contact and message for new sender', async () => {
+      const payload = createTwilioPayload();
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/twilio/sms',
+        payload: toUrlEncoded(payload as unknown as Record<string, string>),
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.headers['content-type']).toContain('application/xml');
+      expect(response.body).toContain('<Response>');
+
+      // Verify contact was created
+      const contactResult = await pool.query(
+        `SELECT c.id, c.display_name, ce.endpoint_value
+           FROM contact c
+           JOIN contact_endpoint ce ON ce.contact_id = c.id
+          WHERE ce.endpoint_type = 'phone'
+            AND ce.normalized_value LIKE '%4155551234%'`
+      );
+      expect(contactResult.rows.length).toBe(1);
+      expect(contactResult.rows[0].display_name).toContain('+14155551234');
+    });
+
+    it('reuses existing contact for known phone number', async () => {
+      // Create first message
+      const payload1 = createTwilioPayload({
+        MessageSid: 'SM0001',
+        Body: 'First message',
+      });
+
+      await app.inject({
+        method: 'POST',
+        url: '/api/twilio/sms',
+        payload: toUrlEncoded(payload1 as unknown as Record<string, string>),
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      });
+
+      // Get contact count
+      const count1 = await pool.query('SELECT COUNT(*) FROM contact');
+
+      // Create second message from same number
+      const payload2 = createTwilioPayload({
+        MessageSid: 'SM0002',
+        Body: 'Second message',
+      });
+
+      await app.inject({
+        method: 'POST',
+        url: '/api/twilio/sms',
+        payload: toUrlEncoded(payload2 as unknown as Record<string, string>),
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      });
+
+      // Verify contact count unchanged
+      const count2 = await pool.query('SELECT COUNT(*) FROM contact');
+      expect(count2.rows[0].count).toBe(count1.rows[0].count);
+
+      // Verify both messages exist
+      const messages = await pool.query('SELECT COUNT(*) FROM external_message');
+      expect(parseInt(messages.rows[0].count, 10)).toBe(2);
+    });
+
+    it('creates thread for SMS conversation', async () => {
+      const payload = createTwilioPayload();
+
+      await app.inject({
+        method: 'POST',
+        url: '/api/twilio/sms',
+        payload: toUrlEncoded(payload as unknown as Record<string, string>),
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      });
+
+      const threadResult = await pool.query(
+        `SELECT * FROM external_thread WHERE channel = 'phone'`
+      );
+      expect(threadResult.rows.length).toBe(1);
+      expect(threadResult.rows[0].external_thread_key).toContain('sms:');
+      expect(threadResult.rows[0].metadata).toEqual(
+        expect.objectContaining({
+          fromPhone: expect.any(String),
+          toPhone: expect.any(String),
+          source: 'twilio',
+        })
+      );
+    });
+
+    it('stores full Twilio payload in raw field', async () => {
+      const payload = createTwilioPayload({
+        NumMedia: '1',
+        MediaContentType0: 'image/jpeg',
+        MediaUrl0: 'https://api.twilio.com/media/image.jpg',
+      });
+
+      await app.inject({
+        method: 'POST',
+        url: '/api/twilio/sms',
+        payload: toUrlEncoded(payload as unknown as Record<string, string>),
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      });
+
+      const messageResult = await pool.query(
+        `SELECT raw FROM external_message WHERE external_message_key = $1`,
+        [payload.MessageSid]
+      );
+      expect(messageResult.rows.length).toBe(1);
+      expect(messageResult.rows[0].raw.MessageSid).toBe(payload.MessageSid);
+      expect(messageResult.rows[0].raw.NumMedia).toBe('1');
+      expect(messageResult.rows[0].raw.MediaUrl0).toBe('https://api.twilio.com/media/image.jpg');
+    });
+
+    it('normalizes phone numbers to E.164', async () => {
+      const payload = createTwilioPayload({
+        From: '4155551234', // Missing + and country code
+      });
+
+      await app.inject({
+        method: 'POST',
+        url: '/api/twilio/sms',
+        payload: toUrlEncoded(payload as unknown as Record<string, string>),
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      });
+
+      const endpointResult = await pool.query(
+        `SELECT endpoint_value, normalized_value FROM contact_endpoint WHERE endpoint_type = 'phone'`
+      );
+      expect(endpointResult.rows.length).toBe(1);
+      expect(endpointResult.rows[0].endpoint_value).toBe('+14155551234');
+    });
+
+    it('includes geographic info in contact metadata', async () => {
+      const payload = createTwilioPayload({
+        FromCity: 'San Francisco',
+        FromState: 'CA',
+        FromCountry: 'US',
+      });
+
+      await app.inject({
+        method: 'POST',
+        url: '/api/twilio/sms',
+        payload: toUrlEncoded(payload as unknown as Record<string, string>),
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      });
+
+      const endpointResult = await pool.query(
+        `SELECT metadata FROM contact_endpoint WHERE endpoint_type = 'phone'`
+      );
+      expect(endpointResult.rows[0].metadata).toEqual(
+        expect.objectContaining({
+          source: 'twilio',
+          fromCity: 'San Francisco',
+          fromState: 'CA',
+          fromCountry: 'US',
+        })
+      );
+    });
+
+    it('returns empty TwiML response (no auto-reply)', async () => {
+      const payload = createTwilioPayload();
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/twilio/sms',
+        payload: toUrlEncoded(payload as unknown as Record<string, string>),
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.body).toBe('<?xml version="1.0" encoding="UTF-8"?><Response></Response>');
+    });
+
+    it('handles duplicate message gracefully (idempotent)', async () => {
+      const payload = createTwilioPayload();
+
+      // Send same message twice
+      await app.inject({
+        method: 'POST',
+        url: '/api/twilio/sms',
+        payload: toUrlEncoded(payload as unknown as Record<string, string>),
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/twilio/sms',
+        payload: toUrlEncoded(payload as unknown as Record<string, string>), // Same MessageSid
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      });
+
+      expect(response.statusCode).toBe(200);
+
+      // Should only have one message (ON CONFLICT updates)
+      const count = await pool.query(
+        `SELECT COUNT(*) FROM external_message WHERE external_message_key = $1`,
+        [payload.MessageSid]
+      );
+      expect(parseInt(count.rows[0].count, 10)).toBe(1);
+    });
+  });
+
+  describe('Signature Verification', () => {
+    beforeEach(() => {
+      // Enable signature verification
+      delete process.env.CLAWDBOT_AUTH_DISABLED;
+    });
+
+    it('returns 401 for invalid signature', async () => {
+      const payload = createTwilioPayload();
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/twilio/sms',
+        payload: toUrlEncoded(payload as unknown as Record<string, string>),
+        headers: {
+          'content-type': 'application/x-www-form-urlencoded',
+          'x-twilio-signature': 'invalid-signature',
+        },
+      });
+
+      expect(response.statusCode).toBe(401);
+    });
+
+    it('returns 401 when signature header is missing', async () => {
+      const payload = createTwilioPayload();
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/twilio/sms',
+        payload: toUrlEncoded(payload as unknown as Record<string, string>),
+        headers: {
+          'content-type': 'application/x-www-form-urlencoded',
+          // No x-twilio-signature header
+        },
+      });
+
+      expect(response.statusCode).toBe(401);
+    });
+
+    it('accepts request when auth is disabled (development mode)', async () => {
+      // Re-enable auth disabled for this test
+      process.env.CLAWDBOT_AUTH_DISABLED = 'true';
+
+      const payload = createTwilioPayload();
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/twilio/sms',
+        payload: toUrlEncoded(payload as unknown as Record<string, string>),
+        headers: {
+          'content-type': 'application/x-www-form-urlencoded',
+          // No signature header - should work with auth disabled
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+    });
+
+    it('returns 503 when TWILIO_AUTH_TOKEN not configured', async () => {
+      delete process.env.TWILIO_AUTH_TOKEN;
+
+      const payload = createTwilioPayload();
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/twilio/sms',
+        payload: toUrlEncoded(payload as unknown as Record<string, string>),
+        headers: {
+          'content-type': 'application/x-www-form-urlencoded',
+        },
+      });
+
+      expect(response.statusCode).toBe(503);
+      expect(response.json().error).toBe('Twilio webhook not configured');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `POST /api/twilio/sms` endpoint for receiving Twilio SMS webhooks
- Phone number normalization to E.164 format (handles various input formats)
- Auto-create contacts for unknown phone numbers with geographic metadata
- Create/find SMS conversation threads by phone number pairs
- Full Twilio payload stored in message `raw` field for debugging
- Uses signature verification from #224 (HMAC-SHA1)

## Module Structure
- `src/api/twilio/types.ts` - Type definitions for Twilio webhook payloads
- `src/api/twilio/phone-utils.ts` - Phone number normalization utilities
- `src/api/twilio/service.ts` - SMS processing business logic
- `src/api/twilio/index.ts` - Module exports

## Configuration
- `TWILIO_AUTH_TOKEN` - Required for signature verification (or use `CLAWDBOT_AUTH_DISABLED=true`)
- Webhook endpoint skips bearer token auth (uses Twilio signature auth instead)

## Test Plan
- [x] 14 tests for phone number utilities (normalization, display formatting, thread keys)
- [x] 13 tests for webhook endpoint (contact creation, threading, idempotency, auth)
- [x] Full test suite passes (1233 tests)

Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)