### PR TITLE
[#210] Implement Cloudflare Email Workers inbound webhook

### DIFF
--- a/src/api/cloudflare-email/index.ts
+++ b/src/api/cloudflare-email/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Cloudflare Email Workers webhook integration.
+ * Part of Issue #210.
+ */
+
+export * from './types.js';
+export * from './service.js';

--- a/src/api/cloudflare-email/service.ts
+++ b/src/api/cloudflare-email/service.ts
@@ -1,0 +1,206 @@
+/**
+ * Cloudflare Email Workers webhook service.
+ * Part of Issue #210.
+ */
+
+import { Pool } from 'pg';
+import type { CloudflareEmailPayload, CloudflareEmailResult } from './types.js';
+import {
+  normalizeEmail,
+  createEmailThreadKey,
+  getBestPlainText,
+} from '../postmark/email-utils.js';
+
+/**
+ * Parse the Message-ID header, removing angle brackets if present.
+ */
+function parseMessageId(value: string | undefined): string | null {
+  if (!value) return null;
+  return value.replace(/^<|>$/g, '').trim() || null;
+}
+
+/**
+ * Parse the References header into an array of message IDs.
+ */
+function parseReferences(value: string | undefined): string[] {
+  if (!value) return [];
+  return value
+    .split(/\s+/)
+    .map((ref) => ref.replace(/^<|>$/g, '').trim())
+    .filter(Boolean);
+}
+
+/**
+ * Process an inbound Cloudflare email webhook.
+ *
+ * This function:
+ * 1. Parses and normalizes email addresses
+ * 2. Creates or finds the contact/endpoint for the sender
+ * 3. Creates or finds the email thread using Message-ID headers
+ * 4. Stores the email with the full payload
+ *
+ * @param pool - Database connection pool
+ * @param payload - Cloudflare Worker webhook payload
+ * @returns Result with all created/found IDs
+ */
+export async function processCloudflareEmail(
+  pool: Pool,
+  payload: CloudflareEmailPayload
+): Promise<CloudflareEmailResult> {
+  const client = await pool.connect();
+
+  try {
+    await client.query('BEGIN');
+
+    // Extract sender info
+    const senderEmail = normalizeEmail(payload.from);
+
+    // Extract threading info from headers
+    const messageId =
+      parseMessageId(payload.headers['message-id']) || `cf-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const inReplyTo = parseMessageId(payload.headers['in-reply-to']);
+    const references = parseReferences(payload.headers.references);
+
+    // Try to find an existing endpoint for the sender's email
+    const existingEndpoint = await client.query(
+      `SELECT ce.id::text as id, ce.contact_id::text as contact_id
+         FROM contact_endpoint ce
+        WHERE ce.endpoint_type = 'email'
+          AND ce.normalized_value = normalize_contact_endpoint_value('email', $1)
+        LIMIT 1`,
+      [senderEmail]
+    );
+
+    let contactId: string;
+    let endpointId: string;
+    let isNewContact = false;
+
+    if (existingEndpoint.rows.length > 0) {
+      endpointId = existingEndpoint.rows[0].id;
+      contactId = existingEndpoint.rows[0].contact_id;
+    } else {
+      // Create new contact
+      isNewContact = true;
+      const displayName = senderEmail;
+
+      const contact = await client.query(
+        `INSERT INTO contact (display_name)
+         VALUES ($1)
+         RETURNING id::text as id`,
+        [displayName]
+      );
+      contactId = contact.rows[0].id;
+
+      const endpoint = await client.query(
+        `INSERT INTO contact_endpoint (contact_id, endpoint_type, endpoint_value, metadata)
+         VALUES ($1, 'email', $2, $3::jsonb)
+         RETURNING id::text as id`,
+        [
+          contactId,
+          senderEmail,
+          JSON.stringify({
+            source: 'cloudflare-email',
+          }),
+        ]
+      );
+      endpointId = endpoint.rows[0].id;
+    }
+
+    // Create or find thread
+    const threadKey = createEmailThreadKey(messageId, inReplyTo, references);
+
+    // Check if thread exists
+    const existingThread = await client.query(
+      `SELECT id::text as id FROM external_thread
+        WHERE channel = 'email'
+          AND external_thread_key = $1`,
+      [threadKey]
+    );
+
+    let threadId: string;
+    let isNewThread = false;
+
+    if (existingThread.rows.length > 0) {
+      threadId = existingThread.rows[0].id;
+
+      // Update thread's endpoint to the latest sender
+      await client.query(
+        `UPDATE external_thread
+            SET endpoint_id = $1, updated_at = now()
+          WHERE id = $2`,
+        [endpointId, threadId]
+      );
+    } else {
+      isNewThread = true;
+
+      const thread = await client.query(
+        `INSERT INTO external_thread (endpoint_id, channel, external_thread_key, metadata)
+         VALUES ($1, 'email', $2, $3::jsonb)
+         RETURNING id::text as id`,
+        [
+          endpointId,
+          threadKey,
+          JSON.stringify({
+            source: 'cloudflare-email',
+            subject: payload.subject,
+            messageId,
+            inReplyTo,
+            references,
+          }),
+        ]
+      );
+      threadId = thread.rows[0].id;
+    }
+
+    // Get best plain text content
+    const body = getBestPlainText(payload.text_body, payload.html_body);
+
+    // Normalize recipient
+    const toAddress = normalizeEmail(payload.to);
+
+    // Insert the message
+    const message = await client.query(
+      `INSERT INTO external_message (
+         thread_id, external_message_key, direction, body, raw, received_at,
+         subject, from_address, to_addresses
+       )
+       VALUES ($1, $2, 'inbound', $3, $4::jsonb, $5::timestamptz,
+               $6, $7, $8)
+       ON CONFLICT (thread_id, external_message_key)
+       DO UPDATE SET
+         body = EXCLUDED.body,
+         raw = EXCLUDED.raw,
+         subject = EXCLUDED.subject,
+         from_address = EXCLUDED.from_address,
+         to_addresses = EXCLUDED.to_addresses
+       RETURNING id::text as id`,
+      [
+        threadId,
+        messageId,
+        body,
+        JSON.stringify(payload),
+        payload.timestamp || new Date().toISOString(),
+        payload.subject,
+        senderEmail,
+        [toAddress],
+      ]
+    );
+    const messageDBId = message.rows[0].id;
+
+    await client.query('COMMIT');
+
+    return {
+      contactId,
+      endpointId,
+      threadId,
+      messageId: messageDBId,
+      isNewContact,
+      isNewThread,
+    };
+  } catch (error) {
+    await client.query('ROLLBACK');
+    throw error;
+  } finally {
+    client.release();
+  }
+}

--- a/src/api/cloudflare-email/types.ts
+++ b/src/api/cloudflare-email/types.ts
@@ -1,0 +1,59 @@
+/**
+ * Cloudflare Email Workers webhook types.
+ * Part of Issue #210.
+ */
+
+/**
+ * Payload sent from Cloudflare Email Worker to our webhook.
+ * This format is defined by the example Worker we document.
+ */
+export interface CloudflareEmailPayload {
+  /** Sender email address */
+  from: string;
+  /** Recipient email address */
+  to: string;
+  /** Email subject line */
+  subject: string;
+  /** Plain text body (extracted from MIME) */
+  text_body?: string;
+  /** HTML body (extracted from MIME) */
+  html_body?: string;
+  /** Email headers object */
+  headers: CloudflareEmailHeaders;
+  /** Full raw MIME message (optional, for debugging) */
+  raw?: string;
+  /** ISO timestamp when Worker processed the email */
+  timestamp: string;
+}
+
+/**
+ * Email headers extracted by the Cloudflare Worker.
+ */
+export interface CloudflareEmailHeaders {
+  /** Message-ID header */
+  'message-id'?: string;
+  /** In-Reply-To header for threading */
+  'in-reply-to'?: string;
+  /** References header for threading */
+  references?: string;
+  /** Additional headers the Worker may include */
+  [key: string]: string | undefined;
+}
+
+/**
+ * Result of processing a Cloudflare email webhook.
+ */
+export interface CloudflareEmailResult {
+  /** Database ID of the contact */
+  contactId: string;
+  /** Database ID of the contact endpoint */
+  endpointId: string;
+  /** Database ID of the external thread */
+  threadId: string;
+  /** Database ID of the stored message */
+  messageId: string;
+  /** Whether a new contact was created */
+  isNewContact: boolean;
+  /** Whether a new thread was created */
+  isNewThread: boolean;
+}

--- a/tests/cloudflare-email/inbound-webhook.test.ts
+++ b/tests/cloudflare-email/inbound-webhook.test.ts
@@ -1,0 +1,383 @@
+/**
+ * Tests for Cloudflare Email Workers inbound webhook endpoint.
+ * Part of Issue #210.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { Pool } from 'pg';
+import { buildServer } from '../../src/api/server.ts';
+import { createTestPool, truncateAllTables } from '../helpers/db.ts';
+import type { CloudflareEmailPayload } from '../../src/api/cloudflare-email/types.ts';
+
+describe('Cloudflare Email Inbound Webhook', () => {
+  const originalEnv = process.env;
+  let pool: Pool;
+  let app: ReturnType<typeof buildServer>;
+
+  const webhookSecret = 'cloudflare-email-secret-for-tests';
+
+  function createCloudflarePayload(
+    overrides: Partial<CloudflareEmailPayload> = {}
+  ): CloudflareEmailPayload {
+    const messageId = `${Date.now()}.${Math.random().toString(36).slice(2)}@cloudflare.test`;
+    return {
+      from: 'sender@example.com',
+      to: 'support@myapp.com',
+      subject: 'Test Email Subject',
+      text_body: 'This is the plain text body.',
+      html_body: '<p>This is the <strong>HTML</strong> body.</p>',
+      headers: {
+        'message-id': `<${messageId}>`,
+      },
+      timestamp: new Date().toISOString(),
+      ...overrides,
+    };
+  }
+
+  beforeEach(async () => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+    process.env.CLOUDFLARE_EMAIL_SECRET = webhookSecret;
+    process.env.CLAWDBOT_AUTH_DISABLED = 'true'; // Disable auth for most tests
+
+    pool = createTestPool();
+    await truncateAllTables(pool);
+    app = buildServer({ logger: false });
+  });
+
+  afterEach(async () => {
+    process.env = originalEnv;
+    await pool.end();
+  });
+
+  describe('POST /api/cloudflare/email', () => {
+    it('returns 400 for missing required fields', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/cloudflare/email',
+        payload: { subject: 'Test' }, // Missing from, to, timestamp
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.json().error).toContain('Missing required fields');
+    });
+
+    it('returns 400 for stale timestamp', async () => {
+      const staleTimestamp = new Date(Date.now() - 10 * 60 * 1000).toISOString(); // 10 minutes ago
+      const payload = createCloudflarePayload({ timestamp: staleTimestamp });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/cloudflare/email',
+        payload,
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.json().error).toContain('stale timestamp');
+    });
+
+    it('returns 400 for invalid timestamp format', async () => {
+      const payload = createCloudflarePayload({ timestamp: 'not-a-date' });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/cloudflare/email',
+        payload,
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.json().error).toContain('Invalid or stale timestamp');
+    });
+
+    it('creates contact and message for new sender', async () => {
+      const payload = createCloudflarePayload();
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/cloudflare/email',
+        payload,
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json().success).toBe(true);
+      expect(response.json().receiptId).toBeDefined();
+      expect(response.json().contactId).toBeDefined();
+      expect(response.json().messageId).toBeDefined();
+
+      // Verify contact was created
+      const contactResult = await pool.query(
+        `SELECT c.id, c.display_name, ce.endpoint_value
+           FROM contact c
+           JOIN contact_endpoint ce ON ce.contact_id = c.id
+          WHERE ce.endpoint_type = 'email'
+            AND ce.normalized_value LIKE '%sender@example.com%'`
+      );
+      expect(contactResult.rows.length).toBe(1);
+      expect(contactResult.rows[0].display_name).toBe('sender@example.com');
+    });
+
+    it('reuses existing contact for known email', async () => {
+      // Create first message
+      const payload1 = createCloudflarePayload({
+        headers: { 'message-id': '<msg1@cloudflare.test>' },
+      });
+
+      const response1 = await app.inject({
+        method: 'POST',
+        url: '/api/cloudflare/email',
+        payload: payload1,
+      });
+      expect(response1.statusCode).toBe(200);
+
+      // Get contact count
+      const count1 = await pool.query('SELECT COUNT(*) FROM contact');
+
+      // Create second message from same sender (different thread)
+      const payload2 = createCloudflarePayload({
+        subject: 'Second Email',
+        headers: { 'message-id': '<msg2@cloudflare.test>' },
+      });
+
+      const response2 = await app.inject({
+        method: 'POST',
+        url: '/api/cloudflare/email',
+        payload: payload2,
+      });
+      expect(response2.statusCode).toBe(200);
+
+      // Verify contact count unchanged
+      const count2 = await pool.query('SELECT COUNT(*) FROM contact');
+      expect(count2.rows[0].count).toBe(count1.rows[0].count);
+
+      // Verify both messages exist
+      const messages = await pool.query('SELECT COUNT(*) FROM external_message');
+      expect(parseInt(messages.rows[0].count, 10)).toBe(2);
+    });
+
+    it('creates thread for email using Message-ID', async () => {
+      const payload = createCloudflarePayload({
+        headers: { 'message-id': '<unique-msg@cloudflare.test>' },
+      });
+
+      await app.inject({
+        method: 'POST',
+        url: '/api/cloudflare/email',
+        payload,
+      });
+
+      const threadResult = await pool.query(
+        `SELECT * FROM external_thread WHERE channel = 'email'`
+      );
+      expect(threadResult.rows.length).toBe(1);
+      expect(threadResult.rows[0].external_thread_key).toContain('email:');
+      expect(threadResult.rows[0].metadata).toEqual(
+        expect.objectContaining({
+          source: 'cloudflare-email',
+          subject: payload.subject,
+        })
+      );
+    });
+
+    it('threads replies using In-Reply-To header', async () => {
+      // Create original email
+      const originalPayload = createCloudflarePayload({
+        subject: 'Original Email',
+        headers: {
+          'message-id': '<original@cloudflare.test>',
+        },
+      });
+
+      const response1 = await app.inject({
+        method: 'POST',
+        url: '/api/cloudflare/email',
+        payload: originalPayload,
+      });
+      expect(response1.statusCode).toBe(200);
+      const originalThreadId = response1.json().threadId;
+
+      // Create reply with In-Reply-To header
+      const replyPayload = createCloudflarePayload({
+        subject: 'Re: Original Email',
+        headers: {
+          'message-id': '<reply@cloudflare.test>',
+          'in-reply-to': '<original@cloudflare.test>',
+        },
+      });
+
+      const response2 = await app.inject({
+        method: 'POST',
+        url: '/api/cloudflare/email',
+        payload: replyPayload,
+      });
+      expect(response2.statusCode).toBe(200);
+      const replyThreadId = response2.json().threadId;
+
+      // Both should be in the same thread
+      expect(replyThreadId).toBe(originalThreadId);
+
+      // Verify two messages in same thread
+      const messages = await pool.query(
+        `SELECT COUNT(*) FROM external_message WHERE thread_id = $1`,
+        [originalThreadId]
+      );
+      expect(parseInt(messages.rows[0].count, 10)).toBe(2);
+    });
+
+    it('stores email fields correctly', async () => {
+      const payload = createCloudflarePayload({
+        from: 'sender@test.com',
+        to: 'support@myapp.com',
+        subject: 'Important Subject',
+        text_body: 'Plain text content',
+        html_body: '<p>HTML content</p>',
+      });
+
+      await app.inject({
+        method: 'POST',
+        url: '/api/cloudflare/email',
+        payload,
+      });
+
+      const messageResult = await pool.query(
+        `SELECT subject, from_address, to_addresses, body
+           FROM external_message
+          LIMIT 1`
+      );
+      expect(messageResult.rows.length).toBe(1);
+      expect(messageResult.rows[0].subject).toBe('Important Subject');
+      expect(messageResult.rows[0].from_address).toBe('sender@test.com');
+      expect(messageResult.rows[0].to_addresses).toContain('support@myapp.com');
+      expect(messageResult.rows[0].body).toBe('Plain text content');
+    });
+
+    it('falls back to HTML body when text_body is empty', async () => {
+      const payload = createCloudflarePayload({
+        text_body: '',
+        html_body: '<p>HTML only content</p>',
+      });
+
+      await app.inject({
+        method: 'POST',
+        url: '/api/cloudflare/email',
+        payload,
+      });
+
+      const messageResult = await pool.query(
+        `SELECT body FROM external_message LIMIT 1`
+      );
+      expect(messageResult.rows[0].body).toContain('HTML only content');
+    });
+
+    it('stores full payload in raw field', async () => {
+      const payload = createCloudflarePayload({
+        raw: 'Full MIME message here',
+      });
+
+      await app.inject({
+        method: 'POST',
+        url: '/api/cloudflare/email',
+        payload,
+      });
+
+      const messageResult = await pool.query(
+        `SELECT raw FROM external_message LIMIT 1`
+      );
+      expect(messageResult.rows.length).toBe(1);
+      expect(messageResult.rows[0].raw.from).toBe(payload.from);
+      expect(messageResult.rows[0].raw.raw).toBe('Full MIME message here');
+    });
+
+    it('handles duplicate message gracefully (idempotent)', async () => {
+      const payload = createCloudflarePayload({
+        headers: { 'message-id': '<duplicate@cloudflare.test>' },
+      });
+
+      // Send same message twice
+      await app.inject({
+        method: 'POST',
+        url: '/api/cloudflare/email',
+        payload,
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/cloudflare/email',
+        payload, // Same message-id
+      });
+
+      expect(response.statusCode).toBe(200);
+
+      // Should only have one message (ON CONFLICT updates)
+      const count = await pool.query('SELECT COUNT(*) FROM external_message');
+      expect(parseInt(count.rows[0].count, 10)).toBe(1);
+    });
+  });
+
+  describe('Secret Header Authentication', () => {
+    beforeEach(() => {
+      // Enable authentication
+      delete process.env.CLAWDBOT_AUTH_DISABLED;
+    });
+
+    it('returns 401 when signature is missing', async () => {
+      const payload = createCloudflarePayload();
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/cloudflare/email',
+        payload,
+        headers: {
+          // No X-Webhook-Signature header
+        },
+      });
+
+      expect(response.statusCode).toBe(401);
+      expect(response.json().error).toContain('Invalid signature');
+    });
+
+    it('returns 401 for invalid secret', async () => {
+      const payload = createCloudflarePayload();
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/cloudflare/email',
+        payload,
+        headers: {
+          'x-cloudflare-email-secret': 'wrong-secret',
+        },
+      });
+
+      expect(response.statusCode).toBe(401);
+      expect(response.json().error).toContain('Invalid signature');
+    });
+
+    it('accepts request with valid secret header', async () => {
+      const payload = createCloudflarePayload();
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/cloudflare/email',
+        payload,
+        headers: {
+          'x-cloudflare-email-secret': webhookSecret,
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+    });
+
+    it('accepts request when auth is disabled', async () => {
+      process.env.CLAWDBOT_AUTH_DISABLED = 'true';
+      const payload = createCloudflarePayload();
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/cloudflare/email',
+        payload,
+        // No Authorization header
+      });
+
+      expect(response.statusCode).toBe(200);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements the Cloudflare Email Workers inbound webhook endpoint for Issue #210.

- Adds `POST /api/cloudflare/email` endpoint for receiving emails forwarded from Cloudflare Workers
- Creates `src/api/cloudflare-email/` module with types and service layer
- Reuses Postmark email utilities for threading and HTML conversion
- Simple JSON payload format expected from the Cloudflare Worker
- Timestamp replay protection (reject if >5 minutes old)
- Secret header authentication via `X-Cloudflare-Email-Secret`
- Idempotent message handling via ON CONFLICT upsert

### Key Files
- `src/api/cloudflare-email/types.ts` - TypeScript types for Cloudflare Worker payloads
- `src/api/cloudflare-email/service.ts` - Database operations for email processing
- `src/api/server.ts` - New endpoint registration
- `tests/cloudflare-email/inbound-webhook.test.ts` - 15 tests covering endpoint behavior

### Example Cloudflare Worker

The user must deploy a Cloudflare Worker that:
1. Parses incoming email (from, to, subject, headers)
2. Extracts text/HTML body from raw MIME
3. Signs request with shared secret header
4. POSTs to this webhook endpoint

## Test plan

- [x] All 15 Cloudflare email tests pass
- [x] Full test suite passes (1295 tests)
- [ ] Document example Cloudflare Worker code (in issue #210)
- [ ] Verify webhook works with real Cloudflare Worker

Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)