### PR TITLE
[#315] Add message search tool to plugin

### DIFF
--- a/packages/openclaw-plugin/src/tools/index.ts
+++ b/packages/openclaw-plugin/src/tools/index.ts
@@ -117,6 +117,16 @@ export {
   type EmailSendToolOptions,
 } from './email-send.js'
 
+// Message search tools
+export {
+  createMessageSearchTool,
+  MessageSearchParamsSchema,
+  type MessageSearchParams,
+  type MessageSearchTool,
+  type MessageSearchResult,
+  type MessageSearchToolOptions,
+} from './message-search.js'
+
 /** Tool factory types */
 export interface ToolFactoryOptions {
   // Common options for tool factories

--- a/packages/openclaw-plugin/src/tools/message-search.ts
+++ b/packages/openclaw-plugin/src/tools/message-search.ts
@@ -1,0 +1,244 @@
+/**
+ * message_search tool implementation.
+ * Searches message history semantically using pgvector embeddings.
+ */
+
+import { z } from 'zod'
+import type { ApiClient } from '../api-client.js'
+import type { Logger } from '../logger.js'
+import type { PluginConfig } from '../config.js'
+
+/** Channel type enum */
+const ChannelType = z.enum(['sms', 'email', 'all'])
+type ChannelType = z.infer<typeof ChannelType>
+
+/** Maximum results limit */
+const MAX_LIMIT = 100
+
+/** Default results limit */
+const DEFAULT_LIMIT = 10
+
+/** Parameters for message_search tool */
+export const MessageSearchParamsSchema = z.object({
+  query: z
+    .string()
+    .min(1, 'Search query cannot be empty'),
+  channel: ChannelType.default('all'),
+  contactId: z.string().uuid().optional(),
+  limit: z
+    .number()
+    .int()
+    .min(1, 'Limit must be at least 1')
+    .max(MAX_LIMIT, `Limit must be ${MAX_LIMIT} or less`)
+    .default(DEFAULT_LIMIT),
+  includeThread: z.boolean().default(false),
+})
+export type MessageSearchParams = z.infer<typeof MessageSearchParamsSchema>
+
+/** Message search result from API */
+interface MessageSearchApiResult {
+  id: string
+  body: string
+  direction: 'inbound' | 'outbound'
+  channel: string
+  contactName?: string
+  timestamp: string
+  score: number
+  threadId?: string
+  threadMessages?: Array<{
+    id: string
+    body: string
+    direction: 'inbound' | 'outbound'
+    timestamp: string
+  }>
+}
+
+/** API response for message search */
+interface MessageSearchApiResponse {
+  results: MessageSearchApiResult[]
+  total: number
+}
+
+/** Message result for tool output */
+interface MessageResult {
+  id: string
+  body: string
+  direction: 'inbound' | 'outbound'
+  channel: string
+  contactName?: string
+  timestamp: string
+  similarity: number
+  threadId?: string
+  threadContext?: Array<{
+    id: string
+    body: string
+    direction: string
+    timestamp: string
+  }>
+}
+
+/** Successful tool result */
+export interface MessageSearchSuccess {
+  success: true
+  data: {
+    content: string
+    details: {
+      messages: MessageResult[]
+      total: number
+      userId: string
+    }
+  }
+}
+
+/** Failed tool result */
+export interface MessageSearchFailure {
+  success: false
+  error: string
+}
+
+/** Tool result type */
+export type MessageSearchResult = MessageSearchSuccess | MessageSearchFailure
+
+/** Tool configuration */
+export interface MessageSearchToolOptions {
+  client: ApiClient
+  logger: Logger
+  config: PluginConfig
+  userId: string
+}
+
+/** Tool definition */
+export interface MessageSearchTool {
+  name: string
+  description: string
+  parameters: typeof MessageSearchParamsSchema
+  execute: (params: MessageSearchParams) => Promise<MessageSearchResult>
+}
+
+/**
+ * Creates the message_search tool.
+ */
+export function createMessageSearchTool(options: MessageSearchToolOptions): MessageSearchTool {
+  const { client, logger, userId } = options
+
+  return {
+    name: 'message_search',
+    description:
+      'Search message history semantically. Use when you need to find past conversations, ' +
+      'messages about specific topics, or communications with contacts. ' +
+      'Supports filtering by channel (SMS/email) and contact.',
+    parameters: MessageSearchParamsSchema,
+
+    async execute(params: MessageSearchParams): Promise<MessageSearchResult> {
+      // Validate parameters
+      const parseResult = MessageSearchParamsSchema.safeParse(params)
+      if (!parseResult.success) {
+        const errorMessage = parseResult.error.errors
+          .map((e) => `${e.path.join('.')}: ${e.message}`)
+          .join(', ')
+        return { success: false, error: errorMessage }
+      }
+
+      const { query, channel, contactId, limit, includeThread } = parseResult.data
+
+      // Log invocation
+      logger.info('message_search invoked', {
+        userId,
+        queryLength: query.length,
+        channel,
+        hasContactId: !!contactId,
+        limit,
+        includeThread,
+      })
+
+      try {
+        // Build query parameters
+        const queryParams = new URLSearchParams()
+        queryParams.set('q', query)
+        queryParams.set('types', 'message')
+        queryParams.set('limit', String(limit))
+
+        if (channel !== 'all') {
+          queryParams.set('channel', channel)
+        }
+        if (contactId) {
+          queryParams.set('contactId', contactId)
+        }
+        if (includeThread) {
+          queryParams.set('includeThread', 'true')
+        }
+
+        // Call API
+        const response = await client.get<MessageSearchApiResponse>(
+          `/api/search?${queryParams}`,
+          { userId }
+        )
+
+        if (!response.success) {
+          logger.error('message_search API error', {
+            userId,
+            status: response.error.status,
+            code: response.error.code,
+          })
+          return {
+            success: false,
+            error: response.error.message || 'Failed to search messages',
+          }
+        }
+
+        const { results, total } = response.data
+
+        // Transform results
+        const messages: MessageResult[] = results.map((r) => ({
+          id: r.id,
+          body: r.body,
+          direction: r.direction,
+          channel: r.channel,
+          contactName: r.contactName,
+          timestamp: r.timestamp,
+          similarity: r.score,
+          threadId: r.threadId,
+          threadContext: r.threadMessages,
+        }))
+
+        logger.debug('message_search completed', {
+          userId,
+          resultCount: messages.length,
+          total,
+        })
+
+        // Format content for display
+        const content = messages.length > 0
+          ? messages.map((m) => {
+              const prefix = m.direction === 'inbound' ? '←' : '→'
+              const contact = m.contactName || 'Unknown'
+              const similarity = `(${Math.round(m.similarity * 100)}%)`
+              return `${prefix} [${m.channel}] ${contact} ${similarity}: ${m.body.substring(0, 100)}${m.body.length > 100 ? '...' : ''}`
+            }).join('\n')
+          : 'No messages found matching your query.'
+
+        return {
+          success: true,
+          data: {
+            content,
+            details: {
+              messages,
+              total,
+              userId,
+            },
+          },
+        }
+      } catch (error) {
+        logger.error('message_search failed', {
+          userId,
+          error: error instanceof Error ? error.message : String(error),
+        })
+
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : 'An unexpected error occurred while searching messages.',
+        }
+      }
+    },
+  }
+}

--- a/packages/openclaw-plugin/tests/register-openclaw.test.ts
+++ b/packages/openclaw-plugin/tests/register-openclaw.test.ts
@@ -51,10 +51,10 @@ describe('OpenClaw 2026 API Registration', () => {
   })
 
   describe('registration', () => {
-    it('should register all 14 tools', async () => {
+    it('should register all 15 tools', async () => {
       await registerOpenClaw(mockApi)
 
-      expect(registeredTools).toHaveLength(14)
+      expect(registeredTools).toHaveLength(15)
       const toolNames = registeredTools.map((t) => t.name)
       expect(toolNames).toContain('memory_recall')
       expect(toolNames).toContain('memory_store')
@@ -70,6 +70,7 @@ describe('OpenClaw 2026 API Registration', () => {
       expect(toolNames).toContain('contact_create')
       expect(toolNames).toContain('sms_send')
       expect(toolNames).toContain('email_send')
+      expect(toolNames).toContain('message_search')
     })
 
     it('should register beforeAgentStart hook when autoRecall is true', async () => {
@@ -109,7 +110,7 @@ describe('OpenClaw 2026 API Registration', () => {
       expect(mockApi.logger.info).toHaveBeenCalledWith(
         'OpenClaw Projects plugin registered',
         expect.objectContaining({
-          toolCount: 14,
+          toolCount: 15,
         })
       )
     })
@@ -165,6 +166,7 @@ describe('OpenClaw 2026 API Registration', () => {
       expect(schemas.contactCreate).toBeDefined()
       expect(schemas.smsSend).toBeDefined()
       expect(schemas.emailSend).toBeDefined()
+      expect(schemas.messageSearch).toBeDefined()
     })
 
     it('should have valid schema structure', () => {

--- a/packages/openclaw-plugin/tests/tools/message-search.test.ts
+++ b/packages/openclaw-plugin/tests/tools/message-search.test.ts
@@ -1,0 +1,409 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { createMessageSearchTool, MessageSearchParamsSchema } from '../../src/tools/message-search.js'
+import type { ApiClient } from '../../src/api-client.js'
+import type { Logger } from '../../src/logger.js'
+import type { PluginConfig } from '../../src/config.js'
+
+describe('message_search tool', () => {
+  let mockClient: ApiClient
+  let mockLogger: Logger
+  let mockConfig: PluginConfig
+  const userId = 'test-user-id'
+
+  beforeEach(() => {
+    mockClient = {
+      get: vi.fn(),
+      post: vi.fn(),
+      put: vi.fn(),
+      patch: vi.fn(),
+      delete: vi.fn(),
+    } as unknown as ApiClient
+
+    mockLogger = {
+      info: vi.fn(),
+      debug: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    } as unknown as Logger
+
+    mockConfig = {
+      apiUrl: 'https://api.example.com',
+      apiKey: 'test-key',
+      autoRecall: true,
+      autoCapture: true,
+      userScoping: 'agent',
+      maxRecallMemories: 5,
+      minRecallScore: 0.7,
+      timeout: 30000,
+      maxRetries: 3,
+      secretCommandTimeout: 5000,
+      debug: false,
+    }
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('MessageSearchParamsSchema', () => {
+    it('should accept valid query-only parameters', () => {
+      const result = MessageSearchParamsSchema.safeParse({
+        query: 'What did John say about the meeting?',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('should accept parameters with all optional fields', () => {
+      const result = MessageSearchParamsSchema.safeParse({
+        query: 'invoice discussion',
+        channel: 'email',
+        contactId: '123e4567-e89b-12d3-a456-426614174000',
+        limit: 20,
+        includeThread: true,
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('should reject missing query', () => {
+      const result = MessageSearchParamsSchema.safeParse({
+        channel: 'sms',
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('should reject empty query', () => {
+      const result = MessageSearchParamsSchema.safeParse({
+        query: '',
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('should reject invalid channel', () => {
+      const result = MessageSearchParamsSchema.safeParse({
+        query: 'test',
+        channel: 'invalid',
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('should accept valid channel values', () => {
+      const channels = ['sms', 'email', 'all']
+      for (const channel of channels) {
+        const result = MessageSearchParamsSchema.safeParse({
+          query: 'test',
+          channel,
+        })
+        expect(result.success, `Expected channel '${channel}' to be valid`).toBe(true)
+      }
+    })
+
+    it('should reject limit below 1', () => {
+      const result = MessageSearchParamsSchema.safeParse({
+        query: 'test',
+        limit: 0,
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('should reject limit above 100', () => {
+      const result = MessageSearchParamsSchema.safeParse({
+        query: 'test',
+        limit: 101,
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('should use default limit of 10 when not provided', () => {
+      const result = MessageSearchParamsSchema.safeParse({
+        query: 'test',
+      })
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.limit).toBe(10)
+      }
+    })
+
+    it('should use default channel of all when not provided', () => {
+      const result = MessageSearchParamsSchema.safeParse({
+        query: 'test',
+      })
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.channel).toBe('all')
+      }
+    })
+  })
+
+  describe('createMessageSearchTool', () => {
+    it('should create tool with correct name', () => {
+      const tool = createMessageSearchTool({
+        client: mockClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId,
+      })
+      expect(tool.name).toBe('message_search')
+    })
+
+    it('should have a description', () => {
+      const tool = createMessageSearchTool({
+        client: mockClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId,
+      })
+      expect(tool.description).toBeDefined()
+      expect(tool.description.length).toBeGreaterThan(10)
+    })
+
+    it('should have parameters schema', () => {
+      const tool = createMessageSearchTool({
+        client: mockClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId,
+      })
+      expect(tool.parameters).toBeDefined()
+    })
+  })
+
+  describe('execute', () => {
+    it('should search messages successfully', async () => {
+      vi.mocked(mockClient.get).mockResolvedValue({
+        success: true,
+        data: {
+          results: [
+            {
+              id: 'msg-1',
+              body: 'Let me check the invoice',
+              direction: 'inbound',
+              channel: 'email',
+              contactName: 'John Smith',
+              timestamp: '2024-01-15T10:30:00Z',
+              score: 0.95,
+            },
+            {
+              id: 'msg-2',
+              body: 'Invoice #1234 has been paid',
+              direction: 'outbound',
+              channel: 'email',
+              contactName: 'John Smith',
+              timestamp: '2024-01-15T10:35:00Z',
+              score: 0.87,
+            },
+          ],
+          total: 2,
+        },
+      })
+
+      const tool = createMessageSearchTool({
+        client: mockClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId,
+      })
+
+      const result = await tool.execute({
+        query: 'invoice',
+      })
+
+      expect(result.success).toBe(true)
+      expect(result.data).toBeDefined()
+      expect(result.data?.details?.messages).toHaveLength(2)
+      expect(result.data?.details?.total).toBe(2)
+    })
+
+    it('should call API with correct parameters', async () => {
+      vi.mocked(mockClient.get).mockResolvedValue({
+        success: true,
+        data: { results: [], total: 0 },
+      })
+
+      const tool = createMessageSearchTool({
+        client: mockClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId,
+      })
+
+      await tool.execute({
+        query: 'meeting notes',
+        channel: 'sms',
+        contactId: '123e4567-e89b-12d3-a456-426614174000',
+        limit: 15,
+      })
+
+      expect(mockClient.get).toHaveBeenCalledWith(
+        expect.stringContaining('/api/search'),
+        { userId }
+      )
+      const callUrl = (mockClient.get as ReturnType<typeof vi.fn>).mock.calls[0][0] as string
+      expect(callUrl).toContain('q=meeting+notes')
+      expect(callUrl).toContain('types=message')
+      expect(callUrl).toContain('channel=sms')
+      expect(callUrl).toContain('contactId=123e4567-e89b-12d3-a456-426614174000')
+      expect(callUrl).toContain('limit=15')
+    })
+
+    it('should not send channel when set to all', async () => {
+      vi.mocked(mockClient.get).mockResolvedValue({
+        success: true,
+        data: { results: [], total: 0 },
+      })
+
+      const tool = createMessageSearchTool({
+        client: mockClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId,
+      })
+
+      await tool.execute({
+        query: 'test',
+        channel: 'all',
+      })
+
+      const callUrl = (mockClient.get as ReturnType<typeof vi.fn>).mock.calls[0][0] as string
+      expect(callUrl).not.toContain('channel=')
+    })
+
+    it('should handle API errors', async () => {
+      vi.mocked(mockClient.get).mockResolvedValue({
+        success: false,
+        error: {
+          status: 500,
+          code: 'INTERNAL_ERROR',
+          message: 'Search service unavailable',
+        },
+      })
+
+      const tool = createMessageSearchTool({
+        client: mockClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId,
+      })
+
+      const result = await tool.execute({
+        query: 'test',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('Search service unavailable')
+    })
+
+    it('should handle network errors', async () => {
+      vi.mocked(mockClient.get).mockRejectedValue(new Error('Network error'))
+
+      const tool = createMessageSearchTool({
+        client: mockClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId,
+      })
+
+      const result = await tool.execute({
+        query: 'test',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBeDefined()
+    })
+
+    it('should validate parameters before searching', async () => {
+      const tool = createMessageSearchTool({
+        client: mockClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId,
+      })
+
+      const result = await tool.execute({
+        query: '',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('query')
+      expect(mockClient.get).not.toHaveBeenCalled()
+    })
+
+    it('should return empty results gracefully', async () => {
+      vi.mocked(mockClient.get).mockResolvedValue({
+        success: true,
+        data: { results: [], total: 0 },
+      })
+
+      const tool = createMessageSearchTool({
+        client: mockClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId,
+      })
+
+      const result = await tool.execute({
+        query: 'nonexistent message',
+      })
+
+      expect(result.success).toBe(true)
+      expect(result.data?.content).toContain('No messages found')
+      expect(result.data?.details?.messages).toHaveLength(0)
+    })
+
+    it('should log search invocation', async () => {
+      vi.mocked(mockClient.get).mockResolvedValue({
+        success: true,
+        data: { results: [], total: 0 },
+      })
+
+      const tool = createMessageSearchTool({
+        client: mockClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId,
+      })
+
+      await tool.execute({
+        query: 'test search',
+      })
+
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        'message_search invoked',
+        expect.objectContaining({ userId })
+      )
+    })
+
+    it('should format results with similarity scores', async () => {
+      vi.mocked(mockClient.get).mockResolvedValue({
+        success: true,
+        data: {
+          results: [
+            {
+              id: 'msg-1',
+              body: 'Test message content',
+              direction: 'inbound',
+              channel: 'sms',
+              contactName: 'Test Contact',
+              timestamp: '2024-01-15T10:30:00Z',
+              score: 0.92,
+            },
+          ],
+          total: 1,
+        },
+      })
+
+      const tool = createMessageSearchTool({
+        client: mockClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId,
+      })
+
+      const result = await tool.execute({
+        query: 'test',
+      })
+
+      expect(result.success).toBe(true)
+      expect(result.data?.details?.messages[0]?.similarity).toBe(0.92)
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Adds `message_search` tool for semantic search over message history
- Uses pgvector embeddings for semantic matching
- Channel filtering (SMS/email/all)
- Contact ID filtering
- Configurable result limit (1-100, default 10)
- Optional thread context inclusion
- Returns similarity scores for ranking
- Comprehensive test coverage (22 tests)

## Test plan
- [x] Unit tests for MessageSearchParamsSchema validation
- [x] Unit tests for tool creation and properties
- [x] Unit tests for successful message search
- [x] Unit tests for API error handling
- [x] Unit tests for network error handling
- [x] Unit tests for empty results
- [x] Unit tests for channel filtering
- [x] Unit tests for similarity score formatting
- [x] Typecheck passes
- [x] Build passes

Closes #315

🤖 Generated with [Claude Code](https://claude.com/claude-code)