### PR TITLE
[#296] Add outbound messaging and delivery tracking documentation

### DIFF
--- a/docs/api/messaging.md
+++ b/docs/api/messaging.md
@@ -1,0 +1,250 @@
+# Messaging API Reference
+
+This document covers the outbound messaging APIs for SMS and Email, including delivery status tracking.
+
+## SMS Endpoints
+
+### Send SMS
+
+**POST** `/api/twilio/sms/send`
+
+Send an SMS message via Twilio. Messages are queued for async delivery.
+
+**Request Body:**
+```json
+{
+  "to": "+15551234567",
+  "body": "Hello from OpenClaw!",
+  "idempotencyKey": "my-unique-key-123"
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `to` | string | Yes | Recipient phone number in E.164 format |
+| `body` | string | Yes | Message content (max 1600 chars) |
+| `idempotencyKey` | string | No | Unique key for deduplication |
+
+**Response (202 Accepted):**
+```json
+{
+  "messageId": "019c1234-5678-7890-abcd-ef1234567890",
+  "threadId": "019c1234-5678-7890-abcd-ef1234567891",
+  "status": "queued",
+  "idempotencyKey": "my-unique-key-123"
+}
+```
+
+**Error Responses:**
+- `400 Bad Request` - Invalid phone number or empty body
+- `401 Unauthorized` - Missing or invalid auth token
+- `500 Internal Server Error` - Server-side error
+
+**Example:**
+```bash
+curl -X POST https://api.example.com/api/twilio/sms/send \
+  -H "Authorization: Bearer $API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "to": "+15551234567",
+    "body": "Your appointment is confirmed for tomorrow at 2pm."
+  }'
+```
+
+### SMS Delivery Status Webhook
+
+**POST** `/api/twilio/sms/status`
+
+Webhook endpoint for Twilio delivery status callbacks. Configure in your Twilio console.
+
+**Request Body (from Twilio):**
+```
+MessageSid=SM1234567890abcdef&
+MessageStatus=delivered&
+To=%2B15551234567&
+From=%2B15559876543&
+AccountSid=AC1234567890
+```
+
+**Response:** `200 OK` with empty body
+
+**Status Values:**
+| Status | Description |
+|--------|-------------|
+| `queued` | Message queued for sending |
+| `sending` | Message being sent to carrier |
+| `sent` | Message accepted by carrier |
+| `delivered` | Message delivered to recipient |
+| `undelivered` | Message could not be delivered |
+| `failed` | Message failed to send |
+
+---
+
+## Email Endpoints
+
+### Send Email
+
+**POST** `/api/postmark/email/send`
+
+Send an email via Postmark. Messages are queued for async delivery.
+
+**Request Body:**
+```json
+{
+  "to": "user@example.com",
+  "subject": "Welcome to Our Service",
+  "body": "Thank you for signing up!",
+  "htmlBody": "<h1>Welcome!</h1><p>Thank you for signing up!</p>",
+  "replyToMessageId": "optional-message-id-for-threading",
+  "idempotencyKey": "email-unique-key-456"
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `to` | string | Yes | Recipient email address |
+| `subject` | string | Yes | Email subject line |
+| `body` | string | Yes | Plain text body |
+| `htmlBody` | string | No | HTML body (optional) |
+| `threadId` | string | No | Existing thread ID for replies |
+| `replyToMessageId` | string | No | Message ID for threading |
+| `idempotencyKey` | string | No | Unique key for deduplication |
+
+**Response (202 Accepted):**
+```json
+{
+  "messageId": "019c1234-5678-7890-abcd-ef1234567892",
+  "threadId": "019c1234-5678-7890-abcd-ef1234567893",
+  "status": "queued",
+  "idempotencyKey": "email-unique-key-456"
+}
+```
+
+**Error Responses:**
+- `400 Bad Request` - Invalid email address, empty subject, or empty body
+- `401 Unauthorized` - Missing or invalid auth token
+- `500 Internal Server Error` - Server-side error
+
+**Example:**
+```bash
+curl -X POST https://api.example.com/api/postmark/email/send \
+  -H "Authorization: Bearer $API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "to": "user@example.com",
+    "subject": "Order Confirmation",
+    "body": "Your order #12345 has been confirmed.",
+    "htmlBody": "<h1>Order Confirmed</h1><p>Your order #12345 has been confirmed.</p>"
+  }'
+```
+
+### Email Delivery Status Webhook
+
+**POST** `/api/postmark/email/status`
+
+Webhook endpoint for Postmark delivery status callbacks. Configure in your Postmark server settings.
+
+**Request Body (Delivery Event):**
+```json
+{
+  "RecordType": "Delivery",
+  "MessageID": "a8b9c0d1-e2f3-4a5b-6c7d-8e9f0a1b2c3d",
+  "Recipient": "user@example.com",
+  "DeliveredAt": "2024-01-15T12:00:00Z",
+  "MessageStream": "outbound",
+  "ServerID": 12345
+}
+```
+
+**Request Body (Bounce Event):**
+```json
+{
+  "RecordType": "Bounce",
+  "MessageID": "a8b9c0d1-e2f3-4a5b-6c7d-8e9f0a1b2c3d",
+  "Recipient": "user@example.com",
+  "Type": "HardBounce",
+  "TypeCode": 1,
+  "Name": "Hard bounce",
+  "Description": "The server was unable to deliver your message",
+  "BouncedAt": "2024-01-15T12:00:00Z",
+  "MessageStream": "outbound",
+  "ServerID": 12345
+}
+```
+
+**Response:** `200 OK`
+
+**Postmark Event Types:**
+| RecordType | Our Status | Description |
+|------------|------------|-------------|
+| `Delivery` | `delivered` | Email delivered to recipient |
+| `Bounce` (HardBounce) | `bounced` | Permanent delivery failure |
+| `Bounce` (SoftBounce) | `failed` | Temporary delivery failure |
+| `SpamComplaint` | (recorded) | Recipient marked as spam |
+
+---
+
+## Delivery Status Tracking
+
+### Message Lifecycle
+
+```
+pending → queued → sending → sent → delivered
+                              ↘    → failed
+                                   → bounced
+                                   → undelivered
+```
+
+### Status Definitions
+
+| Status | Description |
+|--------|-------------|
+| `pending` | Message created, waiting to be processed |
+| `queued` | Message added to send queue |
+| `sending` | Message being transmitted to provider |
+| `sent` | Provider accepted the message |
+| `delivered` | Recipient received the message |
+| `failed` | Temporary failure (may retry) |
+| `bounced` | Permanent delivery failure |
+| `undelivered` | Message could not be delivered |
+
+### Idempotency
+
+Both SMS and Email endpoints support idempotency keys:
+
+1. **First request**: Message is created and queued
+2. **Duplicate request** (same key): Returns original message ID without creating duplicate
+
+Use idempotency keys to safely retry failed requests without sending duplicate messages.
+
+```bash
+# Safe to retry - only sends once
+curl -X POST /api/twilio/sms/send \
+  -d '{"to": "+15551234567", "body": "Hello", "idempotencyKey": "retry-safe-123"}'
+```
+
+---
+
+## Rate Limits
+
+| Endpoint | Limit | Window |
+|----------|-------|--------|
+| SMS send | 30 req | 1 minute |
+| Email send | 30 req | 1 minute |
+| Status webhooks | 100 req | 1 minute |
+
+Exceeding rate limits returns `429 Too Many Requests`.
+
+---
+
+## Authentication
+
+All API endpoints require Bearer token authentication:
+
+```bash
+Authorization: Bearer your-api-token
+```
+
+Webhook endpoints verify signatures:
+- **Twilio**: X-Twilio-Signature header validation
+- **Postmark**: Basic auth or API token validation

--- a/docs/development/messaging-setup.md
+++ b/docs/development/messaging-setup.md
@@ -1,0 +1,306 @@
+# Local Development: Messaging Setup
+
+This guide covers setting up SMS and Email messaging for local development and testing.
+
+## Prerequisites
+
+- Docker and Docker Compose
+- Node.js 18+
+- ngrok (for webhook testing)
+
+## Quick Start
+
+```bash
+# 1. Start the development environment
+docker compose up -d
+
+# 2. Copy environment template
+cp .env.example .env
+
+# 3. Run migrations
+pnpm migrate up
+
+# 4. Start the dev server
+pnpm dev
+```
+
+## Twilio SMS Setup
+
+### Test Credentials
+
+For development, use Twilio test credentials:
+
+```bash
+# .env
+TWILIO_ACCOUNT_SID=ACtest... # Your test account SID
+TWILIO_AUTH_TOKEN=your-test-auth-token
+TWILIO_PHONE_NUMBER=+15005550006  # Twilio magic test number
+```
+
+### Twilio Test Numbers
+
+| Number | Behavior |
+|--------|----------|
+| `+15005550006` | Valid sender |
+| `+15005550001` | Returns invalid number error |
+| `+15005550009` | Returns cannot route error |
+
+### Getting Real Credentials
+
+1. Sign up at [twilio.com](https://www.twilio.com)
+2. Get Account SID and Auth Token from Console
+3. Purchase a phone number
+4. Configure webhook URL for status callbacks
+
+### Webhook Testing with ngrok
+
+```bash
+# Start ngrok
+ngrok http 3000
+
+# Configure Twilio webhook URL
+# https://xxxxx.ngrok.io/api/twilio/sms/status
+```
+
+## Postmark Email Setup
+
+### Test Mode
+
+Postmark provides a test server for development:
+
+```bash
+# .env
+POSTMARK_SERVER_TOKEN=POSTMARK_API_TEST  # Test token
+POSTMARK_FROM_EMAIL=test@example.com     # Any email for tests
+```
+
+### Production Setup
+
+1. Sign up at [postmarkapp.com](https://postmarkapp.com)
+2. Verify your sending domain
+3. Create a server and get the Server Token
+4. Configure webhooks for delivery events
+
+```bash
+# .env (production)
+POSTMARK_SERVER_TOKEN=your-server-token
+POSTMARK_FROM_EMAIL=noreply@yourdomain.com
+```
+
+### Webhook Configuration
+
+In Postmark server settings:
+1. Go to **Webhooks** tab
+2. Add webhook URL: `https://yourdomain.com/api/postmark/email/status`
+3. Select events: Delivery, Bounce, SpamComplaint
+
+## Testing Endpoints
+
+### Send Test SMS
+
+```bash
+# Without auth (dev mode)
+curl -X POST http://localhost:3000/api/twilio/sms/send \
+  -H "Content-Type: application/json" \
+  -d '{
+    "to": "+15551234567",
+    "body": "Test message from local dev"
+  }'
+```
+
+### Send Test Email
+
+```bash
+curl -X POST http://localhost:3000/api/postmark/email/send \
+  -H "Content-Type: application/json" \
+  -d '{
+    "to": "test@example.com",
+    "subject": "Test Email",
+    "body": "This is a test email from local development."
+  }'
+```
+
+### Simulate Webhook Events
+
+#### Twilio SMS Status
+
+```bash
+curl -X POST http://localhost:3000/api/twilio/sms/status \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "MessageSid=SM12345&MessageStatus=delivered&To=%2B15551234567"
+```
+
+#### Postmark Delivery
+
+```bash
+curl -X POST http://localhost:3000/api/postmark/email/status \
+  -H "Content-Type: application/json" \
+  -d '{
+    "RecordType": "Delivery",
+    "MessageID": "your-message-id",
+    "Recipient": "test@example.com",
+    "DeliveredAt": "2024-01-15T12:00:00Z",
+    "MessageStream": "outbound",
+    "ServerID": 12345
+  }'
+```
+
+#### Postmark Bounce
+
+```bash
+curl -X POST http://localhost:3000/api/postmark/email/status \
+  -H "Content-Type: application/json" \
+  -d '{
+    "RecordType": "Bounce",
+    "MessageID": "your-message-id",
+    "Recipient": "invalid@example.com",
+    "Type": "HardBounce",
+    "TypeCode": 1,
+    "Name": "Hard bounce",
+    "Description": "Invalid email address",
+    "BouncedAt": "2024-01-15T12:00:00Z",
+    "MessageStream": "outbound",
+    "ServerID": 12345
+  }'
+```
+
+## Running Tests
+
+### Unit Tests
+
+```bash
+# Run all messaging tests
+pnpm test tests/twilio
+pnpm test tests/postmark
+pnpm test tests/message-embeddings.test.ts
+
+# Run specific test file
+pnpm test tests/twilio/sms-outbound.test.ts
+```
+
+### Integration Tests
+
+Integration tests require a running PostgreSQL instance:
+
+```bash
+# Ensure database is running
+docker compose up -d postgres
+
+# Run migrations
+pnpm migrate up
+
+# Run integration tests
+pnpm test:integration
+```
+
+## Environment Variables Reference
+
+### Twilio
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `TWILIO_ACCOUNT_SID` | Yes | Twilio Account SID |
+| `TWILIO_AUTH_TOKEN` | Yes | Twilio Auth Token |
+| `TWILIO_PHONE_NUMBER` | Yes | Sender phone number |
+
+### Postmark
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `POSTMARK_SERVER_TOKEN` | Yes* | Server API token |
+| `POSTMARK_TRANSACTIONAL_TOKEN` | Yes* | Alternative token name |
+| `POSTMARK_TRANSACTIONAL_TOKEN_FILE` | Yes* | Path to token file |
+| `POSTMARK_FROM_EMAIL` | Yes | Verified sender email |
+
+*One of the token options is required.
+
+### Embeddings (for semantic search)
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `VOYAGE_API_KEY` | No | VoyageAI API key |
+| `OPENAI_API_KEY` | No | OpenAI API key |
+| `GOOGLE_AI_API_KEY` | No | Google AI API key |
+| `EMBEDDING_PROVIDER` | No | Force specific provider |
+
+## Troubleshooting
+
+### SMS not sending
+
+1. Check Twilio credentials are correct
+2. Verify phone number format (E.164: +15551234567)
+3. Check Twilio console for errors
+4. Verify sender number is active
+
+### Email not sending
+
+1. Check Postmark server token
+2. Verify sender domain is verified in Postmark
+3. Check Postmark activity feed for errors
+4. Ensure `POSTMARK_FROM_EMAIL` matches verified domain
+
+### Webhooks not received
+
+1. Verify ngrok is running and URL is correct
+2. Check webhook configuration in Twilio/Postmark console
+3. Look for errors in application logs
+4. Test with curl to local endpoint first
+
+### Embeddings not generating
+
+1. Ensure at least one embedding provider is configured
+2. Check API key is valid
+3. Run backfill: `pnpm cli embeddings backfill-messages`
+4. Check message has body content (empty messages are skipped)
+
+## Database Schema
+
+### Key Tables
+
+```sql
+-- Messages with delivery tracking
+external_message (
+  id, thread_id, direction, body, subject,
+  delivery_status,      -- pending, queued, sending, sent, delivered, failed, bounced
+  provider_message_id,  -- Twilio SID or Postmark MessageID
+  provider_status_raw,  -- Full webhook payload
+  embedding,            -- Vector for semantic search
+  embedding_status      -- pending, complete, failed
+)
+
+-- Conversations
+external_thread (
+  id, endpoint_id, channel, external_thread_key
+)
+
+-- Contact endpoints with bounce tracking
+contact_endpoint (
+  id, contact_id, endpoint_type, endpoint_value,
+  metadata  -- Contains { bounced: true, bounce_type: 'HardBounce' }
+)
+
+-- Background jobs
+internal_job (
+  id, kind,           -- message.send.sms, message.send.email, message.embed
+  payload, run_at, attempts, completed_at
+)
+```
+
+### Useful Queries
+
+```sql
+-- Check message status
+SELECT id, delivery_status, provider_message_id
+FROM external_message
+WHERE id = 'your-message-id';
+
+-- Find pending embedding jobs
+SELECT COUNT(*) FROM internal_job
+WHERE kind = 'message.embed' AND completed_at IS NULL;
+
+-- Find bounced endpoints
+SELECT ce.*, c.display_name
+FROM contact_endpoint ce
+JOIN contact c ON c.id = ce.contact_id
+WHERE ce.metadata->>'bounced' = 'true';
+```

--- a/docs/guides/openclaw-messaging-integration.md
+++ b/docs/guides/openclaw-messaging-integration.md
@@ -1,0 +1,265 @@
+# OpenClaw Messaging Integration Guide
+
+This guide explains how OpenClaw agents should integrate with the messaging APIs to send SMS and email messages, and handle delivery status updates.
+
+## Overview
+
+The messaging system provides:
+- **Asynchronous delivery** - Messages are queued and processed in the background
+- **Delivery tracking** - Status updates via webhooks
+- **Semantic search** - Find messages by meaning, not just keywords
+- **Thread management** - Automatic conversation threading
+
+## Sending Messages
+
+### SMS Messages
+
+```typescript
+// Send an SMS
+const response = await fetch('/api/twilio/sms/send', {
+  method: 'POST',
+  headers: {
+    'Authorization': `Bearer ${apiToken}`,
+    'Content-Type': 'application/json'
+  },
+  body: JSON.stringify({
+    to: '+15551234567',
+    body: 'Your appointment is confirmed for tomorrow at 2pm.',
+    idempotencyKey: `reminder:${appointmentId}:${Date.now()}`
+  })
+});
+
+const result = await response.json();
+// { messageId: '...', threadId: '...', status: 'queued', idempotencyKey: '...' }
+```
+
+### Email Messages
+
+```typescript
+// Send an email
+const response = await fetch('/api/postmark/email/send', {
+  method: 'POST',
+  headers: {
+    'Authorization': `Bearer ${apiToken}`,
+    'Content-Type': 'application/json'
+  },
+  body: JSON.stringify({
+    to: 'user@example.com',
+    subject: 'Order Confirmation',
+    body: 'Your order #12345 has been confirmed and will ship within 2 business days.',
+    htmlBody: '<h1>Order Confirmed!</h1><p>Your order #12345 has been confirmed...</p>',
+    idempotencyKey: `order:${orderId}:confirmation`
+  })
+});
+```
+
+## Idempotency Best Practices
+
+Always use idempotency keys to prevent duplicate messages:
+
+```typescript
+// Good: Unique key based on business context
+idempotencyKey: `appointment:${appointmentId}:reminder:24h`
+
+// Good: Include timestamp for time-sensitive messages
+idempotencyKey: `daily-digest:${userId}:${formatDate(new Date())}`
+
+// Bad: Random key - no deduplication benefit
+idempotencyKey: uuidv4()
+
+// Bad: No key - duplicate requests create duplicate messages
+// (omitted)
+```
+
+## Handling Delivery Status
+
+### Webhook Configuration
+
+Configure your Twilio and Postmark accounts to send delivery status webhooks to:
+- SMS: `https://your-domain/api/twilio/sms/status`
+- Email: `https://your-domain/api/postmark/email/status`
+
+### Status Flow
+
+```
+┌─────────┐   ┌────────┐   ┌─────────┐   ┌──────┐   ┌───────────┐
+│ pending │──▶│ queued │──▶│ sending │──▶│ sent │──▶│ delivered │
+└─────────┘   └────────┘   └─────────┘   └──────┘   └───────────┘
+                                            │
+                                            ├──▶ failed
+                                            ├──▶ bounced
+                                            └──▶ undelivered
+```
+
+### Querying Message Status
+
+```typescript
+// Get message by ID
+const message = await fetch(`/api/messages/${messageId}`, {
+  headers: { 'Authorization': `Bearer ${apiToken}` }
+});
+
+// Check delivery status
+if (message.delivery_status === 'delivered') {
+  console.log('Message delivered successfully');
+} else if (message.delivery_status === 'bounced') {
+  console.log('Permanent delivery failure - email may be invalid');
+}
+```
+
+## Error Handling
+
+### Retry Strategy
+
+```typescript
+async function sendWithRetry(endpoint, payload, maxRetries = 3) {
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      const response = await fetch(endpoint, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${apiToken}`,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(payload)
+      });
+
+      if (response.ok) {
+        return await response.json();
+      }
+
+      // Don't retry client errors
+      if (response.status < 500) {
+        throw new Error(`Client error: ${response.status}`);
+      }
+
+      // Retry server errors with exponential backoff
+      if (attempt < maxRetries) {
+        await sleep(Math.pow(2, attempt) * 1000);
+      }
+    } catch (error) {
+      if (attempt === maxRetries) throw error;
+      await sleep(Math.pow(2, attempt) * 1000);
+    }
+  }
+}
+```
+
+### Common Error Codes
+
+| Status | Cause | Action |
+|--------|-------|--------|
+| 400 | Invalid input | Check phone/email format, required fields |
+| 401 | Auth failed | Check API token |
+| 429 | Rate limited | Wait and retry with backoff |
+| 500 | Server error | Retry with exponential backoff |
+
+## Semantic Message Search
+
+Messages are automatically embedded for semantic search. Use the unified search API:
+
+```typescript
+// Search messages by meaning
+const results = await fetch('/api/search?' + new URLSearchParams({
+  query: 'conversations about the renovation project',
+  types: 'message',
+  limit: '10'
+}), {
+  headers: { 'Authorization': `Bearer ${apiToken}` }
+});
+
+// Returns messages mentioning home improvement, contractors, etc.
+```
+
+### Search Modes
+
+| Mode | Description |
+|------|-------------|
+| `keyword` | Traditional text matching |
+| `semantic` | Vector similarity search |
+| `hybrid` | Combined keyword + semantic (default) |
+
+## Contact Endpoint Handling
+
+### Bounce Handling
+
+When a hard bounce occurs, the contact endpoint is automatically flagged:
+
+```typescript
+// Check if endpoint is bounced
+const endpoint = await getContactEndpoint(endpointId);
+if (endpoint.metadata?.bounced) {
+  console.log(`Endpoint bounced: ${endpoint.metadata.bounce_type}`);
+  // Consider alternative contact methods or manual intervention
+}
+```
+
+### Best Practices
+
+1. **Check bounce status** before sending to known endpoints
+2. **Provide fallback** contact methods when primary fails
+3. **Monitor bounce rates** to identify systematic issues
+4. **Clean email lists** regularly based on bounce data
+
+## Threading
+
+Messages are automatically threaded by conversation:
+
+```typescript
+// Reply to existing thread
+const response = await fetch('/api/postmark/email/send', {
+  method: 'POST',
+  headers: { /* ... */ },
+  body: JSON.stringify({
+    to: 'user@example.com',
+    subject: 'Re: Order Confirmation',
+    body: 'Your order has shipped!',
+    threadId: existingThreadId  // Links to existing conversation
+  })
+});
+```
+
+## Rate Limiting
+
+Respect rate limits in your integration:
+
+```typescript
+class RateLimiter {
+  private queue: Array<() => Promise<any>> = [];
+  private processing = false;
+
+  async add<T>(fn: () => Promise<T>): Promise<T> {
+    return new Promise((resolve, reject) => {
+      this.queue.push(async () => {
+        try {
+          resolve(await fn());
+        } catch (e) {
+          reject(e);
+        }
+      });
+      this.process();
+    });
+  }
+
+  private async process() {
+    if (this.processing) return;
+    this.processing = true;
+
+    while (this.queue.length > 0) {
+      const fn = this.queue.shift()!;
+      await fn();
+      await sleep(2000); // 30 req/min = 1 every 2 seconds
+    }
+
+    this.processing = false;
+  }
+}
+```
+
+## Security Considerations
+
+1. **Never log** full message content - use truncation
+2. **Sanitize** user input in message bodies
+3. **Validate** phone numbers and email addresses
+4. **Use HTTPS** for all API calls
+5. **Rotate** API tokens regularly


### PR DESCRIPTION
## Summary
- Add API reference documentation for SMS and Email endpoints
- Create integration guide for OpenClaw agents
- Provide local development setup instructions

## Documentation Created

### API Reference (`docs/api/messaging.md`)
- POST `/api/twilio/sms/send` - Send SMS
- POST `/api/postmark/email/send` - Send Email
- Webhook endpoints for delivery status
- Status codes and lifecycle
- Rate limits and authentication

### Integration Guide (`docs/guides/openclaw-messaging-integration.md`)
- How to send messages
- Idempotency best practices
- Handling delivery status
- Error handling and retry strategies
- Semantic search usage
- Threading and contact management

### Development Setup (`docs/development/messaging-setup.md`)
- Twilio test credentials setup
- Postmark test mode configuration
- ngrok webhook testing
- Mock webhook payloads
- Database schema reference
- Troubleshooting guide

## Test plan
- [x] Documentation renders correctly in markdown
- [x] All code examples use correct endpoint paths
- [x] Example curl commands work with dev server
- [x] No broken links or references

Closes #296

🤖 Generated with [Claude Code](https://claude.com/claude-code)