### PR TITLE
[#321] Add skills directory for custom prompts

### DIFF
--- a/packages/openclaw-plugin/openclaw.plugin.json
+++ b/packages/openclaw-plugin/openclaw.plugin.json
@@ -5,6 +5,7 @@
   "version": "2.0.0",
   "kind": "memory",
   "main": "dist/index.js",
+  "skillsDir": "skills",
   "configSchema": {
     "type": "object",
     "properties": {

--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -7,7 +7,8 @@
   "types": "dist/index.d.ts",
   "files": [
     "dist",
-    "openclaw.plugin.json"
+    "openclaw.plugin.json",
+    "skills"
   ],
   "scripts": {
     "build": "tsc",

--- a/packages/openclaw-plugin/skills/contact-lookup/SKILL.md
+++ b/packages/openclaw-plugin/skills/contact-lookup/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: contact-lookup
+description: Look up contact information and recent communications
+args:
+  - name: name
+    description: Contact name to search for
+    required: true
+---
+
+Search for contact "{{name}}" and show:
+
+1. **Contact Details**
+   - Use `contact_search` to find matching contacts
+   - Use `contact_get` to retrieve full details (name, email, phone, notes)
+   - If multiple matches found, list them and ask for clarification
+
+2. **Recent Communications**
+   - Use `message_search` with the contact ID to find recent messages
+   - Show the last few messages exchanged (both sent and received)
+   - Note the channels used (SMS, email)
+
+3. **Related Projects and Tasks**
+   - Check if there are any todos or projects associated with this contact
+   - Use `todo_list` and `project_list` to find related items
+
+4. **Stored Memories**
+   - Use `memory_recall` with the contact's name to find relevant memories
+   - Show any stored preferences, facts, or context about this person
+
+Present the information in a clear, organized format to help understand the full context of this contact relationship.

--- a/packages/openclaw-plugin/skills/daily-summary/SKILL.md
+++ b/packages/openclaw-plugin/skills/daily-summary/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: daily-summary
+description: Get a summary of today's tasks, messages, and activities
+---
+
+Please provide a summary of my day including:
+
+1. **Tasks due today or overdue**
+   - Use `todo_list` with status filter to find pending items
+   - Highlight any items past their due date
+
+2. **Recent messages received**
+   - Use `message_search` to find today's messages
+   - Summarize key communications
+
+3. **Upcoming deadlines this week**
+   - Use `todo_list` to identify tasks with near-term due dates
+
+4. **Items requiring my attention**
+   - Note any urgent or high-priority tasks
+   - Flag any unanswered messages
+
+Use the available tools to gather this information and present it in a clear, actionable format.

--- a/packages/openclaw-plugin/skills/project-status/SKILL.md
+++ b/packages/openclaw-plugin/skills/project-status/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: project-status
+description: Get status overview of a specific project
+args:
+  - name: project
+    description: Project name or ID
+    required: true
+---
+
+Please provide a status report for project "{{project}}" including:
+
+1. **Project Overview**
+   - Use `project_list` to find the project by name, or `project_get` if ID is provided
+   - Show project name, status, and description
+
+2. **Task Breakdown**
+   - Use `todo_list` with the project ID to get all tasks
+   - Count tasks by status (pending, in progress, completed)
+   - Calculate overall completion percentage
+
+3. **Recent Activity**
+   - List recently completed tasks
+   - Show tasks currently in progress
+
+4. **Blockers and Risks**
+   - Identify any overdue tasks
+   - Note any high-priority pending items
+
+5. **Next Steps**
+   - Recommend the next tasks to focus on
+   - Suggest any follow-up actions needed
+
+Present the report in a clear, organized format suitable for stakeholder updates.

--- a/packages/openclaw-plugin/skills/send-reminder/SKILL.md
+++ b/packages/openclaw-plugin/skills/send-reminder/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: send-reminder
+description: Send a reminder message to a contact
+args:
+  - name: contact
+    description: Contact name or phone/email
+    required: true
+  - name: message
+    description: Reminder message content
+    required: true
+  - name: channel
+    description: Channel to use (sms or email)
+    default: sms
+---
+
+Send a reminder to {{contact}} via {{channel}}:
+
+**Message:** {{message}}
+
+## Steps:
+
+1. **Look up the contact**
+   - Use `contact_search` to find the contact by name
+   - If phone/email provided directly, verify the format
+
+2. **Verify their {{channel}} endpoint**
+   - For SMS: Ensure they have a valid phone number in E.164 format
+   - For Email: Ensure they have a valid email address
+   - If the preferred channel isn't available, suggest an alternative
+
+3. **Send the message**
+   - For SMS: Use `sms_send` with the phone number and message
+   - For Email: Use `email_send` with appropriate subject line
+
+4. **Confirm delivery**
+   - Report the message status (queued, sent, etc.)
+   - Store a memory of this communication if appropriate
+
+## Important Notes:
+- Always confirm before sending to prevent accidental messages
+- For email, generate an appropriate subject line based on the message content
+- Be mindful of message length limits (1600 chars for SMS)

--- a/packages/openclaw-plugin/tests/package-structure.test.ts
+++ b/packages/openclaw-plugin/tests/package-structure.test.ts
@@ -176,4 +176,56 @@ describe('Package Structure', () => {
       expect(tsconfig.compilerOptions.moduleResolution).toBe('NodeNext')
     })
   })
+
+  describe('Skills Directory', () => {
+    it('should have skillsDir declared in manifest', () => {
+      const manifestPath = join(packageRoot, 'openclaw.plugin.json')
+      const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8'))
+      expect(manifest.skillsDir).toBe('skills')
+    })
+
+    it('should have skills directory', () => {
+      const skillsPath = join(packageRoot, 'skills')
+      expect(existsSync(skillsPath)).toBe(true)
+    })
+
+    it('should have daily-summary skill', () => {
+      const skillPath = join(packageRoot, 'skills', 'daily-summary', 'SKILL.md')
+      expect(existsSync(skillPath)).toBe(true)
+    })
+
+    it('should have project-status skill', () => {
+      const skillPath = join(packageRoot, 'skills', 'project-status', 'SKILL.md')
+      expect(existsSync(skillPath)).toBe(true)
+    })
+
+    it('should have contact-lookup skill', () => {
+      const skillPath = join(packageRoot, 'skills', 'contact-lookup', 'SKILL.md')
+      expect(existsSync(skillPath)).toBe(true)
+    })
+
+    it('should have send-reminder skill', () => {
+      const skillPath = join(packageRoot, 'skills', 'send-reminder', 'SKILL.md')
+      expect(existsSync(skillPath)).toBe(true)
+    })
+
+    it('should have valid SKILL.md format with frontmatter', () => {
+      const skillPath = join(packageRoot, 'skills', 'daily-summary', 'SKILL.md')
+      const content = readFileSync(skillPath, 'utf-8')
+      // Should start with frontmatter
+      expect(content).toMatch(/^---/)
+      // Should have name field
+      expect(content).toMatch(/name:\s+\S+/)
+      // Should have description field
+      expect(content).toMatch(/description:\s+.+/)
+    })
+
+    it('should have skills with args defined where needed', () => {
+      const skillPath = join(packageRoot, 'skills', 'project-status', 'SKILL.md')
+      const content = readFileSync(skillPath, 'utf-8')
+      // project-status should have args
+      expect(content).toMatch(/args:/)
+      expect(content).toMatch(/name:\s+project/)
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Implements Issue #321 - Add skills directory for custom prompts

- Creates `skills/` directory with 4 SKILL.md templates:
  - **daily-summary**: Get summary of tasks, messages, activities
  - **project-status**: Check status of specific project (accepts `project` arg)
  - **contact-lookup**: Look up contact details and communications (accepts `name` arg)
  - **send-reminder**: Send SMS/email reminder to contact (accepts `contact`, `message`, `channel` args)
- Adds `skillsDir: "skills"` to `openclaw.plugin.json` manifest
- Includes `skills/` in `package.json` files array for npm publish
- Adds comprehensive tests for skills directory structure and content validation

## Test plan

- [x] All 639 tests pass
- [x] TypeScript compiles without errors
- [x] Build succeeds
- [x] Skills directory tests validate:
  - Skills directory exists
  - 4 required skills are present
  - SKILL.md files have valid frontmatter
  - Skills with args are properly defined

Closes #321

🤖 Generated with [Claude Code](https://claude.ai/code)