### PR TITLE
[#240] Implement memory_recall tool for semantic memory search

### DIFF
--- a/packages/openclaw-plugin/src/tools/index.ts
+++ b/packages/openclaw-plugin/src/tools/index.ts
@@ -3,8 +3,22 @@
  * Exports all available tools for the plugin.
  */
 
-// Memory tools (to be implemented in #240, #243, #244)
-// export * from './memory.js'
+// Memory tools
+export {
+  createMemoryRecallTool,
+  MemoryRecallParamsSchema,
+  MemoryCategory,
+  type MemoryRecallParams,
+  type MemoryRecallTool,
+  type MemoryRecallResult,
+  type Memory,
+} from './memory-recall.js'
+
+// memory_store tool (to be implemented in #243)
+// export * from './memory-store.js'
+
+// memory_forget tool (to be implemented in #244)
+// export * from './memory-forget.js'
 
 // Project tools (to be implemented in #245)
 // export * from './projects.js'
@@ -15,7 +29,7 @@
 // Contact tools (to be implemented in #247)
 // export * from './contacts.js'
 
-/** Placeholder for tools - actual implementations in separate issues */
-export const tools = {
-  // Will be populated as tools are implemented
+/** Tool factory types */
+export interface ToolFactoryOptions {
+  // Common options for tool factories
 }

--- a/packages/openclaw-plugin/src/tools/memory-recall.ts
+++ b/packages/openclaw-plugin/src/tools/memory-recall.ts
@@ -1,0 +1,217 @@
+/**
+ * memory_recall tool implementation.
+ * Provides semantic search through stored memories.
+ */
+
+import { z } from 'zod'
+import type { ApiClient } from '../api-client.js'
+import type { Logger } from '../logger.js'
+import type { PluginConfig } from '../config.js'
+
+/** Memory categories for filtering */
+export const MemoryCategory = z.enum(['preference', 'fact', 'decision', 'context', 'other'])
+export type MemoryCategory = z.infer<typeof MemoryCategory>
+
+/** Parameters for memory_recall tool */
+export const MemoryRecallParamsSchema = z.object({
+  query: z
+    .string()
+    .min(1, 'Query cannot be empty')
+    .max(1000, 'Query must be 1000 characters or less'),
+  limit: z.number().int().min(1).max(20).optional(),
+  category: MemoryCategory.optional(),
+})
+export type MemoryRecallParams = z.infer<typeof MemoryRecallParamsSchema>
+
+/** Memory item returned from API */
+export interface Memory {
+  id: string
+  content: string
+  category: string
+  score?: number
+  createdAt?: string
+  updatedAt?: string
+}
+
+/** Successful tool result */
+export interface MemoryRecallSuccess {
+  success: true
+  data: {
+    content: string
+    details: {
+      count: number
+      memories: Memory[]
+      userId: string
+    }
+  }
+}
+
+/** Failed tool result */
+export interface MemoryRecallFailure {
+  success: false
+  error: string
+}
+
+/** Tool result type */
+export type MemoryRecallResult = MemoryRecallSuccess | MemoryRecallFailure
+
+/** Tool configuration */
+export interface MemoryRecallToolOptions {
+  client: ApiClient
+  logger: Logger
+  config: PluginConfig
+  userId: string
+}
+
+/** Tool definition */
+export interface MemoryRecallTool {
+  name: string
+  description: string
+  parameters: typeof MemoryRecallParamsSchema
+  execute: (params: MemoryRecallParams) => Promise<MemoryRecallResult>
+}
+
+/**
+ * Sanitize query input to prevent injection and remove control characters.
+ */
+function sanitizeQuery(query: string): string {
+  // Remove control characters (ASCII 0-31 except tab, newline, carriage return)
+  const sanitized = query.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, '')
+  // Trim whitespace
+  return sanitized.trim()
+}
+
+/**
+ * Format memories as a bullet list with category tags.
+ */
+function formatMemoriesAsText(memories: Memory[]): string {
+  if (memories.length === 0) {
+    return 'No relevant memories found.'
+  }
+
+  return memories
+    .map((m) => `- [${m.category}] ${m.content}`)
+    .join('\n')
+}
+
+/**
+ * Create a sanitized error message that doesn't expose internal details.
+ */
+function sanitizeErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    // Remove any internal hostnames, ports, or paths
+    const message = error.message
+      .replace(/\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b/g, '[host]')
+      .replace(/:\d{2,5}\b/g, '')
+      .replace(/\b(?:localhost|internal[-\w]*)\b/gi, '[internal]')
+
+    // If the message still looks like it contains internal details, use generic
+    if (message.includes('[internal]') || message.includes('[host]')) {
+      return 'Failed to search memories. Please try again.'
+    }
+
+    return message
+  }
+  return 'An unexpected error occurred while searching memories.'
+}
+
+/**
+ * Creates the memory_recall tool.
+ */
+export function createMemoryRecallTool(options: MemoryRecallToolOptions): MemoryRecallTool {
+  const { client, logger, config, userId } = options
+
+  return {
+    name: 'memory_recall',
+    description:
+      'Search through long-term memories. Use when you need context about user preferences, past decisions, or previously discussed topics.',
+    parameters: MemoryRecallParamsSchema,
+
+    async execute(params: MemoryRecallParams): Promise<MemoryRecallResult> {
+      // Validate parameters
+      const parseResult = MemoryRecallParamsSchema.safeParse(params)
+      if (!parseResult.success) {
+        const errorMessage = parseResult.error.errors
+          .map((e) => `${e.path.join('.')}: ${e.message}`)
+          .join(', ')
+        return { success: false, error: errorMessage }
+      }
+
+      const { query, limit = config.maxRecallMemories, category } = parseResult.data
+
+      // Sanitize query
+      const sanitizedQuery = sanitizeQuery(query)
+      if (sanitizedQuery.length === 0) {
+        return { success: false, error: 'Query cannot be empty after sanitization' }
+      }
+
+      // Log invocation (without query content for privacy)
+      logger.info('memory_recall invoked', {
+        userId,
+        limit,
+        category: category ?? 'all',
+        queryLength: sanitizedQuery.length,
+      })
+
+      try {
+        // Build API URL
+        const queryParams = new URLSearchParams({
+          q: sanitizedQuery,
+          limit: String(limit),
+        })
+        if (category) {
+          queryParams.set('category', category)
+        }
+
+        const path = `/api/memories/search?${queryParams.toString()}`
+
+        // Call API
+        const response = await client.get<{ memories: Memory[] }>(path, { userId })
+
+        if (!response.success) {
+          logger.error('memory_recall API error', {
+            userId,
+            status: response.error.status,
+            code: response.error.code,
+          })
+          return {
+            success: false,
+            error: response.error.message || 'Failed to search memories',
+          }
+        }
+
+        const memories = response.data.memories ?? []
+
+        // Format response
+        const content = formatMemoriesAsText(memories)
+
+        logger.debug('memory_recall completed', {
+          userId,
+          resultCount: memories.length,
+        })
+
+        return {
+          success: true,
+          data: {
+            content,
+            details: {
+              count: memories.length,
+              memories,
+              userId,
+            },
+          },
+        }
+      } catch (error) {
+        logger.error('memory_recall failed', {
+          userId,
+          error: error instanceof Error ? error.message : String(error),
+        })
+
+        return {
+          success: false,
+          error: sanitizeErrorMessage(error),
+        }
+      }
+    },
+  }
+}

--- a/packages/openclaw-plugin/tests/index.test.ts
+++ b/packages/openclaw-plugin/tests/index.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest'
-import { register, plugin } from '../src/index.js'
+import {
+  register,
+  plugin,
+  createMemoryRecallTool,
+  MemoryRecallParamsSchema,
+  MemoryCategory,
+} from '../src/index.js'
 
 describe('Plugin Entry Point', () => {
   describe('exports', () => {
@@ -44,10 +50,35 @@ describe('Plugin Entry Point', () => {
     it('should return plugin instance', () => {
       const mockContext = {
         config: { apiUrl: 'http://example.com', apiKey: 'test-key' },
-        logger: { info: () => {}, error: () => {}, warn: () => {}, debug: () => {} },
+        logger: { info: () => {}, error: () => {}, warn: () => {}, debug: () => {}, namespace: 'test' },
       }
       const result = register(mockContext)
       expect(result).toBeDefined()
+    })
+
+    it('should return instance with memoryRecall tool', () => {
+      const mockContext = {
+        config: { apiUrl: 'http://example.com', apiKey: 'test-key' },
+        logger: { info: () => {}, error: () => {}, warn: () => {}, debug: () => {}, namespace: 'test' },
+      }
+      const result = register(mockContext)
+      expect(result.tools).toBeDefined()
+      expect(result.tools.memoryRecall).toBeDefined()
+      expect(result.tools.memoryRecall.name).toBe('memory_recall')
+    })
+  })
+
+  describe('tool exports', () => {
+    it('should export createMemoryRecallTool', () => {
+      expect(typeof createMemoryRecallTool).toBe('function')
+    })
+
+    it('should export MemoryRecallParamsSchema', () => {
+      expect(MemoryRecallParamsSchema).toBeDefined()
+    })
+
+    it('should export MemoryCategory enum', () => {
+      expect(MemoryCategory).toBeDefined()
     })
   })
 })

--- a/packages/openclaw-plugin/tests/tools/memory-recall.test.ts
+++ b/packages/openclaw-plugin/tests/tools/memory-recall.test.ts
@@ -1,0 +1,566 @@
+/**
+ * Tests for memory_recall tool.
+ * Verifies semantic memory search functionality.
+ */
+
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { createMemoryRecallTool, MemoryRecallParams } from '../../src/tools/memory-recall.js'
+import type { ApiClient, ApiResponse } from '../../src/api-client.js'
+import type { Logger } from '../../src/logger.js'
+import type { PluginConfig } from '../../src/config.js'
+
+describe('memory_recall tool', () => {
+  const mockLogger: Logger = {
+    namespace: 'test',
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }
+
+  const mockConfig: PluginConfig = {
+    apiUrl: 'https://api.example.com',
+    apiKey: 'test-key',
+    autoRecall: true,
+    autoCapture: true,
+    userScoping: 'agent',
+    maxRecallMemories: 5,
+    minRecallScore: 0.7,
+    timeout: 30000,
+    maxRetries: 3,
+    debug: false,
+  }
+
+  const mockApiClient = {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    healthCheck: vi.fn(),
+  } as unknown as ApiClient
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('tool metadata', () => {
+    it('should have correct name', () => {
+      const tool = createMemoryRecallTool({
+        client: mockApiClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId: 'agent-1',
+      })
+      expect(tool.name).toBe('memory_recall')
+    })
+
+    it('should have description', () => {
+      const tool = createMemoryRecallTool({
+        client: mockApiClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId: 'agent-1',
+      })
+      expect(tool.description).toBeDefined()
+      expect(tool.description.length).toBeGreaterThan(10)
+    })
+
+    it('should have parameter schema', () => {
+      const tool = createMemoryRecallTool({
+        client: mockApiClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId: 'agent-1',
+      })
+      expect(tool.parameters).toBeDefined()
+    })
+  })
+
+  describe('parameter validation', () => {
+    it('should require query parameter', async () => {
+      const tool = createMemoryRecallTool({
+        client: mockApiClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId: 'agent-1',
+      })
+
+      const result = await tool.execute({} as MemoryRecallParams)
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error).toContain('query')
+      }
+    })
+
+    it('should reject empty query', async () => {
+      const tool = createMemoryRecallTool({
+        client: mockApiClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId: 'agent-1',
+      })
+
+      const result = await tool.execute({ query: '' })
+      expect(result.success).toBe(false)
+    })
+
+    it('should reject query over 1000 characters', async () => {
+      const tool = createMemoryRecallTool({
+        client: mockApiClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId: 'agent-1',
+      })
+
+      const longQuery = 'a'.repeat(1001)
+      const result = await tool.execute({ query: longQuery })
+      expect(result.success).toBe(false)
+    })
+
+    it('should accept valid limit within range', async () => {
+      const mockGet = vi.fn().mockResolvedValue({
+        success: true,
+        data: { memories: [] },
+      })
+      const client = { ...mockApiClient, get: mockGet }
+
+      const tool = createMemoryRecallTool({
+        client: client as unknown as ApiClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId: 'agent-1',
+      })
+
+      await tool.execute({ query: 'test', limit: 10 })
+      expect(mockGet).toHaveBeenCalled()
+    })
+
+    it('should reject limit above 20', async () => {
+      const tool = createMemoryRecallTool({
+        client: mockApiClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId: 'agent-1',
+      })
+
+      const result = await tool.execute({ query: 'test', limit: 21 })
+      expect(result.success).toBe(false)
+    })
+
+    it('should reject limit below 1', async () => {
+      const tool = createMemoryRecallTool({
+        client: mockApiClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId: 'agent-1',
+      })
+
+      const result = await tool.execute({ query: 'test', limit: 0 })
+      expect(result.success).toBe(false)
+    })
+
+    it('should accept valid category filter', async () => {
+      const mockGet = vi.fn().mockResolvedValue({
+        success: true,
+        data: { memories: [] },
+      })
+      const client = { ...mockApiClient, get: mockGet }
+
+      const tool = createMemoryRecallTool({
+        client: client as unknown as ApiClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId: 'agent-1',
+      })
+
+      await tool.execute({ query: 'test', category: 'preference' })
+      expect(mockGet).toHaveBeenCalled()
+    })
+
+    it('should reject invalid category', async () => {
+      const tool = createMemoryRecallTool({
+        client: mockApiClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId: 'agent-1',
+      })
+
+      const result = await tool.execute({
+        query: 'test',
+        category: 'invalid' as MemoryRecallParams['category'],
+      })
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('API interaction', () => {
+    it('should call API with query and limit', async () => {
+      const mockGet = vi.fn().mockResolvedValue({
+        success: true,
+        data: { memories: [] },
+      })
+      const client = { ...mockApiClient, get: mockGet }
+
+      const tool = createMemoryRecallTool({
+        client: client as unknown as ApiClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId: 'agent-1',
+      })
+
+      await tool.execute({ query: 'coffee preferences', limit: 5 })
+
+      expect(mockGet).toHaveBeenCalledWith(
+        expect.stringContaining('/api/memories/search'),
+        expect.objectContaining({ userId: 'agent-1' })
+      )
+    })
+
+    it('should include category in API call when provided', async () => {
+      const mockGet = vi.fn().mockResolvedValue({
+        success: true,
+        data: { memories: [] },
+      })
+      const client = { ...mockApiClient, get: mockGet }
+
+      const tool = createMemoryRecallTool({
+        client: client as unknown as ApiClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId: 'agent-1',
+      })
+
+      await tool.execute({ query: 'coffee', category: 'preference' })
+
+      expect(mockGet).toHaveBeenCalledWith(
+        expect.stringContaining('category=preference'),
+        expect.any(Object)
+      )
+    })
+
+    it('should use default limit of 5 when not specified', async () => {
+      const mockGet = vi.fn().mockResolvedValue({
+        success: true,
+        data: { memories: [] },
+      })
+      const client = { ...mockApiClient, get: mockGet }
+
+      const tool = createMemoryRecallTool({
+        client: client as unknown as ApiClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId: 'agent-1',
+      })
+
+      await tool.execute({ query: 'test' })
+
+      expect(mockGet).toHaveBeenCalledWith(
+        expect.stringContaining('limit=5'),
+        expect.any(Object)
+      )
+    })
+  })
+
+  describe('response formatting', () => {
+    it('should format memories as bullet list', async () => {
+      const mockGet = vi.fn().mockResolvedValue({
+        success: true,
+        data: {
+          memories: [
+            { id: '1', content: 'User prefers oat milk', category: 'preference', score: 0.95 },
+            { id: '2', content: 'User birthday is March 15', category: 'fact', score: 0.85 },
+          ],
+        },
+      })
+      const client = { ...mockApiClient, get: mockGet }
+
+      const tool = createMemoryRecallTool({
+        client: client as unknown as ApiClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId: 'agent-1',
+      })
+
+      const result = await tool.execute({ query: 'user info' })
+
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.content).toContain('[preference]')
+        expect(result.data.content).toContain('User prefers oat milk')
+        expect(result.data.content).toContain('[fact]')
+        expect(result.data.content).toContain('User birthday is March 15')
+      }
+    })
+
+    it('should return count and memories in details', async () => {
+      const mockGet = vi.fn().mockResolvedValue({
+        success: true,
+        data: {
+          memories: [
+            { id: '1', content: 'Memory 1', category: 'fact', score: 0.9 },
+          ],
+        },
+      })
+      const client = { ...mockApiClient, get: mockGet }
+
+      const tool = createMemoryRecallTool({
+        client: client as unknown as ApiClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId: 'agent-1',
+      })
+
+      const result = await tool.execute({ query: 'test' })
+
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.details.count).toBe(1)
+        expect(result.data.details.memories).toHaveLength(1)
+        expect(result.data.details.userId).toBe('agent-1')
+      }
+    })
+
+    it('should handle empty results gracefully', async () => {
+      const mockGet = vi.fn().mockResolvedValue({
+        success: true,
+        data: { memories: [] },
+      })
+      const client = { ...mockApiClient, get: mockGet }
+
+      const tool = createMemoryRecallTool({
+        client: client as unknown as ApiClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId: 'agent-1',
+      })
+
+      const result = await tool.execute({ query: 'nonexistent' })
+
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.content).toBe('No relevant memories found.')
+        expect(result.data.details.count).toBe(0)
+      }
+    })
+  })
+
+  describe('error handling', () => {
+    it('should handle API errors gracefully', async () => {
+      const mockGet = vi.fn().mockResolvedValue({
+        success: false,
+        error: { status: 500, message: 'Server error', code: 'SERVER_ERROR' },
+      })
+      const client = { ...mockApiClient, get: mockGet }
+
+      const tool = createMemoryRecallTool({
+        client: client as unknown as ApiClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId: 'agent-1',
+      })
+
+      const result = await tool.execute({ query: 'test' })
+
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error).toContain('Server error')
+      }
+    })
+
+    it('should handle network errors', async () => {
+      const mockGet = vi.fn().mockRejectedValue(new Error('Network error'))
+      const client = { ...mockApiClient, get: mockGet }
+
+      const tool = createMemoryRecallTool({
+        client: client as unknown as ApiClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId: 'agent-1',
+      })
+
+      const result = await tool.execute({ query: 'test' })
+
+      expect(result.success).toBe(false)
+    })
+
+    it('should not expose internal details in error messages', async () => {
+      const mockGet = vi.fn().mockRejectedValue(new Error('Connection refused to internal-host:5432'))
+      const client = { ...mockApiClient, get: mockGet }
+
+      const tool = createMemoryRecallTool({
+        client: client as unknown as ApiClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId: 'agent-1',
+      })
+
+      const result = await tool.execute({ query: 'test' })
+
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        // Should have a generic error, not expose internal details
+        expect(result.error).not.toContain('5432')
+        expect(result.error).not.toContain('internal-host')
+      }
+    })
+  })
+
+  describe('input sanitization', () => {
+    it('should sanitize query with control characters', async () => {
+      const mockGet = vi.fn().mockResolvedValue({
+        success: true,
+        data: { memories: [] },
+      })
+      const client = { ...mockApiClient, get: mockGet }
+
+      const tool = createMemoryRecallTool({
+        client: client as unknown as ApiClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId: 'agent-1',
+      })
+
+      // Query with control characters
+      await tool.execute({ query: 'test\x00\x1F query' })
+
+      // Should have called API with sanitized query
+      expect(mockGet).toHaveBeenCalled()
+      const calledUrl = mockGet.mock.calls[0][0] as string
+      expect(calledUrl).not.toContain('\x00')
+      expect(calledUrl).not.toContain('\x1F')
+    })
+
+    it('should trim whitespace from query', async () => {
+      const mockGet = vi.fn().mockResolvedValue({
+        success: true,
+        data: { memories: [] },
+      })
+      const client = { ...mockApiClient, get: mockGet }
+
+      const tool = createMemoryRecallTool({
+        client: client as unknown as ApiClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId: 'agent-1',
+      })
+
+      await tool.execute({ query: '  test query  ' })
+
+      const calledUrl = mockGet.mock.calls[0][0] as string
+      // URLSearchParams encodes spaces as + (application/x-www-form-urlencoded)
+      expect(calledUrl).toContain('q=test+query')
+    })
+  })
+
+  describe('logging', () => {
+    it('should log tool invocation at info level', async () => {
+      const mockGet = vi.fn().mockResolvedValue({
+        success: true,
+        data: { memories: [] },
+      })
+      const client = { ...mockApiClient, get: mockGet }
+
+      const tool = createMemoryRecallTool({
+        client: client as unknown as ApiClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId: 'agent-1',
+      })
+
+      await tool.execute({ query: 'test' })
+
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        'memory_recall invoked',
+        expect.objectContaining({ userId: 'agent-1' })
+      )
+    })
+
+    it('should NOT log query content at info level', async () => {
+      const mockGet = vi.fn().mockResolvedValue({
+        success: true,
+        data: { memories: [] },
+      })
+      const client = { ...mockApiClient, get: mockGet }
+
+      const tool = createMemoryRecallTool({
+        client: client as unknown as ApiClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId: 'agent-1',
+      })
+
+      await tool.execute({ query: 'sensitive query about medical info' })
+
+      // Check that info log doesn't contain the actual query
+      const infoCalls = mockLogger.info.mock.calls
+      for (const call of infoCalls) {
+        const logMessage = JSON.stringify(call)
+        expect(logMessage).not.toContain('sensitive query')
+        expect(logMessage).not.toContain('medical info')
+      }
+    })
+
+    it('should log errors', async () => {
+      const mockGet = vi.fn().mockRejectedValue(new Error('Test error'))
+      const client = { ...mockApiClient, get: mockGet }
+
+      const tool = createMemoryRecallTool({
+        client: client as unknown as ApiClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId: 'agent-1',
+      })
+
+      await tool.execute({ query: 'test' })
+
+      expect(mockLogger.error).toHaveBeenCalled()
+    })
+  })
+
+  describe('user scoping', () => {
+    it('should use provided userId for API calls', async () => {
+      const mockGet = vi.fn().mockResolvedValue({
+        success: true,
+        data: { memories: [] },
+      })
+      const client = { ...mockApiClient, get: mockGet }
+
+      const tool = createMemoryRecallTool({
+        client: client as unknown as ApiClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId: 'custom-user-123',
+      })
+
+      await tool.execute({ query: 'test' })
+
+      expect(mockGet).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ userId: 'custom-user-123' })
+      )
+    })
+
+    it('should include userId in response details', async () => {
+      const mockGet = vi.fn().mockResolvedValue({
+        success: true,
+        data: { memories: [] },
+      })
+      const client = { ...mockApiClient, get: mockGet }
+
+      const tool = createMemoryRecallTool({
+        client: client as unknown as ApiClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId: 'my-agent',
+      })
+
+      const result = await tool.execute({ query: 'test' })
+
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.details.userId).toBe('my-agent')
+      }
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Implement memory_recall tool for semantic memory search
- Add Zod parameter validation (query, limit, category)
- Sanitize query input (remove control characters, trim whitespace)
- Support category filtering (preference, fact, decision, context, other)
- Format results as bullet list with category tags
- Handle empty results gracefully with "No relevant memories found."
- Sanitize error messages to avoid exposing internal details
- Log invocations without exposing query content for privacy
- Integrate tool with plugin registration

Closes #240

## Test plan
- [x] All 27 memory_recall tests pass
- [x] Tests cover parameter validation
- [x] Tests cover API interaction
- [x] Tests cover response formatting
- [x] Tests cover error handling
- [x] Tests cover input sanitization
- [x] Tests cover logging (no query exposure)
- [x] Tests cover user scoping
- [x] All 180 plugin tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)