### PR TITLE
[#290] Add outbound message queue infrastructure and status tracking

### DIFF
--- a/migrations/038_outbound_message_status.down.sql
+++ b/migrations/038_outbound_message_status.down.sql
@@ -1,0 +1,23 @@
+-- Rollback Issue #290: Outbound message queue infrastructure
+
+-- Drop indexes
+DROP INDEX IF EXISTS external_message_provider_message_id_idx;
+DROP INDEX IF EXISTS external_message_delivery_status_idx;
+
+-- Drop triggers
+DROP TRIGGER IF EXISTS trg_external_message_validate_status ON external_message;
+DROP TRIGGER IF EXISTS trg_external_message_set_defaults ON external_message;
+
+-- Drop functions
+DROP FUNCTION IF EXISTS external_message_validate_status_transition();
+DROP FUNCTION IF EXISTS external_message_set_defaults();
+
+-- Remove columns
+ALTER TABLE external_message
+  DROP COLUMN IF EXISTS status_updated_at,
+  DROP COLUMN IF EXISTS provider_status_raw,
+  DROP COLUMN IF EXISTS provider_message_id,
+  DROP COLUMN IF EXISTS delivery_status;
+
+-- Drop enum type
+DROP TYPE IF EXISTS message_delivery_status;

--- a/migrations/038_outbound_message_status.up.sql
+++ b/migrations/038_outbound_message_status.up.sql
@@ -1,0 +1,153 @@
+-- Issue #290: Add outbound message queue infrastructure and status tracking
+-- Part of Epic #289 (Unified Communications Platform)
+
+-- Create enum for message delivery status
+-- Values align with Twilio/Postmark terminology where possible
+DO $$ BEGIN
+  CREATE TYPE message_delivery_status AS ENUM (
+    'pending',      -- Created, not yet queued for sending
+    'queued',       -- In the send queue, awaiting processing
+    'sending',      -- Currently being sent to provider
+    'sent',         -- Provider accepted the message
+    'delivered',    -- Provider confirmed delivery (terminal success)
+    'failed',       -- Permanent failure (terminal)
+    'bounced',      -- Email bounced (terminal)
+    'undelivered'   -- Provider could not deliver (terminal)
+  );
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+-- Add new columns to external_message for delivery tracking
+ALTER TABLE external_message
+  ADD COLUMN IF NOT EXISTS delivery_status message_delivery_status,
+  ADD COLUMN IF NOT EXISTS provider_message_id text,
+  ADD COLUMN IF NOT EXISTS provider_status_raw jsonb NOT NULL DEFAULT '{}'::jsonb,
+  ADD COLUMN IF NOT EXISTS status_updated_at timestamptz;
+
+-- Set default for delivery_status on outbound messages
+-- Inbound messages don't need delivery status tracking
+UPDATE external_message
+   SET delivery_status = 'delivered',
+       status_updated_at = received_at
+ WHERE direction = 'inbound' AND delivery_status IS NULL;
+
+UPDATE external_message
+   SET delivery_status = 'pending',
+       status_updated_at = created_at
+ WHERE direction = 'outbound' AND delivery_status IS NULL;
+
+-- Now set defaults for future inserts based on direction
+-- We'll use a trigger since DEFAULT can't reference other columns
+CREATE OR REPLACE FUNCTION external_message_set_defaults()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  -- Set delivery_status based on direction if not provided
+  IF NEW.delivery_status IS NULL THEN
+    IF NEW.direction = 'outbound' THEN
+      NEW.delivery_status := 'pending';
+    ELSE
+      NEW.delivery_status := 'delivered';
+    END IF;
+  END IF;
+
+  -- Set status_updated_at if not provided
+  IF NEW.status_updated_at IS NULL THEN
+    NEW.status_updated_at := COALESCE(NEW.received_at, now());
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_external_message_set_defaults ON external_message;
+CREATE TRIGGER trg_external_message_set_defaults
+BEFORE INSERT ON external_message
+FOR EACH ROW
+EXECUTE FUNCTION external_message_set_defaults();
+
+-- Define valid status transitions
+-- Terminal states: delivered, failed, bounced, undelivered
+-- Non-terminal states: pending, queued, sending, sent
+CREATE OR REPLACE FUNCTION external_message_validate_status_transition()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  terminal_states message_delivery_status[] := ARRAY['delivered', 'failed', 'bounced', 'undelivered']::message_delivery_status[];
+  old_ordinal int;
+  new_ordinal int;
+BEGIN
+  -- Skip if status unchanged or this is an insert
+  IF OLD.delivery_status = NEW.delivery_status THEN
+    RETURN NEW;
+  END IF;
+
+  -- Prevent any transition FROM terminal states
+  IF OLD.delivery_status = ANY(terminal_states) THEN
+    RAISE EXCEPTION 'Cannot transition from terminal status: %', OLD.delivery_status
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  -- Allow transitions TO terminal states (failed, bounced, undelivered) from any non-terminal
+  IF NEW.delivery_status = ANY(terminal_states) THEN
+    NEW.status_updated_at := now();
+    RETURN NEW;
+  END IF;
+
+  -- For non-terminal states, enforce forward-only progression
+  -- Order: pending(1) -> queued(2) -> sending(3) -> sent(4) -> delivered(5)
+  old_ordinal := CASE OLD.delivery_status
+    WHEN 'pending' THEN 1
+    WHEN 'queued' THEN 2
+    WHEN 'sending' THEN 3
+    WHEN 'sent' THEN 4
+    WHEN 'delivered' THEN 5
+    ELSE 0
+  END;
+
+  new_ordinal := CASE NEW.delivery_status
+    WHEN 'pending' THEN 1
+    WHEN 'queued' THEN 2
+    WHEN 'sending' THEN 3
+    WHEN 'sent' THEN 4
+    WHEN 'delivered' THEN 5
+    ELSE 0
+  END;
+
+  IF new_ordinal <= old_ordinal THEN
+    RAISE EXCEPTION 'Invalid status transition: % -> % (cannot go backwards)',
+      OLD.delivery_status, NEW.delivery_status
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  -- Update timestamp on valid transition
+  NEW.status_updated_at := now();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_external_message_validate_status ON external_message;
+CREATE TRIGGER trg_external_message_validate_status
+BEFORE UPDATE OF delivery_status ON external_message
+FOR EACH ROW
+EXECUTE FUNCTION external_message_validate_status_transition();
+
+-- Add index on delivery_status for monitoring dashboards
+-- Partial index on non-terminal states for queue processing efficiency
+CREATE INDEX IF NOT EXISTS external_message_delivery_status_idx
+  ON external_message (delivery_status)
+  WHERE delivery_status IN ('pending', 'queued', 'sending', 'sent');
+
+-- Add index for looking up messages by provider ID (for webhook processing)
+CREATE INDEX IF NOT EXISTS external_message_provider_message_id_idx
+  ON external_message (provider_message_id)
+  WHERE provider_message_id IS NOT NULL;
+
+-- Comment on new columns
+COMMENT ON COLUMN external_message.delivery_status IS 'Delivery status for outbound messages (pending -> queued -> sending -> sent -> delivered/failed)';
+COMMENT ON COLUMN external_message.provider_message_id IS 'Provider-specific message ID (Twilio MessageSid, Postmark MessageID)';
+COMMENT ON COLUMN external_message.provider_status_raw IS 'Raw status webhook payload from provider';
+COMMENT ON COLUMN external_message.status_updated_at IS 'Timestamp of last delivery_status change';

--- a/tests/outbound_message_queue.test.ts
+++ b/tests/outbound_message_queue.test.ts
@@ -1,0 +1,410 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { Pool } from 'pg';
+import { runMigrate } from './helpers/migrate.js';
+import { createTestPool, truncateAllTables } from './helpers/db.js';
+
+describe('Outbound message queue infrastructure (#290)', () => {
+  let pool: Pool;
+
+  beforeAll(async () => {
+    await runMigrate('up');
+    pool = createTestPool();
+  });
+
+  beforeEach(async () => {
+    await truncateAllTables(pool);
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  describe('Schema changes to external_message', () => {
+    it('has delivery_status column with correct enum values', async () => {
+      // Verify the enum exists
+      const enumValues = await pool.query(
+        `SELECT unnest(enum_range(NULL::message_delivery_status))::text as value`
+      );
+
+      expect(enumValues.rows.map((r) => r.value)).toEqual([
+        'pending',
+        'queued',
+        'sending',
+        'sent',
+        'delivered',
+        'failed',
+        'bounced',
+        'undelivered',
+      ]);
+    });
+
+    it('has delivery_status column defaulting to pending for outbound messages', async () => {
+      // Create prerequisite data
+      const contact = await pool.query(
+        `INSERT INTO contact (display_name) VALUES ('Test Contact') RETURNING id`
+      );
+      const endpoint = await pool.query(
+        `INSERT INTO contact_endpoint (contact_id, endpoint_type, endpoint_value)
+         VALUES ($1, 'phone', '+15551234567') RETURNING id`,
+        [contact.rows[0].id]
+      );
+      const thread = await pool.query(
+        `INSERT INTO external_thread (endpoint_id, channel, external_thread_key)
+         VALUES ($1, 'phone', 'test-thread-1') RETURNING id`,
+        [endpoint.rows[0].id]
+      );
+
+      // Insert outbound message without specifying delivery_status
+      const msg = await pool.query(
+        `INSERT INTO external_message (thread_id, external_message_key, direction, body)
+         VALUES ($1, 'msg-1', 'outbound', 'Hello!')
+         RETURNING delivery_status::text as delivery_status`,
+        [thread.rows[0].id]
+      );
+
+      expect(msg.rows[0].delivery_status).toBe('pending');
+    });
+
+    it('has provider_message_id column', async () => {
+      const column = await pool.query(
+        `SELECT column_name, data_type, is_nullable
+         FROM information_schema.columns
+         WHERE table_name = 'external_message' AND column_name = 'provider_message_id'`
+      );
+
+      expect(column.rows.length).toBe(1);
+      expect(column.rows[0].data_type).toBe('text');
+      expect(column.rows[0].is_nullable).toBe('YES');
+    });
+
+    it('has provider_status_raw JSONB column', async () => {
+      const column = await pool.query(
+        `SELECT column_name, data_type, is_nullable
+         FROM information_schema.columns
+         WHERE table_name = 'external_message' AND column_name = 'provider_status_raw'`
+      );
+
+      expect(column.rows.length).toBe(1);
+      expect(column.rows[0].data_type).toBe('jsonb');
+    });
+
+    it('has status_updated_at timestamp column', async () => {
+      const column = await pool.query(
+        `SELECT column_name, data_type, is_nullable
+         FROM information_schema.columns
+         WHERE table_name = 'external_message' AND column_name = 'status_updated_at'`
+      );
+
+      expect(column.rows.length).toBe(1);
+      expect(column.rows[0].data_type).toBe('timestamp with time zone');
+    });
+
+    it('has index on delivery_status for monitoring', async () => {
+      const index = await pool.query(
+        `SELECT indexname FROM pg_indexes
+         WHERE tablename = 'external_message'
+         AND indexname LIKE '%delivery_status%'`
+      );
+
+      expect(index.rows.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('Status transition validation', () => {
+    let threadId: string;
+
+    beforeEach(async () => {
+      // Create prerequisite data for status tests
+      const contact = await pool.query(
+        `INSERT INTO contact (display_name) VALUES ('Status Test') RETURNING id`
+      );
+      const endpoint = await pool.query(
+        `INSERT INTO contact_endpoint (contact_id, endpoint_type, endpoint_value)
+         VALUES ($1, 'phone', '+15559999999') RETURNING id`,
+        [contact.rows[0].id]
+      );
+      const thread = await pool.query(
+        `INSERT INTO external_thread (endpoint_id, channel, external_thread_key)
+         VALUES ($1, 'phone', 'status-test-thread') RETURNING id`,
+        [endpoint.rows[0].id]
+      );
+      threadId = thread.rows[0].id;
+    });
+
+    it('allows valid forward transitions (pending -> queued -> sending -> sent -> delivered)', async () => {
+      const msg = await pool.query(
+        `INSERT INTO external_message (thread_id, external_message_key, direction, body, delivery_status)
+         VALUES ($1, 'status-msg-1', 'outbound', 'Test', 'pending')
+         RETURNING id`,
+        [threadId]
+      );
+      const msgId = msg.rows[0].id;
+
+      // pending -> queued
+      await pool.query(`UPDATE external_message SET delivery_status = 'queued' WHERE id = $1`, [msgId]);
+
+      // queued -> sending
+      await pool.query(`UPDATE external_message SET delivery_status = 'sending' WHERE id = $1`, [msgId]);
+
+      // sending -> sent
+      await pool.query(`UPDATE external_message SET delivery_status = 'sent' WHERE id = $1`, [msgId]);
+
+      // sent -> delivered
+      await pool.query(`UPDATE external_message SET delivery_status = 'delivered' WHERE id = $1`, [msgId]);
+
+      const final = await pool.query(
+        `SELECT delivery_status::text as status FROM external_message WHERE id = $1`,
+        [msgId]
+      );
+      expect(final.rows[0].status).toBe('delivered');
+    });
+
+    it('allows transition to failed from any non-terminal state', async () => {
+      const msg = await pool.query(
+        `INSERT INTO external_message (thread_id, external_message_key, direction, body, delivery_status)
+         VALUES ($1, 'status-msg-2', 'outbound', 'Test', 'sending')
+         RETURNING id`,
+        [threadId]
+      );
+      const msgId = msg.rows[0].id;
+
+      // sending -> failed is allowed
+      await pool.query(`UPDATE external_message SET delivery_status = 'failed' WHERE id = $1`, [msgId]);
+
+      const result = await pool.query(
+        `SELECT delivery_status::text as status FROM external_message WHERE id = $1`,
+        [msgId]
+      );
+      expect(result.rows[0].status).toBe('failed');
+    });
+
+    it('prevents backward transitions (delivered -> sending should fail)', async () => {
+      const msg = await pool.query(
+        `INSERT INTO external_message (thread_id, external_message_key, direction, body, delivery_status)
+         VALUES ($1, 'status-msg-3', 'outbound', 'Test', 'delivered')
+         RETURNING id`,
+        [threadId]
+      );
+      const msgId = msg.rows[0].id;
+
+      // delivered -> sending should fail
+      await expect(
+        pool.query(`UPDATE external_message SET delivery_status = 'sending' WHERE id = $1`, [msgId])
+      ).rejects.toThrow(/invalid.*status.*transition|cannot.*transition/i);
+    });
+
+    it('prevents transitions from terminal states (failed -> queued should fail)', async () => {
+      const msg = await pool.query(
+        `INSERT INTO external_message (thread_id, external_message_key, direction, body, delivery_status)
+         VALUES ($1, 'status-msg-4', 'outbound', 'Test', 'failed')
+         RETURNING id`,
+        [threadId]
+      );
+      const msgId = msg.rows[0].id;
+
+      // failed -> queued should fail
+      await expect(
+        pool.query(`UPDATE external_message SET delivery_status = 'queued' WHERE id = $1`, [msgId])
+      ).rejects.toThrow(/invalid.*status.*transition|cannot.*transition/i);
+    });
+
+    it('updates status_updated_at when delivery_status changes', async () => {
+      const msg = await pool.query(
+        `INSERT INTO external_message (thread_id, external_message_key, direction, body, delivery_status)
+         VALUES ($1, 'status-msg-5', 'outbound', 'Test', 'pending')
+         RETURNING id, status_updated_at`,
+        [threadId]
+      );
+      const msgId = msg.rows[0].id;
+      const initialTimestamp = msg.rows[0].status_updated_at;
+
+      // Small delay to ensure timestamp difference
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      await pool.query(`UPDATE external_message SET delivery_status = 'queued' WHERE id = $1`, [msgId]);
+
+      const updated = await pool.query(`SELECT status_updated_at FROM external_message WHERE id = $1`, [
+        msgId,
+      ]);
+      expect(updated.rows[0].status_updated_at).not.toEqual(initialTimestamp);
+    });
+  });
+
+  describe('Message sending job types', () => {
+    it('can enqueue message.send.sms job with idempotency', async () => {
+      const messageId = '550e8400-e29b-41d4-a716-446655440000';
+      const idempotencyKey = `sms:${messageId}`;
+
+      // Enqueue twice - second should be no-op
+      const first = await pool.query(
+        `SELECT internal_job_enqueue($1, now(), $2, $3) as id`,
+        ['message.send.sms', JSON.stringify({ message_id: messageId, to: '+15551234567' }), idempotencyKey]
+      );
+
+      const second = await pool.query(
+        `SELECT internal_job_enqueue($1, now(), $2, $3) as id`,
+        ['message.send.sms', JSON.stringify({ message_id: messageId, to: '+15551234567' }), idempotencyKey]
+      );
+
+      expect(first.rows[0].id).not.toBeNull();
+      expect(second.rows[0].id).toBeNull(); // Idempotent - returns null on duplicate
+
+      // Verify only one job exists
+      const jobs = await pool.query(
+        `SELECT COUNT(*) as count FROM internal_job WHERE kind = 'message.send.sms'`
+      );
+      expect(jobs.rows[0].count).toBe('1');
+    });
+
+    it('can enqueue message.send.email job with idempotency', async () => {
+      const messageId = '550e8400-e29b-41d4-a716-446655440001';
+      const idempotencyKey = `email:${messageId}`;
+
+      // Enqueue twice - second should be no-op
+      const first = await pool.query(
+        `SELECT internal_job_enqueue($1, now(), $2, $3) as id`,
+        [
+          'message.send.email',
+          JSON.stringify({ message_id: messageId, to: 'test@example.com' }),
+          idempotencyKey,
+        ]
+      );
+
+      const second = await pool.query(
+        `SELECT internal_job_enqueue($1, now(), $2, $3) as id`,
+        [
+          'message.send.email',
+          JSON.stringify({ message_id: messageId, to: 'test@example.com' }),
+          idempotencyKey,
+        ]
+      );
+
+      expect(first.rows[0].id).not.toBeNull();
+      expect(second.rows[0].id).toBeNull(); // Idempotent - returns null on duplicate
+
+      // Verify only one job exists
+      const jobs = await pool.query(
+        `SELECT COUNT(*) as count FROM internal_job WHERE kind = 'message.send.email'`
+      );
+      expect(jobs.rows[0].count).toBe('1');
+    });
+
+    it('allows different message IDs even for same job kind', async () => {
+      const msg1 = '550e8400-e29b-41d4-a716-446655440002';
+      const msg2 = '550e8400-e29b-41d4-a716-446655440003';
+
+      await pool.query(`SELECT internal_job_enqueue($1, now(), $2, $3)`, [
+        'message.send.sms',
+        JSON.stringify({ message_id: msg1 }),
+        `sms:${msg1}`,
+      ]);
+
+      await pool.query(`SELECT internal_job_enqueue($1, now(), $2, $3)`, [
+        'message.send.sms',
+        JSON.stringify({ message_id: msg2 }),
+        `sms:${msg2}`,
+      ]);
+
+      const jobs = await pool.query(
+        `SELECT COUNT(*) as count FROM internal_job WHERE kind = 'message.send.sms'`
+      );
+      expect(jobs.rows[0].count).toBe('2');
+    });
+
+    it('message jobs can be claimed and completed', async () => {
+      const messageId = '550e8400-e29b-41d4-a716-446655440004';
+
+      await pool.query(`SELECT internal_job_enqueue($1, now(), $2, $3)`, [
+        'message.send.sms',
+        JSON.stringify({ message_id: messageId, to: '+15557654321' }),
+        `sms:${messageId}`,
+      ]);
+
+      // Claim the job
+      const claimed = await pool.query(`SELECT * FROM internal_job_claim('test-worker', 1)`);
+      expect(claimed.rows.length).toBe(1);
+      expect(claimed.rows[0].kind).toBe('message.send.sms');
+
+      const payload = claimed.rows[0].payload;
+      expect(payload.message_id).toBe(messageId);
+      expect(payload.to).toBe('+15557654321');
+
+      // Complete the job
+      await pool.query(`SELECT internal_job_complete($1)`, [claimed.rows[0].id]);
+
+      // Verify completed
+      const completed = await pool.query(
+        `SELECT completed_at FROM internal_job WHERE id = $1`,
+        [claimed.rows[0].id]
+      );
+      expect(completed.rows[0].completed_at).not.toBeNull();
+    });
+  });
+
+  describe('Provider message ID handling', () => {
+    let threadId: string;
+
+    beforeEach(async () => {
+      const contact = await pool.query(
+        `INSERT INTO contact (display_name) VALUES ('Provider Test') RETURNING id`
+      );
+      const endpoint = await pool.query(
+        `INSERT INTO contact_endpoint (contact_id, endpoint_type, endpoint_value)
+         VALUES ($1, 'phone', '+15558888888') RETURNING id`,
+        [contact.rows[0].id]
+      );
+      const thread = await pool.query(
+        `INSERT INTO external_thread (endpoint_id, channel, external_thread_key)
+         VALUES ($1, 'phone', 'provider-test-thread') RETURNING id`,
+        [endpoint.rows[0].id]
+      );
+      threadId = thread.rows[0].id;
+    });
+
+    it('can store Twilio MessageSid as provider_message_id', async () => {
+      const twilioSid = 'SM1234567890abcdef1234567890abcdef';
+
+      const msg = await pool.query(
+        `INSERT INTO external_message (thread_id, external_message_key, direction, body, provider_message_id)
+         VALUES ($1, 'twilio-msg', 'outbound', 'Hello', $2)
+         RETURNING provider_message_id`,
+        [threadId, twilioSid]
+      );
+
+      expect(msg.rows[0].provider_message_id).toBe(twilioSid);
+    });
+
+    it('can store Postmark MessageID as provider_message_id', async () => {
+      const postmarkId = 'a8b9c0d1-e2f3-4a5b-6c7d-8e9f0a1b2c3d';
+
+      const msg = await pool.query(
+        `INSERT INTO external_message (thread_id, external_message_key, direction, body, provider_message_id)
+         VALUES ($1, 'postmark-msg', 'outbound', 'Hello', $2)
+         RETURNING provider_message_id`,
+        [threadId, postmarkId]
+      );
+
+      expect(msg.rows[0].provider_message_id).toBe(postmarkId);
+    });
+
+    it('can store raw provider status payload', async () => {
+      const rawStatus = {
+        AccountSid: 'AC123',
+        MessageSid: 'SM456',
+        MessageStatus: 'delivered',
+        To: '+15551234567',
+        From: '+15559876543',
+        Timestamp: '2024-01-15T12:00:00Z',
+      };
+
+      const msg = await pool.query(
+        `INSERT INTO external_message (thread_id, external_message_key, direction, body, provider_status_raw)
+         VALUES ($1, 'raw-status-msg', 'outbound', 'Hello', $2)
+         RETURNING provider_status_raw`,
+        [threadId, JSON.stringify(rawStatus)]
+      );
+
+      expect(msg.rows[0].provider_status_raw).toEqual(rawStatus);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `message_delivery_status` enum with Twilio/Postmark-compatible values
- Extends `external_message` table with delivery tracking columns:
  - `delivery_status` - tracks message state through send pipeline
  - `provider_message_id` - stores Twilio MessageSid / Postmark MessageID
  - `provider_status_raw` - raw webhook payloads from providers
  - `status_updated_at` - tracks when status last changed
- Implements status transition validation via PostgreSQL trigger
- Adds indexes for monitoring and webhook processing

## Test plan

- [x] Schema tests verify enum values and column presence
- [x] Status transition tests verify forward-only progression
- [x] Terminal state tests verify no escape from delivered/failed/bounced/undelivered
- [x] Job idempotency tests verify message.send.sms and message.send.email
- [x] Provider ID tests verify storage of Twilio/Postmark identifiers
- [x] Full test suite passes (2609 tests)

Closes #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)