### PR TITLE
Add Google Cloud SDK and Azure CLI to devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -67,3 +67,26 @@ RUN set -eux; \
     apt-get update; \
     apt-get install -y --no-install-recommends gh; \
     rm -rf /var/lib/apt/lists/*
+
+# Install Google Cloud SDK (gcloud).
+# Ref: https://cloud.google.com/sdk/docs/install#deb
+RUN set -eux; \
+    curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg \
+      | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg; \
+    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" \
+      > /etc/apt/sources.list.d/google-cloud-sdk.list; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends google-cloud-cli; \
+    rm -rf /var/lib/apt/lists/*
+
+# Install Azure CLI (az).
+# Ref: https://learn.microsoft.com/en-us/cli/azure/install-azure-cli-linux
+RUN set -eux; \
+    curl -sLS https://packages.microsoft.com/keys/microsoft.asc \
+      | gpg --dearmor -o /etc/apt/keyrings/microsoft.gpg; \
+    chmod go+r /etc/apt/keyrings/microsoft.gpg; \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/microsoft.gpg] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" \
+      > /etc/apt/sources.list.d/azure-cli.list; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends azure-cli; \
+    rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary

- Adds `gcloud` CLI to devcontainer (Google Cloud SDK)
- Adds `az` CLI to devcontainer (Azure CLI)
- Adds `restore_cloud_credentials()` function to postCreate.sh that:
  - Restores Google Cloud Application Default Credentials from env vars
  - Logs in to Azure using service principal from env vars

## Environment Variables

These are read from `.env` via docker-compose `env_file`:

| Variable | Purpose |
|----------|---------|
| `GOOGLE_CLOUD_CLIENT_ID` | OAuth client ID for ADC |
| `GOOGLE_CLOUD_CLIENT_SECRET` | OAuth client secret for ADC |
| `GOOGLE_CLOUD_QUOTA_PROJECT` | Default quota project |
| `GOOGLE_CLOUD_REFRESH_TOKEN` | OAuth refresh token |
| `AZURE_TENANT_ID` | Microsoft Entra tenant ID |
| `AZURE_CLIENT_ID` | Service principal app ID |
| `AZURE_CLIENT_SECRET` | Service principal secret |

## Test plan

- [ ] Rebuild devcontainer
- [ ] Verify `gcloud --version` works
- [ ] Verify `az --version` works
- [ ] Verify Google Cloud ADC is restored (check `~/.config/gcloud/application_default_credentials.json`)
- [ ] Verify Azure login works (`az account show`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)