### PR TITLE
[#249] Implement CLI commands for memory plugin

### DIFF
--- a/packages/openclaw-plugin/src/cli.ts
+++ b/packages/openclaw-plugin/src/cli.ts
@@ -1,0 +1,376 @@
+/**
+ * CLI command handlers for the OpenClaw plugin.
+ * These handlers can be registered with an OpenClaw CLI API.
+ */
+
+import type { ApiClient } from './api-client.js'
+import type { Logger } from './logger.js'
+import type { PluginConfig } from './config.js'
+
+/** Default limit for recall command */
+const DEFAULT_RECALL_LIMIT = 5
+
+/** Context required for CLI commands */
+export interface CliContext {
+  client: ApiClient
+  logger: Logger
+  config: PluginConfig
+  userId: string
+}
+
+/** Result from a CLI command */
+export interface CommandResult<T = unknown> {
+  success: boolean
+  message: string
+  data?: T
+}
+
+/** Options for recall command */
+export interface RecallOptions {
+  query: string
+  limit?: number
+}
+
+/** Options for export command */
+export interface ExportOptions {
+  output?: string
+}
+
+/** Status command result data */
+export interface StatusData {
+  healthy: boolean
+  latencyMs: number
+  apiUrl: string
+}
+
+/** Users command result data */
+export interface UsersData {
+  scopingMode: string
+  description: string
+  currentUserId: string
+}
+
+/** Memory item for recall results */
+export interface MemoryItem {
+  id: string
+  content: string
+  score: number
+  category?: string
+}
+
+/** Recall command result data */
+export interface RecallData {
+  memories: MemoryItem[]
+  query: string
+  limit: number
+}
+
+/** Stats command result data */
+export interface StatsData {
+  totalMemories: number
+  byCategory: Record<string, number>
+  recentActivity?: {
+    last24h: number
+    last7d: number
+  }
+}
+
+/** Export command result data */
+export interface ExportData {
+  memories: Array<{
+    id: string
+    content: string
+    category?: string
+  }>
+  exportedAt: string
+  userId: string
+  suggestedPath?: string
+}
+
+/** User scoping mode descriptions */
+const SCOPING_DESCRIPTIONS: Record<string, string> = {
+  agent: 'Memories are scoped by agent ID. One agent = one user. All sessions for this agent share the same memories.',
+  identity: 'Memories are scoped by canonical identity from identity links. Useful when a single user may interact through multiple agents.',
+  session: 'Memories are scoped by full session key. Most isolated mode - each session has separate memories.',
+}
+
+/**
+ * Creates the status command handler.
+ * Tests API connectivity and displays health information.
+ */
+export function createStatusCommand(
+  ctx: CliContext
+): () => Promise<CommandResult<StatusData>> {
+  const { client, logger, config } = ctx
+
+  return async (): Promise<CommandResult<StatusData>> => {
+    logger.info('CLI status command invoked', { userId: ctx.userId })
+
+    try {
+      const response = await client.healthCheck()
+
+      if (response.healthy) {
+        return {
+          success: true,
+          message: `API is healthy (latency: ${response.latencyMs}ms)`,
+          data: {
+            healthy: true,
+            latencyMs: response.latencyMs,
+            apiUrl: config.apiUrl,
+          },
+        }
+      } else {
+        return {
+          success: false,
+          message: 'API is unhealthy',
+          data: {
+            healthy: false,
+            latencyMs: response.latencyMs,
+            apiUrl: config.apiUrl,
+          },
+        }
+      }
+    } catch (error) {
+      logger.error('CLI status command error', {
+        error: error instanceof Error ? error.message : String(error),
+      })
+
+      return {
+        success: false,
+        message: `Connection error: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      }
+    }
+  }
+}
+
+/**
+ * Creates the users command handler.
+ * Displays current user scoping configuration.
+ */
+export function createUsersCommand(
+  ctx: CliContext
+): () => Promise<CommandResult<UsersData>> {
+  const { logger, config, userId } = ctx
+
+  return async (): Promise<CommandResult<UsersData>> => {
+    logger.info('CLI users command invoked', { userId })
+
+    const scopingMode = config.userScoping
+    const description = SCOPING_DESCRIPTIONS[scopingMode] ?? 'Unknown scoping mode'
+
+    return {
+      success: true,
+      message: `User scoping mode: ${scopingMode}`,
+      data: {
+        scopingMode,
+        description,
+        currentUserId: userId,
+      },
+    }
+  }
+}
+
+/**
+ * Creates the recall command handler.
+ * Searches memories from the command line.
+ */
+export function createRecallCommand(
+  ctx: CliContext
+): (options: RecallOptions) => Promise<CommandResult<RecallData>> {
+  const { client, logger, config, userId } = ctx
+
+  return async (options: RecallOptions): Promise<CommandResult<RecallData>> => {
+    const { query, limit = config.maxRecallMemories ?? DEFAULT_RECALL_LIMIT } = options
+
+    // Log without query content for privacy
+    logger.info('CLI recall command invoked', {
+      userId,
+      queryLength: query?.length ?? 0,
+      limit,
+    })
+
+    if (!query || query.trim() === '') {
+      return {
+        success: false,
+        message: 'Error: query is required',
+      }
+    }
+
+    try {
+      const queryParams = new URLSearchParams({
+        query: query.substring(0, 500), // Limit query length
+        limit: String(limit),
+      })
+
+      const response = await client.get<{ memories: MemoryItem[] }>(
+        `/api/memory/recall?${queryParams.toString()}`,
+        { userId }
+      )
+
+      if (!response.success) {
+        logger.error('CLI recall command API error', {
+          userId,
+          status: response.error.status,
+          code: response.error.code,
+        })
+
+        return {
+          success: false,
+          message: `API error: ${response.error.message}`,
+        }
+      }
+
+      const memories = response.data.memories ?? []
+
+      return {
+        success: true,
+        message: `Found ${memories.length} memories`,
+        data: {
+          memories,
+          query,
+          limit,
+        },
+      }
+    } catch (error) {
+      logger.error('CLI recall command error', {
+        userId,
+        error: error instanceof Error ? error.message : String(error),
+      })
+
+      return {
+        success: false,
+        message: `Error: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      }
+    }
+  }
+}
+
+/**
+ * Creates the stats command handler.
+ * Displays memory statistics.
+ */
+export function createStatsCommand(
+  ctx: CliContext
+): () => Promise<CommandResult<StatsData>> {
+  const { client, logger, userId } = ctx
+
+  return async (): Promise<CommandResult<StatsData>> => {
+    logger.info('CLI stats command invoked', { userId })
+
+    try {
+      const response = await client.get<StatsData>(
+        '/api/memory/stats',
+        { userId }
+      )
+
+      if (!response.success) {
+        logger.error('CLI stats command API error', {
+          userId,
+          status: response.error.status,
+          code: response.error.code,
+        })
+
+        return {
+          success: false,
+          message: `API error: ${response.error.message}`,
+        }
+      }
+
+      return {
+        success: true,
+        message: `Total memories: ${response.data.totalMemories}`,
+        data: response.data,
+      }
+    } catch (error) {
+      logger.error('CLI stats command error', {
+        userId,
+        error: error instanceof Error ? error.message : String(error),
+      })
+
+      return {
+        success: false,
+        message: `Error: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      }
+    }
+  }
+}
+
+/**
+ * Creates the export command handler.
+ * Exports all memories for GDPR data portability.
+ */
+export function createExportCommand(
+  ctx: CliContext
+): (options?: ExportOptions) => Promise<CommandResult<ExportData>> {
+  const { client, logger, userId } = ctx
+
+  return async (options?: ExportOptions): Promise<CommandResult<ExportData>> => {
+    logger.info('CLI export command invoked', { userId })
+
+    try {
+      const response = await client.get<{
+        memories: Array<{ id: string; content: string; category?: string }>
+        exportedAt: string
+      }>(
+        '/api/memory/export',
+        { userId }
+      )
+
+      if (!response.success) {
+        logger.error('CLI export command API error', {
+          userId,
+          status: response.error.status,
+          code: response.error.code,
+        })
+
+        return {
+          success: false,
+          message: `API error: ${response.error.message}`,
+        }
+      }
+
+      return {
+        success: true,
+        message: `Exported ${response.data.memories.length} memories`,
+        data: {
+          memories: response.data.memories,
+          exportedAt: response.data.exportedAt,
+          userId,
+          suggestedPath: options?.output,
+        },
+      }
+    } catch (error) {
+      logger.error('CLI export command error', {
+        userId,
+        error: error instanceof Error ? error.message : String(error),
+      })
+
+      return {
+        success: false,
+        message: `Error: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      }
+    }
+  }
+}
+
+/** All CLI command handlers */
+export interface CliCommands {
+  status: () => Promise<CommandResult<StatusData>>
+  users: () => Promise<CommandResult<UsersData>>
+  recall: (options: RecallOptions) => Promise<CommandResult<RecallData>>
+  stats: () => Promise<CommandResult<StatsData>>
+  export: (options?: ExportOptions) => Promise<CommandResult<ExportData>>
+}
+
+/**
+ * Creates all CLI command handlers.
+ */
+export function createCliCommands(ctx: CliContext): CliCommands {
+  return {
+    status: createStatusCommand(ctx),
+    users: createUsersCommand(ctx),
+    recall: createRecallCommand(ctx),
+    stats: createStatsCommand(ctx),
+    export: createExportCommand(ctx),
+  }
+}

--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -20,6 +20,12 @@ import {
   type HealthCheckResult,
 } from './hooks.js'
 import {
+  createCliCommands,
+  type CliCommands,
+  type CliContext,
+  type CommandResult,
+} from './cli.js'
+import {
   createMemoryRecallTool,
   createMemoryStoreTool,
   createMemoryForgetTool,
@@ -85,6 +91,7 @@ export interface PluginInstance {
   context: PluginContext
   tools: PluginTools
   hooks: PluginHooks
+  cli: CliCommands
   healthCheck: () => Promise<HealthCheckResult>
 }
 
@@ -208,6 +215,14 @@ export function register(ctx: RegistrationContext): PluginInstance {
   // Create health check
   const healthCheck = createHealthCheck({ client: apiClient, logger })
 
+  // Create CLI commands
+  const cli = createCliCommands({
+    client: apiClient,
+    logger,
+    config,
+    userId,
+  })
+
   logger.info('Plugin registered', {
     agentId: context.agent.agentId,
     sessionId: context.session.sessionId,
@@ -223,6 +238,7 @@ export function register(ctx: RegistrationContext): PluginInstance {
     context,
     tools,
     hooks,
+    cli,
     healthCheck,
   }
 }
@@ -341,3 +357,26 @@ export {
   createAutoCaptureHook,
   createHealthCheck,
 } from './hooks.js'
+
+// Re-export CLI
+export type {
+  CliContext,
+  CliCommands,
+  CommandResult,
+  RecallOptions,
+  ExportOptions,
+  StatusData,
+  UsersData,
+  RecallData,
+  StatsData,
+  ExportData,
+  MemoryItem,
+} from './cli.js'
+export {
+  createCliCommands,
+  createStatusCommand,
+  createUsersCommand,
+  createRecallCommand,
+  createStatsCommand,
+  createExportCommand,
+} from './cli.js'

--- a/packages/openclaw-plugin/tests/cli.test.ts
+++ b/packages/openclaw-plugin/tests/cli.test.ts
@@ -1,0 +1,574 @@
+/**
+ * Tests for CLI command handlers.
+ * Covers status, users, recall, stats, and export commands.
+ */
+
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import {
+  createStatusCommand,
+  createUsersCommand,
+  createRecallCommand,
+  createStatsCommand,
+  createExportCommand,
+  createCliCommands,
+  type CliContext,
+  type CommandResult,
+} from '../src/cli.js'
+import type { ApiClient } from '../src/api-client.js'
+import type { Logger } from '../src/logger.js'
+import type { PluginConfig } from '../src/config.js'
+
+describe('CLI Commands', () => {
+  const mockLogger: Logger = {
+    namespace: 'test',
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }
+
+  const mockConfig: PluginConfig = {
+    apiUrl: 'https://api.example.com',
+    apiKey: 'test-key-secret-12345',
+    autoRecall: true,
+    autoCapture: true,
+    userScoping: 'agent',
+    maxRecallMemories: 5,
+    minRecallScore: 0.7,
+    timeout: 30000,
+    maxRetries: 3,
+    debug: false,
+  }
+
+  const mockApiClient = {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    healthCheck: vi.fn(),
+  } as unknown as ApiClient
+
+  const mockContext: CliContext = {
+    client: mockApiClient,
+    logger: mockLogger,
+    config: mockConfig,
+    userId: 'agent-1',
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('status command', () => {
+    it('should create a callable command function', () => {
+      const command = createStatusCommand(mockContext)
+      expect(typeof command).toBe('function')
+    })
+
+    it('should return success when API is healthy', async () => {
+      const mockHealthCheck = vi.fn().mockResolvedValue({
+        healthy: true,
+        latencyMs: 50,
+      })
+      const client = { ...mockApiClient, healthCheck: mockHealthCheck }
+
+      const command = createStatusCommand({
+        ...mockContext,
+        client: client as unknown as ApiClient,
+      })
+
+      const result = await command()
+
+      expect(result.success).toBe(true)
+      expect(result.message).toContain('healthy')
+      expect(result.data?.latencyMs).toBe(50)
+    })
+
+    it('should return failure when API is unhealthy', async () => {
+      const mockHealthCheck = vi.fn().mockResolvedValue({
+        healthy: false,
+        latencyMs: 0,
+      })
+      const client = { ...mockApiClient, healthCheck: mockHealthCheck }
+
+      const command = createStatusCommand({
+        ...mockContext,
+        client: client as unknown as ApiClient,
+      })
+
+      const result = await command()
+
+      expect(result.success).toBe(false)
+      expect(result.message).toContain('unhealthy')
+    })
+
+    it('should return failure on network error', async () => {
+      const mockHealthCheck = vi.fn().mockRejectedValue(new Error('Connection refused'))
+      const client = { ...mockApiClient, healthCheck: mockHealthCheck }
+
+      const command = createStatusCommand({
+        ...mockContext,
+        client: client as unknown as ApiClient,
+      })
+
+      const result = await command()
+
+      expect(result.success).toBe(false)
+      expect(result.message).toContain('error')
+    })
+
+    it('should never display API key in output', async () => {
+      const mockHealthCheck = vi.fn().mockResolvedValue({
+        healthy: true,
+        latencyMs: 50,
+      })
+      const client = { ...mockApiClient, healthCheck: mockHealthCheck }
+
+      const command = createStatusCommand({
+        ...mockContext,
+        client: client as unknown as ApiClient,
+      })
+
+      const result = await command()
+
+      expect(JSON.stringify(result)).not.toContain('test-key-secret')
+      expect(JSON.stringify(result)).not.toContain(mockConfig.apiKey)
+    })
+
+    it('should include API URL in status (without credentials)', async () => {
+      const mockHealthCheck = vi.fn().mockResolvedValue({
+        healthy: true,
+        latencyMs: 50,
+      })
+      const client = { ...mockApiClient, healthCheck: mockHealthCheck }
+
+      const command = createStatusCommand({
+        ...mockContext,
+        client: client as unknown as ApiClient,
+      })
+
+      const result = await command()
+
+      expect(result.data?.apiUrl).toBe('https://api.example.com')
+    })
+  })
+
+  describe('users command', () => {
+    it('should create a callable command function', () => {
+      const command = createUsersCommand(mockContext)
+      expect(typeof command).toBe('function')
+    })
+
+    it('should display current user scoping mode', async () => {
+      const command = createUsersCommand(mockContext)
+      const result = await command()
+
+      expect(result.success).toBe(true)
+      expect(result.data?.scopingMode).toBe('agent')
+    })
+
+    it('should explain agent scoping mode', async () => {
+      const command = createUsersCommand({
+        ...mockContext,
+        config: { ...mockConfig, userScoping: 'agent' },
+      })
+
+      const result = await command()
+
+      expect(result.data?.description).toContain('agent')
+    })
+
+    it('should explain identity scoping mode', async () => {
+      const command = createUsersCommand({
+        ...mockContext,
+        config: { ...mockConfig, userScoping: 'identity' },
+      })
+
+      const result = await command()
+
+      expect(result.data?.scopingMode).toBe('identity')
+      expect(result.data?.description).toContain('identity')
+    })
+
+    it('should explain session scoping mode', async () => {
+      const command = createUsersCommand({
+        ...mockContext,
+        config: { ...mockConfig, userScoping: 'session' },
+      })
+
+      const result = await command()
+
+      expect(result.data?.scopingMode).toBe('session')
+      expect(result.data?.description).toContain('session')
+    })
+
+    it('should include current userId', async () => {
+      const command = createUsersCommand(mockContext)
+      const result = await command()
+
+      expect(result.data?.currentUserId).toBe('agent-1')
+    })
+
+    it('should never display API key', async () => {
+      const command = createUsersCommand(mockContext)
+      const result = await command()
+
+      expect(JSON.stringify(result)).not.toContain('test-key-secret')
+    })
+  })
+
+  describe('recall command', () => {
+    it('should create a callable command function', () => {
+      const command = createRecallCommand(mockContext)
+      expect(typeof command).toBe('function')
+    })
+
+    it('should search memories with query', async () => {
+      const mockGet = vi.fn().mockResolvedValue({
+        success: true,
+        data: {
+          memories: [
+            { id: '1', content: 'User prefers dark mode', score: 0.95 },
+            { id: '2', content: 'User is in timezone UTC+10', score: 0.85 },
+          ],
+        },
+      })
+      const client = { ...mockApiClient, get: mockGet }
+
+      const command = createRecallCommand({
+        ...mockContext,
+        client: client as unknown as ApiClient,
+      })
+
+      const result = await command({ query: 'preferences' })
+
+      expect(result.success).toBe(true)
+      expect(result.data?.memories).toHaveLength(2)
+      expect(mockGet).toHaveBeenCalledWith(
+        expect.stringContaining('/api/memory/recall'),
+        expect.any(Object)
+      )
+    })
+
+    it('should support limit option', async () => {
+      const mockGet = vi.fn().mockResolvedValue({
+        success: true,
+        data: { memories: [] },
+      })
+      const client = { ...mockApiClient, get: mockGet }
+
+      const command = createRecallCommand({
+        ...mockContext,
+        client: client as unknown as ApiClient,
+      })
+
+      await command({ query: 'test', limit: 10 })
+
+      expect(mockGet).toHaveBeenCalledWith(
+        expect.stringContaining('limit=10'),
+        expect.any(Object)
+      )
+    })
+
+    it('should use default limit when not specified', async () => {
+      const mockGet = vi.fn().mockResolvedValue({
+        success: true,
+        data: { memories: [] },
+      })
+      const client = { ...mockApiClient, get: mockGet }
+
+      const command = createRecallCommand({
+        ...mockContext,
+        client: client as unknown as ApiClient,
+      })
+
+      await command({ query: 'test' })
+
+      expect(mockGet).toHaveBeenCalledWith(
+        expect.stringContaining('limit=5'),
+        expect.any(Object)
+      )
+    })
+
+    it('should return error when query is empty', async () => {
+      const command = createRecallCommand(mockContext)
+      const result = await command({ query: '' })
+
+      expect(result.success).toBe(false)
+      expect(result.message).toContain('query')
+    })
+
+    it('should handle API errors gracefully', async () => {
+      const mockGet = vi.fn().mockResolvedValue({
+        success: false,
+        error: { status: 500, message: 'Server error', code: 'SERVER_ERROR' },
+      })
+      const client = { ...mockApiClient, get: mockGet }
+
+      const command = createRecallCommand({
+        ...mockContext,
+        client: client as unknown as ApiClient,
+      })
+
+      const result = await command({ query: 'test' })
+
+      expect(result.success).toBe(false)
+      expect(result.message).toContain('error')
+    })
+
+    it('should format memories for display', async () => {
+      const mockGet = vi.fn().mockResolvedValue({
+        success: true,
+        data: {
+          memories: [
+            { id: '1', content: 'Memory content', score: 0.95, category: 'preference' },
+          ],
+        },
+      })
+      const client = { ...mockApiClient, get: mockGet }
+
+      const command = createRecallCommand({
+        ...mockContext,
+        client: client as unknown as ApiClient,
+      })
+
+      const result = await command({ query: 'test' })
+
+      expect(result.data?.memories[0]).toHaveProperty('content')
+      expect(result.data?.memories[0]).toHaveProperty('score')
+    })
+  })
+
+  describe('stats command', () => {
+    it('should create a callable command function', () => {
+      const command = createStatsCommand(mockContext)
+      expect(typeof command).toBe('function')
+    })
+
+    it('should fetch and display memory statistics', async () => {
+      const mockGet = vi.fn().mockResolvedValue({
+        success: true,
+        data: {
+          totalMemories: 42,
+          byCategory: {
+            preference: 15,
+            fact: 20,
+            decision: 5,
+            context: 2,
+          },
+          recentActivity: {
+            last24h: 5,
+            last7d: 12,
+          },
+        },
+      })
+      const client = { ...mockApiClient, get: mockGet }
+
+      const command = createStatsCommand({
+        ...mockContext,
+        client: client as unknown as ApiClient,
+      })
+
+      const result = await command()
+
+      expect(result.success).toBe(true)
+      expect(result.data?.totalMemories).toBe(42)
+      expect(result.data?.byCategory).toBeDefined()
+    })
+
+    it('should handle API errors gracefully', async () => {
+      const mockGet = vi.fn().mockResolvedValue({
+        success: false,
+        error: { status: 500, message: 'Server error', code: 'SERVER_ERROR' },
+      })
+      const client = { ...mockApiClient, get: mockGet }
+
+      const command = createStatsCommand({
+        ...mockContext,
+        client: client as unknown as ApiClient,
+      })
+
+      const result = await command()
+
+      expect(result.success).toBe(false)
+    })
+
+    it('should call stats endpoint', async () => {
+      const mockGet = vi.fn().mockResolvedValue({
+        success: true,
+        data: { totalMemories: 0, byCategory: {} },
+      })
+      const client = { ...mockApiClient, get: mockGet }
+
+      const command = createStatsCommand({
+        ...mockContext,
+        client: client as unknown as ApiClient,
+      })
+
+      await command()
+
+      expect(mockGet).toHaveBeenCalledWith(
+        expect.stringContaining('/api/memory/stats'),
+        expect.any(Object)
+      )
+    })
+  })
+
+  describe('export command', () => {
+    it('should create a callable command function', () => {
+      const command = createExportCommand(mockContext)
+      expect(typeof command).toBe('function')
+    })
+
+    it('should fetch all memories for export', async () => {
+      const mockGet = vi.fn().mockResolvedValue({
+        success: true,
+        data: {
+          memories: [
+            { id: '1', content: 'Memory 1', category: 'preference' },
+            { id: '2', content: 'Memory 2', category: 'fact' },
+          ],
+          exportedAt: '2024-01-15T12:00:00Z',
+        },
+      })
+      const client = { ...mockApiClient, get: mockGet }
+
+      const command = createExportCommand({
+        ...mockContext,
+        client: client as unknown as ApiClient,
+      })
+
+      const result = await command()
+
+      expect(result.success).toBe(true)
+      expect(result.data?.memories).toHaveLength(2)
+    })
+
+    it('should include export metadata', async () => {
+      const mockGet = vi.fn().mockResolvedValue({
+        success: true,
+        data: {
+          memories: [],
+          exportedAt: '2024-01-15T12:00:00Z',
+        },
+      })
+      const client = { ...mockApiClient, get: mockGet }
+
+      const command = createExportCommand({
+        ...mockContext,
+        client: client as unknown as ApiClient,
+      })
+
+      const result = await command()
+
+      expect(result.data?.exportedAt).toBeDefined()
+      expect(result.data?.userId).toBe('agent-1')
+    })
+
+    it('should handle API errors gracefully', async () => {
+      const mockGet = vi.fn().mockResolvedValue({
+        success: false,
+        error: { status: 500, message: 'Server error', code: 'SERVER_ERROR' },
+      })
+      const client = { ...mockApiClient, get: mockGet }
+
+      const command = createExportCommand({
+        ...mockContext,
+        client: client as unknown as ApiClient,
+      })
+
+      const result = await command()
+
+      expect(result.success).toBe(false)
+    })
+
+    it('should support output path option', async () => {
+      const mockGet = vi.fn().mockResolvedValue({
+        success: true,
+        data: {
+          memories: [],
+          exportedAt: '2024-01-15T12:00:00Z',
+        },
+      })
+      const client = { ...mockApiClient, get: mockGet }
+
+      const command = createExportCommand({
+        ...mockContext,
+        client: client as unknown as ApiClient,
+      })
+
+      const result = await command({ output: '/tmp/export.json' })
+
+      expect(result.data?.suggestedPath).toBe('/tmp/export.json')
+    })
+
+    it('should never include API key in export', async () => {
+      const mockGet = vi.fn().mockResolvedValue({
+        success: true,
+        data: {
+          memories: [{ id: '1', content: 'test' }],
+          exportedAt: '2024-01-15T12:00:00Z',
+        },
+      })
+      const client = { ...mockApiClient, get: mockGet }
+
+      const command = createExportCommand({
+        ...mockContext,
+        client: client as unknown as ApiClient,
+      })
+
+      const result = await command()
+
+      expect(JSON.stringify(result)).not.toContain('test-key-secret')
+    })
+  })
+
+  describe('createCliCommands', () => {
+    it('should create all command handlers', () => {
+      const commands = createCliCommands(mockContext)
+
+      expect(commands.status).toBeDefined()
+      expect(commands.users).toBeDefined()
+      expect(commands.recall).toBeDefined()
+      expect(commands.stats).toBeDefined()
+      expect(commands.export).toBeDefined()
+    })
+
+    it('should create callable functions for each command', () => {
+      const commands = createCliCommands(mockContext)
+
+      expect(typeof commands.status).toBe('function')
+      expect(typeof commands.users).toBe('function')
+      expect(typeof commands.recall).toBe('function')
+      expect(typeof commands.stats).toBe('function')
+      expect(typeof commands.export).toBe('function')
+    })
+  })
+
+  describe('security', () => {
+    it('should log CLI command execution without content', async () => {
+      const mockGet = vi.fn().mockResolvedValue({
+        success: true,
+        data: { memories: [] },
+      })
+      const client = { ...mockApiClient, get: mockGet }
+
+      const command = createRecallCommand({
+        ...mockContext,
+        client: client as unknown as ApiClient,
+      })
+
+      await command({ query: 'secret password info' })
+
+      // Check that logger was called
+      expect(mockLogger.info).toHaveBeenCalled()
+
+      // Check that the query content is not logged at info level
+      for (const call of (mockLogger.info as ReturnType<typeof vi.fn>).mock.calls) {
+        const logMessage = JSON.stringify(call)
+        expect(logMessage).not.toContain('secret password')
+      }
+    })
+  })
+})

--- a/packages/openclaw-plugin/tests/index.test.ts
+++ b/packages/openclaw-plugin/tests/index.test.ts
@@ -17,6 +17,12 @@ import {
   createAutoRecallHook,
   createAutoCaptureHook,
   createHealthCheck,
+  createCliCommands,
+  createStatusCommand,
+  createUsersCommand,
+  createRecallCommand,
+  createStatsCommand,
+  createExportCommand,
   MemoryRecallParamsSchema,
   MemoryStoreParamsSchema,
   MemoryForgetParamsSchema,
@@ -233,6 +239,20 @@ describe('Plugin Entry Point', () => {
       const result = register(mockContext)
       expect(typeof result.healthCheck).toBe('function')
     })
+
+    it('should return instance with CLI commands', () => {
+      const mockContext = {
+        config: { apiUrl: 'http://example.com', apiKey: 'test-key' },
+        logger: { info: () => {}, error: () => {}, warn: () => {}, debug: () => {}, namespace: 'test' },
+      }
+      const result = register(mockContext)
+      expect(result.cli).toBeDefined()
+      expect(typeof result.cli.status).toBe('function')
+      expect(typeof result.cli.users).toBe('function')
+      expect(typeof result.cli.recall).toBe('function')
+      expect(typeof result.cli.stats).toBe('function')
+      expect(typeof result.cli.export).toBe('function')
+    })
   })
 
   describe('tool exports', () => {
@@ -350,6 +370,30 @@ describe('Plugin Entry Point', () => {
 
     it('should export createHealthCheck', () => {
       expect(typeof createHealthCheck).toBe('function')
+    })
+
+    it('should export createCliCommands', () => {
+      expect(typeof createCliCommands).toBe('function')
+    })
+
+    it('should export createStatusCommand', () => {
+      expect(typeof createStatusCommand).toBe('function')
+    })
+
+    it('should export createUsersCommand', () => {
+      expect(typeof createUsersCommand).toBe('function')
+    })
+
+    it('should export createRecallCommand', () => {
+      expect(typeof createRecallCommand).toBe('function')
+    })
+
+    it('should export createStatsCommand', () => {
+      expect(typeof createStatsCommand).toBe('function')
+    })
+
+    it('should export createExportCommand', () => {
+      expect(typeof createExportCommand).toBe('function')
     })
   })
 })


### PR DESCRIPTION
## Summary
- Implement CLI command handlers for the OpenClaw plugin
- Add 5 commands: status, users, recall, stats, export
- Commands are exported as factory functions for OpenClaw CLI registration

## Commands

### `status`
Tests API connectivity and displays health information with latency.

### `users`
Shows current user scoping configuration with explanation of what each mode means.

### `recall <query>`
Manually searches memories from CLI with optional `--limit` support.

### `stats`
Shows memory statistics by category and recent activity.

### `export`
Exports all memories for GDPR data portability with optional `--output` path.

## Security
- ✅ No API key displayed in any CLI output
- ✅ Command executions logged without content for privacy
- ✅ User-friendly error messages without internal details

## Test Plan
- [x] 33 new unit tests for CLI commands
- [x] Tests verify no credential exposure in output
- [x] Tests verify error handling
- [x] TypeScript compilation passes
- [x] All 423 tests passing

Closes #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)