### PR TITLE
[#214] Implement audit logging with database triggers

### DIFF
--- a/migrations/034_audit_log.down.sql
+++ b/migrations/034_audit_log.down.sql
@@ -1,0 +1,38 @@
+-- Issue #214: Rollback audit logging
+
+-- Drop triggers
+DROP TRIGGER IF EXISTS audit_memory_delete ON memory;
+DROP TRIGGER IF EXISTS audit_memory_update ON memory;
+DROP TRIGGER IF EXISTS audit_memory_insert ON memory;
+
+DROP TRIGGER IF EXISTS audit_contact_delete ON contact;
+DROP TRIGGER IF EXISTS audit_contact_update ON contact;
+DROP TRIGGER IF EXISTS audit_contact_insert ON contact;
+
+DROP TRIGGER IF EXISTS audit_work_item_delete ON work_item;
+DROP TRIGGER IF EXISTS audit_work_item_update ON work_item;
+DROP TRIGGER IF EXISTS audit_work_item_insert ON work_item;
+
+-- Drop trigger functions
+DROP FUNCTION IF EXISTS audit_memory_changes();
+DROP FUNCTION IF EXISTS audit_contact_changes();
+DROP FUNCTION IF EXISTS audit_work_item_changes();
+
+-- Drop helper function
+DROP FUNCTION IF EXISTS create_audit_log(audit_actor_type, text, audit_action_type, text, uuid, jsonb, jsonb);
+
+-- Drop indexes
+DROP INDEX IF EXISTS audit_log_entity_lookup_idx;
+DROP INDEX IF EXISTS audit_log_entity_id_idx;
+DROP INDEX IF EXISTS audit_log_entity_type_idx;
+DROP INDEX IF EXISTS audit_log_action_idx;
+DROP INDEX IF EXISTS audit_log_actor_id_idx;
+DROP INDEX IF EXISTS audit_log_actor_type_idx;
+DROP INDEX IF EXISTS audit_log_timestamp_idx;
+
+-- Drop table
+DROP TABLE IF EXISTS audit_log;
+
+-- Drop enums
+DROP TYPE IF EXISTS audit_action_type;
+DROP TYPE IF EXISTS audit_actor_type;

--- a/migrations/034_audit_log.up.sql
+++ b/migrations/034_audit_log.up.sql
@@ -1,0 +1,242 @@
+-- Issue #214: Audit logging for all mutations
+
+-- Create actor type enum
+DO $$ BEGIN
+  CREATE TYPE audit_actor_type AS ENUM ('agent', 'human', 'system');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+-- Create action type enum
+DO $$ BEGIN
+  CREATE TYPE audit_action_type AS ENUM ('create', 'update', 'delete', 'auth', 'webhook');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+-- Create audit_log table
+CREATE TABLE IF NOT EXISTS audit_log (
+  id uuid PRIMARY KEY DEFAULT new_uuid(),
+  timestamp timestamptz NOT NULL DEFAULT now(),
+  actor_type audit_actor_type NOT NULL DEFAULT 'system',
+  actor_id text,                    -- Agent name, user email, or null for system
+  action audit_action_type NOT NULL,
+  entity_type text NOT NULL,        -- 'work_item', 'memory', 'contact', etc.
+  entity_id uuid,                   -- May be null for some events (e.g., failed auth)
+  changes jsonb,                    -- What changed (old/new values)
+  metadata jsonb,                   -- Request ID, IP, user agent, etc.
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Indexes for common query patterns
+CREATE INDEX IF NOT EXISTS audit_log_timestamp_idx ON audit_log(timestamp DESC);
+CREATE INDEX IF NOT EXISTS audit_log_actor_type_idx ON audit_log(actor_type);
+CREATE INDEX IF NOT EXISTS audit_log_actor_id_idx ON audit_log(actor_id) WHERE actor_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS audit_log_action_idx ON audit_log(action);
+CREATE INDEX IF NOT EXISTS audit_log_entity_type_idx ON audit_log(entity_type);
+CREATE INDEX IF NOT EXISTS audit_log_entity_id_idx ON audit_log(entity_id) WHERE entity_id IS NOT NULL;
+
+-- Combined index for entity lookups
+CREATE INDEX IF NOT EXISTS audit_log_entity_lookup_idx ON audit_log(entity_type, entity_id);
+
+-- Partition hint for future: consider partitioning by month if this table grows large
+
+-- Function to create audit log entry
+CREATE OR REPLACE FUNCTION create_audit_log(
+  p_actor_type audit_actor_type,
+  p_actor_id text,
+  p_action audit_action_type,
+  p_entity_type text,
+  p_entity_id uuid,
+  p_changes jsonb DEFAULT NULL,
+  p_metadata jsonb DEFAULT NULL
+)
+RETURNS uuid
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_id uuid;
+BEGIN
+  INSERT INTO audit_log (actor_type, actor_id, action, entity_type, entity_id, changes, metadata)
+  VALUES (p_actor_type, p_actor_id, p_action, p_entity_type, p_entity_id, p_changes, p_metadata)
+  RETURNING id INTO v_id;
+
+  RETURN v_id;
+END;
+$$;
+
+-- Trigger function for automatic work_item audit logging
+CREATE OR REPLACE FUNCTION audit_work_item_changes()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_action audit_action_type;
+  v_changes jsonb;
+  v_entity_id uuid;
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    v_action := 'create';
+    v_entity_id := NEW.id;
+    v_changes := jsonb_build_object('new', row_to_json(NEW));
+  ELSIF TG_OP = 'UPDATE' THEN
+    v_action := 'update';
+    v_entity_id := NEW.id;
+    v_changes := jsonb_build_object('old', row_to_json(OLD), 'new', row_to_json(NEW));
+  ELSIF TG_OP = 'DELETE' THEN
+    v_action := 'delete';
+    v_entity_id := OLD.id;
+    v_changes := jsonb_build_object('old', row_to_json(OLD));
+  END IF;
+
+  -- Insert audit log entry (default to system actor - API layer can update with actual actor)
+  INSERT INTO audit_log (actor_type, action, entity_type, entity_id, changes)
+  VALUES ('system', v_action, 'work_item', v_entity_id, v_changes);
+
+  IF TG_OP = 'DELETE' THEN
+    RETURN OLD;
+  ELSE
+    RETURN NEW;
+  END IF;
+END;
+$$;
+
+-- Create triggers for work_item
+DROP TRIGGER IF EXISTS audit_work_item_insert ON work_item;
+DROP TRIGGER IF EXISTS audit_work_item_update ON work_item;
+DROP TRIGGER IF EXISTS audit_work_item_delete ON work_item;
+
+CREATE TRIGGER audit_work_item_insert
+  AFTER INSERT ON work_item
+  FOR EACH ROW
+  EXECUTE FUNCTION audit_work_item_changes();
+
+CREATE TRIGGER audit_work_item_update
+  AFTER UPDATE ON work_item
+  FOR EACH ROW
+  EXECUTE FUNCTION audit_work_item_changes();
+
+CREATE TRIGGER audit_work_item_delete
+  AFTER DELETE ON work_item
+  FOR EACH ROW
+  EXECUTE FUNCTION audit_work_item_changes();
+
+-- Trigger function for automatic contact audit logging
+CREATE OR REPLACE FUNCTION audit_contact_changes()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_action audit_action_type;
+  v_changes jsonb;
+  v_entity_id uuid;
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    v_action := 'create';
+    v_entity_id := NEW.id;
+    v_changes := jsonb_build_object('new', row_to_json(NEW));
+  ELSIF TG_OP = 'UPDATE' THEN
+    v_action := 'update';
+    v_entity_id := NEW.id;
+    v_changes := jsonb_build_object('old', row_to_json(OLD), 'new', row_to_json(NEW));
+  ELSIF TG_OP = 'DELETE' THEN
+    v_action := 'delete';
+    v_entity_id := OLD.id;
+    v_changes := jsonb_build_object('old', row_to_json(OLD));
+  END IF;
+
+  INSERT INTO audit_log (actor_type, action, entity_type, entity_id, changes)
+  VALUES ('system', v_action, 'contact', v_entity_id, v_changes);
+
+  IF TG_OP = 'DELETE' THEN
+    RETURN OLD;
+  ELSE
+    RETURN NEW;
+  END IF;
+END;
+$$;
+
+-- Create triggers for contact
+DROP TRIGGER IF EXISTS audit_contact_insert ON contact;
+DROP TRIGGER IF EXISTS audit_contact_update ON contact;
+DROP TRIGGER IF EXISTS audit_contact_delete ON contact;
+
+CREATE TRIGGER audit_contact_insert
+  AFTER INSERT ON contact
+  FOR EACH ROW
+  EXECUTE FUNCTION audit_contact_changes();
+
+CREATE TRIGGER audit_contact_update
+  AFTER UPDATE ON contact
+  FOR EACH ROW
+  EXECUTE FUNCTION audit_contact_changes();
+
+CREATE TRIGGER audit_contact_delete
+  AFTER DELETE ON contact
+  FOR EACH ROW
+  EXECUTE FUNCTION audit_contact_changes();
+
+-- Trigger function for automatic memory audit logging
+CREATE OR REPLACE FUNCTION audit_memory_changes()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_action audit_action_type;
+  v_changes jsonb;
+  v_entity_id uuid;
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    v_action := 'create';
+    v_entity_id := NEW.id;
+    v_changes := jsonb_build_object('new', row_to_json(NEW));
+  ELSIF TG_OP = 'UPDATE' THEN
+    v_action := 'update';
+    v_entity_id := NEW.id;
+    v_changes := jsonb_build_object('old', row_to_json(OLD), 'new', row_to_json(NEW));
+  ELSIF TG_OP = 'DELETE' THEN
+    v_action := 'delete';
+    v_entity_id := OLD.id;
+    v_changes := jsonb_build_object('old', row_to_json(OLD));
+  END IF;
+
+  INSERT INTO audit_log (actor_type, action, entity_type, entity_id, changes)
+  VALUES ('system', v_action, 'memory', v_entity_id, v_changes);
+
+  IF TG_OP = 'DELETE' THEN
+    RETURN OLD;
+  ELSE
+    RETURN NEW;
+  END IF;
+END;
+$$;
+
+-- Create triggers for memory
+DROP TRIGGER IF EXISTS audit_memory_insert ON memory;
+DROP TRIGGER IF EXISTS audit_memory_update ON memory;
+DROP TRIGGER IF EXISTS audit_memory_delete ON memory;
+
+CREATE TRIGGER audit_memory_insert
+  AFTER INSERT ON memory
+  FOR EACH ROW
+  EXECUTE FUNCTION audit_memory_changes();
+
+CREATE TRIGGER audit_memory_update
+  AFTER UPDATE ON memory
+  FOR EACH ROW
+  EXECUTE FUNCTION audit_memory_changes();
+
+CREATE TRIGGER audit_memory_delete
+  AFTER DELETE ON memory
+  FOR EACH ROW
+  EXECUTE FUNCTION audit_memory_changes();
+
+-- Comments
+COMMENT ON TABLE audit_log IS 'Audit trail for all entity mutations';
+COMMENT ON COLUMN audit_log.actor_type IS 'Type of actor: agent, human, or system';
+COMMENT ON COLUMN audit_log.actor_id IS 'Identifier for the actor (agent name, user email, etc.)';
+COMMENT ON COLUMN audit_log.action IS 'Type of action performed';
+COMMENT ON COLUMN audit_log.entity_type IS 'Type of entity affected';
+COMMENT ON COLUMN audit_log.entity_id IS 'UUID of the affected entity';
+COMMENT ON COLUMN audit_log.changes IS 'JSON object with old/new values';
+COMMENT ON COLUMN audit_log.metadata IS 'Additional context (request ID, IP, etc.)';

--- a/src/api/audit/index.ts
+++ b/src/api/audit/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Audit logging module.
+ * Part of Issue #214.
+ */
+
+export * from './types.js';
+export * from './service.js';

--- a/src/api/audit/service.ts
+++ b/src/api/audit/service.ts
@@ -1,0 +1,313 @@
+/**
+ * Audit logging service.
+ * Part of Issue #214.
+ */
+
+import type { Pool } from 'pg';
+import type {
+  AuditLogEntry,
+  AuditLogQueryOptions,
+  AuditLogCreateParams,
+  AuditActor,
+  AuditActorType,
+} from './types.js';
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 500;
+
+/**
+ * Create an audit log entry
+ */
+export async function createAuditLog(
+  pool: Pool,
+  params: AuditLogCreateParams
+): Promise<string> {
+  const result = await pool.query(
+    `INSERT INTO audit_log (actor_type, actor_id, action, entity_type, entity_id, changes, metadata)
+     VALUES ($1::audit_actor_type, $2, $3::audit_action_type, $4, $5, $6, $7)
+     RETURNING id::text`,
+    [
+      params.actorType,
+      params.actorId || null,
+      params.action,
+      params.entityType,
+      params.entityId || null,
+      params.changes ? JSON.stringify(params.changes) : null,
+      params.metadata ? JSON.stringify(params.metadata) : null,
+    ]
+  );
+
+  return result.rows[0].id;
+}
+
+/**
+ * Query audit log entries with filtering
+ */
+export async function queryAuditLog(
+  pool: Pool,
+  options: AuditLogQueryOptions = {}
+): Promise<{ entries: AuditLogEntry[]; total: number }> {
+  const conditions: string[] = [];
+  const params: unknown[] = [];
+  let paramIndex = 1;
+
+  if (options.entityType) {
+    conditions.push(`entity_type = $${paramIndex++}`);
+    params.push(options.entityType);
+  }
+
+  if (options.entityId) {
+    conditions.push(`entity_id = $${paramIndex++}`);
+    params.push(options.entityId);
+  }
+
+  if (options.actorType) {
+    conditions.push(`actor_type = $${paramIndex++}::audit_actor_type`);
+    params.push(options.actorType);
+  }
+
+  if (options.actorId) {
+    conditions.push(`actor_id = $${paramIndex++}`);
+    params.push(options.actorId);
+  }
+
+  if (options.action) {
+    conditions.push(`action = $${paramIndex++}::audit_action_type`);
+    params.push(options.action);
+  }
+
+  if (options.startDate) {
+    conditions.push(`timestamp >= $${paramIndex++}`);
+    params.push(options.startDate);
+  }
+
+  if (options.endDate) {
+    conditions.push(`timestamp <= $${paramIndex++}`);
+    params.push(options.endDate);
+  }
+
+  const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+
+  // Get total count
+  const countResult = await pool.query(
+    `SELECT COUNT(*) FROM audit_log ${whereClause}`,
+    params
+  );
+  const total = parseInt(countResult.rows[0].count, 10);
+
+  // Get paginated results
+  const limit = Math.min(options.limit || DEFAULT_LIMIT, MAX_LIMIT);
+  const offset = options.offset || 0;
+
+  params.push(limit);
+  params.push(offset);
+
+  const result = await pool.query(
+    `SELECT
+      id::text,
+      timestamp,
+      actor_type,
+      actor_id,
+      action,
+      entity_type,
+      entity_id::text,
+      changes,
+      metadata
+    FROM audit_log
+    ${whereClause}
+    ORDER BY timestamp DESC
+    LIMIT $${paramIndex++} OFFSET $${paramIndex++}`,
+    params
+  );
+
+  const entries: AuditLogEntry[] = result.rows.map((row) => ({
+    id: row.id,
+    timestamp: row.timestamp,
+    actorType: row.actor_type as AuditActorType,
+    actorId: row.actor_id,
+    action: row.action,
+    entityType: row.entity_type,
+    entityId: row.entity_id,
+    changes: row.changes,
+    metadata: row.metadata,
+  }));
+
+  return { entries, total };
+}
+
+/**
+ * Get audit log entries for a specific entity
+ */
+export async function getEntityAuditLog(
+  pool: Pool,
+  entityType: string,
+  entityId: string,
+  options: { limit?: number; offset?: number } = {}
+): Promise<AuditLogEntry[]> {
+  const result = await queryAuditLog(pool, {
+    entityType,
+    entityId,
+    limit: options.limit,
+    offset: options.offset,
+  });
+  return result.entries;
+}
+
+/**
+ * Get audit log entries for a specific actor
+ */
+export async function getActorAuditLog(
+  pool: Pool,
+  actorType: AuditActorType,
+  actorId: string,
+  options: { limit?: number; offset?: number } = {}
+): Promise<AuditLogEntry[]> {
+  const result = await queryAuditLog(pool, {
+    actorType,
+    actorId,
+    limit: options.limit,
+    offset: options.offset,
+  });
+  return result.entries;
+}
+
+/**
+ * Log an authentication event
+ */
+export async function logAuthEvent(
+  pool: Pool,
+  params: {
+    actorType: AuditActorType;
+    actorId?: string;
+    success: boolean;
+    metadata?: Record<string, unknown>;
+  }
+): Promise<string> {
+  return createAuditLog(pool, {
+    actorType: params.actorType,
+    actorId: params.actorId,
+    action: 'auth',
+    entityType: 'session',
+    changes: { success: params.success },
+    metadata: params.metadata,
+  });
+}
+
+/**
+ * Log a webhook receipt
+ */
+export async function logWebhookEvent(
+  pool: Pool,
+  params: {
+    source: string; // 'twilio', 'postmark', 'cloudflare'
+    entityType?: string;
+    entityId?: string;
+    metadata?: Record<string, unknown>;
+  }
+): Promise<string> {
+  return createAuditLog(pool, {
+    actorType: 'system',
+    actorId: `webhook:${params.source}`,
+    action: 'webhook',
+    entityType: params.entityType || 'webhook',
+    entityId: params.entityId,
+    metadata: {
+      source: params.source,
+      ...params.metadata,
+    },
+  });
+}
+
+/**
+ * Purge old audit log entries (for retention)
+ */
+export async function purgeOldEntries(
+  pool: Pool,
+  retentionDays: number = 90
+): Promise<number> {
+  const result = await pool.query(
+    `DELETE FROM audit_log
+     WHERE timestamp < now() - INTERVAL '1 day' * $1
+     RETURNING id`,
+    [retentionDays]
+  );
+
+  return result.rowCount || 0;
+}
+
+/**
+ * Update the most recent audit log entry for an entity with actor information
+ * This allows the trigger-created entry to be enriched with the actual actor
+ */
+export async function updateLatestAuditEntry(
+  pool: Pool,
+  entityType: string,
+  entityId: string,
+  actor: AuditActor,
+  metadata?: Record<string, unknown>
+): Promise<boolean> {
+  const result = await pool.query(
+    `UPDATE audit_log
+     SET actor_type = $1::audit_actor_type,
+         actor_id = $2,
+         metadata = COALESCE(metadata, '{}'::jsonb) || $3::jsonb
+     WHERE id = (
+       SELECT id FROM audit_log
+       WHERE entity_type = $4 AND entity_id = $5
+       ORDER BY timestamp DESC
+       LIMIT 1
+     )`,
+    [
+      actor.type,
+      actor.id,
+      JSON.stringify(metadata || {}),
+      entityType,
+      entityId,
+    ]
+  );
+
+  return result.rowCount !== null && result.rowCount > 0;
+}
+
+/**
+ * Extract actor information from request headers
+ */
+export function extractActor(headers: Record<string, string | undefined>): AuditActor {
+  // Check for agent header
+  const agentName = headers['x-agent-name'];
+  if (agentName) {
+    return { type: 'agent', id: agentName };
+  }
+
+  // Check for user header (from session middleware)
+  const userId = headers['x-user-id'] || headers['x-user-email'];
+  if (userId) {
+    return { type: 'human', id: userId };
+  }
+
+  // Default to system
+  return { type: 'system', id: null };
+}
+
+/**
+ * Build metadata from request
+ */
+export function buildRequestMetadata(
+  req: { ip?: string; headers?: Record<string, string | string[] | undefined>; id?: string }
+): Record<string, unknown> {
+  const metadata: Record<string, unknown> = {};
+
+  if (req.ip) {
+    metadata.ip = req.ip;
+  }
+
+  if (req.id) {
+    metadata.requestId = req.id;
+  }
+
+  if (req.headers?.['user-agent']) {
+    metadata.userAgent = req.headers['user-agent'];
+  }
+
+  return metadata;
+}

--- a/src/api/audit/types.ts
+++ b/src/api/audit/types.ts
@@ -1,0 +1,46 @@
+/**
+ * Types for audit logging.
+ * Part of Issue #214.
+ */
+
+export type AuditActorType = 'agent' | 'human' | 'system';
+export type AuditActionType = 'create' | 'update' | 'delete' | 'auth' | 'webhook';
+
+export interface AuditLogEntry {
+  id: string;
+  timestamp: Date;
+  actorType: AuditActorType;
+  actorId: string | null;
+  action: AuditActionType;
+  entityType: string;
+  entityId: string | null;
+  changes: Record<string, unknown> | null;
+  metadata: Record<string, unknown> | null;
+}
+
+export interface AuditLogQueryOptions {
+  entityType?: string;
+  entityId?: string;
+  actorType?: AuditActorType;
+  actorId?: string;
+  action?: AuditActionType;
+  startDate?: Date;
+  endDate?: Date;
+  limit?: number;
+  offset?: number;
+}
+
+export interface AuditLogCreateParams {
+  actorType: AuditActorType;
+  actorId?: string | null;
+  action: AuditActionType;
+  entityType: string;
+  entityId?: string | null;
+  changes?: Record<string, unknown> | null;
+  metadata?: Record<string, unknown> | null;
+}
+
+export interface AuditActor {
+  type: AuditActorType;
+  id: string | null;
+}

--- a/tests/audit/api-endpoints.test.ts
+++ b/tests/audit/api-endpoints.test.ts
@@ -1,0 +1,337 @@
+/**
+ * Tests for audit log API endpoints.
+ * Part of Issue #214.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { Pool } from 'pg';
+import { buildServer } from '../../src/api/server.ts';
+import { createTestPool, truncateAllTables } from '../helpers/db.ts';
+
+describe('Audit Log API Endpoints', () => {
+  const originalEnv = process.env;
+  let pool: Pool;
+  let app: ReturnType<typeof buildServer>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+    process.env.CLAWDBOT_AUTH_DISABLED = 'true';
+
+    pool = createTestPool();
+    await truncateAllTables(pool);
+    // Clear the audit_log table after truncation
+    await pool.query('TRUNCATE TABLE audit_log CASCADE');
+    app = buildServer({ logger: false });
+  });
+
+  afterEach(async () => {
+    process.env = originalEnv;
+    await pool.end();
+  });
+
+  describe('GET /api/audit-log', () => {
+    beforeEach(async () => {
+      // Create some work items to generate audit entries via triggers
+      await pool.query(`INSERT INTO work_item (title) VALUES ('Task 1')`);
+      await pool.query(`INSERT INTO work_item (title) VALUES ('Task 2')`);
+      await pool.query(`INSERT INTO contact (display_name) VALUES ('Contact 1')`);
+    });
+
+    it('returns all audit log entries', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/audit-log',
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json();
+      expect(body.entries).toBeDefined();
+      expect(body.total).toBeDefined();
+      expect(body.entries.length).toBeGreaterThanOrEqual(3);
+    });
+
+    it('filters by entity type', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/audit-log?entityType=work_item',
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json();
+      expect(body.entries.every((e: { entityType: string }) => e.entityType === 'work_item')).toBe(true);
+    });
+
+    it('filters by action', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/audit-log?action=create',
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json();
+      expect(body.entries.every((e: { action: string }) => e.action === 'create')).toBe(true);
+    });
+
+    it('supports pagination', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/audit-log?limit=1&offset=0',
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json();
+      expect(body.entries.length).toBe(1);
+      expect(body.limit).toBe(1);
+      expect(body.offset).toBe(0);
+    });
+
+    it('filters by date range', async () => {
+      // Get entries created in the last hour (the entries were created in beforeEach)
+      const hourAgo = new Date(Date.now() - 60 * 60 * 1000);
+      const tomorrow = new Date(Date.now() + 24 * 60 * 60 * 1000);
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/audit-log?startDate=${hourAgo.toISOString()}&endDate=${tomorrow.toISOString()}`,
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json();
+      expect(body.entries.length).toBeGreaterThan(0);
+    });
+
+    it('returns 400 for invalid actorType', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/audit-log?actorType=invalid',
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.json().error).toContain('Invalid actorType');
+    });
+
+    it('returns 400 for invalid action', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/audit-log?action=invalid',
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.json().error).toContain('Invalid action');
+    });
+
+    it('returns 400 for invalid date format', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/audit-log?startDate=not-a-date',
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.json().error).toContain('Invalid startDate');
+    });
+  });
+
+  describe('GET /api/audit-log/entity/:type/:id', () => {
+    it('returns audit log for a specific entity', async () => {
+      // Create a work item to generate audit entries
+      const result = await pool.query(
+        `INSERT INTO work_item (title) VALUES ('Audit Test Task') RETURNING id::text`
+      );
+      const workItemId = result.rows[0].id;
+
+      // Update the work item to create another audit entry
+      await pool.query(
+        `UPDATE work_item SET title = 'Updated Task' WHERE id = $1`,
+        [workItemId]
+      );
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/audit-log/entity/work_item/${workItemId}`,
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json();
+      expect(body.entityType).toBe('work_item');
+      expect(body.entityId).toBe(workItemId);
+      expect(body.entries.length).toBe(2);
+      expect(body.count).toBe(2);
+    });
+
+    it('returns empty array for non-existent entity', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/audit-log/entity/work_item/00000000-0000-0000-0000-000000000000',
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json();
+      expect(body.entries).toHaveLength(0);
+    });
+
+    it('supports pagination', async () => {
+      const result = await pool.query(
+        `INSERT INTO work_item (title) VALUES ('Pagination Test') RETURNING id::text`
+      );
+      const workItemId = result.rows[0].id;
+
+      // Create multiple updates
+      for (let i = 0; i < 3; i++) {
+        await pool.query(
+          `UPDATE work_item SET title = $1 WHERE id = $2`,
+          [`Title ${i}`, workItemId]
+        );
+      }
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/audit-log/entity/work_item/${workItemId}?limit=2`,
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json();
+      expect(body.entries.length).toBe(2);
+    });
+  });
+
+  describe('POST /api/audit-log/purge', () => {
+    it('purges old entries', async () => {
+      // Create an entry
+      await pool.query(`INSERT INTO work_item (title) VALUES ('Old Task')`);
+
+      // Make it old
+      await pool.query(
+        `UPDATE audit_log SET timestamp = now() - INTERVAL '100 days'`
+      );
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/audit-log/purge',
+        payload: { retentionDays: 90 },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json();
+      expect(body.success).toBe(true);
+      expect(body.purged).toBeGreaterThan(0);
+    });
+
+    it('uses default retention days', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/audit-log/purge',
+        payload: {},
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json();
+      expect(body.retentionDays).toBe(90);
+    });
+
+    it('accepts positive retention days in valid range', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/audit-log/purge',
+        payload: { retentionDays: 30 },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json().retentionDays).toBe(30);
+    });
+
+    it('returns 400 for retention days too large', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/audit-log/purge',
+        payload: { retentionDays: 5000 },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+  });
+});
+
+describe('Audit Log Trigger Verification via API', () => {
+  const originalEnv = process.env;
+  let pool: Pool;
+  let app: ReturnType<typeof buildServer>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+    process.env.CLAWDBOT_AUTH_DISABLED = 'true';
+
+    pool = createTestPool();
+    await truncateAllTables(pool);
+    await pool.query('TRUNCATE TABLE audit_log CASCADE');
+    app = buildServer({ logger: false });
+  });
+
+  afterEach(async () => {
+    process.env = originalEnv;
+    await pool.end();
+  });
+
+  it('creates audit entry when work item is created via API', async () => {
+    const createResponse = await app.inject({
+      method: 'POST',
+      url: '/api/work-items',
+      payload: { title: 'API Created Task' },
+    });
+
+    expect(createResponse.statusCode).toBe(201);
+    const workItemId = createResponse.json().id;
+
+    const auditResponse = await app.inject({
+      method: 'GET',
+      url: `/api/audit-log/entity/work_item/${workItemId}`,
+    });
+
+    expect(auditResponse.statusCode).toBe(200);
+    const body = auditResponse.json();
+    expect(body.entries.length).toBe(1);
+    expect(body.entries[0].action).toBe('create');
+  });
+
+  it('creates audit entry when contact is created via API', async () => {
+    const createResponse = await app.inject({
+      method: 'POST',
+      url: '/api/contacts',
+      payload: { displayName: 'API Created Contact' },
+    });
+
+    expect(createResponse.statusCode).toBe(201);
+    const contactId = createResponse.json().id;
+
+    const auditResponse = await app.inject({
+      method: 'GET',
+      url: `/api/audit-log/entity/contact/${contactId}`,
+    });
+
+    expect(auditResponse.statusCode).toBe(200);
+    const body = auditResponse.json();
+    expect(body.entries.length).toBe(1);
+    expect(body.entries[0].action).toBe('create');
+  });
+
+  it('creates audit entry when memory is created directly', async () => {
+    // Create memory directly in the database
+    const result = await pool.query(
+      `INSERT INTO memory (title, content, memory_type)
+       VALUES ('Test Memory', 'Test content', 'note')
+       RETURNING id::text`
+    );
+    const memoryId = result.rows[0].id;
+
+    const auditResponse = await app.inject({
+      method: 'GET',
+      url: `/api/audit-log/entity/memory/${memoryId}`,
+    });
+
+    expect(auditResponse.statusCode).toBe(200);
+    const body = auditResponse.json();
+    expect(body.entries.length).toBe(1);
+    expect(body.entries[0].action).toBe('create');
+  });
+});

--- a/tests/audit/service.test.ts
+++ b/tests/audit/service.test.ts
@@ -1,0 +1,516 @@
+/**
+ * Tests for audit logging service.
+ * Part of Issue #214.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type { Pool } from 'pg';
+import { createTestPool, truncateAllTables } from '../helpers/db.ts';
+import {
+  createAuditLog,
+  queryAuditLog,
+  getEntityAuditLog,
+  getActorAuditLog,
+  logAuthEvent,
+  logWebhookEvent,
+  purgeOldEntries,
+  updateLatestAuditEntry,
+  extractActor,
+  buildRequestMetadata,
+} from '../../src/api/audit/service.ts';
+
+describe('Audit Service', () => {
+  let pool: Pool;
+
+  beforeEach(async () => {
+    pool = createTestPool();
+    await truncateAllTables(pool);
+    // Clear the audit_log table after truncation since triggers fire during truncation
+    await pool.query('TRUNCATE TABLE audit_log CASCADE');
+  });
+
+  afterEach(async () => {
+    await pool.end();
+  });
+
+  describe('createAuditLog', () => {
+    it('creates an audit log entry', async () => {
+      const id = await createAuditLog(pool, {
+        actorType: 'human',
+        actorId: 'user@example.com',
+        action: 'create',
+        entityType: 'work_item',
+        entityId: '00000000-0000-0000-0000-000000000001',
+        changes: { title: 'New Task' },
+        metadata: { ip: '127.0.0.1' },
+      });
+
+      expect(id).toBeDefined();
+
+      // Verify the entry
+      const result = await pool.query(
+        `SELECT * FROM audit_log WHERE id = $1`,
+        [id]
+      );
+      expect(result.rows.length).toBe(1);
+      expect(result.rows[0].actor_type).toBe('human');
+      expect(result.rows[0].actor_id).toBe('user@example.com');
+      expect(result.rows[0].action).toBe('create');
+      expect(result.rows[0].entity_type).toBe('work_item');
+    });
+
+    it('creates entry with null actor_id for system actor', async () => {
+      const id = await createAuditLog(pool, {
+        actorType: 'system',
+        action: 'create',
+        entityType: 'work_item',
+      });
+
+      expect(id).toBeDefined();
+
+      const result = await pool.query(
+        `SELECT actor_id FROM audit_log WHERE id = $1`,
+        [id]
+      );
+      expect(result.rows[0].actor_id).toBeNull();
+    });
+  });
+
+  describe('queryAuditLog', () => {
+    beforeEach(async () => {
+      // Create some test entries
+      await createAuditLog(pool, {
+        actorType: 'human',
+        actorId: 'user1@example.com',
+        action: 'create',
+        entityType: 'work_item',
+        entityId: '00000000-0000-0000-0000-000000000001',
+      });
+      await createAuditLog(pool, {
+        actorType: 'agent',
+        actorId: 'agent-1',
+        action: 'update',
+        entityType: 'work_item',
+        entityId: '00000000-0000-0000-0000-000000000001',
+      });
+      await createAuditLog(pool, {
+        actorType: 'human',
+        actorId: 'user1@example.com',
+        action: 'create',
+        entityType: 'contact',
+        entityId: '00000000-0000-0000-0000-000000000002',
+      });
+    });
+
+    it('returns all entries with no filter', async () => {
+      const { entries, total } = await queryAuditLog(pool);
+      expect(entries.length).toBe(3);
+      expect(total).toBe(3);
+    });
+
+    it('filters by entity type', async () => {
+      const { entries, total } = await queryAuditLog(pool, {
+        entityType: 'work_item',
+      });
+      expect(entries.length).toBe(2);
+      expect(total).toBe(2);
+    });
+
+    it('filters by entity ID', async () => {
+      const { entries, total } = await queryAuditLog(pool, {
+        entityId: '00000000-0000-0000-0000-000000000001',
+      });
+      expect(entries.length).toBe(2);
+      expect(total).toBe(2);
+    });
+
+    it('filters by actor type', async () => {
+      const { entries, total } = await queryAuditLog(pool, {
+        actorType: 'human',
+      });
+      expect(entries.length).toBe(2);
+      expect(total).toBe(2);
+    });
+
+    it('filters by actor ID', async () => {
+      const { entries, total } = await queryAuditLog(pool, {
+        actorId: 'agent-1',
+      });
+      expect(entries.length).toBe(1);
+      expect(total).toBe(1);
+    });
+
+    it('filters by action', async () => {
+      const { entries, total } = await queryAuditLog(pool, {
+        action: 'create',
+      });
+      expect(entries.length).toBe(2);
+      expect(total).toBe(2);
+    });
+
+    it('supports pagination', async () => {
+      const { entries: page1 } = await queryAuditLog(pool, { limit: 2, offset: 0 });
+      expect(page1.length).toBe(2);
+
+      const { entries: page2 } = await queryAuditLog(pool, { limit: 2, offset: 2 });
+      expect(page2.length).toBe(1);
+    });
+
+    it('filters by date range', async () => {
+      const now = new Date();
+      const yesterday = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+      const tomorrow = new Date(now.getTime() + 24 * 60 * 60 * 1000);
+
+      const { total: inRange } = await queryAuditLog(pool, {
+        startDate: yesterday,
+        endDate: tomorrow,
+      });
+      expect(inRange).toBe(3);
+
+      const { total: beforeNow } = await queryAuditLog(pool, {
+        endDate: yesterday,
+      });
+      expect(beforeNow).toBe(0);
+    });
+  });
+
+  describe('getEntityAuditLog', () => {
+    it('returns audit entries for a specific entity', async () => {
+      await createAuditLog(pool, {
+        actorType: 'human',
+        action: 'create',
+        entityType: 'work_item',
+        entityId: '00000000-0000-0000-0000-000000000001',
+      });
+      await createAuditLog(pool, {
+        actorType: 'human',
+        action: 'update',
+        entityType: 'work_item',
+        entityId: '00000000-0000-0000-0000-000000000001',
+      });
+
+      const entries = await getEntityAuditLog(
+        pool,
+        'work_item',
+        '00000000-0000-0000-0000-000000000001'
+      );
+      expect(entries.length).toBe(2);
+    });
+  });
+
+  describe('getActorAuditLog', () => {
+    it('returns audit entries for a specific actor', async () => {
+      await createAuditLog(pool, {
+        actorType: 'agent',
+        actorId: 'my-agent',
+        action: 'create',
+        entityType: 'work_item',
+      });
+      await createAuditLog(pool, {
+        actorType: 'agent',
+        actorId: 'my-agent',
+        action: 'update',
+        entityType: 'contact',
+      });
+
+      const entries = await getActorAuditLog(pool, 'agent', 'my-agent');
+      expect(entries.length).toBe(2);
+    });
+  });
+
+  describe('logAuthEvent', () => {
+    it('logs a successful auth event', async () => {
+      const id = await logAuthEvent(pool, {
+        actorType: 'human',
+        actorId: 'user@example.com',
+        success: true,
+        metadata: { method: 'magic_link' },
+      });
+
+      expect(id).toBeDefined();
+
+      const result = await pool.query(
+        `SELECT * FROM audit_log WHERE id = $1`,
+        [id]
+      );
+      expect(result.rows[0].action).toBe('auth');
+      expect(result.rows[0].entity_type).toBe('session');
+      expect(result.rows[0].changes.success).toBe(true);
+    });
+
+    it('logs a failed auth event', async () => {
+      const id = await logAuthEvent(pool, {
+        actorType: 'human',
+        actorId: 'attacker@evil.com',
+        success: false,
+        metadata: { reason: 'invalid_token' },
+      });
+
+      const result = await pool.query(
+        `SELECT * FROM audit_log WHERE id = $1`,
+        [id]
+      );
+      expect(result.rows[0].changes.success).toBe(false);
+    });
+  });
+
+  describe('logWebhookEvent', () => {
+    it('logs a webhook receipt', async () => {
+      const id = await logWebhookEvent(pool, {
+        source: 'twilio',
+        entityType: 'external_message',
+        entityId: '00000000-0000-0000-0000-000000000001',
+        metadata: { from: '+15551234567' },
+      });
+
+      expect(id).toBeDefined();
+
+      const result = await pool.query(
+        `SELECT * FROM audit_log WHERE id = $1`,
+        [id]
+      );
+      expect(result.rows[0].action).toBe('webhook');
+      expect(result.rows[0].actor_id).toBe('webhook:twilio');
+      expect(result.rows[0].metadata.source).toBe('twilio');
+    });
+  });
+
+  describe('purgeOldEntries', () => {
+    it('purges entries older than retention period', async () => {
+      // Create an entry
+      await createAuditLog(pool, {
+        actorType: 'system',
+        action: 'create',
+        entityType: 'work_item',
+      });
+
+      // Update timestamp to be old
+      await pool.query(
+        `UPDATE audit_log SET timestamp = now() - INTERVAL '100 days'`
+      );
+
+      const purged = await purgeOldEntries(pool, 90);
+      expect(purged).toBe(1);
+
+      const { total } = await queryAuditLog(pool);
+      expect(total).toBe(0);
+    });
+
+    it('keeps entries within retention period', async () => {
+      await createAuditLog(pool, {
+        actorType: 'system',
+        action: 'create',
+        entityType: 'work_item',
+      });
+
+      const purged = await purgeOldEntries(pool, 90);
+      expect(purged).toBe(0);
+
+      const { total } = await queryAuditLog(pool);
+      expect(total).toBe(1);
+    });
+  });
+
+  describe('updateLatestAuditEntry', () => {
+    it('updates the most recent audit entry for an entity', async () => {
+      // The trigger will create an entry when we insert a work_item
+      const workItemResult = await pool.query(
+        `INSERT INTO work_item (title) VALUES ('Test Task') RETURNING id::text`
+      );
+      const workItemId = workItemResult.rows[0].id;
+
+      // Update the audit entry with actor info
+      const updated = await updateLatestAuditEntry(
+        pool,
+        'work_item',
+        workItemId,
+        { type: 'human', id: 'user@example.com' },
+        { ip: '192.168.1.1' }
+      );
+
+      expect(updated).toBe(true);
+
+      // Verify the update
+      const entries = await getEntityAuditLog(pool, 'work_item', workItemId);
+      expect(entries[0].actorType).toBe('human');
+      expect(entries[0].actorId).toBe('user@example.com');
+      expect(entries[0].metadata?.ip).toBe('192.168.1.1');
+    });
+  });
+
+  describe('extractActor', () => {
+    it('extracts agent from X-Agent-Name header', () => {
+      const actor = extractActor({ 'x-agent-name': 'my-agent' });
+      expect(actor.type).toBe('agent');
+      expect(actor.id).toBe('my-agent');
+    });
+
+    it('extracts human from X-User-Id header', () => {
+      const actor = extractActor({ 'x-user-id': 'user123' });
+      expect(actor.type).toBe('human');
+      expect(actor.id).toBe('user123');
+    });
+
+    it('extracts human from X-User-Email header', () => {
+      const actor = extractActor({ 'x-user-email': 'user@example.com' });
+      expect(actor.type).toBe('human');
+      expect(actor.id).toBe('user@example.com');
+    });
+
+    it('prefers agent over human headers', () => {
+      const actor = extractActor({
+        'x-agent-name': 'my-agent',
+        'x-user-id': 'user123',
+      });
+      expect(actor.type).toBe('agent');
+      expect(actor.id).toBe('my-agent');
+    });
+
+    it('defaults to system with no headers', () => {
+      const actor = extractActor({});
+      expect(actor.type).toBe('system');
+      expect(actor.id).toBeNull();
+    });
+  });
+
+  describe('buildRequestMetadata', () => {
+    it('builds metadata from request', () => {
+      const metadata = buildRequestMetadata({
+        ip: '192.168.1.1',
+        id: 'req-123',
+        headers: { 'user-agent': 'Mozilla/5.0' },
+      });
+
+      expect(metadata.ip).toBe('192.168.1.1');
+      expect(metadata.requestId).toBe('req-123');
+      expect(metadata.userAgent).toBe('Mozilla/5.0');
+    });
+
+    it('handles missing fields gracefully', () => {
+      const metadata = buildRequestMetadata({});
+      expect(Object.keys(metadata)).toHaveLength(0);
+    });
+  });
+});
+
+describe('Automatic Audit Triggers', () => {
+  let pool: Pool;
+
+  beforeEach(async () => {
+    pool = createTestPool();
+    await truncateAllTables(pool);
+    // Clear the audit_log table after truncation since triggers fire during truncation
+    await pool.query('TRUNCATE TABLE audit_log CASCADE');
+  });
+
+  afterEach(async () => {
+    await pool.end();
+  });
+
+  describe('work_item triggers', () => {
+    it('logs work_item creation', async () => {
+      const result = await pool.query(
+        `INSERT INTO work_item (title) VALUES ('Test Task') RETURNING id::text`
+      );
+      const workItemId = result.rows[0].id;
+
+      const entries = await getEntityAuditLog(pool, 'work_item', workItemId);
+      expect(entries.length).toBe(1);
+      expect(entries[0].action).toBe('create');
+      expect(entries[0].changes?.new).toBeDefined();
+    });
+
+    it('logs work_item update', async () => {
+      const result = await pool.query(
+        `INSERT INTO work_item (title) VALUES ('Test Task') RETURNING id::text`
+      );
+      const workItemId = result.rows[0].id;
+
+      await pool.query(
+        `UPDATE work_item SET title = 'Updated Task' WHERE id = $1`,
+        [workItemId]
+      );
+
+      const entries = await getEntityAuditLog(pool, 'work_item', workItemId);
+      expect(entries.length).toBe(2);
+      expect(entries[0].action).toBe('update');
+      expect(entries[0].changes?.old).toBeDefined();
+      expect(entries[0].changes?.new).toBeDefined();
+    });
+
+    it('logs work_item deletion', async () => {
+      const result = await pool.query(
+        `INSERT INTO work_item (title) VALUES ('Test Task') RETURNING id::text`
+      );
+      const workItemId = result.rows[0].id;
+
+      await pool.query(`DELETE FROM work_item WHERE id = $1`, [workItemId]);
+
+      // The audit entry should still exist even though the work item is deleted
+      const auditResult = await pool.query(
+        `SELECT * FROM audit_log WHERE entity_type = 'work_item' AND entity_id = $1 AND action = 'delete'`,
+        [workItemId]
+      );
+      expect(auditResult.rows.length).toBe(1);
+      expect(auditResult.rows[0].changes.old).toBeDefined();
+    });
+  });
+
+  describe('contact triggers', () => {
+    it('logs contact creation', async () => {
+      const result = await pool.query(
+        `INSERT INTO contact (display_name) VALUES ('Test Contact') RETURNING id::text`
+      );
+      const contactId = result.rows[0].id;
+
+      const entries = await getEntityAuditLog(pool, 'contact', contactId);
+      expect(entries.length).toBe(1);
+      expect(entries[0].action).toBe('create');
+    });
+
+    it('logs contact update', async () => {
+      const result = await pool.query(
+        `INSERT INTO contact (display_name) VALUES ('Test Contact') RETURNING id::text`
+      );
+      const contactId = result.rows[0].id;
+
+      await pool.query(
+        `UPDATE contact SET display_name = 'Updated Contact' WHERE id = $1`,
+        [contactId]
+      );
+
+      const entries = await getEntityAuditLog(pool, 'contact', contactId);
+      expect(entries.length).toBe(2);
+      expect(entries[0].action).toBe('update');
+    });
+  });
+
+  describe('memory triggers', () => {
+    it('logs memory creation', async () => {
+      const result = await pool.query(
+        `INSERT INTO memory (title, content, memory_type) VALUES ('Test Memory', 'Content', 'note') RETURNING id::text`
+      );
+      const memoryId = result.rows[0].id;
+
+      const entries = await getEntityAuditLog(pool, 'memory', memoryId);
+      expect(entries.length).toBe(1);
+      expect(entries[0].action).toBe('create');
+    });
+
+    it('logs memory update', async () => {
+      const result = await pool.query(
+        `INSERT INTO memory (title, content, memory_type) VALUES ('Test Memory', 'Content', 'note') RETURNING id::text`
+      );
+      const memoryId = result.rows[0].id;
+
+      await pool.query(
+        `UPDATE memory SET title = 'Updated Memory' WHERE id = $1`,
+        [memoryId]
+      );
+
+      const entries = await getEntityAuditLog(pool, 'memory', memoryId);
+      expect(entries.length).toBe(2);
+      expect(entries[0].action).toBe('update');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `audit_log` table with actor tracking (agent/human/system), action types (create/update/delete/auth/webhook), and jsonb changes column
- Create database triggers for automatic audit logging on work_item, contact, and memory tables
- Implement audit service with filtering (entityType, action, actorType, date range), pagination, and retention purge
- Add API endpoints: `GET /api/audit-log`, `GET /api/audit-log/entity/:type/:id`, `POST /api/audit-log/purge`
- Include helper functions for extracting actor from headers and building request metadata

## Test plan
- [x] Run audit service tests (32 tests)
- [x] Run API endpoint tests (18 tests)
- [x] Verify triggers create audit entries on work_item/contact/memory changes
- [x] Test filtering by entity type, action, actor type, and date range
- [x] Test pagination with limit/offset
- [x] Test purge with retention days parameter
- [x] Verify error handling for invalid parameters

Closes #214

🤖 Generated with [Claude Code](https://claude.com/claude-code)