### PR TITLE
[#313] Add SMS send tool to plugin

### DIFF
--- a/packages/openclaw-plugin/src/tools/index.ts
+++ b/packages/openclaw-plugin/src/tools/index.ts
@@ -97,6 +97,16 @@ export {
   type ContactToolOptions,
 } from './contacts.js'
 
+// SMS tools
+export {
+  createSmsSendTool,
+  SmsSendParamsSchema,
+  type SmsSendParams,
+  type SmsSendTool,
+  type SmsSendResult,
+  type SmsSendToolOptions,
+} from './sms-send.js'
+
 /** Tool factory types */
 export interface ToolFactoryOptions {
   // Common options for tool factories

--- a/packages/openclaw-plugin/src/tools/sms-send.ts
+++ b/packages/openclaw-plugin/src/tools/sms-send.ts
@@ -1,0 +1,192 @@
+/**
+ * sms_send tool implementation.
+ * Sends SMS messages via Twilio.
+ */
+
+import { z } from 'zod'
+import type { ApiClient } from '../api-client.js'
+import type { Logger } from '../logger.js'
+import type { PluginConfig } from '../config.js'
+
+/** E.164 phone number regex */
+const E164_REGEX = /^\+[1-9]\d{1,14}$/
+
+/** Maximum SMS body length (Twilio standard) */
+const MAX_BODY_LENGTH = 1600
+
+/** Parameters for sms_send tool */
+export const SmsSendParamsSchema = z.object({
+  to: z
+    .string()
+    .regex(E164_REGEX, 'Phone number must be in E.164 format (e.g., +15551234567)'),
+  body: z
+    .string()
+    .min(1, 'Message body cannot be empty')
+    .max(MAX_BODY_LENGTH, `Message body must be ${MAX_BODY_LENGTH} characters or less`),
+  idempotencyKey: z.string().optional(),
+})
+export type SmsSendParams = z.infer<typeof SmsSendParamsSchema>
+
+/** SMS send response from API */
+interface SmsSendApiResponse {
+  messageId: string
+  threadId?: string
+  status: 'queued' | 'sending' | 'sent' | 'failed' | 'delivered'
+}
+
+/** Successful tool result */
+export interface SmsSendSuccess {
+  success: true
+  data: {
+    content: string
+    details: {
+      messageId: string
+      threadId?: string
+      status: string
+      userId: string
+    }
+  }
+}
+
+/** Failed tool result */
+export interface SmsSendFailure {
+  success: false
+  error: string
+}
+
+/** Tool result type */
+export type SmsSendResult = SmsSendSuccess | SmsSendFailure
+
+/** Tool configuration */
+export interface SmsSendToolOptions {
+  client: ApiClient
+  logger: Logger
+  config: PluginConfig
+  userId: string
+}
+
+/** Tool definition */
+export interface SmsSendTool {
+  name: string
+  description: string
+  parameters: typeof SmsSendParamsSchema
+  execute: (params: SmsSendParams) => Promise<SmsSendResult>
+}
+
+/**
+ * Sanitize phone numbers from error messages for privacy.
+ */
+function sanitizeErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    // Remove phone numbers from error messages
+    const sanitized = error.message.replace(/\+\d{1,15}/g, '[phone]')
+    return sanitized
+  }
+  return 'An unexpected error occurred while sending SMS.'
+}
+
+/**
+ * Check if Twilio is configured.
+ */
+function isTwilioConfigured(config: PluginConfig): boolean {
+  return !!(config.twilioAccountSid && config.twilioAuthToken && config.twilioPhoneNumber)
+}
+
+/**
+ * Creates the sms_send tool.
+ */
+export function createSmsSendTool(options: SmsSendToolOptions): SmsSendTool {
+  const { client, logger, config, userId } = options
+
+  return {
+    name: 'sms_send',
+    description:
+      'Send an SMS message to a phone number. Use when you need to notify someone via text message. ' +
+      'Requires the recipient phone number in E.164 format (e.g., +15551234567).',
+    parameters: SmsSendParamsSchema,
+
+    async execute(params: SmsSendParams): Promise<SmsSendResult> {
+      // Validate parameters
+      const parseResult = SmsSendParamsSchema.safeParse(params)
+      if (!parseResult.success) {
+        const errorMessage = parseResult.error.errors
+          .map((e) => `${e.path.join('.')}: ${e.message}`)
+          .join(', ')
+        return { success: false, error: errorMessage }
+      }
+
+      const { to, body, idempotencyKey } = parseResult.data
+
+      // Check Twilio configuration
+      if (!isTwilioConfigured(config)) {
+        return {
+          success: false,
+          error: 'Twilio is not configured. Please configure Twilio credentials.',
+        }
+      }
+
+      // Log invocation (without phone number for privacy)
+      logger.info('sms_send invoked', {
+        userId,
+        bodyLength: body.length,
+        hasIdempotencyKey: !!idempotencyKey,
+      })
+
+      try {
+        // Call API
+        const response = await client.post<SmsSendApiResponse>(
+          '/api/twilio/sms/send',
+          {
+            to,
+            body,
+            idempotencyKey,
+          },
+          { userId }
+        )
+
+        if (!response.success) {
+          logger.error('sms_send API error', {
+            userId,
+            status: response.error.status,
+            code: response.error.code,
+          })
+          return {
+            success: false,
+            error: response.error.message || 'Failed to send SMS',
+          }
+        }
+
+        const { messageId, threadId, status } = response.data
+
+        logger.debug('sms_send completed', {
+          userId,
+          messageId,
+          status,
+        })
+
+        return {
+          success: true,
+          data: {
+            content: `SMS sent successfully (ID: ${messageId}, Status: ${status})`,
+            details: {
+              messageId,
+              threadId,
+              status,
+              userId,
+            },
+          },
+        }
+      } catch (error) {
+        logger.error('sms_send failed', {
+          userId,
+          error: error instanceof Error ? error.message : String(error),
+        })
+
+        return {
+          success: false,
+          error: sanitizeErrorMessage(error),
+        }
+      }
+    },
+  }
+}

--- a/packages/openclaw-plugin/tests/register-openclaw.test.ts
+++ b/packages/openclaw-plugin/tests/register-openclaw.test.ts
@@ -51,10 +51,10 @@ describe('OpenClaw 2026 API Registration', () => {
   })
 
   describe('registration', () => {
-    it('should register all 12 tools', async () => {
+    it('should register all 13 tools', async () => {
       await registerOpenClaw(mockApi)
 
-      expect(registeredTools).toHaveLength(12)
+      expect(registeredTools).toHaveLength(13)
       const toolNames = registeredTools.map((t) => t.name)
       expect(toolNames).toContain('memory_recall')
       expect(toolNames).toContain('memory_store')
@@ -68,6 +68,7 @@ describe('OpenClaw 2026 API Registration', () => {
       expect(toolNames).toContain('contact_search')
       expect(toolNames).toContain('contact_get')
       expect(toolNames).toContain('contact_create')
+      expect(toolNames).toContain('sms_send')
     })
 
     it('should register beforeAgentStart hook when autoRecall is true', async () => {
@@ -107,7 +108,7 @@ describe('OpenClaw 2026 API Registration', () => {
       expect(mockApi.logger.info).toHaveBeenCalledWith(
         'OpenClaw Projects plugin registered',
         expect.objectContaining({
-          toolCount: 12,
+          toolCount: 13,
         })
       )
     })
@@ -161,6 +162,7 @@ describe('OpenClaw 2026 API Registration', () => {
       expect(schemas.contactSearch).toBeDefined()
       expect(schemas.contactGet).toBeDefined()
       expect(schemas.contactCreate).toBeDefined()
+      expect(schemas.smsSend).toBeDefined()
     })
 
     it('should have valid schema structure', () => {

--- a/packages/openclaw-plugin/tests/tools/sms-send.test.ts
+++ b/packages/openclaw-plugin/tests/tools/sms-send.test.ts
@@ -1,0 +1,357 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { createSmsSendTool, SmsSendParamsSchema } from '../../src/tools/sms-send.js'
+import type { ApiClient } from '../../src/api-client.js'
+import type { Logger } from '../../src/logger.js'
+import type { PluginConfig } from '../../src/config.js'
+
+describe('sms_send tool', () => {
+  let mockClient: ApiClient
+  let mockLogger: Logger
+  let mockConfig: PluginConfig
+  const userId = 'test-user-id'
+
+  beforeEach(() => {
+    mockClient = {
+      get: vi.fn(),
+      post: vi.fn(),
+      put: vi.fn(),
+      patch: vi.fn(),
+      delete: vi.fn(),
+    } as unknown as ApiClient
+
+    mockLogger = {
+      info: vi.fn(),
+      debug: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    } as unknown as Logger
+
+    mockConfig = {
+      apiUrl: 'https://api.example.com',
+      apiKey: 'test-key',
+      twilioAccountSid: 'ACtest123',
+      twilioAuthToken: 'test-token',
+      twilioPhoneNumber: '+15551234567',
+      autoRecall: true,
+      autoCapture: true,
+      userScoping: 'agent',
+      maxRecallMemories: 5,
+      minRecallScore: 0.7,
+      timeout: 30000,
+      maxRetries: 3,
+      secretCommandTimeout: 5000,
+      debug: false,
+    }
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('SmsSendParamsSchema', () => {
+    it('should accept valid parameters', () => {
+      const result = SmsSendParamsSchema.safeParse({
+        to: '+15559876543',
+        body: 'Hello, this is a test message!',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('should accept parameters with idempotencyKey', () => {
+      const result = SmsSendParamsSchema.safeParse({
+        to: '+15559876543',
+        body: 'Test message',
+        idempotencyKey: 'unique-key-123',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('should reject missing to', () => {
+      const result = SmsSendParamsSchema.safeParse({
+        body: 'Test message',
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('should reject missing body', () => {
+      const result = SmsSendParamsSchema.safeParse({
+        to: '+15559876543',
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('should reject empty body', () => {
+      const result = SmsSendParamsSchema.safeParse({
+        to: '+15559876543',
+        body: '',
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('should reject body over 1600 characters', () => {
+      const result = SmsSendParamsSchema.safeParse({
+        to: '+15559876543',
+        body: 'a'.repeat(1601),
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('should reject invalid phone number format', () => {
+      const result = SmsSendParamsSchema.safeParse({
+        to: '555-123-4567', // Not E.164 format
+        body: 'Test message',
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('should accept international E.164 numbers', () => {
+      const result = SmsSendParamsSchema.safeParse({
+        to: '+447911123456', // UK number
+        body: 'Test message',
+      })
+      expect(result.success).toBe(true)
+    })
+  })
+
+  describe('createSmsSendTool', () => {
+    it('should create tool with correct name', () => {
+      const tool = createSmsSendTool({
+        client: mockClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId,
+      })
+      expect(tool.name).toBe('sms_send')
+    })
+
+    it('should have a description', () => {
+      const tool = createSmsSendTool({
+        client: mockClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId,
+      })
+      expect(tool.description).toBeDefined()
+      expect(tool.description.length).toBeGreaterThan(10)
+    })
+
+    it('should have parameters schema', () => {
+      const tool = createSmsSendTool({
+        client: mockClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId,
+      })
+      expect(tool.parameters).toBeDefined()
+    })
+  })
+
+  describe('execute', () => {
+    it('should send SMS successfully', async () => {
+      vi.mocked(mockClient.post).mockResolvedValue({
+        success: true,
+        data: {
+          messageId: 'SM123456',
+          threadId: 'TH789',
+          status: 'queued',
+        },
+      })
+
+      const tool = createSmsSendTool({
+        client: mockClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId,
+      })
+
+      const result = await tool.execute({
+        to: '+15559876543',
+        body: 'Hello, this is a test!',
+      })
+
+      expect(result.success).toBe(true)
+      expect(result.data).toBeDefined()
+      expect(result.data?.details?.messageId).toBe('SM123456')
+      expect(result.data?.details?.status).toBe('queued')
+    })
+
+    it('should call API with correct parameters', async () => {
+      vi.mocked(mockClient.post).mockResolvedValue({
+        success: true,
+        data: { messageId: 'SM123', status: 'queued' },
+      })
+
+      const tool = createSmsSendTool({
+        client: mockClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId,
+      })
+
+      await tool.execute({
+        to: '+15559876543',
+        body: 'Test message',
+        idempotencyKey: 'key-123',
+      })
+
+      expect(mockClient.post).toHaveBeenCalledWith(
+        '/api/twilio/sms/send',
+        {
+          to: '+15559876543',
+          body: 'Test message',
+          idempotencyKey: 'key-123',
+        },
+        { userId }
+      )
+    })
+
+    it('should handle API errors', async () => {
+      vi.mocked(mockClient.post).mockResolvedValue({
+        success: false,
+        error: {
+          status: 400,
+          code: 'INVALID_PHONE',
+          message: 'Invalid phone number format',
+        },
+      })
+
+      const tool = createSmsSendTool({
+        client: mockClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId,
+      })
+
+      const result = await tool.execute({
+        to: '+15559876543',
+        body: 'Test message',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('Invalid phone number format')
+    })
+
+    it('should handle network errors', async () => {
+      vi.mocked(mockClient.post).mockRejectedValue(new Error('Network error'))
+
+      const tool = createSmsSendTool({
+        client: mockClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId,
+      })
+
+      const result = await tool.execute({
+        to: '+15559876543',
+        body: 'Test message',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBeDefined()
+    })
+
+    it('should validate parameters before sending', async () => {
+      const tool = createSmsSendTool({
+        client: mockClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId,
+      })
+
+      const result = await tool.execute({
+        to: 'invalid-phone',
+        body: 'Test message',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('to')
+      expect(mockClient.post).not.toHaveBeenCalled()
+    })
+
+    it('should validate body length before sending', async () => {
+      const tool = createSmsSendTool({
+        client: mockClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId,
+      })
+
+      const result = await tool.execute({
+        to: '+15559876543',
+        body: 'a'.repeat(1601),
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('1600')
+      expect(mockClient.post).not.toHaveBeenCalled()
+    })
+
+    it('should warn when Twilio is not configured', async () => {
+      const configWithoutTwilio = {
+        ...mockConfig,
+        twilioAccountSid: undefined,
+        twilioAuthToken: undefined,
+        twilioPhoneNumber: undefined,
+      }
+
+      const tool = createSmsSendTool({
+        client: mockClient,
+        logger: mockLogger,
+        config: configWithoutTwilio,
+        userId,
+      })
+
+      const result = await tool.execute({
+        to: '+15559876543',
+        body: 'Test message',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('Twilio')
+    })
+
+    it('should log successful sends', async () => {
+      vi.mocked(mockClient.post).mockResolvedValue({
+        success: true,
+        data: { messageId: 'SM123', status: 'queued' },
+      })
+
+      const tool = createSmsSendTool({
+        client: mockClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId,
+      })
+
+      await tool.execute({
+        to: '+15559876543',
+        body: 'Test message',
+      })
+
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        'sms_send invoked',
+        expect.objectContaining({ userId })
+      )
+    })
+
+    it('should not log phone number in errors', async () => {
+      vi.mocked(mockClient.post).mockRejectedValue(new Error('Connection failed to +15559876543'))
+
+      const tool = createSmsSendTool({
+        client: mockClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId,
+      })
+
+      const result = await tool.execute({
+        to: '+15559876543',
+        body: 'Test message',
+      })
+
+      expect(result.success).toBe(false)
+      // Error message should be sanitized
+      expect(result.error).not.toContain('+15559876543')
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Adds `sms_send` tool for sending SMS messages via Twilio
- Includes E.164 phone number validation
- Implements 1600 character body limit per Twilio standard
- Supports idempotency keys for duplicate prevention
- Privacy-aware error sanitization (removes phone numbers from errors)
- Comprehensive test coverage (20 tests)

## Test plan
- [x] Unit tests for SmsSendParamsSchema validation
- [x] Unit tests for tool creation and properties
- [x] Unit tests for successful SMS send execution
- [x] Unit tests for API error handling
- [x] Unit tests for network error handling
- [x] Unit tests for Twilio configuration validation
- [x] Unit tests for phone number sanitization in errors
- [x] Typecheck passes
- [x] Build passes

Closes #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)