### PR TITLE
[#317] Implement auto-capture endpoint

### DIFF
--- a/src/api/context/capture.ts
+++ b/src/api/context/capture.ts
@@ -1,0 +1,161 @@
+/**
+ * Context capture service for the auto-capture feature.
+ * Part of Epic #310 - Issue #317.
+ *
+ * This service captures conversation context and stores it as a memory
+ * when an agent session ends.
+ */
+
+import type { Pool } from 'pg';
+
+/** Input for context capture */
+export interface ContextCaptureInput {
+  /** The conversation summary to capture */
+  conversation: string;
+  /** Number of messages in the conversation */
+  messageCount: number;
+  /** User identifier for scoping the memory */
+  userId?: string;
+}
+
+/** Result of context capture */
+export interface ContextCaptureResult {
+  /** Number of memories captured (0 or 1) */
+  captured: number;
+  /** ID of the captured memory, if any */
+  memoryId?: string;
+  /** Reason if capture was skipped */
+  reason?: string;
+  /** Error message if capture failed */
+  error?: string;
+}
+
+/** Minimum message count to consider capturing */
+const MIN_MESSAGE_COUNT = 2;
+
+/** Minimum content length to consider capturing */
+const MIN_CONTENT_LENGTH = 100;
+
+/** Maximum content length to store */
+const MAX_CONTENT_LENGTH = 2000;
+
+/**
+ * Validates input parameters for context capture.
+ * Returns an error message if invalid, null if valid.
+ */
+export function validateCaptureInput(input: ContextCaptureInput): string | null {
+  // Conversation validation
+  if (input.conversation === undefined || input.conversation === null || typeof input.conversation !== 'string') {
+    return 'conversation is required';
+  }
+  if (input.conversation.trim().length === 0) {
+    return 'conversation cannot be empty';
+  }
+
+  // messageCount validation
+  if (input.messageCount === undefined || input.messageCount === null) {
+    return 'messageCount is required';
+  }
+  if (typeof input.messageCount !== 'number' || input.messageCount < 1 || !Number.isInteger(input.messageCount)) {
+    return 'messageCount must be a positive integer';
+  }
+
+  return null;
+}
+
+/**
+ * Captures conversation context as a memory.
+ *
+ * This function is called when an agent session ends to persist
+ * relevant context for future recall.
+ *
+ * Skips capture if:
+ * - Message count is less than 2
+ * - Conversation content is less than 100 characters
+ */
+export async function captureContext(
+  pool: Pool,
+  input: ContextCaptureInput
+): Promise<ContextCaptureResult> {
+  const { conversation, messageCount, userId } = input;
+
+  // Skip if conversation is too short
+  if (messageCount < MIN_MESSAGE_COUNT) {
+    return {
+      captured: 0,
+      reason: 'conversation too short',
+    };
+  }
+
+  // Skip if content is too short
+  if (conversation.trim().length < MIN_CONTENT_LENGTH) {
+    return {
+      captured: 0,
+      reason: 'content too short',
+    };
+  }
+
+  // Truncate content if necessary
+  const content = conversation.substring(0, MAX_CONTENT_LENGTH);
+
+  // Generate a title based on the first line or first 50 chars
+  const firstLine = conversation.split('\n')[0].trim();
+  const title = firstLine.length > 50
+    ? firstLine.substring(0, 47) + '...'
+    : firstLine || 'Conversation Context';
+
+  try {
+    const result = await pool.query(
+      `INSERT INTO memory (
+        user_email,
+        title,
+        content,
+        memory_type,
+        created_by_agent,
+        created_by_human,
+        importance,
+        confidence
+      ) VALUES ($1, $2, $3, $4::memory_type, $5, $6, $7, $8)
+      RETURNING
+        id::text,
+        title,
+        content,
+        memory_type::text,
+        importance,
+        created_at,
+        updated_at`,
+      [
+        userId ?? null,
+        title,
+        content,
+        'context',
+        'auto-capture',
+        false,
+        5, // Default importance
+        1.0, // High confidence for auto-captured context
+      ]
+    );
+
+    if (result.rows.length === 0) {
+      return {
+        captured: 0,
+        reason: 'insertion returned no rows',
+      };
+    }
+
+    const row = result.rows[0] as { id: string };
+
+    return {
+      captured: 1,
+      memoryId: row.id,
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    console.error('[Context Capture] Database error:', errorMessage);
+
+    return {
+      captured: 0,
+      error: `Database error: ${errorMessage}`,
+    };
+  }
+}

--- a/tests/api/context-capture.test.ts
+++ b/tests/api/context-capture.test.ts
@@ -1,0 +1,333 @@
+/**
+ * Tests for context capture endpoint.
+ * Part of Epic #310, Issue #317.
+ */
+
+import { describe, it, expect, beforeEach, vi, type Mock } from 'vitest';
+import type { Pool, QueryResult } from 'pg';
+import {
+  captureContext,
+  validateCaptureInput,
+  type ContextCaptureInput,
+  type ContextCaptureResult,
+} from '../../src/api/context/capture.ts';
+
+// Mock pool
+function createMockPool(): Pool {
+  return {
+    query: vi.fn(),
+    end: vi.fn(),
+  } as unknown as Pool;
+}
+
+describe('Context Capture Service', () => {
+  let mockPool: Pool;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPool = createMockPool();
+  });
+
+  describe('validateCaptureInput', () => {
+    it('should return null for valid input', () => {
+      const input: ContextCaptureInput = {
+        conversation: 'This is a conversation that happened between user and agent.',
+        messageCount: 5,
+      };
+      expect(validateCaptureInput(input)).toBeNull();
+    });
+
+    it('should require conversation', () => {
+      const input = {
+        messageCount: 5,
+      } as ContextCaptureInput;
+      expect(validateCaptureInput(input)).toBe('conversation is required');
+    });
+
+    it('should require non-empty conversation', () => {
+      const input: ContextCaptureInput = {
+        conversation: '   ',
+        messageCount: 5,
+      };
+      expect(validateCaptureInput(input)).toBe('conversation cannot be empty');
+    });
+
+    it('should require conversation string type', () => {
+      const input = {
+        conversation: 123,
+        messageCount: 5,
+      } as unknown as ContextCaptureInput;
+      expect(validateCaptureInput(input)).toBe('conversation is required');
+    });
+
+    it('should require messageCount', () => {
+      const input = {
+        conversation: 'Some conversation',
+      } as ContextCaptureInput;
+      expect(validateCaptureInput(input)).toBe('messageCount is required');
+    });
+
+    it('should require messageCount to be a number', () => {
+      const input = {
+        conversation: 'Some conversation',
+        messageCount: 'five',
+      } as unknown as ContextCaptureInput;
+      expect(validateCaptureInput(input)).toBe('messageCount must be a positive integer');
+    });
+
+    it('should require messageCount to be positive', () => {
+      const input: ContextCaptureInput = {
+        conversation: 'Some conversation',
+        messageCount: 0,
+      };
+      expect(validateCaptureInput(input)).toBe('messageCount must be a positive integer');
+    });
+
+    it('should accept optional userId', () => {
+      const input: ContextCaptureInput = {
+        conversation: 'A conversation with sufficient content for testing purposes.',
+        messageCount: 5,
+        userId: 'user@example.com',
+      };
+      expect(validateCaptureInput(input)).toBeNull();
+    });
+  });
+
+  describe('captureContext', () => {
+    it('should skip capture for short conversations (< 2 messages)', async () => {
+      const input: ContextCaptureInput = {
+        conversation: 'Short conversation',
+        messageCount: 1,
+      };
+
+      const result = await captureContext(mockPool, input);
+
+      expect(result.captured).toBe(0);
+      expect(result.reason).toBe('conversation too short');
+      expect((mockPool.query as Mock).mock.calls.length).toBe(0);
+    });
+
+    it('should skip capture for short content (< 100 characters)', async () => {
+      const input: ContextCaptureInput = {
+        conversation: 'A very short summary.',
+        messageCount: 5,
+      };
+
+      const result = await captureContext(mockPool, input);
+
+      expect(result.captured).toBe(0);
+      expect(result.reason).toBe('content too short');
+      expect((mockPool.query as Mock).mock.calls.length).toBe(0);
+    });
+
+    it('should store context as memory for valid input', async () => {
+      const longConversation = 'This is a conversation summary that is long enough to meet the minimum content requirement. The user discussed their preferences and decisions during this session.';
+      const input: ContextCaptureInput = {
+        conversation: longConversation,
+        messageCount: 10,
+        userId: 'user@example.com',
+      };
+
+      (mockPool.query as Mock).mockResolvedValue({
+        rows: [{
+          id: '123e4567-e89b-12d3-a456-426614174000',
+          title: 'Conversation Context',
+          content: longConversation.substring(0, 2000),
+          memory_type: 'context',
+          importance: 5,
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        }],
+      });
+
+      const result = await captureContext(mockPool, input);
+
+      expect(result.captured).toBe(1);
+      expect(result.memoryId).toBeDefined();
+      expect((mockPool.query as Mock).mock.calls.length).toBe(1);
+    });
+
+    it('should truncate content to 2000 characters', async () => {
+      const veryLongConversation = 'x'.repeat(3000);
+      const input: ContextCaptureInput = {
+        conversation: veryLongConversation,
+        messageCount: 20,
+      };
+
+      (mockPool.query as Mock).mockResolvedValue({
+        rows: [{
+          id: '123e4567-e89b-12d3-a456-426614174000',
+          title: 'Conversation Context',
+          content: veryLongConversation.substring(0, 2000),
+          memory_type: 'context',
+          importance: 5,
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        }],
+      });
+
+      await captureContext(mockPool, input);
+
+      const query = (mockPool.query as Mock).mock.calls[0][0] as string;
+      const params = (mockPool.query as Mock).mock.calls[0][1] as unknown[];
+      // Content parameter (4th or 5th position depending on query structure)
+      const contentParam = params.find(p => typeof p === 'string' && p.length === 2000);
+      expect(contentParam).toBeDefined();
+      expect((contentParam as string).length).toBe(2000);
+    });
+
+    it('should use auto-capture agent name', async () => {
+      const conversation = 'A conversation summary with enough content to trigger capture and storage in the memory system. This needs to be at least 100 characters long.';
+      const input: ContextCaptureInput = {
+        conversation,
+        messageCount: 5,
+      };
+
+      (mockPool.query as Mock).mockResolvedValue({
+        rows: [{
+          id: '123e4567-e89b-12d3-a456-426614174000',
+          title: 'Conversation Context',
+          content: conversation,
+          memory_type: 'context',
+          importance: 5,
+          created_by_agent: 'auto-capture',
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        }],
+      });
+
+      await captureContext(mockPool, input);
+
+      const params = (mockPool.query as Mock).mock.calls[0][1] as unknown[];
+      expect(params).toContain('auto-capture');
+    });
+
+    it('should handle database errors gracefully', async () => {
+      const conversation = 'A conversation summary with enough content to trigger capture and storage in the memory system. This needs to be at least 100 characters long.';
+      const input: ContextCaptureInput = {
+        conversation,
+        messageCount: 5,
+      };
+
+      (mockPool.query as Mock).mockRejectedValue(new Error('Database connection failed'));
+
+      const result = await captureContext(mockPool, input);
+
+      expect(result.captured).toBe(0);
+      expect(result.error).toBeDefined();
+      expect(result.error).toContain('Database');
+    });
+
+    it('should set memory type to context', async () => {
+      const conversation = 'A conversation summary with enough content to trigger capture and storage in the memory system. This needs to be at least 100 characters long.';
+      const input: ContextCaptureInput = {
+        conversation,
+        messageCount: 5,
+      };
+
+      (mockPool.query as Mock).mockResolvedValue({
+        rows: [{
+          id: '123e4567-e89b-12d3-a456-426614174000',
+          title: 'Conversation Context',
+          content: conversation,
+          memory_type: 'context',
+          importance: 5,
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        }],
+      });
+
+      await captureContext(mockPool, input);
+
+      const query = (mockPool.query as Mock).mock.calls[0][0] as string;
+      expect(query).toContain('memory_type');
+      const params = (mockPool.query as Mock).mock.calls[0][1] as unknown[];
+      expect(params).toContain('context');
+    });
+
+    it('should return captured count of 0 when no rows returned', async () => {
+      const conversation = 'A conversation summary with enough content to trigger capture and storage in the memory system. This needs to be at least 100 characters long.';
+      const input: ContextCaptureInput = {
+        conversation,
+        messageCount: 5,
+      };
+
+      (mockPool.query as Mock).mockResolvedValue({
+        rows: [],
+      });
+
+      const result = await captureContext(mockPool, input);
+
+      expect(result.captured).toBe(0);
+      expect(result.reason).toBe('insertion returned no rows');
+    });
+
+    it('should set default importance of 5', async () => {
+      const conversation = 'A conversation summary with enough content to trigger capture and storage in the memory system. This needs to be at least 100 characters long.';
+      const input: ContextCaptureInput = {
+        conversation,
+        messageCount: 5,
+      };
+
+      (mockPool.query as Mock).mockResolvedValue({
+        rows: [{
+          id: '123e4567-e89b-12d3-a456-426614174000',
+          title: 'Conversation Context',
+          content: conversation,
+          memory_type: 'context',
+          importance: 5,
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        }],
+      });
+
+      await captureContext(mockPool, input);
+
+      const params = (mockPool.query as Mock).mock.calls[0][1] as unknown[];
+      expect(params).toContain(5);
+    });
+  });
+
+  describe('Result types', () => {
+    it('should have proper structure for success result', async () => {
+      const conversation = 'A conversation summary with enough content to trigger capture and storage in the memory system. This needs to be at least 100 characters long.';
+      const input: ContextCaptureInput = {
+        conversation,
+        messageCount: 5,
+      };
+
+      (mockPool.query as Mock).mockResolvedValue({
+        rows: [{
+          id: '123e4567-e89b-12d3-a456-426614174000',
+          title: 'Conversation Context',
+          content: conversation,
+          memory_type: 'context',
+          importance: 5,
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        }],
+      });
+
+      const result = await captureContext(mockPool, input);
+
+      expect(result).toHaveProperty('captured');
+      expect(result).toHaveProperty('memoryId');
+      expect(typeof result.captured).toBe('number');
+      expect(typeof result.memoryId).toBe('string');
+    });
+
+    it('should have proper structure for skip result', async () => {
+      const input: ContextCaptureInput = {
+        conversation: 'Short',
+        messageCount: 1,
+      };
+
+      const result = await captureContext(mockPool, input);
+
+      expect(result).toHaveProperty('captured');
+      expect(result).toHaveProperty('reason');
+      expect(result.captured).toBe(0);
+      expect(typeof result.reason).toBe('string');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements Issue #317 - Implement auto-capture endpoint

The plugin's `agentEnd` hook calls `POST /api/context/capture` to store conversation context as a memory when an agent session ends.

### Implementation

- **src/api/context/capture.ts** - New service module with:
  - `ContextCaptureInput` interface - conversation, messageCount, userId
  - `ContextCaptureResult` interface - captured count, memoryId, reason/error
  - `validateCaptureInput()` - validates required fields
  - `captureContext()` - captures conversation as memory

- **POST /api/context/capture** endpoint - Added to server.ts

### Behavior

- Accepts conversation summary and message count
- Skips capture for short conversations (< 2 messages)
- Skips capture for short content (< 100 characters)
- Truncates content to 2000 characters
- Stores as 'context' memory type with 'auto-capture' agent name
- Returns `{ captured: 0/1, memoryId?, reason?, error? }`

## Test plan

- [x] 19 tests pass in tests/api/context-capture.test.ts
- [x] All 2382 project tests pass
- [x] Tests cover validation, skip conditions, successful capture, error handling

Closes #317

🤖 Generated with [Claude Code](https://claude.ai/code)