### PR TITLE
[#327] Fix naming consistency - clarify third-party relationship to OpenClaw

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,9 @@ If you are an automated agent (including dev-major/dev-adhoc, Claude Code, Codex
 
 ## What This Project Is
 
-**clawdbot-projects** is the backend service for [OpenClaw](https://docs.openclaw.ai/) — providing project management, memory storage, and communications handling for AI agents.
+**clawdbot-projects** is a **third-party backend service** designed for integration with [OpenClaw](https://docs.openclaw.ai/) — providing project management, memory storage, and communications handling for AI agents.
+
+> This is NOT part of OpenClaw itself. We build integrations FOR OpenClaw.
 
 ### Who Uses This API
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,9 @@ This repo is intended to be maintained by both humans and automated agents. The 
 
 ## What This Project Is
 
-**clawdbot-projects** is the **project management, memory, and communications backend** for [OpenClaw](https://docs.openclaw.ai/) — the open-source AI agent gateway.
+**clawdbot-projects** is a **third-party project management, memory, and communications backend** designed for integration with [OpenClaw](https://docs.openclaw.ai/) — the open-source AI agent gateway.
+
+> This is **not** part of OpenClaw itself. We build tools and integrations FOR OpenClaw agents.
 
 ### Primary Users: OpenClaw Agents
 

--- a/README.md
+++ b/README.md
@@ -1,33 +1,66 @@
 # clawdbot-projects
 
-A Postgres-backed project + task management system intended to be used collaboratively by humans (e.g. Troy, Matty) and Clawdbot.
+A Postgres-backed project management, memory, and communications backend designed for integration with [OpenClaw](https://docs.openclaw.ai/) AI agents.
 
-## Goals
+> **Note:** OpenClaw (the AI agent gateway we integrate with) was previously known as "Clawdbot" and "Moltbot". This project name (`clawdbot-projects`) reflects the original name but now integrates with the current OpenClaw ecosystem.
+
+## What This Is
+
+**clawdbot-projects** is a **third-party backend service** that provides OpenClaw agents with:
+
+- **Project Management**: Projects, epics, initiatives, issues, and tasks with full hierarchy
+- **Memory System**: Long-term memory storage with pgvector semantic search
+- **Communications**: SMS (Twilio) and email (Postmark) integration
+- **Contact Management**: Contact storage with endpoint linking (email, phone, etc.)
+
+This is **not** part of OpenClaw itself — it's an independent project that OpenClaw agents can connect to via the `@troykelly/openclaw-projects` plugin.
+
+## Features
 
 - Projects contain initiatives → epics → issues/tasks
 - Standalone tasks not attached to a project (but still participating in dependencies)
-- Full dependency graph: blocks/blocked-by/etc across all item types
+- Full dependency graph: blocks/blocked-by across all item types
 - Multi-user roles per item (owner/assignee/watcher/etc)
 - Priorities (P0, P1, …)
 - Task types (coding/dev/admin/etc)
 - Scheduling constraints: not_before / not_after
 - Dashboard at `/dashboard` with magic-link login (15 min link), 7-day sessions
+- Semantic memory search via pgvector
+- Inbound/outbound messaging (SMS, email)
 
-## Architecture (planned)
+## Architecture
 
-- **Postgres 18** (+ extensions: TimescaleDB, PostGIS, pg_cron, pgvector, plus additional standard extensions as needed)
-- Backend API (TBD language)
-- Web dashboard
+- **Postgres 18** with extensions:
+  - pgvector (semantic search)
+  - pg_cron (scheduled hooks)
+  - TimescaleDB (time-series)
+  - PostGIS (optional, location-aware features)
+- **Node.js/TypeScript** backend API
+- Web dashboard (planned)
+- **OpenClaw Plugin** (`packages/openclaw-plugin`) for agent integration
+
+## OpenClaw Integration
+
+OpenClaw agents connect to this backend via the plugin:
+
+```bash
+npm install @troykelly/openclaw-projects
+```
+
+The plugin provides tools for memory, projects, todos, and contacts that agents can use during conversations. See [packages/openclaw-plugin/README.md](packages/openclaw-plugin/README.md) for details.
 
 ## Operations
 
 See `ops/README.md` for the production Docker Compose deployment runbook (including Traefik wiring).
 
-## Development rules
+## Development
 
-- **Issue-driven development:** every change is tied to a GitHub issue.
-- **TDD:** tests written first.
+- **Issue-driven development:** every change is tied to a GitHub issue
+- **TDD:** tests written first
+- See `CLAUDE.md` for full development guidelines
 
-## Status
+## Links
 
-Scaffolding / design stage.
+- [OpenClaw Documentation](https://docs.openclaw.ai/)
+- [Plugin Documentation](packages/openclaw-plugin/README.md)
+- [Report Issues](https://github.com/troykelly/clawdbot-projects/issues)

--- a/packages/openclaw-plugin/README.md
+++ b/packages/openclaw-plugin/README.md
@@ -1,6 +1,8 @@
 # @troykelly/openclaw-projects
 
-OpenClaw plugin for project management, memory, todos, and contacts integration with the clawdbot-projects backend.
+An [OpenClaw](https://docs.openclaw.ai/) plugin that connects agents to the clawdbot-projects backend for project management, memory, todos, and contacts.
+
+> **Note:** This is a third-party plugin — not part of OpenClaw itself. It provides OpenClaw agents with tools to interact with the [clawdbot-projects](https://github.com/troykelly/clawdbot-projects) backend service.
 
 ## Features
 


### PR DESCRIPTION
## Summary

- Updates main README.md to clearly position clawdbot-projects as a **third-party backend** for OpenClaw integration
- Adds note about OpenClaw's name history (Clawdbot → Moltbot → OpenClaw) for context
- Updates CLAUDE.md and AGENTS.md to clarify we are NOT part of OpenClaw
- Updates plugin README.md to note it's a third-party plugin

## Changes

| File | Change |
|------|--------|
| README.md | Rewritten to emphasize third-party positioning, added name history note |
| CLAUDE.md | Added "third-party" qualifier and clarification note |
| AGENTS.md | Added "third-party" qualifier and clarification note |
| packages/openclaw-plugin/README.md | Added note about being third-party plugin |

## Test plan

- [x] Documentation only - no code changes
- [x] Reviewed all changes for accuracy

Closes #327

🤖 Generated with [Claude Code](https://claude.com/claude-code)