### PR TITLE
[#316] Add thread list/get tools to plugin

### DIFF
--- a/packages/openclaw-plugin/src/tools/index.ts
+++ b/packages/openclaw-plugin/src/tools/index.ts
@@ -127,6 +127,21 @@ export {
   type MessageSearchToolOptions,
 } from './message-search.js'
 
+// Thread tools
+export {
+  createThreadListTool,
+  createThreadGetTool,
+  ThreadListParamsSchema,
+  ThreadGetParamsSchema,
+  type ThreadListParams,
+  type ThreadGetParams,
+  type ThreadListTool,
+  type ThreadGetTool,
+  type ThreadListResult,
+  type ThreadGetResult,
+  type ThreadToolOptions,
+} from './threads.js'
+
 /** Tool factory types */
 export interface ToolFactoryOptions {
   // Common options for tool factories

--- a/packages/openclaw-plugin/src/tools/threads.ts
+++ b/packages/openclaw-plugin/src/tools/threads.ts
@@ -1,0 +1,355 @@
+/**
+ * Thread tools implementation.
+ * Provides thread_list and thread_get tools for viewing message threads.
+ */
+
+import { z } from 'zod'
+import type { ApiClient } from '../api-client.js'
+import type { Logger } from '../logger.js'
+import type { PluginConfig } from '../config.js'
+
+/** Channel type enum */
+const ChannelType = z.enum(['sms', 'email'])
+type ChannelType = z.infer<typeof ChannelType>
+
+/** Default and max limits */
+const DEFAULT_LIST_LIMIT = 20
+const MAX_LIST_LIMIT = 100
+const DEFAULT_MESSAGE_LIMIT = 50
+const MAX_MESSAGE_LIMIT = 200
+
+// =====================================================
+// Thread List Tool
+// =====================================================
+
+/** Parameters for thread_list tool */
+export const ThreadListParamsSchema = z.object({
+  channel: ChannelType.optional(),
+  contactId: z.string().uuid().optional(),
+  limit: z
+    .number()
+    .int()
+    .min(1, 'Limit must be at least 1')
+    .max(MAX_LIST_LIMIT, `Limit must be ${MAX_LIST_LIMIT} or less`)
+    .default(DEFAULT_LIST_LIMIT),
+})
+export type ThreadListParams = z.infer<typeof ThreadListParamsSchema>
+
+/** Thread in list response */
+interface ThreadListItem {
+  id: string
+  channel: string
+  contactName?: string
+  endpointValue: string
+  messageCount: number
+  lastMessageAt?: string
+}
+
+/** API response for thread list */
+interface ThreadListApiResponse {
+  threads: ThreadListItem[]
+  total: number
+}
+
+/** Successful tool result */
+export interface ThreadListSuccess {
+  success: true
+  data: {
+    content: string
+    details: {
+      threads: ThreadListItem[]
+      total: number
+      userId: string
+    }
+  }
+}
+
+/** Failed tool result */
+export interface ThreadListFailure {
+  success: false
+  error: string
+}
+
+export type ThreadListResult = ThreadListSuccess | ThreadListFailure
+
+/** Tool configuration */
+export interface ThreadToolOptions {
+  client: ApiClient
+  logger: Logger
+  config: PluginConfig
+  userId: string
+}
+
+/** Tool definition */
+export interface ThreadListTool {
+  name: string
+  description: string
+  parameters: typeof ThreadListParamsSchema
+  execute: (params: ThreadListParams) => Promise<ThreadListResult>
+}
+
+/**
+ * Creates the thread_list tool.
+ */
+export function createThreadListTool(options: ThreadToolOptions): ThreadListTool {
+  const { client, logger, userId } = options
+
+  return {
+    name: 'thread_list',
+    description:
+      'List message threads (conversations). Use to see recent conversations with contacts. ' +
+      'Can filter by channel (SMS/email) or contact.',
+    parameters: ThreadListParamsSchema,
+
+    async execute(params: ThreadListParams): Promise<ThreadListResult> {
+      // Validate parameters
+      const parseResult = ThreadListParamsSchema.safeParse(params)
+      if (!parseResult.success) {
+        const errorMessage = parseResult.error.errors
+          .map((e) => `${e.path.join('.')}: ${e.message}`)
+          .join(', ')
+        return { success: false, error: errorMessage }
+      }
+
+      const { channel, contactId, limit } = parseResult.data
+
+      logger.info('thread_list invoked', {
+        userId,
+        channel,
+        hasContactId: !!contactId,
+        limit,
+      })
+
+      try {
+        // Build query parameters
+        const queryParams = new URLSearchParams()
+        queryParams.set('limit', String(limit))
+
+        if (channel) {
+          queryParams.set('channel', channel)
+        }
+        if (contactId) {
+          queryParams.set('contactId', contactId)
+        }
+
+        const response = await client.get<ThreadListApiResponse>(
+          `/api/threads?${queryParams}`,
+          { userId }
+        )
+
+        if (!response.success) {
+          logger.error('thread_list API error', {
+            userId,
+            status: response.error.status,
+            code: response.error.code,
+          })
+          return {
+            success: false,
+            error: response.error.message || 'Failed to list threads',
+          }
+        }
+
+        const { threads, total } = response.data
+
+        logger.debug('thread_list completed', {
+          userId,
+          threadCount: threads.length,
+          total,
+        })
+
+        // Format content for display
+        const content = threads.length > 0
+          ? threads.map((t) => {
+              const contact = t.contactName || t.endpointValue
+              const msgCount = `${t.messageCount} message${t.messageCount !== 1 ? 's' : ''}`
+              return `[${t.channel}] ${contact} - ${msgCount}`
+            }).join('\n')
+          : 'No threads found.'
+
+        return {
+          success: true,
+          data: {
+            content,
+            details: { threads, total, userId },
+          },
+        }
+      } catch (error) {
+        logger.error('thread_list failed', {
+          userId,
+          error: error instanceof Error ? error.message : String(error),
+        })
+
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : 'An unexpected error occurred while listing threads.',
+        }
+      }
+    },
+  }
+}
+
+// =====================================================
+// Thread Get Tool
+// =====================================================
+
+/** Parameters for thread_get tool */
+export const ThreadGetParamsSchema = z.object({
+  threadId: z.string().min(1, 'Thread ID is required'),
+  messageLimit: z
+    .number()
+    .int()
+    .min(1, 'Message limit must be at least 1')
+    .max(MAX_MESSAGE_LIMIT, `Message limit must be ${MAX_MESSAGE_LIMIT} or less`)
+    .default(DEFAULT_MESSAGE_LIMIT),
+})
+export type ThreadGetParams = z.infer<typeof ThreadGetParamsSchema>
+
+/** Thread detail */
+interface ThreadDetail {
+  id: string
+  channel: string
+  contactName?: string
+  endpointValue?: string
+}
+
+/** Message in thread */
+interface ThreadMessage {
+  id: string
+  direction: 'inbound' | 'outbound'
+  body: string
+  subject?: string
+  deliveryStatus?: string
+  createdAt: string
+}
+
+/** API response for thread get */
+interface ThreadGetApiResponse {
+  thread: ThreadDetail
+  messages: ThreadMessage[]
+}
+
+/** Successful tool result */
+export interface ThreadGetSuccess {
+  success: true
+  data: {
+    content: string
+    details: {
+      thread: ThreadDetail
+      messages: ThreadMessage[]
+      userId: string
+    }
+  }
+}
+
+/** Failed tool result */
+export interface ThreadGetFailure {
+  success: false
+  error: string
+}
+
+export type ThreadGetResult = ThreadGetSuccess | ThreadGetFailure
+
+/** Tool definition */
+export interface ThreadGetTool {
+  name: string
+  description: string
+  parameters: typeof ThreadGetParamsSchema
+  execute: (params: ThreadGetParams) => Promise<ThreadGetResult>
+}
+
+/**
+ * Creates the thread_get tool.
+ */
+export function createThreadGetTool(options: ThreadToolOptions): ThreadGetTool {
+  const { client, logger, userId } = options
+
+  return {
+    name: 'thread_get',
+    description:
+      'Get a thread with its message history. Use to view the full conversation in a thread.',
+    parameters: ThreadGetParamsSchema,
+
+    async execute(params: ThreadGetParams): Promise<ThreadGetResult> {
+      // Validate parameters
+      const parseResult = ThreadGetParamsSchema.safeParse(params)
+      if (!parseResult.success) {
+        const errorMessage = parseResult.error.errors
+          .map((e) => `${e.path.join('.')}: ${e.message}`)
+          .join(', ')
+        return { success: false, error: errorMessage }
+      }
+
+      const { threadId, messageLimit } = parseResult.data
+
+      logger.info('thread_get invoked', {
+        userId,
+        threadId,
+        messageLimit,
+      })
+
+      try {
+        const queryParams = new URLSearchParams()
+        queryParams.set('messageLimit', String(messageLimit))
+
+        const response = await client.get<ThreadGetApiResponse>(
+          `/api/threads/${threadId}?${queryParams}`,
+          { userId }
+        )
+
+        if (!response.success) {
+          logger.error('thread_get API error', {
+            userId,
+            threadId,
+            status: response.error.status,
+            code: response.error.code,
+          })
+          return {
+            success: false,
+            error: response.error.message || 'Failed to get thread',
+          }
+        }
+
+        const { thread, messages } = response.data
+
+        logger.debug('thread_get completed', {
+          userId,
+          threadId,
+          messageCount: messages.length,
+        })
+
+        // Format content for display
+        const contact = thread.contactName || thread.endpointValue || 'Unknown'
+        const header = `Thread with ${contact} [${thread.channel}]`
+
+        const messageContent = messages.length > 0
+          ? messages.map((m) => {
+              const prefix = m.direction === 'inbound' ? '←' : '→'
+              const timestamp = new Date(m.createdAt).toLocaleString()
+              return `${prefix} [${timestamp}] ${m.body}`
+            }).join('\n')
+          : 'No messages in this thread.'
+
+        const content = `${header}\n\n${messageContent}`
+
+        return {
+          success: true,
+          data: {
+            content,
+            details: { thread, messages, userId },
+          },
+        }
+      } catch (error) {
+        logger.error('thread_get failed', {
+          userId,
+          threadId,
+          error: error instanceof Error ? error.message : String(error),
+        })
+
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : 'An unexpected error occurred while getting thread.',
+        }
+      }
+    },
+  }
+}

--- a/packages/openclaw-plugin/tests/register-openclaw.test.ts
+++ b/packages/openclaw-plugin/tests/register-openclaw.test.ts
@@ -51,10 +51,10 @@ describe('OpenClaw 2026 API Registration', () => {
   })
 
   describe('registration', () => {
-    it('should register all 15 tools', async () => {
+    it('should register all 17 tools', async () => {
       await registerOpenClaw(mockApi)
 
-      expect(registeredTools).toHaveLength(15)
+      expect(registeredTools).toHaveLength(17)
       const toolNames = registeredTools.map((t) => t.name)
       expect(toolNames).toContain('memory_recall')
       expect(toolNames).toContain('memory_store')
@@ -71,6 +71,8 @@ describe('OpenClaw 2026 API Registration', () => {
       expect(toolNames).toContain('sms_send')
       expect(toolNames).toContain('email_send')
       expect(toolNames).toContain('message_search')
+      expect(toolNames).toContain('thread_list')
+      expect(toolNames).toContain('thread_get')
     })
 
     it('should register beforeAgentStart hook when autoRecall is true', async () => {
@@ -110,7 +112,7 @@ describe('OpenClaw 2026 API Registration', () => {
       expect(mockApi.logger.info).toHaveBeenCalledWith(
         'OpenClaw Projects plugin registered',
         expect.objectContaining({
-          toolCount: 15,
+          toolCount: 17,
         })
       )
     })
@@ -167,6 +169,8 @@ describe('OpenClaw 2026 API Registration', () => {
       expect(schemas.smsSend).toBeDefined()
       expect(schemas.emailSend).toBeDefined()
       expect(schemas.messageSearch).toBeDefined()
+      expect(schemas.threadList).toBeDefined()
+      expect(schemas.threadGet).toBeDefined()
     })
 
     it('should have valid schema structure', () => {

--- a/packages/openclaw-plugin/tests/tools/threads.test.ts
+++ b/packages/openclaw-plugin/tests/tools/threads.test.ts
@@ -1,0 +1,480 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import {
+  createThreadListTool,
+  createThreadGetTool,
+  ThreadListParamsSchema,
+  ThreadGetParamsSchema,
+} from '../../src/tools/threads.js'
+import type { ApiClient } from '../../src/api-client.js'
+import type { Logger } from '../../src/logger.js'
+import type { PluginConfig } from '../../src/config.js'
+
+describe('thread tools', () => {
+  let mockClient: ApiClient
+  let mockLogger: Logger
+  let mockConfig: PluginConfig
+  const userId = 'test-user-id'
+
+  beforeEach(() => {
+    mockClient = {
+      get: vi.fn(),
+      post: vi.fn(),
+      put: vi.fn(),
+      patch: vi.fn(),
+      delete: vi.fn(),
+    } as unknown as ApiClient
+
+    mockLogger = {
+      info: vi.fn(),
+      debug: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    } as unknown as Logger
+
+    mockConfig = {
+      apiUrl: 'https://api.example.com',
+      apiKey: 'test-key',
+      autoRecall: true,
+      autoCapture: true,
+      userScoping: 'agent',
+      maxRecallMemories: 5,
+      minRecallScore: 0.7,
+      timeout: 30000,
+      maxRetries: 3,
+      secretCommandTimeout: 5000,
+      debug: false,
+    }
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('thread_list tool', () => {
+    describe('ThreadListParamsSchema', () => {
+      it('should accept empty parameters', () => {
+        const result = ThreadListParamsSchema.safeParse({})
+        expect(result.success).toBe(true)
+      })
+
+      it('should accept parameters with channel filter', () => {
+        const result = ThreadListParamsSchema.safeParse({
+          channel: 'sms',
+        })
+        expect(result.success).toBe(true)
+      })
+
+      it('should accept parameters with all fields', () => {
+        const result = ThreadListParamsSchema.safeParse({
+          channel: 'email',
+          contactId: '123e4567-e89b-12d3-a456-426614174000',
+          limit: 50,
+        })
+        expect(result.success).toBe(true)
+      })
+
+      it('should reject invalid channel', () => {
+        const result = ThreadListParamsSchema.safeParse({
+          channel: 'invalid',
+        })
+        expect(result.success).toBe(false)
+      })
+
+      it('should accept valid channel values', () => {
+        const channels = ['sms', 'email']
+        for (const channel of channels) {
+          const result = ThreadListParamsSchema.safeParse({ channel })
+          expect(result.success, `Expected channel '${channel}' to be valid`).toBe(true)
+        }
+      })
+
+      it('should use default limit of 20', () => {
+        const result = ThreadListParamsSchema.safeParse({})
+        expect(result.success).toBe(true)
+        if (result.success) {
+          expect(result.data.limit).toBe(20)
+        }
+      })
+
+      it('should reject limit below 1', () => {
+        const result = ThreadListParamsSchema.safeParse({
+          limit: 0,
+        })
+        expect(result.success).toBe(false)
+      })
+
+      it('should reject limit above 100', () => {
+        const result = ThreadListParamsSchema.safeParse({
+          limit: 101,
+        })
+        expect(result.success).toBe(false)
+      })
+    })
+
+    describe('createThreadListTool', () => {
+      it('should create tool with correct name', () => {
+        const tool = createThreadListTool({
+          client: mockClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId,
+        })
+        expect(tool.name).toBe('thread_list')
+      })
+
+      it('should have a description', () => {
+        const tool = createThreadListTool({
+          client: mockClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId,
+        })
+        expect(tool.description).toBeDefined()
+        expect(tool.description.length).toBeGreaterThan(10)
+      })
+    })
+
+    describe('execute', () => {
+      it('should list threads successfully', async () => {
+        vi.mocked(mockClient.get).mockResolvedValue({
+          success: true,
+          data: {
+            threads: [
+              {
+                id: 'thread-1',
+                channel: 'sms',
+                contactName: 'John Smith',
+                endpointValue: '+15551234567',
+                messageCount: 15,
+                lastMessageAt: '2024-01-15T10:30:00Z',
+              },
+              {
+                id: 'thread-2',
+                channel: 'email',
+                contactName: 'Jane Doe',
+                endpointValue: 'jane@example.com',
+                messageCount: 8,
+                lastMessageAt: '2024-01-14T14:20:00Z',
+              },
+            ],
+            total: 2,
+          },
+        })
+
+        const tool = createThreadListTool({
+          client: mockClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId,
+        })
+
+        const result = await tool.execute({})
+
+        expect(result.success).toBe(true)
+        expect(result.data).toBeDefined()
+        expect(result.data?.details?.threads).toHaveLength(2)
+      })
+
+      it('should call API with correct parameters', async () => {
+        vi.mocked(mockClient.get).mockResolvedValue({
+          success: true,
+          data: { threads: [], total: 0 },
+        })
+
+        const tool = createThreadListTool({
+          client: mockClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId,
+        })
+
+        await tool.execute({
+          channel: 'sms',
+          contactId: '123e4567-e89b-12d3-a456-426614174000',
+          limit: 30,
+        })
+
+        expect(mockClient.get).toHaveBeenCalledWith(
+          expect.stringContaining('/api/threads'),
+          { userId }
+        )
+        const callUrl = (mockClient.get as ReturnType<typeof vi.fn>).mock.calls[0][0] as string
+        expect(callUrl).toContain('channel=sms')
+        expect(callUrl).toContain('contactId=123e4567-e89b-12d3-a456-426614174000')
+        expect(callUrl).toContain('limit=30')
+      })
+
+      it('should handle API errors', async () => {
+        vi.mocked(mockClient.get).mockResolvedValue({
+          success: false,
+          error: {
+            status: 500,
+            code: 'INTERNAL_ERROR',
+            message: 'Database error',
+          },
+        })
+
+        const tool = createThreadListTool({
+          client: mockClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId,
+        })
+
+        const result = await tool.execute({})
+
+        expect(result.success).toBe(false)
+        expect(result.error).toBe('Database error')
+      })
+
+      it('should return empty results gracefully', async () => {
+        vi.mocked(mockClient.get).mockResolvedValue({
+          success: true,
+          data: { threads: [], total: 0 },
+        })
+
+        const tool = createThreadListTool({
+          client: mockClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId,
+        })
+
+        const result = await tool.execute({})
+
+        expect(result.success).toBe(true)
+        expect(result.data?.content).toContain('No threads found')
+      })
+    })
+  })
+
+  describe('thread_get tool', () => {
+    describe('ThreadGetParamsSchema', () => {
+      it('should accept valid threadId', () => {
+        const result = ThreadGetParamsSchema.safeParse({
+          threadId: '123e4567-e89b-12d3-a456-426614174000',
+        })
+        expect(result.success).toBe(true)
+      })
+
+      it('should accept threadId with messageLimit', () => {
+        const result = ThreadGetParamsSchema.safeParse({
+          threadId: '123e4567-e89b-12d3-a456-426614174000',
+          messageLimit: 100,
+        })
+        expect(result.success).toBe(true)
+      })
+
+      it('should reject missing threadId', () => {
+        const result = ThreadGetParamsSchema.safeParse({})
+        expect(result.success).toBe(false)
+      })
+
+      it('should use default messageLimit of 50', () => {
+        const result = ThreadGetParamsSchema.safeParse({
+          threadId: '123e4567-e89b-12d3-a456-426614174000',
+        })
+        expect(result.success).toBe(true)
+        if (result.success) {
+          expect(result.data.messageLimit).toBe(50)
+        }
+      })
+
+      it('should reject messageLimit below 1', () => {
+        const result = ThreadGetParamsSchema.safeParse({
+          threadId: '123e4567-e89b-12d3-a456-426614174000',
+          messageLimit: 0,
+        })
+        expect(result.success).toBe(false)
+      })
+
+      it('should reject messageLimit above 200', () => {
+        const result = ThreadGetParamsSchema.safeParse({
+          threadId: '123e4567-e89b-12d3-a456-426614174000',
+          messageLimit: 201,
+        })
+        expect(result.success).toBe(false)
+      })
+    })
+
+    describe('createThreadGetTool', () => {
+      it('should create tool with correct name', () => {
+        const tool = createThreadGetTool({
+          client: mockClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId,
+        })
+        expect(tool.name).toBe('thread_get')
+      })
+
+      it('should have a description', () => {
+        const tool = createThreadGetTool({
+          client: mockClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId,
+        })
+        expect(tool.description).toBeDefined()
+        expect(tool.description.length).toBeGreaterThan(10)
+      })
+    })
+
+    describe('execute', () => {
+      it('should get thread with messages successfully', async () => {
+        vi.mocked(mockClient.get).mockResolvedValue({
+          success: true,
+          data: {
+            thread: {
+              id: 'thread-1',
+              channel: 'sms',
+              contactName: 'John Smith',
+              endpointValue: '+15551234567',
+            },
+            messages: [
+              {
+                id: 'msg-1',
+                direction: 'inbound',
+                body: 'Hello there',
+                deliveryStatus: 'delivered',
+                createdAt: '2024-01-15T10:30:00Z',
+              },
+              {
+                id: 'msg-2',
+                direction: 'outbound',
+                body: 'Hi! How can I help?',
+                deliveryStatus: 'sent',
+                createdAt: '2024-01-15T10:31:00Z',
+              },
+            ],
+          },
+        })
+
+        const tool = createThreadGetTool({
+          client: mockClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId,
+        })
+
+        const result = await tool.execute({
+          threadId: '123e4567-e89b-12d3-a456-426614174000',
+        })
+
+        expect(result.success).toBe(true)
+        expect(result.data).toBeDefined()
+        expect(result.data?.details?.thread).toBeDefined()
+        expect(result.data?.details?.messages).toHaveLength(2)
+      })
+
+      it('should call API with correct parameters', async () => {
+        vi.mocked(mockClient.get).mockResolvedValue({
+          success: true,
+          data: { thread: {}, messages: [] },
+        })
+
+        const tool = createThreadGetTool({
+          client: mockClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId,
+        })
+
+        await tool.execute({
+          threadId: '123e4567-e89b-12d3-a456-426614174000',
+          messageLimit: 75,
+        })
+
+        expect(mockClient.get).toHaveBeenCalledWith(
+          expect.stringContaining('/api/threads/123e4567-e89b-12d3-a456-426614174000'),
+          { userId }
+        )
+        const callUrl = (mockClient.get as ReturnType<typeof vi.fn>).mock.calls[0][0] as string
+        expect(callUrl).toContain('messageLimit=75')
+      })
+
+      it('should handle thread not found', async () => {
+        vi.mocked(mockClient.get).mockResolvedValue({
+          success: false,
+          error: {
+            status: 404,
+            code: 'NOT_FOUND',
+            message: 'Thread not found',
+          },
+        })
+
+        const tool = createThreadGetTool({
+          client: mockClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId,
+        })
+
+        const result = await tool.execute({
+          threadId: '123e4567-e89b-12d3-a456-426614174000',
+        })
+
+        expect(result.success).toBe(false)
+        expect(result.error).toBe('Thread not found')
+      })
+
+      it('should validate threadId before fetching', async () => {
+        const tool = createThreadGetTool({
+          client: mockClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId,
+        })
+
+        const result = await tool.execute({
+          threadId: '',
+        })
+
+        expect(result.success).toBe(false)
+        expect(mockClient.get).not.toHaveBeenCalled()
+      })
+
+      it('should format messages in chronological order', async () => {
+        vi.mocked(mockClient.get).mockResolvedValue({
+          success: true,
+          data: {
+            thread: {
+              id: 'thread-1',
+              channel: 'sms',
+              contactName: 'John',
+            },
+            messages: [
+              {
+                id: 'msg-1',
+                direction: 'inbound',
+                body: 'First message',
+                createdAt: '2024-01-15T10:30:00Z',
+              },
+              {
+                id: 'msg-2',
+                direction: 'outbound',
+                body: 'Second message',
+                createdAt: '2024-01-15T10:31:00Z',
+              },
+            ],
+          },
+        })
+
+        const tool = createThreadGetTool({
+          client: mockClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId,
+        })
+
+        const result = await tool.execute({
+          threadId: '123e4567-e89b-12d3-a456-426614174000',
+        })
+
+        expect(result.success).toBe(true)
+        expect(result.data?.content).toContain('First message')
+        expect(result.data?.content).toContain('Second message')
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Adds `thread_list` tool for listing message threads (conversations)
- Adds `thread_get` tool for viewing full thread with message history
- Channel filtering (SMS/email)
- Contact filtering support
- Configurable limits
- Comprehensive test coverage (27 tests)

**Note:** This PR implements the plugin portion of #316. The backend endpoints (`GET /api/threads` and `GET /api/threads/:id`) need to be created separately.

## Test plan
- [x] Unit tests for ThreadListParamsSchema validation
- [x] Unit tests for ThreadGetParamsSchema validation
- [x] Unit tests for thread list tool creation and execution
- [x] Unit tests for thread get tool creation and execution
- [x] Unit tests for API error handling
- [x] Unit tests for empty results
- [x] Unit tests for channel filtering
- [x] Typecheck passes
- [x] Build passes

Closes #316

🤖 Generated with [Claude Code](https://claude.com/claude-code)