### PR TITLE
[#322] Implement hybrid search (BM25 + vector)

### DIFF
--- a/src/api/search/hybrid.ts
+++ b/src/api/search/hybrid.ts
@@ -1,0 +1,385 @@
+/**
+ * Hybrid search combining BM25 (text) and vector similarity search.
+ * Part of Epic #310, Issue #322.
+ *
+ * Addresses the weakness of pure vector search on "exact, high-signal tokens"
+ * (IDs, error strings, specific names) while leveraging its strength on paraphrases.
+ *
+ * Default weights:
+ * - Vector: 0.7 (semantic meaning)
+ * - Text: 0.3 (exact tokens)
+ */
+
+import type { Pool } from 'pg';
+import type { MemoryEntry, MemoryType } from '../memory/types.ts';
+
+/** Options for hybrid search */
+export interface HybridSearchOptions {
+  /** User email to filter by */
+  userEmail?: string;
+  /** Work item ID to filter by */
+  workItemId?: string;
+  /** Contact ID to filter by */
+  contactId?: string;
+  /** Memory type to filter by */
+  memoryType?: MemoryType;
+  /** Maximum results to return (default: 10) */
+  limit?: number;
+  /** Offset for pagination (default: 0) */
+  offset?: number;
+  /** Minimum combined score threshold (0-1, default: 0.3) */
+  minScore?: number;
+  /** Weight for vector (semantic) search (default: 0.7) */
+  vectorWeight?: number;
+  /** Weight for text (BM25) search (default: 0.3) */
+  textWeight?: number;
+}
+
+/** A memory with search scores */
+export interface HybridSearchMemory extends MemoryEntry {
+  /** Vector similarity score (0-1) */
+  vectorScore?: number;
+  /** Text search score (normalized 0-1) */
+  textScore?: number;
+  /** Combined weighted score */
+  combinedScore: number;
+}
+
+/** Result of hybrid search */
+export interface HybridSearchResult {
+  /** Matched memories with scores */
+  results: HybridSearchMemory[];
+  /** Type of search performed */
+  searchType: 'hybrid' | 'vector' | 'text';
+  /** Weights used for scoring */
+  weights: {
+    vectorWeight: number;
+    textWeight: number;
+  };
+  /** Embedding provider if vector search was used */
+  queryEmbeddingProvider?: string;
+}
+
+/**
+ * Normalize a score to 0-1 range.
+ *
+ * @param score - Raw score value
+ * @param min - Minimum expected value
+ * @param max - Maximum expected value
+ * @returns Normalized score (0-1)
+ */
+export function normalizeScore(
+  score: number | null | undefined,
+  min: number,
+  max: number
+): number {
+  if (score === null || score === undefined) return 0;
+
+  if (max === min) return 1; // Avoid division by zero
+
+  const normalized = (score - min) / (max - min);
+  return Math.max(0, Math.min(1, normalized)); // Clamp to 0-1
+}
+
+/**
+ * Combine vector and text scores using weighted average.
+ *
+ * @param vectorScore - Normalized vector similarity score (0-1)
+ * @param textScore - Normalized text search score (0-1)
+ * @param vectorWeight - Weight for vector score (default 0.7)
+ * @param textWeight - Weight for text score (default 0.3)
+ * @returns Combined score
+ */
+export function combineScores(
+  vectorScore: number,
+  textScore: number,
+  vectorWeight: number = 0.7,
+  textWeight: number = 0.3
+): number {
+  return vectorScore * vectorWeight + textScore * textWeight;
+}
+
+/**
+ * Maps a database row to a MemoryEntry.
+ */
+function mapRowToMemory(row: Record<string, unknown>): MemoryEntry {
+  return {
+    id: row.id as string,
+    userEmail: row.user_email as string | null,
+    workItemId: row.work_item_id as string | null,
+    contactId: row.contact_id as string | null,
+    title: row.title as string,
+    content: row.content as string,
+    memoryType: row.memory_type as MemoryType,
+    createdByAgent: row.created_by_agent as string | null,
+    createdByHuman: (row.created_by_human as boolean) ?? false,
+    sourceUrl: row.source_url as string | null,
+    importance: row.importance as number,
+    confidence: row.confidence as number,
+    expiresAt: row.expires_at ? new Date(row.expires_at as string) : null,
+    supersededBy: row.superseded_by as string | null,
+    embeddingStatus: row.embedding_status as 'pending' | 'complete' | 'failed',
+    createdAt: new Date(row.created_at as string),
+    updatedAt: new Date(row.updated_at as string),
+  };
+}
+
+/**
+ * Build filter conditions for search queries.
+ */
+function buildFilterConditions(
+  options: HybridSearchOptions,
+  startIdx: number
+): { conditions: string[]; params: unknown[]; nextIdx: number } {
+  const conditions: string[] = [
+    '(expires_at IS NULL OR expires_at > NOW())',
+    'superseded_by IS NULL',
+  ];
+  const params: unknown[] = [];
+  let idx = startIdx;
+
+  if (options.userEmail !== undefined) {
+    conditions.push(`user_email = $${idx}`);
+    params.push(options.userEmail);
+    idx++;
+  }
+  if (options.workItemId !== undefined) {
+    conditions.push(`work_item_id = $${idx}`);
+    params.push(options.workItemId);
+    idx++;
+  }
+  if (options.contactId !== undefined) {
+    conditions.push(`contact_id = $${idx}`);
+    params.push(options.contactId);
+    idx++;
+  }
+  if (options.memoryType !== undefined) {
+    conditions.push(`memory_type = $${idx}::memory_type`);
+    params.push(options.memoryType);
+    idx++;
+  }
+
+  return { conditions, params, nextIdx: idx };
+}
+
+/**
+ * Perform vector search for memories.
+ */
+async function vectorSearch(
+  pool: Pool,
+  queryEmbedding: number[],
+  options: HybridSearchOptions,
+  candidateLimit: number
+): Promise<Map<string, { memory: MemoryEntry; vectorScore: number }>> {
+  const { conditions, params, nextIdx } = buildFilterConditions(options, 2);
+
+  const embeddingStr = `[${queryEmbedding.join(',')}]`;
+  const allParams = [embeddingStr, ...params, candidateLimit];
+
+  const whereClause = conditions.length > 0 ? `AND ${conditions.join(' AND ')}` : '';
+
+  const result = await pool.query(
+    `SELECT
+      id::text, user_email, work_item_id::text, contact_id::text,
+      title, content, memory_type::text,
+      created_by_agent, created_by_human, source_url,
+      importance, confidence, expires_at, superseded_by::text,
+      embedding_status, created_at, updated_at,
+      1 - (embedding <=> $1::vector) as similarity
+    FROM memory
+    WHERE embedding IS NOT NULL
+      ${whereClause}
+    ORDER BY similarity DESC
+    LIMIT $${nextIdx}`,
+    allParams
+  );
+
+  const results = new Map<string, { memory: MemoryEntry; vectorScore: number }>();
+
+  for (const row of result.rows) {
+    const memory = mapRowToMemory(row as Record<string, unknown>);
+    results.set(memory.id, {
+      memory,
+      vectorScore: parseFloat(row.similarity as string),
+    });
+  }
+
+  return results;
+}
+
+/**
+ * Perform text search for memories using PostgreSQL full-text search.
+ */
+async function textSearch(
+  pool: Pool,
+  query: string,
+  options: HybridSearchOptions,
+  candidateLimit: number
+): Promise<Map<string, { memory: MemoryEntry; textScore: number }>> {
+  const { conditions, params, nextIdx } = buildFilterConditions(options, 2);
+
+  const allParams = [query, ...params, candidateLimit];
+
+  const whereClause = conditions.length > 0 ? `AND ${conditions.join(' AND ')}` : '';
+
+  const result = await pool.query(
+    `SELECT
+      id::text, user_email, work_item_id::text, contact_id::text,
+      title, content, memory_type::text,
+      created_by_agent, created_by_human, source_url,
+      importance, confidence, expires_at, superseded_by::text,
+      embedding_status, created_at, updated_at,
+      ts_rank(search_vector, websearch_to_tsquery('english', $1)) as ts_rank
+    FROM memory
+    WHERE search_vector @@ websearch_to_tsquery('english', $1)
+      ${whereClause}
+    ORDER BY ts_rank DESC
+    LIMIT $${nextIdx}`,
+    allParams
+  );
+
+  const results = new Map<string, { memory: MemoryEntry; textScore: number }>();
+
+  for (const row of result.rows) {
+    const memory = mapRowToMemory(row as Record<string, unknown>);
+    results.set(memory.id, {
+      memory,
+      textScore: parseFloat(row.ts_rank as string),
+    });
+  }
+
+  return results;
+}
+
+/**
+ * Search memories using hybrid search (combining vector and text).
+ *
+ * This function:
+ * 1. Performs vector (semantic) search to find semantically similar memories
+ * 2. Performs text (BM25) search to find keyword-matching memories
+ * 3. Combines results with configurable weights (default 0.7 vector, 0.3 text)
+ * 4. Returns deduplicated, sorted results
+ *
+ * @param pool - Database connection pool
+ * @param query - Search query
+ * @param options - Search options including weights
+ * @returns Hybrid search results
+ */
+export async function searchMemoriesHybrid(
+  pool: Pool,
+  query: string,
+  options: HybridSearchOptions = {}
+): Promise<HybridSearchResult> {
+  const {
+    limit = 10,
+    minScore = 0.3,
+    vectorWeight = 0.7,
+    textWeight = 0.3,
+  } = options;
+
+  // Get more candidates than needed to allow for deduplication and filtering
+  const candidateLimit = Math.min(limit * 4, 100);
+
+  let vectorResults: Map<string, { memory: MemoryEntry; vectorScore: number }> = new Map();
+  let queryEmbeddingProvider: string | undefined;
+  let vectorSearchEnabled = false;
+
+  // Try vector search
+  try {
+    const { embeddingService } = await import('../embeddings/index.ts');
+
+    if (embeddingService.isConfigured()) {
+      const embeddingResult = await embeddingService.embed(query);
+
+      if (embeddingResult) {
+        vectorSearchEnabled = true;
+        queryEmbeddingProvider = embeddingResult.provider;
+        vectorResults = await vectorSearch(pool, embeddingResult.embedding, options, candidateLimit);
+      }
+    }
+  } catch (error) {
+    console.warn('[Hybrid Search] Vector search failed:', error);
+  }
+
+  // If vector search is not available, fall back to text-only
+  if (!vectorSearchEnabled) {
+    const textResults = await textSearch(pool, query, options, limit);
+
+    // Find max ts_rank for normalization
+    let maxTextScore = 0;
+    for (const { textScore } of textResults.values()) {
+      maxTextScore = Math.max(maxTextScore, textScore);
+    }
+
+    const results: HybridSearchMemory[] = [];
+    for (const { memory, textScore } of textResults.values()) {
+      const normalizedTextScore = maxTextScore > 0 ? textScore / maxTextScore : 0;
+      results.push({
+        ...memory,
+        textScore: normalizedTextScore,
+        combinedScore: normalizedTextScore, // Only text score available
+      });
+    }
+
+    results.sort((a, b) => b.combinedScore - a.combinedScore);
+
+    return {
+      results: results.slice(0, limit),
+      searchType: 'text',
+      weights: { vectorWeight, textWeight },
+    };
+  }
+
+  // Perform text search
+  const textResults = await textSearch(pool, query, options, candidateLimit);
+
+  // Find max ts_rank for normalization (ts_rank is not normalized like cosine similarity)
+  let maxTextScore = 0;
+  for (const { textScore } of textResults.values()) {
+    maxTextScore = Math.max(maxTextScore, textScore);
+  }
+
+  // Combine results
+  const combinedMap = new Map<string, HybridSearchMemory>();
+
+  // Add vector results
+  for (const [id, { memory, vectorScore }] of vectorResults) {
+    const textResult = textResults.get(id);
+    const rawTextScore = textResult?.textScore ?? 0;
+    const normalizedTextScore = maxTextScore > 0 ? rawTextScore / maxTextScore : 0;
+
+    combinedMap.set(id, {
+      ...memory,
+      vectorScore,
+      textScore: normalizedTextScore,
+      combinedScore: combineScores(vectorScore, normalizedTextScore, vectorWeight, textWeight),
+    });
+  }
+
+  // Add text-only results (not in vector results)
+  for (const [id, { memory, textScore }] of textResults) {
+    if (!combinedMap.has(id)) {
+      const normalizedTextScore = maxTextScore > 0 ? textScore / maxTextScore : 0;
+
+      combinedMap.set(id, {
+        ...memory,
+        vectorScore: 0,
+        textScore: normalizedTextScore,
+        combinedScore: combineScores(0, normalizedTextScore, vectorWeight, textWeight),
+      });
+    }
+  }
+
+  // Convert to array, filter, and sort
+  const results = Array.from(combinedMap.values())
+    .filter((m) => m.combinedScore >= minScore)
+    .sort((a, b) => b.combinedScore - a.combinedScore)
+    .slice(0, limit);
+
+  return {
+    results,
+    searchType: 'hybrid',
+    weights: { vectorWeight, textWeight },
+    queryEmbeddingProvider,
+  };
+}

--- a/tests/api/hybrid-search.test.ts
+++ b/tests/api/hybrid-search.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Tests for hybrid search (BM25 + vector) functionality.
+ * Part of Epic #310, Issue #322.
+ */
+
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import type { Pool, QueryResult } from 'pg';
+import {
+  searchMemoriesHybrid,
+  type HybridSearchOptions,
+  type HybridSearchResult,
+  normalizeScore,
+  combineScores,
+} from '../../src/api/search/hybrid.ts';
+
+// Mock pool
+function createMockPool(): Pool {
+  return {
+    query: vi.fn(),
+    end: vi.fn(),
+  } as unknown as Pool;
+}
+
+// Mock embedding service
+vi.mock('../../src/api/embeddings/index.ts', () => ({
+  embeddingService: {
+    isConfigured: vi.fn(() => true),
+    embed: vi.fn((query: string) => Promise.resolve({
+      embedding: new Array(1024).fill(0.1),
+      provider: 'test',
+    })),
+  },
+}));
+
+describe('Hybrid Search', () => {
+  describe('normalizeScore', () => {
+    it('should return 0 for null/undefined', () => {
+      expect(normalizeScore(null, 0, 1)).toBe(0);
+      expect(normalizeScore(undefined, 0, 1)).toBe(0);
+    });
+
+    it('should normalize scores to 0-1 range', () => {
+      expect(normalizeScore(5, 0, 10)).toBe(0.5);
+      expect(normalizeScore(0, 0, 10)).toBe(0);
+      expect(normalizeScore(10, 0, 10)).toBe(1);
+    });
+
+    it('should handle equal min and max', () => {
+      expect(normalizeScore(5, 5, 5)).toBe(1);
+    });
+
+    it('should clamp values outside range', () => {
+      expect(normalizeScore(15, 0, 10)).toBe(1);
+      expect(normalizeScore(-5, 0, 10)).toBe(0);
+    });
+  });
+
+  describe('combineScores', () => {
+    it('should combine scores with default weights (0.7 vector, 0.3 text)', () => {
+      const combined = combineScores(1.0, 1.0);
+      expect(combined).toBeCloseTo(1.0, 5);
+    });
+
+    it('should combine scores with custom weights', () => {
+      const combined = combineScores(1.0, 0.0, 0.5, 0.5);
+      expect(combined).toBeCloseTo(0.5, 5);
+    });
+
+    it('should weight vector score higher by default', () => {
+      // Vector score 0.8, text score 0.2
+      // 0.7 * 0.8 + 0.3 * 0.2 = 0.56 + 0.06 = 0.62
+      const combined = combineScores(0.8, 0.2);
+      expect(combined).toBeCloseTo(0.62, 5);
+    });
+
+    it('should handle zero scores', () => {
+      expect(combineScores(0, 0)).toBe(0);
+      expect(combineScores(1.0, 0)).toBeCloseTo(0.7, 5);
+      expect(combineScores(0, 1.0)).toBeCloseTo(0.3, 5);
+    });
+  });
+
+  describe('searchMemoriesHybrid', () => {
+    let mockPool: Pool;
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+      mockPool = createMockPool();
+    });
+
+    it('should perform hybrid search combining vector and text results', async () => {
+      // Mock vector search results
+      const vectorQueryMock = vi.fn().mockResolvedValueOnce({
+        rows: [
+          { id: 'mem-1', title: 'Memory 1', content: 'Content 1', similarity: '0.9', memory_type: 'fact' },
+          { id: 'mem-2', title: 'Memory 2', content: 'Content 2', similarity: '0.8', memory_type: 'fact' },
+        ],
+      });
+
+      // Mock text search results
+      const textQueryMock = vi.fn().mockResolvedValueOnce({
+        rows: [
+          { id: 'mem-1', title: 'Memory 1', content: 'Content 1', ts_rank: '0.5', memory_type: 'fact' },
+          { id: 'mem-3', title: 'Memory 3', content: 'Content 3', ts_rank: '0.3', memory_type: 'fact' },
+        ],
+      });
+
+      (mockPool.query as ReturnType<typeof vi.fn>)
+        .mockImplementationOnce(vectorQueryMock)
+        .mockImplementationOnce(textQueryMock);
+
+      const result = await searchMemoriesHybrid(mockPool, 'test query', {
+        limit: 10,
+      });
+
+      expect(result.searchType).toBe('hybrid');
+      expect(result.results.length).toBeGreaterThan(0);
+      // mem-1 should appear (it's in both vector and text results)
+      expect(result.results.some(r => r.id === 'mem-1')).toBe(true);
+    });
+
+    it('should use configurable weights', async () => {
+      (mockPool.query as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce({
+          rows: [{ id: 'mem-1', title: 'Memory 1', content: 'Content 1', similarity: '0.8', memory_type: 'fact' }],
+        })
+        .mockResolvedValueOnce({
+          rows: [{ id: 'mem-1', title: 'Memory 1', content: 'Content 1', ts_rank: '0.8', memory_type: 'fact' }],
+        });
+
+      const result = await searchMemoriesHybrid(mockPool, 'test query', {
+        vectorWeight: 0.5,
+        textWeight: 0.5,
+      });
+
+      expect(result.weights.vectorWeight).toBe(0.5);
+      expect(result.weights.textWeight).toBe(0.5);
+    });
+
+    it('should fall back to text-only when embedding service unavailable', async () => {
+      const { embeddingService } = await import('../../src/api/embeddings/index.ts');
+      (embeddingService.isConfigured as ReturnType<typeof vi.fn>).mockReturnValueOnce(false);
+
+      (mockPool.query as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        rows: [
+          { id: 'mem-1', title: 'Memory 1', content: 'Content 1', ts_rank: '0.5', memory_type: 'fact' },
+        ],
+      });
+
+      const result = await searchMemoriesHybrid(mockPool, 'test query', {});
+
+      expect(result.searchType).toBe('text');
+    });
+
+    it('should respect limit parameter', async () => {
+      const manyResults = Array.from({ length: 20 }, (_, i) => ({
+        id: `mem-${i}`,
+        title: `Memory ${i}`,
+        content: `Content ${i}`,
+        similarity: String(1 - i * 0.05),
+        memory_type: 'fact',
+      }));
+
+      (mockPool.query as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce({ rows: manyResults })
+        .mockResolvedValueOnce({ rows: [] });
+
+      const result = await searchMemoriesHybrid(mockPool, 'test query', {
+        limit: 5,
+      });
+
+      expect(result.results.length).toBeLessThanOrEqual(5);
+    });
+
+    it('should filter by userEmail when provided', async () => {
+      (mockPool.query as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [] });
+
+      await searchMemoriesHybrid(mockPool, 'test query', {
+        userEmail: 'test@example.com',
+      });
+
+      const vectorCall = (mockPool.query as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(vectorCall[0]).toContain('user_email');
+      expect(vectorCall[1]).toContain('test@example.com');
+    });
+
+    it('should deduplicate results appearing in both vector and text search', async () => {
+      // Same memory appears in both
+      (mockPool.query as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce({
+          rows: [{ id: 'mem-1', title: 'Memory 1', content: 'Content 1', similarity: '0.9', memory_type: 'fact' }],
+        })
+        .mockResolvedValueOnce({
+          rows: [{ id: 'mem-1', title: 'Memory 1', content: 'Content 1', ts_rank: '0.5', memory_type: 'fact' }],
+        });
+
+      const result = await searchMemoriesHybrid(mockPool, 'test query', {});
+
+      // Should only appear once but with combined score
+      const mem1Entries = result.results.filter(r => r.id === 'mem-1');
+      expect(mem1Entries.length).toBe(1);
+      // Combined score should be higher than either individual score
+      expect(mem1Entries[0].combinedScore).toBeGreaterThan(0);
+    });
+
+    it('should return results with both scores when available', async () => {
+      (mockPool.query as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce({
+          rows: [{ id: 'mem-1', title: 'Memory 1', content: 'Content 1', similarity: '0.9', memory_type: 'fact' }],
+        })
+        .mockResolvedValueOnce({
+          rows: [{ id: 'mem-1', title: 'Memory 1', content: 'Content 1', ts_rank: '0.5', memory_type: 'fact' }],
+        });
+
+      const result = await searchMemoriesHybrid(mockPool, 'test query', {});
+
+      const mem1 = result.results.find(r => r.id === 'mem-1')!;
+      expect(mem1.vectorScore).toBeDefined();
+      expect(mem1.textScore).toBeDefined();
+      expect(mem1.combinedScore).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements Issue #322 - Hybrid search combining BM25 (text) and vector similarity search.

Per [OpenClaw docs](https://docs.openclaw.ai/concepts/memory.md#hybrid-search-bm25--vector):
> Combines semantic similarity with keyword matching through weighted scoring:
> - Vector weight: 0.7 (semantic meaning)
> - Text weight: 0.3 (exact tokens like IDs, error strings)

This addresses vector weakness on "exact, high-signal tokens" (IDs, error strings, specific names) while leveraging its strength on paraphrases.

### Implementation

**New module: `src/api/search/hybrid.ts`**

- `searchMemoriesHybrid(pool, query, options)` - Main hybrid search function
- `normalizeScore(score, min, max)` - Normalize ts_rank to 0-1 range
- `combineScores(vectorScore, textScore, vectorWeight, textWeight)` - Weighted combination

**Search Flow:**
1. Perform vector (semantic) search using pgvector
2. Perform text (BM25) search using PostgreSQL ts_rank
3. Normalize text scores to 0-1 range (cosine similarity is already normalized)
4. Combine scores: `0.7 * vectorScore + 0.3 * textScore`
5. Deduplicate and sort by combined score
6. Fall back to text-only if embedding service unavailable

**Configurable Options:**
- `vectorWeight` - Weight for semantic similarity (default: 0.7)
- `textWeight` - Weight for keyword matching (default: 0.3)
- `minScore` - Minimum combined score threshold (default: 0.3)
- Filter options: userEmail, workItemId, contactId, memoryType

## Test plan

- [x] 15 tests pass in tests/api/hybrid-search.test.ts
- [x] Tests cover score normalization and combination
- [x] Tests cover deduplication of results in both searches
- [x] Tests cover fallback to text-only search

Closes #322

🤖 Generated with [Claude Code](https://claude.ai/code)