### PR TITLE
[#311] Implement flexible secret handling (file/command/direct)

### DIFF
--- a/packages/openclaw-plugin/openclaw.plugin.json
+++ b/packages/openclaw-plugin/openclaw.plugin.json
@@ -8,16 +8,112 @@
   "configSchema": {
     "type": "object",
     "properties": {
-      "apiUrl": { "type": "string", "description": "Backend API URL" },
-      "apiKey": { "type": "string", "description": "API authentication key" },
-      "autoRecall": { "type": "boolean", "default": true },
-      "autoCapture": { "type": "boolean", "default": true },
+      "apiUrl": {
+        "type": "string",
+        "description": "Backend API URL (must be HTTPS in production)"
+      },
+      "apiKey": {
+        "type": "string",
+        "description": "API authentication key (direct value, least secure)"
+      },
+      "apiKeyFile": {
+        "type": "string",
+        "description": "Path to file containing API key (e.g., ~/.secrets/api_key)"
+      },
+      "apiKeyCommand": {
+        "type": "string",
+        "description": "Command to execute to get API key (e.g., op read op://Personal/openclaw/api_key)"
+      },
+      "twilioAccountSid": {
+        "type": "string",
+        "description": "Twilio Account SID (direct value)"
+      },
+      "twilioAccountSidFile": {
+        "type": "string",
+        "description": "Path to file containing Twilio Account SID"
+      },
+      "twilioAccountSidCommand": {
+        "type": "string",
+        "description": "Command to get Twilio Account SID"
+      },
+      "twilioAuthToken": {
+        "type": "string",
+        "description": "Twilio Auth Token (direct value)"
+      },
+      "twilioAuthTokenFile": {
+        "type": "string",
+        "description": "Path to file containing Twilio Auth Token"
+      },
+      "twilioAuthTokenCommand": {
+        "type": "string",
+        "description": "Command to get Twilio Auth Token"
+      },
+      "twilioPhoneNumber": {
+        "type": "string",
+        "description": "Twilio Phone Number (direct value)"
+      },
+      "twilioPhoneNumberFile": {
+        "type": "string",
+        "description": "Path to file containing Twilio Phone Number"
+      },
+      "twilioPhoneNumberCommand": {
+        "type": "string",
+        "description": "Command to get Twilio Phone Number"
+      },
+      "postmarkToken": {
+        "type": "string",
+        "description": "Postmark API Token (direct value)"
+      },
+      "postmarkTokenFile": {
+        "type": "string",
+        "description": "Path to file containing Postmark Token"
+      },
+      "postmarkTokenCommand": {
+        "type": "string",
+        "description": "Command to get Postmark Token"
+      },
+      "postmarkFromEmail": {
+        "type": "string",
+        "format": "email",
+        "description": "Postmark From Email address (direct value)"
+      },
+      "postmarkFromEmailFile": {
+        "type": "string",
+        "description": "Path to file containing Postmark From Email"
+      },
+      "postmarkFromEmailCommand": {
+        "type": "string",
+        "description": "Command to get Postmark From Email"
+      },
+      "secretCommandTimeout": {
+        "type": "integer",
+        "minimum": 1000,
+        "maximum": 30000,
+        "default": 5000,
+        "description": "Timeout for secret command execution in milliseconds"
+      },
+      "autoRecall": {
+        "type": "boolean",
+        "default": true,
+        "description": "Automatically recall relevant memories on conversation start"
+      },
+      "autoCapture": {
+        "type": "boolean",
+        "default": true,
+        "description": "Automatically capture important information as memories"
+      },
       "userScoping": {
         "type": "string",
         "enum": ["agent", "identity", "session"],
-        "default": "agent"
+        "default": "agent",
+        "description": "How to scope user memories"
       }
     },
-    "required": ["apiUrl", "apiKey"]
+    "required": ["apiUrl"],
+    "anyOf": [
+      { "required": ["apiKey"] },
+      { "required": ["apiKeyFile"] },
+      { "required": ["apiKeyCommand"] }
+    ]
   }
 }

--- a/packages/openclaw-plugin/src/config.ts
+++ b/packages/openclaw-plugin/src/config.ts
@@ -1,9 +1,15 @@
 /**
  * Plugin configuration schema using Zod.
  * Validates configuration at runtime to ensure type safety.
+ *
+ * Supports flexible secret handling with three patterns:
+ * 1. Direct value (e.g., apiKey: "sk-xxx")
+ * 2. File reference (e.g., apiKeyFile: "~/.secrets/api_key")
+ * 3. Command reference (e.g., apiKeyCommand: "op read op://...")
  */
 
 import { z } from 'zod'
+import { resolveSecret, type SecretConfig } from './secrets.js'
 
 /** User scoping strategies for memory isolation */
 export const UserScopingSchema = z.enum(['agent', 'identity', 'session'])
@@ -16,90 +22,208 @@ function isProduction(): boolean {
   return process.env.NODE_ENV === 'production'
 }
 
-/** Plugin configuration schema */
+/**
+ * Raw plugin configuration schema (before secret resolution).
+ * Accepts direct values, file references, or command references for secrets.
+ */
+export const RawPluginConfigSchema = z
+  .object({
+    /** Backend API URL (must be HTTPS in production) */
+    apiUrl: z
+      .string()
+      .url('apiUrl must be a valid URL')
+      .refine((url) => url.startsWith('https://') || !isProduction(), {
+        message: 'apiUrl must use HTTPS in production',
+      })
+      .describe('Backend API URL'),
+
+    // API Key - supports three patterns
+    /** API authentication key (direct value) */
+    apiKey: z.string().min(1).optional().describe('API key (direct value)'),
+    /** Path to file containing API key */
+    apiKeyFile: z.string().optional().describe('Path to API key file'),
+    /** Command to execute to get API key */
+    apiKeyCommand: z.string().optional().describe('Command to get API key'),
+
+    // Twilio Account SID
+    /** Twilio Account SID (direct value) */
+    twilioAccountSid: z.string().optional().describe('Twilio Account SID'),
+    /** Path to file containing Twilio Account SID */
+    twilioAccountSidFile: z.string().optional().describe('Path to Twilio Account SID file'),
+    /** Command to get Twilio Account SID */
+    twilioAccountSidCommand: z.string().optional().describe('Command to get Twilio Account SID'),
+
+    // Twilio Auth Token
+    /** Twilio Auth Token (direct value) */
+    twilioAuthToken: z.string().optional().describe('Twilio Auth Token'),
+    /** Path to file containing Twilio Auth Token */
+    twilioAuthTokenFile: z.string().optional().describe('Path to Twilio Auth Token file'),
+    /** Command to get Twilio Auth Token */
+    twilioAuthTokenCommand: z.string().optional().describe('Command to get Twilio Auth Token'),
+
+    // Twilio Phone Number
+    /** Twilio Phone Number (direct value) */
+    twilioPhoneNumber: z.string().optional().describe('Twilio Phone Number'),
+    /** Path to file containing Twilio Phone Number */
+    twilioPhoneNumberFile: z.string().optional().describe('Path to Twilio Phone Number file'),
+    /** Command to get Twilio Phone Number */
+    twilioPhoneNumberCommand: z.string().optional().describe('Command to get Twilio Phone Number'),
+
+    // Postmark Token
+    /** Postmark API Token (direct value) */
+    postmarkToken: z.string().optional().describe('Postmark Token'),
+    /** Path to file containing Postmark Token */
+    postmarkTokenFile: z.string().optional().describe('Path to Postmark Token file'),
+    /** Command to get Postmark Token */
+    postmarkTokenCommand: z.string().optional().describe('Command to get Postmark Token'),
+
+    // Postmark From Email
+    /** Postmark From Email address (direct value) */
+    postmarkFromEmail: z.string().email().optional().describe('Postmark From Email'),
+    /** Path to file containing Postmark From Email */
+    postmarkFromEmailFile: z.string().optional().describe('Path to Postmark From Email file'),
+    /** Command to get Postmark From Email */
+    postmarkFromEmailCommand: z.string().optional().describe('Command to get Postmark From Email'),
+
+    /** Timeout for secret command execution in milliseconds */
+    secretCommandTimeout: z
+      .number()
+      .int()
+      .min(1000, 'secretCommandTimeout must be at least 1000ms')
+      .max(30000, 'secretCommandTimeout must be at most 30000ms')
+      .default(5000)
+      .describe('Secret command timeout in ms'),
+
+    /** Automatically recall relevant memories on conversation start */
+    autoRecall: z.boolean().default(true).describe('Auto-recall memories'),
+
+    /** Automatically capture important information as memories */
+    autoCapture: z.boolean().default(true).describe('Auto-capture memories'),
+
+    /** How to scope user memories */
+    userScoping: UserScopingSchema.default('agent').describe('User scoping strategy'),
+
+    /** Maximum memories to inject in auto-recall */
+    maxRecallMemories: z
+      .number()
+      .int()
+      .min(1, 'maxRecallMemories must be at least 1')
+      .max(20, 'maxRecallMemories must be at most 20')
+      .default(5)
+      .describe('Maximum memories to inject'),
+
+    /** Minimum relevance score for auto-recall (0-1) */
+    minRecallScore: z
+      .number()
+      .min(0, 'minRecallScore must be at least 0')
+      .max(1, 'minRecallScore must be at most 1')
+      .default(0.7)
+      .describe('Minimum relevance score'),
+
+    /** Request timeout in milliseconds */
+    timeout: z
+      .number()
+      .int()
+      .min(1000, 'timeout must be at least 1000ms')
+      .max(60000, 'timeout must be at most 60000ms')
+      .default(30000)
+      .describe('Request timeout in ms'),
+
+    /** Maximum retries for failed requests */
+    maxRetries: z
+      .number()
+      .int()
+      .min(0, 'maxRetries must be at least 0')
+      .max(5, 'maxRetries must be at most 5')
+      .default(3)
+      .describe('Maximum retries'),
+
+    /** Enable debug logging (never logs secrets) */
+    debug: z.boolean().default(false).describe('Enable debug logging'),
+  })
+  .refine(
+    (data) => data.apiKey || data.apiKeyFile || data.apiKeyCommand,
+    {
+      message: 'At least one of apiKey, apiKeyFile, or apiKeyCommand is required',
+      path: ['apiKey'],
+    }
+  )
+
+export type RawPluginConfig = z.infer<typeof RawPluginConfigSchema>
+
+/**
+ * Resolved plugin configuration (after secret resolution).
+ * Contains the actual secret values ready for use.
+ */
 export const PluginConfigSchema = z.object({
-  /** Backend API URL (must be HTTPS in production) */
-  apiUrl: z
-    .string()
-    .url('apiUrl must be a valid URL')
-    .refine(
-      (url) => url.startsWith('https://') || !isProduction(),
-      { message: 'apiUrl must use HTTPS in production' }
-    )
-    .describe('Backend API URL'),
+  /** Backend API URL */
+  apiUrl: z.string().url(),
 
-  /** API authentication key */
-  apiKey: z
-    .string()
-    .min(1, 'apiKey is required')
-    .describe('API authentication key'),
+  /** Resolved API authentication key */
+  apiKey: z.string().min(1),
 
-  /** Automatically recall relevant memories on conversation start */
-  autoRecall: z.boolean().default(true).describe('Auto-recall memories'),
+  /** Resolved Twilio Account SID */
+  twilioAccountSid: z.string().optional(),
 
-  /** Automatically capture important information as memories */
-  autoCapture: z.boolean().default(true).describe('Auto-capture memories'),
+  /** Resolved Twilio Auth Token */
+  twilioAuthToken: z.string().optional(),
 
-  /** How to scope user memories */
-  userScoping: UserScopingSchema.default('agent').describe('User scoping strategy'),
+  /** Resolved Twilio Phone Number */
+  twilioPhoneNumber: z.string().optional(),
 
-  /** Maximum memories to inject in auto-recall */
-  maxRecallMemories: z
-    .number()
-    .int()
-    .min(1, 'maxRecallMemories must be at least 1')
-    .max(20, 'maxRecallMemories must be at most 20')
-    .default(5)
-    .describe('Maximum memories to inject'),
+  /** Resolved Postmark Token */
+  postmarkToken: z.string().optional(),
 
-  /** Minimum relevance score for auto-recall (0-1) */
-  minRecallScore: z
-    .number()
-    .min(0, 'minRecallScore must be at least 0')
-    .max(1, 'minRecallScore must be at most 1')
-    .default(0.7)
-    .describe('Minimum relevance score'),
+  /** Resolved Postmark From Email */
+  postmarkFromEmail: z.string().email().optional(),
 
-  /** Request timeout in milliseconds */
-  timeout: z
-    .number()
-    .int()
-    .min(1000, 'timeout must be at least 1000ms')
-    .max(60000, 'timeout must be at most 60000ms')
-    .default(30000)
-    .describe('Request timeout in ms'),
+  /** Secret command timeout */
+  secretCommandTimeout: z.number().int().default(5000),
 
-  /** Maximum retries for failed requests */
-  maxRetries: z
-    .number()
-    .int()
-    .min(0, 'maxRetries must be at least 0')
-    .max(5, 'maxRetries must be at most 5')
-    .default(3)
-    .describe('Maximum retries'),
+  /** Auto-recall memories */
+  autoRecall: z.boolean().default(true),
 
-  /** Enable debug logging (never logs secrets) */
-  debug: z.boolean().default(false).describe('Enable debug logging'),
+  /** Auto-capture memories */
+  autoCapture: z.boolean().default(true),
+
+  /** User scoping strategy */
+  userScoping: UserScopingSchema.default('agent'),
+
+  /** Maximum memories to inject */
+  maxRecallMemories: z.number().int().default(5),
+
+  /** Minimum relevance score */
+  minRecallScore: z.number().default(0.7),
+
+  /** Request timeout in ms */
+  timeout: z.number().int().default(30000),
+
+  /** Maximum retries */
+  maxRetries: z.number().int().default(3),
+
+  /** Enable debug logging */
+  debug: z.boolean().default(false),
 })
 
 export type PluginConfig = z.infer<typeof PluginConfigSchema>
 
 /**
- * Validates plugin configuration.
+ * Validates raw plugin configuration (before secret resolution).
+ * Use this for initial config validation before resolving secrets.
  * Throws a ZodError if validation fails.
  */
-export function validateConfig(config: unknown): PluginConfig {
-  return PluginConfigSchema.parse(config)
+export function validateRawConfig(config: unknown): RawPluginConfig {
+  return RawPluginConfigSchema.parse(config)
 }
 
 /**
- * Safely validates configuration without throwing.
+ * Safely validates raw configuration without throwing.
  * Returns a result object with either the validated config or errors.
  */
-export function safeValidateConfig(
+export function safeValidateRawConfig(
   config: unknown
-): { success: true; data: PluginConfig } | { success: false; errors: z.ZodIssue[] } {
-  const result = PluginConfigSchema.safeParse(config)
+): { success: true; data: RawPluginConfig } | { success: false; errors: z.ZodIssue[] } {
+  const result = RawPluginConfigSchema.safeParse(config)
   if (result.success) {
     return { success: true, data: result.data }
   }
@@ -107,10 +231,118 @@ export function safeValidateConfig(
 }
 
 /**
- * Create a safe-to-log version of config (apiKey redacted).
+ * Validates resolved plugin configuration (after secret resolution).
+ * Throws a ZodError if validation fails.
  */
-export function redactConfig(
-  config: PluginConfig
-): Omit<PluginConfig, 'apiKey'> & { apiKey: string } {
-  return { ...config, apiKey: '[REDACTED]' }
+export function validateConfig(config: unknown): PluginConfig {
+  return PluginConfigSchema.parse(config)
+}
+
+/**
+ * Safely validates resolved configuration without throwing.
+ * Returns a result object with either the validated config or errors.
+ *
+ * Note: This validates raw config for backwards compatibility.
+ * Use safeValidateRawConfig for explicit raw config validation.
+ */
+export function safeValidateConfig(
+  config: unknown
+): { success: true; data: RawPluginConfig } | { success: false; errors: z.ZodIssue[] } {
+  return safeValidateRawConfig(config)
+}
+
+/** Secret fields that should be redacted in logs */
+const SECRET_FIELDS = [
+  'apiKey',
+  'twilioAccountSid',
+  'twilioAuthToken',
+  'twilioPhoneNumber',
+  'postmarkToken',
+] as const
+
+/**
+ * Create a safe-to-log version of config with secrets redacted.
+ */
+export function redactConfig(config: PluginConfig): PluginConfig {
+  const redacted = { ...config }
+  for (const field of SECRET_FIELDS) {
+    if (redacted[field]) {
+      // Type assertion needed because we're setting string fields to '[REDACTED]'
+      ;(redacted as unknown as Record<string, string>)[field] = '[REDACTED]'
+    }
+  }
+  return redacted
+}
+
+/**
+ * Builds a SecretConfig from the raw config for a given secret name.
+ */
+function buildSecretConfig(
+  rawConfig: RawPluginConfig,
+  secretName: keyof RawPluginConfig,
+  timeout: number
+): SecretConfig {
+  const direct = rawConfig[secretName] as string | undefined
+  const file = rawConfig[`${secretName}File` as keyof RawPluginConfig] as string | undefined
+  const command = rawConfig[`${secretName}Command` as keyof RawPluginConfig] as string | undefined
+
+  return {
+    direct,
+    file,
+    command,
+    commandTimeout: timeout,
+  }
+}
+
+/**
+ * Resolves all secrets in a raw config to produce a resolved config.
+ *
+ * @param rawConfig - The raw plugin configuration with secret references
+ * @returns The resolved plugin configuration with actual secret values
+ * @throws If required secrets cannot be resolved
+ */
+export async function resolveConfigSecrets(rawConfig: RawPluginConfig): Promise<PluginConfig> {
+  const timeout = rawConfig.secretCommandTimeout
+
+  // Resolve API key (required)
+  const apiKey = await resolveSecret(
+    buildSecretConfig(rawConfig, 'apiKey', timeout),
+    'apiKey'
+  )
+  if (!apiKey) {
+    throw new Error('Failed to resolve API key from config')
+  }
+
+  // Resolve optional secrets in parallel
+  const [twilioAccountSid, twilioAuthToken, twilioPhoneNumber, postmarkToken, postmarkFromEmail] =
+    await Promise.all([
+      resolveSecret(buildSecretConfig(rawConfig, 'twilioAccountSid', timeout), 'twilioAccountSid'),
+      resolveSecret(buildSecretConfig(rawConfig, 'twilioAuthToken', timeout), 'twilioAuthToken'),
+      resolveSecret(buildSecretConfig(rawConfig, 'twilioPhoneNumber', timeout), 'twilioPhoneNumber'),
+      resolveSecret(buildSecretConfig(rawConfig, 'postmarkToken', timeout), 'postmarkToken'),
+      resolveSecret(buildSecretConfig(rawConfig, 'postmarkFromEmail', timeout), 'postmarkFromEmail'),
+    ])
+
+  // Build the resolved config
+  const resolvedConfig: PluginConfig = {
+    apiUrl: rawConfig.apiUrl,
+    apiKey,
+    twilioAccountSid,
+    twilioAuthToken,
+    twilioPhoneNumber,
+    postmarkToken,
+    postmarkFromEmail,
+    secretCommandTimeout: timeout,
+    autoRecall: rawConfig.autoRecall,
+    autoCapture: rawConfig.autoCapture,
+    userScoping: rawConfig.userScoping,
+    maxRecallMemories: rawConfig.maxRecallMemories,
+    minRecallScore: rawConfig.minRecallScore,
+    timeout: rawConfig.timeout,
+    maxRetries: rawConfig.maxRetries,
+    debug: rawConfig.debug,
+  }
+
+  // Validate the resolved config
+  return validateConfig(resolvedConfig)
 }

--- a/packages/openclaw-plugin/src/secrets.ts
+++ b/packages/openclaw-plugin/src/secrets.ts
@@ -1,0 +1,197 @@
+/**
+ * Flexible secret resolution module.
+ *
+ * Supports three methods for loading secrets (in priority order):
+ * 1. Command execution (e.g., 1Password CLI: `op read op://...`)
+ * 2. File reference (e.g., ~/.secrets/api_key)
+ * 3. Direct value (least secure, for development only)
+ *
+ * Security note: Command execution intentionally uses execSync with shell
+ * because the command comes from trusted configuration, not user input.
+ * This is required to support shell commands like `op read 'op://...'`
+ * for secret managers.
+ *
+ * @module secrets
+ */
+
+import { execSync } from 'node:child_process'
+import { readFileSync, existsSync, statSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+/** Default timeout for command execution in milliseconds */
+const DEFAULT_COMMAND_TIMEOUT = 5000
+
+/** Secret resolution configuration */
+export interface SecretConfig {
+  /** Direct secret value (least secure, for development) */
+  direct?: string
+  /** Path to file containing the secret */
+  file?: string
+  /** Command to execute to retrieve the secret */
+  command?: string
+  /** Timeout for command execution in milliseconds (default: 5000) */
+  commandTimeout?: number
+}
+
+/** Cache for resolved secrets */
+const secretCache = new Map<string, string>()
+
+/**
+ * Expands ~ to the user's home directory.
+ */
+function expandTilde(filePath: string): string {
+  if (filePath.startsWith('~/')) {
+    return join(homedir(), filePath.slice(2))
+  }
+  if (filePath === '~') {
+    return homedir()
+  }
+  return filePath
+}
+
+/**
+ * Checks file permissions and warns if world-readable.
+ */
+function checkFilePermissions(filePath: string): void {
+  try {
+    const stats = statSync(filePath)
+    const mode = stats.mode & 0o777
+    if (mode & 0o004) {
+      console.warn(
+        `[Secrets] Warning: Secret file ${filePath} is world-readable (mode ${mode.toString(8)}). ` +
+          'Consider restricting permissions with: chmod 600 ' +
+          filePath
+      )
+    }
+  } catch {
+    // Ignore permission check errors - file read will fail if there's an issue
+  }
+}
+
+/**
+ * Resolves a secret from command execution.
+ *
+ * Security note: This uses execSync intentionally because:
+ * 1. The command comes from plugin configuration set by system administrators
+ * 2. It must support shell commands like `op read 'op://...'` for secret managers
+ * 3. This is NOT user input - it's trusted configuration
+ */
+function resolveFromCommand(command: string, timeout: number): string {
+  try {
+    // eslint-disable-next-line security/detect-child-process
+    const result = execSync(command, {
+      encoding: 'utf-8',
+      timeout,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    return result.trim()
+  } catch (error) {
+    const err = error as Error & { killed?: boolean }
+    if (err.killed) {
+      throw new Error(`Secret command timed out after ${timeout}ms`)
+    }
+    throw new Error(`Secret command failed: ${err.message}`)
+  }
+}
+
+/**
+ * Resolves a secret from a file.
+ */
+function resolveFromFile(filePath: string): string {
+  const expandedPath = expandTilde(filePath)
+
+  if (!existsSync(expandedPath)) {
+    throw new Error(`Secret file does not exist: ${expandedPath}`)
+  }
+
+  checkFilePermissions(expandedPath)
+
+  try {
+    const content = readFileSync(expandedPath, 'utf-8')
+    return content.trim()
+  } catch (error) {
+    throw new Error(`Failed to read secret file: ${(error as Error).message}`)
+  }
+}
+
+/**
+ * Resolves a secret using the configured method.
+ *
+ * Priority order (highest first):
+ * 1. Command - Execute shell command and use output
+ * 2. File - Read from file path
+ * 3. Direct - Use direct value from config
+ *
+ * @param config - Secret configuration
+ * @param cacheKey - Optional key to cache the resolved secret
+ * @returns The resolved secret, or undefined if not configured
+ */
+export async function resolveSecret(
+  config: SecretConfig,
+  cacheKey?: string
+): Promise<string | undefined> {
+  // Check cache first
+  if (cacheKey && secretCache.has(cacheKey)) {
+    return secretCache.get(cacheKey)
+  }
+
+  let resolved: string | undefined
+
+  // Priority 1: Command
+  if (config.command && config.command.trim()) {
+    const timeout = config.commandTimeout ?? DEFAULT_COMMAND_TIMEOUT
+    resolved = resolveFromCommand(config.command, timeout)
+  }
+  // Priority 2: File
+  else if (config.file && config.file.trim()) {
+    resolved = resolveFromFile(config.file)
+  }
+  // Priority 3: Direct
+  else if (config.direct !== undefined) {
+    const trimmed = config.direct.trim()
+    resolved = trimmed.length > 0 ? trimmed : undefined
+  }
+
+  // Cache if resolved and cacheKey provided
+  if (resolved && cacheKey) {
+    secretCache.set(cacheKey, resolved)
+  }
+
+  return resolved
+}
+
+/**
+ * Resolves multiple secrets in parallel.
+ *
+ * @param configs - Map of secret names to configurations
+ * @returns Map of secret names to resolved values
+ */
+export async function resolveSecrets(
+  configs: Record<string, SecretConfig>
+): Promise<Record<string, string | undefined>> {
+  const entries = Object.entries(configs)
+  const results = await Promise.all(
+    entries.map(async ([key, config]) => {
+      const value = await resolveSecret(config, key)
+      return [key, value] as const
+    })
+  )
+
+  return Object.fromEntries(results)
+}
+
+/**
+ * Clears the secret cache.
+ * Call this when configuration is reloaded or on SIGHUP.
+ */
+export function clearSecretCache(): void {
+  secretCache.clear()
+}
+
+/**
+ * Clears a specific secret from the cache.
+ */
+export function clearCachedSecret(key: string): void {
+  secretCache.delete(key)
+}

--- a/packages/openclaw-plugin/tests/package-structure.test.ts
+++ b/packages/openclaw-plugin/tests/package-structure.test.ts
@@ -83,11 +83,16 @@ describe('Package Structure', () => {
       expect(manifest).toHaveProperty('configSchema')
     })
 
-    it('should have configSchema with required apiUrl and apiKey', () => {
+    it('should have configSchema with required apiUrl and flexible apiKey', () => {
       const manifestPath = join(packageRoot, 'openclaw.plugin.json')
       const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8'))
       expect(manifest.configSchema.required).toContain('apiUrl')
-      expect(manifest.configSchema.required).toContain('apiKey')
+      // apiKey is now flexible - uses anyOf with apiKey, apiKeyFile, or apiKeyCommand
+      expect(manifest.configSchema.anyOf).toBeDefined()
+      expect(manifest.configSchema.anyOf).toHaveLength(3)
+      expect(manifest.configSchema.anyOf[0].required).toContain('apiKey')
+      expect(manifest.configSchema.anyOf[1].required).toContain('apiKeyFile')
+      expect(manifest.configSchema.anyOf[2].required).toContain('apiKeyCommand')
     })
   })
 


### PR DESCRIPTION
## Summary

Implements three-tier secret resolution for all plugin credentials, following the same pattern used in the backend (`src/api/auth/secret.ts`):

- **Direct values** (e.g., `apiKey: "sk-xxx"`) - least secure, for development
- **File references** (e.g., `apiKeyFile: "~/.secrets/api_key"`) - secure
- **Command references** (e.g., `apiKeyCommand: "op read op://..."`) - most secure

### Changes

- **New `src/secrets.ts` module**
  - `resolveSecret()` - resolves a single secret from config
  - `resolveSecrets()` - resolves multiple secrets in parallel  
  - Caching to avoid repeated file reads/command executions
  - Warning when secret files are world-readable
  - Support for `~` expansion in file paths

- **Updated `src/config.ts`**
  - `RawPluginConfig` schema for pre-resolution config
  - `PluginConfig` schema for resolved config
  - `resolveConfigSecrets()` async function to resolve all secrets
  - `secretCommandTimeout` option (default 5s, max 30s)

- **Updated `src/index.ts`**
  - `registerAsync()` for flexible secret handling
  - `register()` kept for backwards compatibility (direct values only)

- **Updated `openclaw.plugin.json`**
  - Added all new config fields with descriptions
  - Uses `anyOf` to require at least one apiKey variant

### Secrets Supported

| Secret | Direct | File | Command |
|--------|--------|------|---------|
| API Key | `apiKey` | `apiKeyFile` | `apiKeyCommand` |
| Twilio Account SID | `twilioAccountSid` | `twilioAccountSidFile` | `twilioAccountSidCommand` |
| Twilio Auth Token | `twilioAuthToken` | `twilioAuthTokenFile` | `twilioAuthTokenCommand` |
| Twilio Phone Number | `twilioPhoneNumber` | `twilioPhoneNumberFile` | `twilioPhoneNumberCommand` |
| Postmark Token | `postmarkToken` | `postmarkTokenFile` | `postmarkTokenCommand` |
| Postmark From Email | `postmarkFromEmail` | `postmarkFromEmailFile` | `postmarkFromEmailCommand` |

## Test plan

- [x] All existing tests pass (526 tests)
- [x] New tests for secret resolution (27 tests in secrets.test.ts)
- [x] New tests for config resolution (7 tests in config.test.ts)
- [x] Typecheck passes
- [x] Lint passes
- [x] Build succeeds

Closes #311

🤖 Generated with [Claude Code](https://claude.com/claude-code)