### PR TITLE
[#314] Add email send tool to plugin

### DIFF
--- a/packages/openclaw-plugin/src/tools/email-send.ts
+++ b/packages/openclaw-plugin/src/tools/email-send.ts
@@ -1,0 +1,203 @@
+/**
+ * email_send tool implementation.
+ * Sends email messages via Postmark.
+ */
+
+import { z } from 'zod'
+import type { ApiClient } from '../api-client.js'
+import type { Logger } from '../logger.js'
+import type { PluginConfig } from '../config.js'
+
+/** Email validation regex (simplified, allowing most valid emails) */
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+/** Maximum subject line length (RFC 2822 recommends 78, but we allow up to 998) */
+const MAX_SUBJECT_LENGTH = 998
+
+/** Parameters for email_send tool */
+export const EmailSendParamsSchema = z.object({
+  to: z
+    .string()
+    .regex(EMAIL_REGEX, 'Invalid email address format'),
+  subject: z
+    .string()
+    .min(1, 'Subject cannot be empty')
+    .max(MAX_SUBJECT_LENGTH, `Subject must be ${MAX_SUBJECT_LENGTH} characters or less`),
+  body: z
+    .string()
+    .min(1, 'Email body cannot be empty'),
+  htmlBody: z.string().optional(),
+  threadId: z.string().optional(),
+  idempotencyKey: z.string().optional(),
+})
+export type EmailSendParams = z.infer<typeof EmailSendParamsSchema>
+
+/** Email send response from API */
+interface EmailSendApiResponse {
+  messageId: string
+  threadId?: string
+  status: 'queued' | 'sending' | 'sent' | 'failed' | 'delivered'
+}
+
+/** Successful tool result */
+export interface EmailSendSuccess {
+  success: true
+  data: {
+    content: string
+    details: {
+      messageId: string
+      threadId?: string
+      status: string
+      userId: string
+    }
+  }
+}
+
+/** Failed tool result */
+export interface EmailSendFailure {
+  success: false
+  error: string
+}
+
+/** Tool result type */
+export type EmailSendResult = EmailSendSuccess | EmailSendFailure
+
+/** Tool configuration */
+export interface EmailSendToolOptions {
+  client: ApiClient
+  logger: Logger
+  config: PluginConfig
+  userId: string
+}
+
+/** Tool definition */
+export interface EmailSendTool {
+  name: string
+  description: string
+  parameters: typeof EmailSendParamsSchema
+  execute: (params: EmailSendParams) => Promise<EmailSendResult>
+}
+
+/**
+ * Sanitize email addresses from error messages for privacy.
+ */
+function sanitizeErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    // Remove email addresses from error messages
+    const sanitized = error.message.replace(/[^\s@]+@[^\s@]+\.[^\s@]+/g, '[email]')
+    return sanitized
+  }
+  return 'An unexpected error occurred while sending email.'
+}
+
+/**
+ * Check if Postmark is configured.
+ */
+function isPostmarkConfigured(config: PluginConfig): boolean {
+  return !!(config.postmarkToken && config.postmarkFromEmail)
+}
+
+/**
+ * Creates the email_send tool.
+ */
+export function createEmailSendTool(options: EmailSendToolOptions): EmailSendTool {
+  const { client, logger, config, userId } = options
+
+  return {
+    name: 'email_send',
+    description:
+      'Send an email message. Use when you need to communicate via email. ' +
+      'Requires the recipient email address, subject, and body.',
+    parameters: EmailSendParamsSchema,
+
+    async execute(params: EmailSendParams): Promise<EmailSendResult> {
+      // Validate parameters
+      const parseResult = EmailSendParamsSchema.safeParse(params)
+      if (!parseResult.success) {
+        const errorMessage = parseResult.error.errors
+          .map((e) => `${e.path.join('.')}: ${e.message}`)
+          .join(', ')
+        return { success: false, error: errorMessage }
+      }
+
+      const { to, subject, body, htmlBody, threadId, idempotencyKey } = parseResult.data
+
+      // Check Postmark configuration
+      if (!isPostmarkConfigured(config)) {
+        return {
+          success: false,
+          error: 'Postmark is not configured. Please configure Postmark credentials.',
+        }
+      }
+
+      // Log invocation (without email address for privacy)
+      logger.info('email_send invoked', {
+        userId,
+        subjectLength: subject.length,
+        bodyLength: body.length,
+        hasHtmlBody: !!htmlBody,
+        hasThreadId: !!threadId,
+        hasIdempotencyKey: !!idempotencyKey,
+      })
+
+      try {
+        // Call API
+        const response = await client.post<EmailSendApiResponse>(
+          '/api/postmark/email/send',
+          {
+            to,
+            subject,
+            body,
+            htmlBody,
+            threadId,
+            idempotencyKey,
+          },
+          { userId }
+        )
+
+        if (!response.success) {
+          logger.error('email_send API error', {
+            userId,
+            status: response.error.status,
+            code: response.error.code,
+          })
+          return {
+            success: false,
+            error: response.error.message || 'Failed to send email',
+          }
+        }
+
+        const { messageId, threadId: responseThreadId, status } = response.data
+
+        logger.debug('email_send completed', {
+          userId,
+          messageId,
+          status,
+        })
+
+        return {
+          success: true,
+          data: {
+            content: `Email sent successfully (ID: ${messageId}, Status: ${status})`,
+            details: {
+              messageId,
+              threadId: responseThreadId,
+              status,
+              userId,
+            },
+          },
+        }
+      } catch (error) {
+        logger.error('email_send failed', {
+          userId,
+          error: error instanceof Error ? error.message : String(error),
+        })
+
+        return {
+          success: false,
+          error: sanitizeErrorMessage(error),
+        }
+      }
+    },
+  }
+}

--- a/packages/openclaw-plugin/src/tools/index.ts
+++ b/packages/openclaw-plugin/src/tools/index.ts
@@ -107,6 +107,16 @@ export {
   type SmsSendToolOptions,
 } from './sms-send.js'
 
+// Email tools
+export {
+  createEmailSendTool,
+  EmailSendParamsSchema,
+  type EmailSendParams,
+  type EmailSendTool,
+  type EmailSendResult,
+  type EmailSendToolOptions,
+} from './email-send.js'
+
 /** Tool factory types */
 export interface ToolFactoryOptions {
   // Common options for tool factories

--- a/packages/openclaw-plugin/tests/register-openclaw.test.ts
+++ b/packages/openclaw-plugin/tests/register-openclaw.test.ts
@@ -51,10 +51,10 @@ describe('OpenClaw 2026 API Registration', () => {
   })
 
   describe('registration', () => {
-    it('should register all 13 tools', async () => {
+    it('should register all 14 tools', async () => {
       await registerOpenClaw(mockApi)
 
-      expect(registeredTools).toHaveLength(13)
+      expect(registeredTools).toHaveLength(14)
       const toolNames = registeredTools.map((t) => t.name)
       expect(toolNames).toContain('memory_recall')
       expect(toolNames).toContain('memory_store')
@@ -69,6 +69,7 @@ describe('OpenClaw 2026 API Registration', () => {
       expect(toolNames).toContain('contact_get')
       expect(toolNames).toContain('contact_create')
       expect(toolNames).toContain('sms_send')
+      expect(toolNames).toContain('email_send')
     })
 
     it('should register beforeAgentStart hook when autoRecall is true', async () => {
@@ -108,7 +109,7 @@ describe('OpenClaw 2026 API Registration', () => {
       expect(mockApi.logger.info).toHaveBeenCalledWith(
         'OpenClaw Projects plugin registered',
         expect.objectContaining({
-          toolCount: 13,
+          toolCount: 14,
         })
       )
     })
@@ -163,6 +164,7 @@ describe('OpenClaw 2026 API Registration', () => {
       expect(schemas.contactGet).toBeDefined()
       expect(schemas.contactCreate).toBeDefined()
       expect(schemas.smsSend).toBeDefined()
+      expect(schemas.emailSend).toBeDefined()
     })
 
     it('should have valid schema structure', () => {

--- a/packages/openclaw-plugin/tests/tools/email-send.test.ts
+++ b/packages/openclaw-plugin/tests/tools/email-send.test.ts
@@ -1,0 +1,435 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { createEmailSendTool, EmailSendParamsSchema } from '../../src/tools/email-send.js'
+import type { ApiClient } from '../../src/api-client.js'
+import type { Logger } from '../../src/logger.js'
+import type { PluginConfig } from '../../src/config.js'
+
+describe('email_send tool', () => {
+  let mockClient: ApiClient
+  let mockLogger: Logger
+  let mockConfig: PluginConfig
+  const userId = 'test-user-id'
+
+  beforeEach(() => {
+    mockClient = {
+      get: vi.fn(),
+      post: vi.fn(),
+      put: vi.fn(),
+      patch: vi.fn(),
+      delete: vi.fn(),
+    } as unknown as ApiClient
+
+    mockLogger = {
+      info: vi.fn(),
+      debug: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    } as unknown as Logger
+
+    mockConfig = {
+      apiUrl: 'https://api.example.com',
+      apiKey: 'test-key',
+      twilioAccountSid: 'ACtest123',
+      twilioAuthToken: 'test-token',
+      twilioPhoneNumber: '+15551234567',
+      postmarkToken: 'pm-test-token',
+      postmarkFromEmail: 'sender@example.com',
+      autoRecall: true,
+      autoCapture: true,
+      userScoping: 'agent',
+      maxRecallMemories: 5,
+      minRecallScore: 0.7,
+      timeout: 30000,
+      maxRetries: 3,
+      secretCommandTimeout: 5000,
+      debug: false,
+    }
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('EmailSendParamsSchema', () => {
+    it('should accept valid parameters', () => {
+      const result = EmailSendParamsSchema.safeParse({
+        to: 'recipient@example.com',
+        subject: 'Test Subject',
+        body: 'This is a test email body.',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('should accept parameters with optional fields', () => {
+      const result = EmailSendParamsSchema.safeParse({
+        to: 'recipient@example.com',
+        subject: 'Test Subject',
+        body: 'This is a test email body.',
+        htmlBody: '<p>This is a test email body.</p>',
+        threadId: 'thread-123',
+        idempotencyKey: 'unique-key-123',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('should reject missing to', () => {
+      const result = EmailSendParamsSchema.safeParse({
+        subject: 'Test Subject',
+        body: 'Test body',
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('should reject missing subject', () => {
+      const result = EmailSendParamsSchema.safeParse({
+        to: 'recipient@example.com',
+        body: 'Test body',
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('should reject missing body', () => {
+      const result = EmailSendParamsSchema.safeParse({
+        to: 'recipient@example.com',
+        subject: 'Test Subject',
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('should reject empty subject', () => {
+      const result = EmailSendParamsSchema.safeParse({
+        to: 'recipient@example.com',
+        subject: '',
+        body: 'Test body',
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('should reject empty body', () => {
+      const result = EmailSendParamsSchema.safeParse({
+        to: 'recipient@example.com',
+        subject: 'Test Subject',
+        body: '',
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('should reject invalid email format', () => {
+      const result = EmailSendParamsSchema.safeParse({
+        to: 'invalid-email',
+        subject: 'Test Subject',
+        body: 'Test body',
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('should accept various valid email formats', () => {
+      const validEmails = [
+        'simple@example.com',
+        'user.name@example.com',
+        'user+tag@example.com',
+        'user@subdomain.example.com',
+      ]
+
+      for (const email of validEmails) {
+        const result = EmailSendParamsSchema.safeParse({
+          to: email,
+          subject: 'Test',
+          body: 'Test',
+        })
+        expect(result.success, `Expected ${email} to be valid`).toBe(true)
+      }
+    })
+
+    it('should reject subject over 998 characters', () => {
+      const result = EmailSendParamsSchema.safeParse({
+        to: 'recipient@example.com',
+        subject: 'a'.repeat(999),
+        body: 'Test body',
+      })
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('createEmailSendTool', () => {
+    it('should create tool with correct name', () => {
+      const tool = createEmailSendTool({
+        client: mockClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId,
+      })
+      expect(tool.name).toBe('email_send')
+    })
+
+    it('should have a description', () => {
+      const tool = createEmailSendTool({
+        client: mockClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId,
+      })
+      expect(tool.description).toBeDefined()
+      expect(tool.description.length).toBeGreaterThan(10)
+    })
+
+    it('should have parameters schema', () => {
+      const tool = createEmailSendTool({
+        client: mockClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId,
+      })
+      expect(tool.parameters).toBeDefined()
+    })
+  })
+
+  describe('execute', () => {
+    it('should send email successfully', async () => {
+      vi.mocked(mockClient.post).mockResolvedValue({
+        success: true,
+        data: {
+          messageId: 'MSG123456',
+          threadId: 'TH789',
+          status: 'sent',
+        },
+      })
+
+      const tool = createEmailSendTool({
+        client: mockClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId,
+      })
+
+      const result = await tool.execute({
+        to: 'recipient@example.com',
+        subject: 'Test Subject',
+        body: 'Test email body',
+      })
+
+      expect(result.success).toBe(true)
+      expect(result.data).toBeDefined()
+      expect(result.data?.details?.messageId).toBe('MSG123456')
+      expect(result.data?.details?.status).toBe('sent')
+    })
+
+    it('should call API with correct parameters', async () => {
+      vi.mocked(mockClient.post).mockResolvedValue({
+        success: true,
+        data: { messageId: 'MSG123', status: 'sent' },
+      })
+
+      const tool = createEmailSendTool({
+        client: mockClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId,
+      })
+
+      await tool.execute({
+        to: 'recipient@example.com',
+        subject: 'Test Subject',
+        body: 'Test message',
+        htmlBody: '<p>Test message</p>',
+        threadId: 'thread-123',
+        idempotencyKey: 'key-123',
+      })
+
+      expect(mockClient.post).toHaveBeenCalledWith(
+        '/api/postmark/email/send',
+        {
+          to: 'recipient@example.com',
+          subject: 'Test Subject',
+          body: 'Test message',
+          htmlBody: '<p>Test message</p>',
+          threadId: 'thread-123',
+          idempotencyKey: 'key-123',
+        },
+        { userId }
+      )
+    })
+
+    it('should handle API errors', async () => {
+      vi.mocked(mockClient.post).mockResolvedValue({
+        success: false,
+        error: {
+          status: 400,
+          code: 'INVALID_EMAIL',
+          message: 'Invalid recipient email address',
+        },
+      })
+
+      const tool = createEmailSendTool({
+        client: mockClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId,
+      })
+
+      const result = await tool.execute({
+        to: 'recipient@example.com',
+        subject: 'Test Subject',
+        body: 'Test message',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('Invalid recipient email address')
+    })
+
+    it('should handle network errors', async () => {
+      vi.mocked(mockClient.post).mockRejectedValue(new Error('Network error'))
+
+      const tool = createEmailSendTool({
+        client: mockClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId,
+      })
+
+      const result = await tool.execute({
+        to: 'recipient@example.com',
+        subject: 'Test Subject',
+        body: 'Test message',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBeDefined()
+    })
+
+    it('should validate parameters before sending', async () => {
+      const tool = createEmailSendTool({
+        client: mockClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId,
+      })
+
+      const result = await tool.execute({
+        to: 'invalid-email',
+        subject: 'Test Subject',
+        body: 'Test message',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('to')
+      expect(mockClient.post).not.toHaveBeenCalled()
+    })
+
+    it('should validate subject before sending', async () => {
+      const tool = createEmailSendTool({
+        client: mockClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId,
+      })
+
+      const result = await tool.execute({
+        to: 'recipient@example.com',
+        subject: '',
+        body: 'Test message',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('subject')
+      expect(mockClient.post).not.toHaveBeenCalled()
+    })
+
+    it('should warn when Postmark is not configured', async () => {
+      const configWithoutPostmark = {
+        ...mockConfig,
+        postmarkToken: undefined,
+        postmarkFromEmail: undefined,
+      }
+
+      const tool = createEmailSendTool({
+        client: mockClient,
+        logger: mockLogger,
+        config: configWithoutPostmark,
+        userId,
+      })
+
+      const result = await tool.execute({
+        to: 'recipient@example.com',
+        subject: 'Test Subject',
+        body: 'Test message',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('Postmark')
+    })
+
+    it('should log successful sends', async () => {
+      vi.mocked(mockClient.post).mockResolvedValue({
+        success: true,
+        data: { messageId: 'MSG123', status: 'sent' },
+      })
+
+      const tool = createEmailSendTool({
+        client: mockClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId,
+      })
+
+      await tool.execute({
+        to: 'recipient@example.com',
+        subject: 'Test Subject',
+        body: 'Test message',
+      })
+
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        'email_send invoked',
+        expect.objectContaining({ userId })
+      )
+    })
+
+    it('should not log email address in errors', async () => {
+      vi.mocked(mockClient.post).mockRejectedValue(new Error('Failed to send to recipient@example.com'))
+
+      const tool = createEmailSendTool({
+        client: mockClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId,
+      })
+
+      const result = await tool.execute({
+        to: 'recipient@example.com',
+        subject: 'Test Subject',
+        body: 'Test message',
+      })
+
+      expect(result.success).toBe(false)
+      // Error message should be sanitized
+      expect(result.error).not.toContain('recipient@example.com')
+    })
+
+    it('should handle bounce errors gracefully', async () => {
+      vi.mocked(mockClient.post).mockResolvedValue({
+        success: false,
+        error: {
+          status: 422,
+          code: 'HARD_BOUNCE',
+          message: 'The recipient email address has bounced',
+        },
+      })
+
+      const tool = createEmailSendTool({
+        client: mockClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId,
+      })
+
+      const result = await tool.execute({
+        to: 'bounced@example.com',
+        subject: 'Test Subject',
+        body: 'Test message',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('bounced')
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Adds `email_send` tool for sending emails via Postmark
- Email address validation
- Subject and body validation (subject max 998 chars)
- Optional HTML body support
- Thread ID support for email replies
- Idempotency key support for duplicate prevention
- Privacy-aware error sanitization (removes email addresses from errors)
- Comprehensive test coverage (23 tests)

## Test plan
- [x] Unit tests for EmailSendParamsSchema validation
- [x] Unit tests for tool creation and properties
- [x] Unit tests for successful email send execution
- [x] Unit tests for API error handling
- [x] Unit tests for network error handling
- [x] Unit tests for Postmark configuration validation
- [x] Unit tests for email address sanitization in errors
- [x] Unit tests for bounce error handling
- [x] Typecheck passes
- [x] Build passes

Closes #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)