### PR TITLE
[#244] Implement memory_forget tool for GDPR-compliant deletion

### DIFF
--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -13,8 +13,10 @@ import { extractContext, getUserScopeKey, type PluginContext } from './context.j
 import {
   createMemoryRecallTool,
   createMemoryStoreTool,
+  createMemoryForgetTool,
   type MemoryRecallTool,
   type MemoryStoreTool,
+  type MemoryForgetTool,
 } from './tools/index.js'
 
 /** Plugin registration context from OpenClaw runtime */
@@ -28,6 +30,7 @@ export interface RegistrationContext {
 export interface PluginTools {
   memoryRecall: MemoryRecallTool
   memoryStore: MemoryStoreTool
+  memoryForget: MemoryForgetTool
 }
 
 /** Plugin instance after registration */
@@ -75,6 +78,12 @@ export function register(ctx: RegistrationContext): PluginInstance {
       userId,
     }),
     memoryStore: createMemoryStoreTool({
+      client: apiClient,
+      logger,
+      config,
+      userId,
+    }),
+    memoryForget: createMemoryForgetTool({
       client: apiClient,
       logger,
       config,
@@ -132,11 +141,16 @@ export type {
   MemoryStoreParams,
   MemoryStoreResult,
   StoredMemory,
+  MemoryForgetTool,
+  MemoryForgetParams,
+  MemoryForgetResult,
 } from './tools/index.js'
 export {
   createMemoryRecallTool,
   createMemoryStoreTool,
+  createMemoryForgetTool,
   MemoryRecallParamsSchema,
   MemoryStoreParamsSchema,
+  MemoryForgetParamsSchema,
   MemoryCategory,
 } from './tools/index.js'

--- a/packages/openclaw-plugin/src/tools/index.ts
+++ b/packages/openclaw-plugin/src/tools/index.ts
@@ -24,8 +24,14 @@ export {
   type StoredMemory,
 } from './memory-store.js'
 
-// memory_forget tool (to be implemented in #244)
-// export * from './memory-forget.js'
+// memory_forget tool
+export {
+  createMemoryForgetTool,
+  MemoryForgetParamsSchema,
+  type MemoryForgetParams,
+  type MemoryForgetTool,
+  type MemoryForgetResult,
+} from './memory-forget.js'
 
 // Project tools (to be implemented in #245)
 // export * from './projects.js'

--- a/packages/openclaw-plugin/src/tools/memory-forget.ts
+++ b/packages/openclaw-plugin/src/tools/memory-forget.ts
@@ -1,0 +1,311 @@
+/**
+ * memory_forget tool implementation.
+ * Provides GDPR-compliant memory deletion.
+ */
+
+import { z } from 'zod'
+import type { ApiClient } from '../api-client.js'
+import type { Logger } from '../logger.js'
+import type { PluginConfig } from '../config.js'
+import type { Memory } from './memory-recall.js'
+
+/** Parameters for memory_forget tool */
+export const MemoryForgetParamsSchema = z
+  .object({
+    memoryId: z.string().optional(),
+    query: z.string().max(1000, 'Query must be 1000 characters or less').optional(),
+    confirmBulkDelete: z.boolean().optional(),
+  })
+  .refine((data) => data.memoryId || data.query, {
+    message: 'Either memoryId or query is required',
+  })
+export type MemoryForgetParams = z.infer<typeof MemoryForgetParamsSchema>
+
+/** Successful tool result */
+export interface MemoryForgetSuccess {
+  success: true
+  data: {
+    content: string
+    details: {
+      deletedCount: number
+      deletedIds: string[]
+      userId: string
+    }
+  }
+}
+
+/** Failed tool result */
+export interface MemoryForgetFailure {
+  success: false
+  error: string
+}
+
+/** Tool result type */
+export type MemoryForgetResult = MemoryForgetSuccess | MemoryForgetFailure
+
+/** Tool configuration */
+export interface MemoryForgetToolOptions {
+  client: ApiClient
+  logger: Logger
+  config: PluginConfig
+  userId: string
+}
+
+/** Tool definition */
+export interface MemoryForgetTool {
+  name: string
+  description: string
+  parameters: typeof MemoryForgetParamsSchema
+  execute: (params: MemoryForgetParams) => Promise<MemoryForgetResult>
+}
+
+/** Bulk delete threshold */
+const BULK_DELETE_THRESHOLD = 5
+
+/**
+ * Sanitize query input to remove control characters.
+ */
+function sanitizeQuery(query: string): string {
+  const sanitized = query.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, '')
+  return sanitized.trim()
+}
+
+/**
+ * Create a sanitized error message that doesn't expose internal details.
+ */
+function sanitizeErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    const message = error.message
+      .replace(/\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b/g, '[host]')
+      .replace(/:\d{2,5}\b/g, '')
+      .replace(/\b(?:localhost|internal[-\w]*)\b/gi, '[internal]')
+
+    if (message.includes('[internal]') || message.includes('[host]')) {
+      return 'Failed to delete memory. Please try again.'
+    }
+
+    return message
+  }
+  return 'An unexpected error occurred while deleting memory.'
+}
+
+/**
+ * Creates the memory_forget tool.
+ */
+export function createMemoryForgetTool(options: MemoryForgetToolOptions): MemoryForgetTool {
+  const { client, logger, userId } = options
+
+  return {
+    name: 'memory_forget',
+    description:
+      'Delete specific memories. Use when the user explicitly requests to forget something. Can delete by ID or by search query.',
+    parameters: MemoryForgetParamsSchema,
+
+    async execute(params: MemoryForgetParams): Promise<MemoryForgetResult> {
+      // Validate parameters
+      const parseResult = MemoryForgetParamsSchema.safeParse(params)
+      if (!parseResult.success) {
+        const errorMessage = parseResult.error.errors
+          .map((e) => e.message)
+          .join(', ')
+        return { success: false, error: errorMessage }
+      }
+
+      const { memoryId, query, confirmBulkDelete } = parseResult.data
+
+      // Log invocation
+      logger.info('memory_forget invoked', {
+        userId,
+        memoryId: memoryId ?? undefined,
+        hasQuery: !!query,
+      })
+
+      try {
+        // Delete by ID
+        if (memoryId) {
+          return await deleteById(client, logger, userId, memoryId)
+        }
+
+        // Delete by query
+        if (query) {
+          return await deleteByQuery(client, logger, userId, query, confirmBulkDelete)
+        }
+
+        // Should not reach here due to validation
+        return { success: false, error: 'Either memoryId or query is required' }
+      } catch (error) {
+        logger.error('memory_forget failed', {
+          userId,
+          error: error instanceof Error ? error.message : String(error),
+        })
+
+        return {
+          success: false,
+          error: sanitizeErrorMessage(error),
+        }
+      }
+    },
+  }
+}
+
+/**
+ * Delete a memory by ID.
+ */
+async function deleteById(
+  client: ApiClient,
+  logger: Logger,
+  userId: string,
+  memoryId: string
+): Promise<MemoryForgetResult> {
+  const response = await client.delete(`/api/memories/${memoryId}`, { userId })
+
+  if (!response.success) {
+    // Handle not found gracefully
+    if (response.error.code === 'NOT_FOUND') {
+      logger.debug('memory_forget completed', {
+        userId,
+        deletedCount: 0,
+        reason: 'not found',
+      })
+      return {
+        success: true,
+        data: {
+          content: 'Memory not found or already deleted.',
+          details: {
+            deletedCount: 0,
+            deletedIds: [],
+            userId,
+          },
+        },
+      }
+    }
+
+    logger.error('memory_forget API error', {
+      userId,
+      memoryId,
+      status: response.error.status,
+      code: response.error.code,
+    })
+    return {
+      success: false,
+      error: response.error.message || 'Failed to delete memory',
+    }
+  }
+
+  logger.debug('memory_forget completed', {
+    userId,
+    deletedCount: 1,
+    memoryId,
+  })
+
+  return {
+    success: true,
+    data: {
+      content: 'Deleted 1 memory.',
+      details: {
+        deletedCount: 1,
+        deletedIds: [memoryId],
+        userId,
+      },
+    },
+  }
+}
+
+/**
+ * Delete memories by search query.
+ */
+async function deleteByQuery(
+  client: ApiClient,
+  logger: Logger,
+  userId: string,
+  query: string,
+  confirmBulkDelete?: boolean
+): Promise<MemoryForgetResult> {
+  const sanitizedQuery = sanitizeQuery(query)
+  if (sanitizedQuery.length === 0) {
+    return { success: false, error: 'Query cannot be empty' }
+  }
+
+  // Search for matching memories
+  const queryParams = new URLSearchParams({
+    q: sanitizedQuery,
+    limit: '100', // Max to find for deletion
+  })
+
+  const searchResponse = await client.get<{ memories: Memory[] }>(
+    `/api/memories/search?${queryParams.toString()}`,
+    { userId }
+  )
+
+  if (!searchResponse.success) {
+    logger.error('memory_forget search error', {
+      userId,
+      status: searchResponse.error.status,
+      code: searchResponse.error.code,
+    })
+    return {
+      success: false,
+      error: searchResponse.error.message || 'Failed to search memories',
+    }
+  }
+
+  const memories = searchResponse.data.memories ?? []
+
+  if (memories.length === 0) {
+    logger.debug('memory_forget completed', {
+      userId,
+      deletedCount: 0,
+      reason: 'no matches',
+    })
+    return {
+      success: true,
+      data: {
+        content: 'No matching memories found to delete.',
+        details: {
+          deletedCount: 0,
+          deletedIds: [],
+          userId,
+        },
+      },
+    }
+  }
+
+  // Check bulk delete threshold
+  if (memories.length > BULK_DELETE_THRESHOLD && !confirmBulkDelete) {
+    logger.warn('memory_forget bulk delete blocked', {
+      userId,
+      matchCount: memories.length,
+    })
+    return {
+      success: false,
+      error: `Found ${memories.length} matching memories. Set confirmBulkDelete: true to delete more than ${BULK_DELETE_THRESHOLD} memories at once.`,
+    }
+  }
+
+  // Delete each memory
+  const deletedIds: string[] = []
+  for (const memory of memories) {
+    const deleteResponse = await client.delete(`/api/memories/${memory.id}`, { userId })
+    if (deleteResponse.success) {
+      deletedIds.push(memory.id)
+    }
+  }
+
+  logger.debug('memory_forget completed', {
+    userId,
+    deletedCount: deletedIds.length,
+    requestedCount: memories.length,
+  })
+
+  return {
+    success: true,
+    data: {
+      content: `Deleted ${deletedIds.length} ${deletedIds.length === 1 ? 'memory' : 'memories'}.`,
+      details: {
+        deletedCount: deletedIds.length,
+        deletedIds,
+        userId,
+      },
+    },
+  }
+}

--- a/packages/openclaw-plugin/tests/index.test.ts
+++ b/packages/openclaw-plugin/tests/index.test.ts
@@ -4,8 +4,10 @@ import {
   plugin,
   createMemoryRecallTool,
   createMemoryStoreTool,
+  createMemoryForgetTool,
   MemoryRecallParamsSchema,
   MemoryStoreParamsSchema,
+  MemoryForgetParamsSchema,
   MemoryCategory,
 } from '../src/index.js'
 
@@ -79,6 +81,17 @@ describe('Plugin Entry Point', () => {
       expect(result.tools.memoryStore).toBeDefined()
       expect(result.tools.memoryStore.name).toBe('memory_store')
     })
+
+    it('should return instance with memoryForget tool', () => {
+      const mockContext = {
+        config: { apiUrl: 'http://example.com', apiKey: 'test-key' },
+        logger: { info: () => {}, error: () => {}, warn: () => {}, debug: () => {}, namespace: 'test' },
+      }
+      const result = register(mockContext)
+      expect(result.tools).toBeDefined()
+      expect(result.tools.memoryForget).toBeDefined()
+      expect(result.tools.memoryForget.name).toBe('memory_forget')
+    })
   })
 
   describe('tool exports', () => {
@@ -90,12 +103,20 @@ describe('Plugin Entry Point', () => {
       expect(typeof createMemoryStoreTool).toBe('function')
     })
 
+    it('should export createMemoryForgetTool', () => {
+      expect(typeof createMemoryForgetTool).toBe('function')
+    })
+
     it('should export MemoryRecallParamsSchema', () => {
       expect(MemoryRecallParamsSchema).toBeDefined()
     })
 
     it('should export MemoryStoreParamsSchema', () => {
       expect(MemoryStoreParamsSchema).toBeDefined()
+    })
+
+    it('should export MemoryForgetParamsSchema', () => {
+      expect(MemoryForgetParamsSchema).toBeDefined()
     })
 
     it('should export MemoryCategory enum', () => {

--- a/packages/openclaw-plugin/tests/tools/memory-forget.test.ts
+++ b/packages/openclaw-plugin/tests/tools/memory-forget.test.ts
@@ -1,0 +1,552 @@
+/**
+ * Tests for memory_forget tool.
+ * Verifies GDPR-compliant memory deletion functionality.
+ */
+
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { createMemoryForgetTool, MemoryForgetParams } from '../../src/tools/memory-forget.js'
+import type { ApiClient } from '../../src/api-client.js'
+import type { Logger } from '../../src/logger.js'
+import type { PluginConfig } from '../../src/config.js'
+
+describe('memory_forget tool', () => {
+  const mockLogger: Logger = {
+    namespace: 'test',
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }
+
+  const mockConfig: PluginConfig = {
+    apiUrl: 'https://api.example.com',
+    apiKey: 'test-key',
+    autoRecall: true,
+    autoCapture: true,
+    userScoping: 'agent',
+    maxRecallMemories: 5,
+    minRecallScore: 0.7,
+    timeout: 30000,
+    maxRetries: 3,
+    debug: false,
+  }
+
+  const mockApiClient = {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    healthCheck: vi.fn(),
+  } as unknown as ApiClient
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('tool metadata', () => {
+    it('should have correct name', () => {
+      const tool = createMemoryForgetTool({
+        client: mockApiClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId: 'agent-1',
+      })
+      expect(tool.name).toBe('memory_forget')
+    })
+
+    it('should have description', () => {
+      const tool = createMemoryForgetTool({
+        client: mockApiClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId: 'agent-1',
+      })
+      expect(tool.description).toBeDefined()
+      expect(tool.description.length).toBeGreaterThan(10)
+    })
+
+    it('should have parameter schema', () => {
+      const tool = createMemoryForgetTool({
+        client: mockApiClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId: 'agent-1',
+      })
+      expect(tool.parameters).toBeDefined()
+    })
+  })
+
+  describe('parameter validation', () => {
+    it('should require either memoryId or query', async () => {
+      const tool = createMemoryForgetTool({
+        client: mockApiClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId: 'agent-1',
+      })
+
+      const result = await tool.execute({} as MemoryForgetParams)
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error).toContain('memoryId')
+      }
+    })
+
+    it('should accept memoryId alone', async () => {
+      const mockDelete = vi.fn().mockResolvedValue({
+        success: true,
+        data: { deleted: true },
+      })
+      const client = { ...mockApiClient, delete: mockDelete }
+
+      const tool = createMemoryForgetTool({
+        client: client as unknown as ApiClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId: 'agent-1',
+      })
+
+      await tool.execute({ memoryId: 'mem-123' })
+      expect(mockDelete).toHaveBeenCalled()
+    })
+
+    it('should accept query alone', async () => {
+      // First GET to find memories, then DELETE
+      const mockGet = vi.fn().mockResolvedValue({
+        success: true,
+        data: { memories: [{ id: 'mem-1' }] },
+      })
+      const mockDelete = vi.fn().mockResolvedValue({
+        success: true,
+        data: { deleted: true },
+      })
+      const client = { ...mockApiClient, get: mockGet, delete: mockDelete }
+
+      const tool = createMemoryForgetTool({
+        client: client as unknown as ApiClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId: 'agent-1',
+      })
+
+      await tool.execute({ query: 'delete my coffee preference' })
+      expect(mockGet).toHaveBeenCalled()
+    })
+
+    it('should reject query over 1000 characters', async () => {
+      const tool = createMemoryForgetTool({
+        client: mockApiClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId: 'agent-1',
+      })
+
+      const longQuery = 'a'.repeat(1001)
+      const result = await tool.execute({ query: longQuery })
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('delete by ID', () => {
+    it('should call DELETE /api/memories/:id', async () => {
+      const mockDelete = vi.fn().mockResolvedValue({
+        success: true,
+        data: { deleted: true },
+      })
+      const client = { ...mockApiClient, delete: mockDelete }
+
+      const tool = createMemoryForgetTool({
+        client: client as unknown as ApiClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId: 'agent-1',
+      })
+
+      await tool.execute({ memoryId: 'mem-123' })
+
+      expect(mockDelete).toHaveBeenCalledWith(
+        '/api/memories/mem-123',
+        expect.objectContaining({ userId: 'agent-1' })
+      )
+    })
+
+    it('should return success for deleted memory', async () => {
+      const mockDelete = vi.fn().mockResolvedValue({
+        success: true,
+        data: { deleted: true },
+      })
+      const client = { ...mockApiClient, delete: mockDelete }
+
+      const tool = createMemoryForgetTool({
+        client: client as unknown as ApiClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId: 'agent-1',
+      })
+
+      const result = await tool.execute({ memoryId: 'mem-123' })
+
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.content).toContain('Deleted')
+        expect(result.data.details.deletedCount).toBe(1)
+      }
+    })
+
+    it('should handle not found gracefully', async () => {
+      const mockDelete = vi.fn().mockResolvedValue({
+        success: false,
+        error: { status: 404, message: 'Memory not found', code: 'NOT_FOUND' },
+      })
+      const client = { ...mockApiClient, delete: mockDelete }
+
+      const tool = createMemoryForgetTool({
+        client: client as unknown as ApiClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId: 'agent-1',
+      })
+
+      const result = await tool.execute({ memoryId: 'nonexistent' })
+
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.content).toContain('not found')
+        expect(result.data.details.deletedCount).toBe(0)
+      }
+    })
+  })
+
+  describe('delete by query', () => {
+    it('should search for memories first', async () => {
+      const mockGet = vi.fn().mockResolvedValue({
+        success: true,
+        data: { memories: [{ id: 'mem-1' }] },
+      })
+      const mockDelete = vi.fn().mockResolvedValue({
+        success: true,
+        data: { deleted: true },
+      })
+      const client = { ...mockApiClient, get: mockGet, delete: mockDelete }
+
+      const tool = createMemoryForgetTool({
+        client: client as unknown as ApiClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId: 'agent-1',
+      })
+
+      await tool.execute({ query: 'coffee' })
+
+      expect(mockGet).toHaveBeenCalledWith(
+        expect.stringContaining('/api/memories/search'),
+        expect.objectContaining({ userId: 'agent-1' })
+      )
+    })
+
+    it('should delete matching memories', async () => {
+      const mockGet = vi.fn().mockResolvedValue({
+        success: true,
+        data: { memories: [{ id: 'mem-1' }, { id: 'mem-2' }] },
+      })
+      const mockDelete = vi.fn().mockResolvedValue({
+        success: true,
+        data: { deleted: true },
+      })
+      const client = { ...mockApiClient, get: mockGet, delete: mockDelete }
+
+      const tool = createMemoryForgetTool({
+        client: client as unknown as ApiClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId: 'agent-1',
+      })
+
+      const result = await tool.execute({ query: 'coffee' })
+
+      expect(mockDelete).toHaveBeenCalledTimes(2)
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.details.deletedCount).toBe(2)
+      }
+    })
+
+    it('should handle no matching memories', async () => {
+      const mockGet = vi.fn().mockResolvedValue({
+        success: true,
+        data: { memories: [] },
+      })
+      const client = { ...mockApiClient, get: mockGet }
+
+      const tool = createMemoryForgetTool({
+        client: client as unknown as ApiClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId: 'agent-1',
+      })
+
+      const result = await tool.execute({ query: 'nonexistent' })
+
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.content).toContain('No matching memories')
+        expect(result.data.details.deletedCount).toBe(0)
+      }
+    })
+  })
+
+  describe('bulk delete protection', () => {
+    it('should require confirmBulkDelete for >5 memories', async () => {
+      const mockGet = vi.fn().mockResolvedValue({
+        success: true,
+        data: {
+          memories: Array(6).fill(null).map((_, i) => ({ id: `mem-${i}` })),
+        },
+      })
+      const client = { ...mockApiClient, get: mockGet }
+
+      const tool = createMemoryForgetTool({
+        client: client as unknown as ApiClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId: 'agent-1',
+      })
+
+      const result = await tool.execute({ query: 'test' })
+
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error).toContain('confirmBulkDelete')
+        expect(result.error).toContain('6')
+      }
+    })
+
+    it('should allow bulk delete with confirmBulkDelete: true', async () => {
+      const mockGet = vi.fn().mockResolvedValue({
+        success: true,
+        data: {
+          memories: Array(6).fill(null).map((_, i) => ({ id: `mem-${i}` })),
+        },
+      })
+      const mockDelete = vi.fn().mockResolvedValue({
+        success: true,
+        data: { deleted: true },
+      })
+      const client = { ...mockApiClient, get: mockGet, delete: mockDelete }
+
+      const tool = createMemoryForgetTool({
+        client: client as unknown as ApiClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId: 'agent-1',
+      })
+
+      const result = await tool.execute({ query: 'test', confirmBulkDelete: true })
+
+      expect(mockDelete).toHaveBeenCalledTimes(6)
+      expect(result.success).toBe(true)
+    })
+
+    it('should not require confirmBulkDelete for <=5 memories', async () => {
+      const mockGet = vi.fn().mockResolvedValue({
+        success: true,
+        data: {
+          memories: Array(5).fill(null).map((_, i) => ({ id: `mem-${i}` })),
+        },
+      })
+      const mockDelete = vi.fn().mockResolvedValue({
+        success: true,
+        data: { deleted: true },
+      })
+      const client = { ...mockApiClient, get: mockGet, delete: mockDelete }
+
+      const tool = createMemoryForgetTool({
+        client: client as unknown as ApiClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId: 'agent-1',
+      })
+
+      const result = await tool.execute({ query: 'test' })
+
+      expect(mockDelete).toHaveBeenCalledTimes(5)
+      expect(result.success).toBe(true)
+    })
+  })
+
+  describe('error handling', () => {
+    it('should handle API errors gracefully', async () => {
+      const mockDelete = vi.fn().mockResolvedValue({
+        success: false,
+        error: { status: 500, message: 'Server error', code: 'SERVER_ERROR' },
+      })
+      const client = { ...mockApiClient, delete: mockDelete }
+
+      const tool = createMemoryForgetTool({
+        client: client as unknown as ApiClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId: 'agent-1',
+      })
+
+      const result = await tool.execute({ memoryId: 'mem-123' })
+
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error).toContain('Server error')
+      }
+    })
+
+    it('should handle network errors', async () => {
+      const mockDelete = vi.fn().mockRejectedValue(new Error('Network error'))
+      const client = { ...mockApiClient, delete: mockDelete }
+
+      const tool = createMemoryForgetTool({
+        client: client as unknown as ApiClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId: 'agent-1',
+      })
+
+      const result = await tool.execute({ memoryId: 'mem-123' })
+
+      expect(result.success).toBe(false)
+    })
+
+    it('should not expose internal details in error messages', async () => {
+      const mockDelete = vi.fn().mockRejectedValue(
+        new Error('Connection refused to internal-db:5432')
+      )
+      const client = { ...mockApiClient, delete: mockDelete }
+
+      const tool = createMemoryForgetTool({
+        client: client as unknown as ApiClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId: 'agent-1',
+      })
+
+      const result = await tool.execute({ memoryId: 'mem-123' })
+
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error).not.toContain('5432')
+        expect(result.error).not.toContain('internal-db')
+      }
+    })
+  })
+
+  describe('logging', () => {
+    it('should log deletion invocation', async () => {
+      const mockDelete = vi.fn().mockResolvedValue({
+        success: true,
+        data: { deleted: true },
+      })
+      const client = { ...mockApiClient, delete: mockDelete }
+
+      const tool = createMemoryForgetTool({
+        client: client as unknown as ApiClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId: 'agent-1',
+      })
+
+      await tool.execute({ memoryId: 'mem-123' })
+
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        'memory_forget invoked',
+        expect.objectContaining({
+          userId: 'agent-1',
+          memoryId: 'mem-123',
+        })
+      )
+    })
+
+    it('should log deletion completion with count', async () => {
+      const mockDelete = vi.fn().mockResolvedValue({
+        success: true,
+        data: { deleted: true },
+      })
+      const client = { ...mockApiClient, delete: mockDelete }
+
+      const tool = createMemoryForgetTool({
+        client: client as unknown as ApiClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId: 'agent-1',
+      })
+
+      await tool.execute({ memoryId: 'mem-123' })
+
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        'memory_forget completed',
+        expect.objectContaining({
+          deletedCount: 1,
+        })
+      )
+    })
+
+    it('should log errors', async () => {
+      const mockDelete = vi.fn().mockRejectedValue(new Error('Test error'))
+      const client = { ...mockApiClient, delete: mockDelete }
+
+      const tool = createMemoryForgetTool({
+        client: client as unknown as ApiClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId: 'agent-1',
+      })
+
+      await tool.execute({ memoryId: 'mem-123' })
+
+      expect(mockLogger.error).toHaveBeenCalled()
+    })
+  })
+
+  describe('user scoping', () => {
+    it('should use provided userId for API calls', async () => {
+      const mockDelete = vi.fn().mockResolvedValue({
+        success: true,
+        data: { deleted: true },
+      })
+      const client = { ...mockApiClient, delete: mockDelete }
+
+      const tool = createMemoryForgetTool({
+        client: client as unknown as ApiClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId: 'custom-user-456',
+      })
+
+      await tool.execute({ memoryId: 'mem-123' })
+
+      expect(mockDelete).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ userId: 'custom-user-456' })
+      )
+    })
+
+    it('should include userId in response details', async () => {
+      const mockDelete = vi.fn().mockResolvedValue({
+        success: true,
+        data: { deleted: true },
+      })
+      const client = { ...mockApiClient, delete: mockDelete }
+
+      const tool = createMemoryForgetTool({
+        client: client as unknown as ApiClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId: 'my-agent',
+      })
+
+      const result = await tool.execute({ memoryId: 'mem-123' })
+
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.details.userId).toBe('my-agent')
+      }
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Implement memory_forget tool for GDPR-compliant memory deletion
- Support deletion by specific memory ID
- Support deletion by search query
- Implement bulk delete protection (require confirmBulkDelete for >5 memories)
- Handle not found gracefully (return success with 0 deletions)
- Format response with deletion count and deleted IDs
- Integrate tool with plugin registration
- Audit logging for deletion events

Closes #244

## Test plan
- [x] All 24 memory_forget tests pass
- [x] Tests cover parameter validation
- [x] Tests cover delete by ID
- [x] Tests cover delete by query
- [x] Tests cover bulk delete protection
- [x] Tests cover error handling
- [x] Tests cover logging
- [x] Tests cover user scoping
- [x] All 236 plugin tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)