### PR TITLE
[#203] Implement Postmark email inbound webhook

### DIFF
--- a/src/api/postmark/email-utils.ts
+++ b/src/api/postmark/email-utils.ts
@@ -1,0 +1,228 @@
+/**
+ * Email utilities for Postmark integration.
+ * Part of Issue #203.
+ */
+
+import type { ParsedEmailAddress, PostmarkHeader } from './types.js';
+
+/**
+ * Parse an email address string into components.
+ * Handles formats like:
+ * - "user@example.com"
+ * - "Name <user@example.com>"
+ * - "<user@example.com>"
+ *
+ * @param address - Raw email address string
+ * @returns Parsed email and name
+ */
+export function parseEmailAddress(address: string): ParsedEmailAddress {
+  const trimmed = address.trim();
+
+  // Try to match "Name <email>" format
+  const match = trimmed.match(/^(.+?)\s*<([^>]+)>$/);
+  if (match) {
+    return {
+      name: match[1].trim().replace(/^["']|["']$/g, '') || null,
+      email: match[2].trim().toLowerCase(),
+    };
+  }
+
+  // Try to match "<email>" format
+  const bracketMatch = trimmed.match(/^<([^>]+)>$/);
+  if (bracketMatch) {
+    return {
+      name: null,
+      email: bracketMatch[1].trim().toLowerCase(),
+    };
+  }
+
+  // Assume it's just an email address
+  return {
+    name: null,
+    email: trimmed.toLowerCase(),
+  };
+}
+
+/**
+ * Normalize an email address to lowercase.
+ *
+ * @param email - Email address
+ * @returns Normalized email
+ */
+export function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+/**
+ * Extract a specific header value from Postmark headers.
+ *
+ * @param headers - Array of Postmark headers
+ * @param name - Header name (case-insensitive)
+ * @returns Header value or null if not found
+ */
+export function getHeader(headers: PostmarkHeader[], name: string): string | null {
+  const lowerName = name.toLowerCase();
+  const header = headers.find((h) => h.Name.toLowerCase() === lowerName);
+  return header?.Value ?? null;
+}
+
+/**
+ * Extract Message-ID header from Postmark headers.
+ * Strips angle brackets if present.
+ *
+ * @param headers - Array of Postmark headers
+ * @returns Message ID or null
+ */
+export function getMessageId(headers: PostmarkHeader[]): string | null {
+  const messageId = getHeader(headers, 'Message-ID') || getHeader(headers, 'Message-Id');
+  if (!messageId) return null;
+  // Remove angle brackets
+  return messageId.replace(/^<|>$/g, '');
+}
+
+/**
+ * Extract In-Reply-To header from Postmark headers.
+ * Strips angle brackets if present.
+ *
+ * @param headers - Array of Postmark headers
+ * @returns In-Reply-To ID or null
+ */
+export function getInReplyTo(headers: PostmarkHeader[]): string | null {
+  const inReplyTo = getHeader(headers, 'In-Reply-To');
+  if (!inReplyTo) return null;
+  // Remove angle brackets
+  return inReplyTo.replace(/^<|>$/g, '');
+}
+
+/**
+ * Extract References header from Postmark headers.
+ * Returns array of message IDs.
+ *
+ * @param headers - Array of Postmark headers
+ * @returns Array of reference message IDs
+ */
+export function getReferences(headers: PostmarkHeader[]): string[] {
+  const references = getHeader(headers, 'References');
+  if (!references) return [];
+
+  // References can be space-separated or comma-separated
+  return references
+    .split(/[\s,]+/)
+    .map((ref) => ref.replace(/^<|>$/g, '').trim())
+    .filter(Boolean);
+}
+
+/**
+ * Create a thread key for email conversations.
+ * Uses Message-ID references for threading.
+ *
+ * @param messageId - Message ID
+ * @param inReplyTo - In-Reply-To header value
+ * @param references - References header values
+ * @returns Thread key string
+ */
+export function createEmailThreadKey(
+  messageId: string | null,
+  inReplyTo: string | null,
+  references: string[]
+): string {
+  // If we have in-reply-to, use the root message from references or in-reply-to
+  if (references.length > 0) {
+    return `email:${references[0]}`;
+  }
+
+  if (inReplyTo) {
+    return `email:${inReplyTo}`;
+  }
+
+  // New thread - use this message's ID
+  if (messageId) {
+    return `email:${messageId}`;
+  }
+
+  // Fallback to random key
+  return `email:${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+/**
+ * Strip quoted content from email reply.
+ * Removes common quote patterns.
+ *
+ * @param text - Email body text
+ * @returns Text without quoted content
+ */
+export function stripQuotedContent(text: string): string {
+  // Common quote patterns
+  const patterns = [
+    // Gmail/Outlook style: "On [date], [name] wrote:"
+    /^On .+? wrote:[\s\S]*$/m,
+    // Forward style: "---------- Forwarded message ---------"
+    /^-+\s*Forwarded message\s*-+[\s\S]*$/mi,
+    // Quote markers: lines starting with ">"
+    /^>.*$/gm,
+    // "Original Message" separator
+    /^-+\s*Original Message\s*-+[\s\S]*$/mi,
+  ];
+
+  let stripped = text;
+  for (const pattern of patterns) {
+    stripped = stripped.replace(pattern, '').trim();
+  }
+
+  return stripped;
+}
+
+/**
+ * Extract plain text from HTML email body.
+ * Simple extraction without full HTML parsing.
+ *
+ * @param html - HTML content
+ * @returns Plain text content
+ */
+export function htmlToPlainText(html: string): string {
+  return html
+    // Remove style and script tags with content
+    .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '')
+    .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '')
+    // Replace br and p tags with newlines
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<\/p>/gi, '\n\n')
+    .replace(/<p[^>]*>/gi, '')
+    // Replace other block-level elements with newlines
+    .replace(/<\/div>/gi, '\n')
+    .replace(/<div[^>]*>/gi, '')
+    .replace(/<\/li>/gi, '\n')
+    .replace(/<li[^>]*>/gi, '• ')
+    // Strip remaining tags
+    .replace(/<[^>]+>/g, '')
+    // Decode common HTML entities
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    // Normalize whitespace
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+/**
+ * Get the best plain text content from an email.
+ * Prefers TextBody, falls back to HtmlBody conversion.
+ *
+ * @param textBody - Plain text body
+ * @param htmlBody - HTML body
+ * @returns Best available plain text
+ */
+export function getBestPlainText(textBody?: string, htmlBody?: string): string {
+  if (textBody && textBody.trim()) {
+    return textBody.trim();
+  }
+
+  if (htmlBody) {
+    return htmlToPlainText(htmlBody);
+  }
+
+  return '';
+}

--- a/src/api/postmark/index.ts
+++ b/src/api/postmark/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Postmark email webhook integration.
+ * Part of Issue #203.
+ */
+
+export * from './types.js';
+export * from './email-utils.js';
+export * from './service.js';

--- a/src/api/postmark/service.ts
+++ b/src/api/postmark/service.ts
@@ -1,0 +1,309 @@
+/**
+ * Postmark email webhook service.
+ * Part of Issue #203.
+ */
+
+import { Pool } from 'pg';
+import type {
+  PostmarkInboundPayload,
+  PostmarkEmailResult,
+  AttachmentMetadata,
+} from './types.js';
+import {
+  normalizeEmail,
+  getMessageId,
+  getInReplyTo,
+  getReferences,
+  createEmailThreadKey,
+  getBestPlainText,
+} from './email-utils.js';
+
+/**
+ * Process an inbound Postmark email webhook.
+ *
+ * This function:
+ * 1. Parses and normalizes email addresses
+ * 2. Creates or finds the contact/endpoint for the sender
+ * 3. Creates or finds the email thread using Message-ID headers
+ * 4. Stores the email with full Postmark payload
+ *
+ * @param pool - Database connection pool
+ * @param payload - Postmark webhook payload
+ * @returns Result with all created/found IDs
+ */
+export async function processPostmarkEmail(
+  pool: Pool,
+  payload: PostmarkInboundPayload
+): Promise<PostmarkEmailResult> {
+  const client = await pool.connect();
+
+  try {
+    await client.query('BEGIN');
+
+    // Extract sender info
+    const senderEmail = normalizeEmail(payload.FromFull.Email);
+    const senderName = payload.FromFull.Name || null;
+
+    // Extract threading info from headers
+    const messageId = getMessageId(payload.Headers) || payload.MessageID;
+    const inReplyTo = getInReplyTo(payload.Headers);
+    const references = getReferences(payload.Headers);
+
+    // Try to find an existing endpoint for the sender's email
+    const existingEndpoint = await client.query(
+      `SELECT ce.id::text as id, ce.contact_id::text as contact_id
+         FROM contact_endpoint ce
+        WHERE ce.endpoint_type = 'email'
+          AND ce.normalized_value = normalize_contact_endpoint_value('email', $1)
+        LIMIT 1`,
+      [senderEmail]
+    );
+
+    let contactId: string;
+    let endpointId: string;
+    let isNewContact = false;
+
+    if (existingEndpoint.rows.length > 0) {
+      endpointId = existingEndpoint.rows[0].id;
+      contactId = existingEndpoint.rows[0].contact_id;
+
+      // Update contact name if we have one and it's better than what we have
+      if (senderName) {
+        await client.query(
+          `UPDATE contact
+              SET display_name = $2,
+                  updated_at = now()
+            WHERE id = $1
+              AND (display_name IS NULL OR display_name = '' OR display_name LIKE '%@%')`,
+          [contactId, senderName]
+        );
+      }
+    } else {
+      // Create new contact
+      isNewContact = true;
+      const displayName = senderName || senderEmail;
+
+      const contact = await client.query(
+        `INSERT INTO contact (display_name)
+         VALUES ($1)
+         RETURNING id::text as id`,
+        [displayName]
+      );
+      contactId = contact.rows[0].id;
+
+      const endpoint = await client.query(
+        `INSERT INTO contact_endpoint (contact_id, endpoint_type, endpoint_value, metadata)
+         VALUES ($1, 'email', $2, $3::jsonb)
+         RETURNING id::text as id`,
+        [
+          contactId,
+          senderEmail,
+          JSON.stringify({
+            source: 'postmark',
+            mailboxHash: payload.FromFull.MailboxHash,
+          }),
+        ]
+      );
+      endpointId = endpoint.rows[0].id;
+    }
+
+    // Create or find thread
+    const threadKey = createEmailThreadKey(messageId, inReplyTo, references);
+
+    // Check if thread exists
+    const existingThread = await client.query(
+      `SELECT id::text as id FROM external_thread
+        WHERE channel = 'email'
+          AND external_thread_key = $1`,
+      [threadKey]
+    );
+
+    let threadId: string;
+    let isNewThread = false;
+
+    if (existingThread.rows.length > 0) {
+      threadId = existingThread.rows[0].id;
+
+      // Update thread's endpoint to the latest sender
+      await client.query(
+        `UPDATE external_thread
+            SET endpoint_id = $1, updated_at = now()
+          WHERE id = $2`,
+        [endpointId, threadId]
+      );
+    } else {
+      isNewThread = true;
+
+      const thread = await client.query(
+        `INSERT INTO external_thread (endpoint_id, channel, external_thread_key, metadata)
+         VALUES ($1, 'email', $2, $3::jsonb)
+         RETURNING id::text as id`,
+        [
+          endpointId,
+          threadKey,
+          JSON.stringify({
+            source: 'postmark',
+            subject: payload.Subject,
+            messageId,
+            inReplyTo,
+            references,
+          }),
+        ]
+      );
+      threadId = thread.rows[0].id;
+    }
+
+    // Extract recipients
+    const toAddresses = payload.ToFull.map((a) => normalizeEmail(a.Email));
+    const ccAddresses = payload.CcFull?.map((a) => normalizeEmail(a.Email)) || [];
+
+    // Extract attachment metadata
+    const attachments: AttachmentMetadata[] = (payload.Attachments || []).map((a) => ({
+      name: a.Name,
+      contentType: a.ContentType,
+      size: a.ContentLength,
+      contentId: a.ContentID,
+    }));
+
+    // Get best plain text content
+    const body = getBestPlainText(payload.TextBody, payload.HtmlBody);
+
+    // Insert the message
+    const message = await client.query(
+      `INSERT INTO external_message (
+         thread_id, external_message_key, direction, body, raw, received_at,
+         subject, from_address, to_addresses, cc_addresses, attachments
+       )
+       VALUES ($1, $2, 'inbound', $3, $4::jsonb, $5::timestamptz,
+               $6, $7, $8, $9, $10::jsonb)
+       ON CONFLICT (thread_id, external_message_key)
+       DO UPDATE SET
+         body = EXCLUDED.body,
+         raw = EXCLUDED.raw,
+         subject = EXCLUDED.subject,
+         from_address = EXCLUDED.from_address,
+         to_addresses = EXCLUDED.to_addresses,
+         cc_addresses = EXCLUDED.cc_addresses,
+         attachments = EXCLUDED.attachments
+       RETURNING id::text as id`,
+      [
+        threadId,
+        messageId,
+        body,
+        JSON.stringify(payload),
+        payload.Date,
+        payload.Subject,
+        senderEmail,
+        toAddresses,
+        ccAddresses,
+        JSON.stringify(attachments),
+      ]
+    );
+    const messageDBId = message.rows[0].id;
+
+    await client.query('COMMIT');
+
+    return {
+      contactId,
+      endpointId,
+      threadId,
+      messageId: messageDBId,
+      isNewContact,
+      isNewThread,
+    };
+  } catch (error) {
+    await client.query('ROLLBACK');
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+/**
+ * Get recent emails for an email address.
+ *
+ * @param pool - Database connection pool
+ * @param email - Email address
+ * @param limit - Maximum messages to return
+ * @returns Array of email records
+ */
+export async function getRecentEmails(
+  pool: Pool,
+  email: string,
+  limit: number = 50
+): Promise<
+  Array<{
+    id: string;
+    threadId: string;
+    direction: 'inbound' | 'outbound';
+    subject: string | null;
+    body: string | null;
+    fromAddress: string | null;
+    toAddresses: string[];
+    receivedAt: Date;
+  }>
+> {
+  const result = await pool.query(
+    `SELECT em.id::text as id,
+            em.thread_id::text as thread_id,
+            em.direction::text as direction,
+            em.subject,
+            em.body,
+            em.from_address,
+            em.to_addresses,
+            em.received_at
+       FROM external_message em
+       JOIN external_thread et ON et.id = em.thread_id
+       JOIN contact_endpoint ce ON ce.id = et.endpoint_id
+      WHERE et.channel = 'email'
+        AND ce.normalized_value = normalize_contact_endpoint_value('email', $1)
+      ORDER BY em.received_at DESC
+      LIMIT $2`,
+    [email, limit]
+  );
+
+  return result.rows.map((row) => ({
+    id: row.id,
+    threadId: row.thread_id,
+    direction: row.direction,
+    subject: row.subject,
+    body: row.body,
+    fromAddress: row.from_address,
+    toAddresses: row.to_addresses || [],
+    receivedAt: row.received_at,
+  }));
+}
+
+/**
+ * Find contact by email address.
+ *
+ * @param pool - Database connection pool
+ * @param email - Email address
+ * @returns Contact info or null if not found
+ */
+export async function findContactByEmail(
+  pool: Pool,
+  email: string
+): Promise<{ contactId: string; endpointId: string; displayName: string } | null> {
+  const result = await pool.query(
+    `SELECT ce.id::text as endpoint_id,
+            c.id::text as contact_id,
+            c.display_name
+       FROM contact_endpoint ce
+       JOIN contact c ON c.id = ce.contact_id
+      WHERE ce.endpoint_type = 'email'
+        AND ce.normalized_value = normalize_contact_endpoint_value('email', $1)
+      LIMIT 1`,
+    [email]
+  );
+
+  if (result.rows.length === 0) {
+    return null;
+  }
+
+  return {
+    contactId: result.rows[0].contact_id,
+    endpointId: result.rows[0].endpoint_id,
+    displayName: result.rows[0].display_name,
+  };
+}

--- a/src/api/postmark/types.ts
+++ b/src/api/postmark/types.ts
@@ -1,0 +1,106 @@
+/**
+ * Postmark webhook types.
+ * Part of Issue #203.
+ */
+
+/**
+ * Postmark inbound email webhook payload.
+ * @see https://postmarkapp.com/developer/webhooks/inbound-webhook
+ */
+export interface PostmarkInboundPayload {
+  // Message identifiers
+  MessageID: string;
+  MessageStream?: string;
+
+  // Sender/Recipient info
+  FromFull: PostmarkAddress;
+  ToFull: PostmarkAddress[];
+  CcFull?: PostmarkAddress[];
+  BccFull?: PostmarkAddress[];
+
+  // Original sender string (e.g., "Name <email@example.com>")
+  From: string;
+  To: string;
+  Cc?: string;
+  Bcc?: string;
+
+  // Reply addresses
+  ReplyTo?: string;
+
+  // Email content
+  Subject: string;
+  TextBody?: string;
+  HtmlBody?: string;
+  StrippedTextReply?: string;
+
+  // Threading headers
+  Headers: PostmarkHeader[];
+
+  // Attachments
+  Attachments?: PostmarkAttachment[];
+
+  // Metadata
+  Date: string;
+  MailboxHash?: string;
+  Tag?: string;
+  OriginalRecipient?: string;
+  RawEmail?: string;
+}
+
+/**
+ * Postmark email address structure.
+ */
+export interface PostmarkAddress {
+  Email: string;
+  Name: string;
+  MailboxHash?: string;
+}
+
+/**
+ * Postmark email header.
+ */
+export interface PostmarkHeader {
+  Name: string;
+  Value: string;
+}
+
+/**
+ * Postmark attachment metadata.
+ */
+export interface PostmarkAttachment {
+  Name: string;
+  Content: string; // Base64 encoded
+  ContentType: string;
+  ContentLength: number;
+  ContentID?: string;
+}
+
+/**
+ * Parsed email address.
+ */
+export interface ParsedEmailAddress {
+  email: string;
+  name: string | null;
+}
+
+/**
+ * Result of processing a Postmark inbound email.
+ */
+export interface PostmarkEmailResult {
+  contactId: string;
+  endpointId: string;
+  threadId: string;
+  messageId: string;
+  isNewContact: boolean;
+  isNewThread: boolean;
+}
+
+/**
+ * Attachment metadata stored in the database.
+ */
+export interface AttachmentMetadata {
+  name: string;
+  contentType: string;
+  size: number;
+  contentId?: string;
+}

--- a/tests/postmark/email-utils.test.ts
+++ b/tests/postmark/email-utils.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Tests for email utilities.
+ * Part of Issue #203.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  parseEmailAddress,
+  normalizeEmail,
+  getHeader,
+  getMessageId,
+  getInReplyTo,
+  getReferences,
+  createEmailThreadKey,
+  stripQuotedContent,
+  htmlToPlainText,
+  getBestPlainText,
+} from '../../src/api/postmark/email-utils.ts';
+import type { PostmarkHeader } from '../../src/api/postmark/types.ts';
+
+describe('Email Utils', () => {
+  describe('parseEmailAddress', () => {
+    it('parses plain email address', () => {
+      const result = parseEmailAddress('user@example.com');
+      expect(result.email).toBe('user@example.com');
+      expect(result.name).toBeNull();
+    });
+
+    it('parses "Name <email>" format', () => {
+      const result = parseEmailAddress('John Doe <john@example.com>');
+      expect(result.email).toBe('john@example.com');
+      expect(result.name).toBe('John Doe');
+    });
+
+    it('parses "<email>" format', () => {
+      const result = parseEmailAddress('<john@example.com>');
+      expect(result.email).toBe('john@example.com');
+      expect(result.name).toBeNull();
+    });
+
+    it('handles quoted names', () => {
+      const result = parseEmailAddress('"Jane Doe" <jane@example.com>');
+      expect(result.email).toBe('jane@example.com');
+      expect(result.name).toBe('Jane Doe');
+    });
+
+    it('normalizes email to lowercase', () => {
+      const result = parseEmailAddress('User@Example.COM');
+      expect(result.email).toBe('user@example.com');
+    });
+
+    it('handles whitespace', () => {
+      const result = parseEmailAddress('  John Doe  <john@example.com>  ');
+      expect(result.email).toBe('john@example.com');
+      expect(result.name).toBe('John Doe');
+    });
+  });
+
+  describe('normalizeEmail', () => {
+    it('converts to lowercase', () => {
+      expect(normalizeEmail('User@Example.COM')).toBe('user@example.com');
+    });
+
+    it('trims whitespace', () => {
+      expect(normalizeEmail('  user@example.com  ')).toBe('user@example.com');
+    });
+  });
+
+  describe('getHeader', () => {
+    const headers: PostmarkHeader[] = [
+      { Name: 'Message-ID', Value: '<abc123@example.com>' },
+      { Name: 'In-Reply-To', Value: '<def456@example.com>' },
+      { Name: 'Content-Type', Value: 'text/plain' },
+    ];
+
+    it('finds header by name', () => {
+      expect(getHeader(headers, 'Message-ID')).toBe('<abc123@example.com>');
+    });
+
+    it('is case-insensitive', () => {
+      expect(getHeader(headers, 'message-id')).toBe('<abc123@example.com>');
+      expect(getHeader(headers, 'MESSAGE-ID')).toBe('<abc123@example.com>');
+    });
+
+    it('returns null for missing header', () => {
+      expect(getHeader(headers, 'X-Custom-Header')).toBeNull();
+    });
+  });
+
+  describe('getMessageId', () => {
+    it('extracts Message-ID without brackets', () => {
+      const headers: PostmarkHeader[] = [
+        { Name: 'Message-ID', Value: '<abc123@example.com>' },
+      ];
+      expect(getMessageId(headers)).toBe('abc123@example.com');
+    });
+
+    it('handles Message-Id variant', () => {
+      const headers: PostmarkHeader[] = [
+        { Name: 'Message-Id', Value: '<abc123@example.com>' },
+      ];
+      expect(getMessageId(headers)).toBe('abc123@example.com');
+    });
+
+    it('returns null when not present', () => {
+      expect(getMessageId([])).toBeNull();
+    });
+  });
+
+  describe('getInReplyTo', () => {
+    it('extracts In-Reply-To without brackets', () => {
+      const headers: PostmarkHeader[] = [
+        { Name: 'In-Reply-To', Value: '<parent123@example.com>' },
+      ];
+      expect(getInReplyTo(headers)).toBe('parent123@example.com');
+    });
+
+    it('returns null when not present', () => {
+      expect(getInReplyTo([])).toBeNull();
+    });
+  });
+
+  describe('getReferences', () => {
+    it('extracts space-separated references', () => {
+      const headers: PostmarkHeader[] = [
+        { Name: 'References', Value: '<ref1@example.com> <ref2@example.com>' },
+      ];
+      const refs = getReferences(headers);
+      expect(refs).toEqual(['ref1@example.com', 'ref2@example.com']);
+    });
+
+    it('handles angle brackets in references', () => {
+      const headers: PostmarkHeader[] = [
+        { Name: 'References', Value: '<ref1@example.com>' },
+      ];
+      const refs = getReferences(headers);
+      expect(refs).toEqual(['ref1@example.com']);
+    });
+
+    it('returns empty array when not present', () => {
+      expect(getReferences([])).toEqual([]);
+    });
+  });
+
+  describe('createEmailThreadKey', () => {
+    it('uses first reference when available', () => {
+      const key = createEmailThreadKey('msg1', 'parent1', ['root1', 'parent1']);
+      expect(key).toBe('email:root1');
+    });
+
+    it('uses in-reply-to when no references', () => {
+      const key = createEmailThreadKey('msg1', 'parent1', []);
+      expect(key).toBe('email:parent1');
+    });
+
+    it('uses message-id for new thread', () => {
+      const key = createEmailThreadKey('msg1', null, []);
+      expect(key).toBe('email:msg1');
+    });
+
+    it('generates fallback key when no IDs', () => {
+      const key = createEmailThreadKey(null, null, []);
+      expect(key).toMatch(/^email:\d+-[a-z0-9]+$/);
+    });
+  });
+
+  describe('stripQuotedContent', () => {
+    it('strips "On ... wrote:" style quotes', () => {
+      const text = `New content here.
+
+On Mon, Jan 1, 2026 at 10:00 AM John Doe wrote:
+> Previous message content`;
+      const result = stripQuotedContent(text);
+      expect(result).toBe('New content here.');
+    });
+
+    it('strips > prefixed lines', () => {
+      const text = `New reply.
+> Quoted line 1
+> Quoted line 2`;
+      const result = stripQuotedContent(text);
+      expect(result).toBe('New reply.');
+    });
+
+    it('preserves non-quoted content', () => {
+      const text = 'Just a simple message.';
+      expect(stripQuotedContent(text)).toBe('Just a simple message.');
+    });
+  });
+
+  describe('htmlToPlainText', () => {
+    it('removes HTML tags', () => {
+      const html = '<p>Hello <strong>World</strong></p>';
+      expect(htmlToPlainText(html)).toContain('Hello');
+      expect(htmlToPlainText(html)).toContain('World');
+      expect(htmlToPlainText(html)).not.toContain('<');
+    });
+
+    it('converts br tags to newlines', () => {
+      const html = 'Line 1<br>Line 2<br/>Line 3';
+      expect(htmlToPlainText(html)).toContain('\n');
+    });
+
+    it('decodes HTML entities', () => {
+      const html = '&lt;tag&gt; &amp; &quot;quoted&quot;';
+      expect(htmlToPlainText(html)).toBe('<tag> & "quoted"');
+    });
+
+    it('removes style and script content', () => {
+      const html = '<style>body { color: red; }</style><p>Visible</p><script>alert(1)</script>';
+      const result = htmlToPlainText(html);
+      expect(result).not.toContain('color');
+      expect(result).not.toContain('alert');
+      expect(result).toContain('Visible');
+    });
+  });
+
+  describe('getBestPlainText', () => {
+    it('prefers TextBody when available', () => {
+      const result = getBestPlainText('Plain text', '<p>HTML text</p>');
+      expect(result).toBe('Plain text');
+    });
+
+    it('falls back to HtmlBody when TextBody is empty', () => {
+      const result = getBestPlainText('', '<p>HTML text</p>');
+      expect(result).toContain('HTML text');
+    });
+
+    it('returns empty string when both are empty', () => {
+      expect(getBestPlainText('', '')).toBe('');
+      expect(getBestPlainText(undefined, undefined)).toBe('');
+    });
+  });
+});

--- a/tests/postmark/inbound-webhook.test.ts
+++ b/tests/postmark/inbound-webhook.test.ts
@@ -1,0 +1,425 @@
+/**
+ * Tests for Postmark inbound email webhook endpoint.
+ * Part of Issue #203.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { Pool } from 'pg';
+import { buildServer } from '../../src/api/server.ts';
+import { createTestPool, truncateAllTables } from '../helpers/db.ts';
+import type { PostmarkInboundPayload, PostmarkAddress, PostmarkHeader } from '../../src/api/postmark/types.ts';
+
+describe('Postmark Inbound Webhook', () => {
+  const originalEnv = process.env;
+  let pool: Pool;
+  let app: ReturnType<typeof buildServer>;
+
+  const webhookUsername = 'postmark-webhook-user';
+  const webhookPassword = 'postmark-webhook-secret';
+
+  function createBasicAuth(user: string, pass: string): string {
+    return `Basic ${Buffer.from(`${user}:${pass}`).toString('base64')}`;
+  }
+
+  function createPostmarkAddress(email: string, name: string = ''): PostmarkAddress {
+    return { Email: email, Name: name };
+  }
+
+  function createPostmarkPayload(
+    overrides: Partial<PostmarkInboundPayload> = {}
+  ): PostmarkInboundPayload {
+    const messageId = `${Date.now()}.${Math.random().toString(36).slice(2)}@postmark.test`;
+    return {
+      MessageID: messageId,
+      From: 'sender@example.com',
+      FromFull: createPostmarkAddress('sender@example.com', 'Test Sender'),
+      To: 'recipient@example.com',
+      ToFull: [createPostmarkAddress('recipient@example.com', 'Test Recipient')],
+      Subject: 'Test Email Subject',
+      TextBody: 'This is the plain text body.',
+      HtmlBody: '<p>This is the <strong>HTML</strong> body.</p>',
+      Headers: [
+        { Name: 'Message-ID', Value: `<${messageId}>` },
+      ],
+      Date: new Date().toISOString(),
+      ...overrides,
+    };
+  }
+
+  beforeEach(async () => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+    process.env.POSTMARK_WEBHOOK_USERNAME = webhookUsername;
+    process.env.POSTMARK_WEBHOOK_PASSWORD = webhookPassword;
+    process.env.CLAWDBOT_AUTH_DISABLED = 'true'; // Disable auth for most tests
+
+    pool = createTestPool();
+    await truncateAllTables(pool);
+    app = buildServer({ logger: false });
+  });
+
+  afterEach(async () => {
+    process.env = originalEnv;
+    await pool.end();
+  });
+
+  describe('POST /api/postmark/inbound', () => {
+    it('returns 400 for missing required fields', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/postmark/inbound',
+        payload: { Subject: 'Test' }, // Missing MessageID and FromFull
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.json().error).toContain('Missing required fields');
+    });
+
+    it('creates contact and message for new sender', async () => {
+      const payload = createPostmarkPayload();
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/postmark/inbound',
+        payload,
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json().success).toBe(true);
+      expect(response.json().contactId).toBeDefined();
+      expect(response.json().messageId).toBeDefined();
+
+      // Verify contact was created
+      const contactResult = await pool.query(
+        `SELECT c.id, c.display_name, ce.endpoint_value
+           FROM contact c
+           JOIN contact_endpoint ce ON ce.contact_id = c.id
+          WHERE ce.endpoint_type = 'email'
+            AND ce.normalized_value LIKE '%sender@example.com%'`
+      );
+      expect(contactResult.rows.length).toBe(1);
+      expect(contactResult.rows[0].display_name).toBe('Test Sender');
+    });
+
+    it('reuses existing contact for known email', async () => {
+      // Create first message
+      const payload1 = createPostmarkPayload({
+        MessageID: 'msg1@test.com',
+        Subject: 'First Email',
+        Headers: [
+          { Name: 'Message-ID', Value: '<msg1@test.com>' },
+        ],
+      });
+
+      const response1 = await app.inject({
+        method: 'POST',
+        url: '/api/postmark/inbound',
+        payload: payload1,
+      });
+      expect(response1.statusCode).toBe(200);
+
+      // Get contact count
+      const count1 = await pool.query('SELECT COUNT(*) FROM contact');
+
+      // Create second message from same sender (different thread)
+      const payload2 = createPostmarkPayload({
+        MessageID: 'msg2@test.com',
+        Subject: 'Second Email',
+        Headers: [
+          { Name: 'Message-ID', Value: '<msg2@test.com>' },
+        ],
+      });
+
+      const response2 = await app.inject({
+        method: 'POST',
+        url: '/api/postmark/inbound',
+        payload: payload2,
+      });
+      expect(response2.statusCode).toBe(200);
+
+      // Verify contact count unchanged
+      const count2 = await pool.query('SELECT COUNT(*) FROM contact');
+      expect(count2.rows[0].count).toBe(count1.rows[0].count);
+
+      // Verify both messages exist
+      const messages = await pool.query('SELECT COUNT(*) FROM external_message');
+      expect(parseInt(messages.rows[0].count, 10)).toBe(2);
+    });
+
+    it('creates thread for email using Message-ID', async () => {
+      const payload = createPostmarkPayload({
+        MessageID: 'unique-msg-id@test.com',
+      });
+
+      await app.inject({
+        method: 'POST',
+        url: '/api/postmark/inbound',
+        payload,
+      });
+
+      const threadResult = await pool.query(
+        `SELECT * FROM external_thread WHERE channel = 'email'`
+      );
+      expect(threadResult.rows.length).toBe(1);
+      expect(threadResult.rows[0].external_thread_key).toContain('email:');
+      expect(threadResult.rows[0].metadata).toEqual(
+        expect.objectContaining({
+          source: 'postmark',
+          subject: payload.Subject,
+        })
+      );
+    });
+
+    it('threads replies using In-Reply-To header', async () => {
+      // Create original email
+      const originalPayload = createPostmarkPayload({
+        MessageID: 'original@test.com',
+        Subject: 'Original Email',
+        Headers: [
+          { Name: 'Message-ID', Value: '<original@test.com>' },
+        ],
+      });
+
+      const response1 = await app.inject({
+        method: 'POST',
+        url: '/api/postmark/inbound',
+        payload: originalPayload,
+      });
+      const originalThreadId = response1.json().threadId;
+
+      // Create reply with In-Reply-To header
+      const replyPayload = createPostmarkPayload({
+        MessageID: 'reply@test.com',
+        Subject: 'Re: Original Email',
+        Headers: [
+          { Name: 'Message-ID', Value: '<reply@test.com>' },
+          { Name: 'In-Reply-To', Value: '<original@test.com>' },
+        ],
+      });
+
+      const response2 = await app.inject({
+        method: 'POST',
+        url: '/api/postmark/inbound',
+        payload: replyPayload,
+      });
+      const replyThreadId = response2.json().threadId;
+
+      // Both should be in the same thread
+      expect(replyThreadId).toBe(originalThreadId);
+
+      // Verify two messages in same thread
+      const messages = await pool.query(
+        `SELECT COUNT(*) FROM external_message WHERE thread_id = $1`,
+        [originalThreadId]
+      );
+      expect(parseInt(messages.rows[0].count, 10)).toBe(2);
+    });
+
+    it('stores email fields correctly', async () => {
+      const payload = createPostmarkPayload({
+        Subject: 'Important Subject',
+        FromFull: createPostmarkAddress('sender@test.com', 'The Sender'),
+        ToFull: [
+          createPostmarkAddress('to1@test.com', 'To 1'),
+          createPostmarkAddress('to2@test.com', 'To 2'),
+        ],
+        CcFull: [
+          createPostmarkAddress('cc@test.com', 'CC Person'),
+        ],
+        TextBody: 'Plain text content',
+        HtmlBody: '<p>HTML content</p>',
+      });
+
+      await app.inject({
+        method: 'POST',
+        url: '/api/postmark/inbound',
+        payload,
+      });
+
+      const messageResult = await pool.query(
+        `SELECT subject, from_address, to_addresses, cc_addresses, body
+           FROM external_message
+          LIMIT 1`
+      );
+      expect(messageResult.rows.length).toBe(1);
+      expect(messageResult.rows[0].subject).toBe('Important Subject');
+      expect(messageResult.rows[0].from_address).toBe('sender@test.com');
+      expect(messageResult.rows[0].to_addresses).toContain('to1@test.com');
+      expect(messageResult.rows[0].to_addresses).toContain('to2@test.com');
+      expect(messageResult.rows[0].cc_addresses).toContain('cc@test.com');
+      expect(messageResult.rows[0].body).toBe('Plain text content');
+    });
+
+    it('stores attachment metadata', async () => {
+      const payload = createPostmarkPayload({
+        Attachments: [
+          {
+            Name: 'document.pdf',
+            Content: 'base64content==',
+            ContentType: 'application/pdf',
+            ContentLength: 12345,
+          },
+          {
+            Name: 'image.png',
+            Content: 'base64imagedata==',
+            ContentType: 'image/png',
+            ContentLength: 67890,
+            ContentID: 'cid:image1',
+          },
+        ],
+      });
+
+      await app.inject({
+        method: 'POST',
+        url: '/api/postmark/inbound',
+        payload,
+      });
+
+      const messageResult = await pool.query(
+        `SELECT attachments FROM external_message LIMIT 1`
+      );
+      expect(messageResult.rows.length).toBe(1);
+      const attachments = messageResult.rows[0].attachments;
+      expect(attachments).toHaveLength(2);
+      expect(attachments[0]).toEqual({
+        name: 'document.pdf',
+        contentType: 'application/pdf',
+        size: 12345,
+      });
+      expect(attachments[1]).toEqual({
+        name: 'image.png',
+        contentType: 'image/png',
+        size: 67890,
+        contentId: 'cid:image1',
+      });
+    });
+
+    it('stores full Postmark payload in raw field', async () => {
+      const payload = createPostmarkPayload({
+        MailboxHash: 'test-hash',
+        Tag: 'test-tag',
+      });
+
+      await app.inject({
+        method: 'POST',
+        url: '/api/postmark/inbound',
+        payload,
+      });
+
+      const messageResult = await pool.query(
+        `SELECT raw FROM external_message LIMIT 1`
+      );
+      expect(messageResult.rows.length).toBe(1);
+      expect(messageResult.rows[0].raw.MessageID).toBe(payload.MessageID);
+      expect(messageResult.rows[0].raw.MailboxHash).toBe('test-hash');
+      expect(messageResult.rows[0].raw.Tag).toBe('test-tag');
+    });
+
+    it('falls back to HTML body when TextBody is empty', async () => {
+      const payload = createPostmarkPayload({
+        TextBody: '',
+        HtmlBody: '<p>HTML only content</p>',
+      });
+
+      await app.inject({
+        method: 'POST',
+        url: '/api/postmark/inbound',
+        payload,
+      });
+
+      const messageResult = await pool.query(
+        `SELECT body FROM external_message LIMIT 1`
+      );
+      expect(messageResult.rows[0].body).toContain('HTML only content');
+    });
+
+    it('handles duplicate message gracefully (idempotent)', async () => {
+      const payload = createPostmarkPayload();
+
+      // Send same message twice
+      await app.inject({
+        method: 'POST',
+        url: '/api/postmark/inbound',
+        payload,
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/postmark/inbound',
+        payload, // Same MessageID
+      });
+
+      expect(response.statusCode).toBe(200);
+
+      // Should only have one message (ON CONFLICT updates)
+      const count = await pool.query('SELECT COUNT(*) FROM external_message');
+      expect(parseInt(count.rows[0].count, 10)).toBe(1);
+    });
+  });
+
+  describe('Authentication', () => {
+    beforeEach(() => {
+      // Enable authentication
+      delete process.env.CLAWDBOT_AUTH_DISABLED;
+    });
+
+    it('returns 401 when credentials missing', async () => {
+      const payload = createPostmarkPayload();
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/postmark/inbound',
+        payload,
+        headers: {
+          // No Authorization header
+        },
+      });
+
+      expect(response.statusCode).toBe(401);
+    });
+
+    it('returns 401 for invalid credentials', async () => {
+      const payload = createPostmarkPayload();
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/postmark/inbound',
+        payload,
+        headers: {
+          authorization: createBasicAuth('wrong-user', 'wrong-pass'),
+        },
+      });
+
+      expect(response.statusCode).toBe(401);
+    });
+
+    it('accepts request with valid credentials', async () => {
+      const payload = createPostmarkPayload();
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/postmark/inbound',
+        payload,
+        headers: {
+          authorization: createBasicAuth(webhookUsername, webhookPassword),
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+    });
+
+    it('accepts request when auth is disabled', async () => {
+      process.env.CLAWDBOT_AUTH_DISABLED = 'true';
+      const payload = createPostmarkPayload();
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/postmark/inbound',
+        payload,
+        // No Authorization header
+      });
+
+      expect(response.statusCode).toBe(200);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements the Postmark inbound email webhook endpoint for Issue #203.

- Adds `POST /api/postmark/inbound` endpoint for receiving Postmark email webhooks
- Creates `src/api/postmark/` module with types, email utilities, and service layer
- Implements email threading using Message-ID, In-Reply-To, and References headers
- Contact creation/lookup by normalized email address
- HTML to plain text conversion and quoted content stripping
- Attachment metadata extraction (name, type, size, contentId)
- Idempotent message handling via ON CONFLICT upsert
- Basic auth verification using POSTMARK_WEBHOOK_USERNAME/PASSWORD env vars

### Key Files
- `src/api/postmark/types.ts` - TypeScript types for Postmark payloads
- `src/api/postmark/email-utils.ts` - Email parsing and threading utilities
- `src/api/postmark/service.ts` - Database operations for email processing
- `src/api/server.ts` - New endpoint registration
- `tests/postmark/*.test.ts` - 47 tests covering utilities and webhook

## Test plan

- [x] All 47 Postmark tests pass
- [x] Full test suite passes (1280 tests)
- [ ] Verify webhook works with real Postmark payload

Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)