### PR TITLE
[#323] Add per-user rate limiting

### DIFF
--- a/src/api/rate-limit/per-user.ts
+++ b/src/api/rate-limit/per-user.ts
@@ -1,0 +1,185 @@
+/**
+ * Per-user rate limiting utilities.
+ * Part of Epic #310, Issue #323.
+ *
+ * Provides user-based rate limiting that falls back to IP when unauthenticated.
+ * Different endpoint categories have different rate limits.
+ */
+
+import type { FastifyRequest } from 'fastify';
+
+/** Rate limit categories for different endpoint types */
+export type RateLimitCategory = 'read' | 'write' | 'search' | 'send' | 'admin' | 'webhook';
+
+/** Rate limit configuration */
+export interface RateLimitConfig {
+  /** Maximum requests allowed in the time window */
+  max: number;
+  /** Time window in milliseconds */
+  timeWindow: number;
+}
+
+/** Default rate limits per category (requests per minute) */
+const DEFAULT_LIMITS: Record<RateLimitCategory, number> = {
+  read: 100,
+  write: 30,
+  search: 20,
+  send: 10,
+  admin: 5,
+  webhook: 60, // Higher limit for external service webhooks
+};
+
+/** Environment variable names for category overrides */
+const ENV_OVERRIDE_KEYS: Record<RateLimitCategory, string> = {
+  read: 'RATE_LIMIT_READ_MAX',
+  write: 'RATE_LIMIT_WRITE_MAX',
+  search: 'RATE_LIMIT_SEARCH_MAX',
+  send: 'RATE_LIMIT_SEND_MAX',
+  admin: 'RATE_LIMIT_ADMIN_MAX',
+  webhook: 'RATE_LIMIT_WEBHOOK_MAX',
+};
+
+/**
+ * Type for session email extraction function.
+ * This allows the rate limiter to use the existing session lookup from server.ts.
+ */
+export type GetSessionEmailFn = (req: FastifyRequest) => Promise<string | null>;
+
+/**
+ * Extract user ID for rate limiting purposes.
+ *
+ * Returns a prefixed key:
+ * - "user:{email}" for authenticated users
+ * - "ip:{ip}" for unauthenticated requests
+ *
+ * @param req - Fastify request
+ * @param getSessionEmail - Function to extract session email from request
+ * @returns Rate limit key
+ */
+export async function extractUserIdForRateLimit(
+  req: FastifyRequest,
+  getSessionEmail: GetSessionEmailFn
+): Promise<string> {
+  try {
+    const email = await getSessionEmail(req);
+    if (email) {
+      return `user:${email}`;
+    }
+  } catch {
+    // Fall through to IP-based limiting on session lookup error
+  }
+
+  return `ip:${req.ip}`;
+}
+
+/**
+ * Determine the rate limit category for an endpoint.
+ *
+ * @param method - HTTP method
+ * @param url - Request URL path
+ * @returns Rate limit category
+ */
+export function getEndpointRateLimitCategory(method: string, url: string): RateLimitCategory {
+  const upperMethod = method.toUpperCase();
+  const path = url.split('?')[0]; // Remove query string
+
+  // Admin endpoints
+  if (path.includes('/admin/')) {
+    return 'admin';
+  }
+
+  // Webhook endpoints (external services calling our API)
+  if (
+    path.startsWith('/api/twilio/sms') &&
+    !path.includes('/send') ||
+    path.startsWith('/api/postmark/') ||
+    path.startsWith('/api/cloudflare/email')
+  ) {
+    return 'webhook';
+  }
+
+  // Message sending endpoints
+  if (
+    path.includes('/send') ||
+    path.includes('/email/send')
+  ) {
+    return 'send';
+  }
+
+  // Search endpoints
+  if (path.includes('/search')) {
+    return 'search';
+  }
+
+  // Write operations (POST/PUT/PATCH/DELETE except webhooks and search)
+  if (['POST', 'PUT', 'PATCH', 'DELETE'].includes(upperMethod)) {
+    return 'write';
+  }
+
+  // Default to read for GET requests
+  return 'read';
+}
+
+/**
+ * Get rate limit configuration for a category.
+ *
+ * Respects environment variable overrides.
+ *
+ * @param category - Rate limit category
+ * @returns Rate limit configuration
+ */
+export function getRateLimitConfig(category: RateLimitCategory): RateLimitConfig {
+  // Check for category-specific override
+  const envKey = ENV_OVERRIDE_KEYS[category];
+  const envValue = process.env[envKey];
+  const max = envValue ? parseInt(envValue, 10) : DEFAULT_LIMITS[category];
+
+  // Get global time window override or default to 1 minute
+  const timeWindow = parseInt(process.env.RATE_LIMIT_WINDOW_MS || '60000', 10);
+
+  return { max, timeWindow };
+}
+
+/**
+ * Create a key generator function for use with @fastify/rate-limit.
+ *
+ * This creates an async key generator that:
+ * 1. Tries to identify the user by session email
+ * 2. Falls back to IP address if not authenticated
+ *
+ * @param getSessionEmail - Function to extract session email from request
+ * @returns Key generator function for rate limiting
+ */
+export function createRateLimitKeyGenerator(
+  getSessionEmail: GetSessionEmailFn
+): (req: FastifyRequest) => Promise<string> {
+  return async (req: FastifyRequest): Promise<string> => {
+    return extractUserIdForRateLimit(req, getSessionEmail);
+  };
+}
+
+/**
+ * Get route-specific rate limit configuration.
+ *
+ * Returns config object suitable for use in Fastify route options.
+ *
+ * @param category - Rate limit category
+ * @param getSessionEmail - Session email extraction function
+ * @returns Rate limit route configuration
+ */
+export function getRouteRateLimitConfig(
+  category: RateLimitCategory,
+  getSessionEmail: GetSessionEmailFn
+): {
+  max: number;
+  timeWindow: number;
+  keyGenerator: (req: FastifyRequest) => Promise<string>;
+} {
+  const { max, timeWindow } = getRateLimitConfig(category);
+
+  return {
+    max,
+    timeWindow,
+    keyGenerator: createRateLimitKeyGenerator(getSessionEmail),
+  };
+}

--- a/tests/api/per-user-rate-limit.test.ts
+++ b/tests/api/per-user-rate-limit.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Tests for per-user rate limiting functionality.
+ * Part of Epic #310, Issue #323.
+ */
+
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import type { FastifyRequest } from 'fastify';
+import {
+  extractUserIdForRateLimit,
+  getRateLimitConfig,
+  getEndpointRateLimitCategory,
+  type RateLimitCategory,
+} from '../../src/api/rate-limit/per-user.ts';
+
+// Mock request creator
+function createMockRequest(options: {
+  ip?: string;
+  sessionEmail?: string | null;
+  bearerToken?: string;
+  url?: string;
+  method?: string;
+}): FastifyRequest {
+  const { ip = '127.0.0.1', sessionEmail, bearerToken, url = '/api/test', method = 'GET' } = options;
+
+  return {
+    ip,
+    url,
+    method,
+    headers: bearerToken ? { authorization: `Bearer ${bearerToken}` } : {},
+    // Mock for session email extraction (will be called by middleware)
+    _sessionEmail: sessionEmail,
+  } as unknown as FastifyRequest;
+}
+
+describe('Per-User Rate Limiting', () => {
+  describe('extractUserIdForRateLimit', () => {
+    it('should return session email when available', async () => {
+      const mockGetSessionEmail = vi.fn().mockResolvedValue('user@example.com');
+      const req = createMockRequest({ ip: '192.168.1.1' });
+
+      const userId = await extractUserIdForRateLimit(req, mockGetSessionEmail);
+
+      expect(userId).toBe('user:user@example.com');
+      expect(mockGetSessionEmail).toHaveBeenCalledWith(req);
+    });
+
+    it('should fall back to IP when no session', async () => {
+      const mockGetSessionEmail = vi.fn().mockResolvedValue(null);
+      const req = createMockRequest({ ip: '192.168.1.100' });
+
+      const userId = await extractUserIdForRateLimit(req, mockGetSessionEmail);
+
+      expect(userId).toBe('ip:192.168.1.100');
+    });
+
+    it('should handle session lookup errors gracefully', async () => {
+      const mockGetSessionEmail = vi.fn().mockRejectedValue(new Error('DB error'));
+      const req = createMockRequest({ ip: '10.0.0.1' });
+
+      const userId = await extractUserIdForRateLimit(req, mockGetSessionEmail);
+
+      expect(userId).toBe('ip:10.0.0.1');
+    });
+
+    it('should prefix user IDs to distinguish from IP keys', async () => {
+      const mockGetSessionEmail = vi.fn().mockResolvedValue('admin@example.com');
+      const req = createMockRequest({ ip: '127.0.0.1' });
+
+      const userId = await extractUserIdForRateLimit(req, mockGetSessionEmail);
+
+      expect(userId.startsWith('user:')).toBe(true);
+    });
+  });
+
+  describe('getEndpointRateLimitCategory', () => {
+    it('should categorize read operations', () => {
+      expect(getEndpointRateLimitCategory('GET', '/api/contacts')).toBe('read');
+      expect(getEndpointRateLimitCategory('GET', '/api/work-items')).toBe('read');
+      expect(getEndpointRateLimitCategory('GET', '/api/memories')).toBe('read');
+    });
+
+    it('should categorize write operations', () => {
+      expect(getEndpointRateLimitCategory('POST', '/api/contacts')).toBe('write');
+      expect(getEndpointRateLimitCategory('PUT', '/api/work-items/123')).toBe('write');
+      expect(getEndpointRateLimitCategory('PATCH', '/api/memories/456')).toBe('write');
+      expect(getEndpointRateLimitCategory('DELETE', '/api/contacts/789')).toBe('write');
+    });
+
+    it('should categorize search operations', () => {
+      expect(getEndpointRateLimitCategory('GET', '/api/search')).toBe('search');
+      expect(getEndpointRateLimitCategory('GET', '/api/memories/search')).toBe('search');
+      expect(getEndpointRateLimitCategory('POST', '/api/search/hybrid')).toBe('search');
+    });
+
+    it('should categorize message sending operations', () => {
+      expect(getEndpointRateLimitCategory('POST', '/api/twilio/sms/send')).toBe('send');
+      expect(getEndpointRateLimitCategory('POST', '/api/email/send')).toBe('send');
+    });
+
+    it('should categorize admin operations', () => {
+      expect(getEndpointRateLimitCategory('POST', '/api/admin/users')).toBe('admin');
+      expect(getEndpointRateLimitCategory('DELETE', '/api/admin/cache')).toBe('admin');
+    });
+
+    it('should categorize webhook operations', () => {
+      expect(getEndpointRateLimitCategory('POST', '/api/twilio/sms')).toBe('webhook');
+      expect(getEndpointRateLimitCategory('POST', '/api/postmark/inbound')).toBe('webhook');
+      expect(getEndpointRateLimitCategory('POST', '/api/cloudflare/email')).toBe('webhook');
+    });
+
+    it('should default to read for health endpoints', () => {
+      expect(getEndpointRateLimitCategory('GET', '/api/health')).toBe('read');
+    });
+  });
+
+  describe('getRateLimitConfig', () => {
+    const originalEnv = process.env;
+
+    beforeEach(() => {
+      process.env = { ...originalEnv };
+    });
+
+    afterEach(() => {
+      process.env = originalEnv;
+    });
+
+    it('should return default limits for read category', () => {
+      const config = getRateLimitConfig('read');
+
+      expect(config.max).toBe(100);
+      expect(config.timeWindow).toBe(60000);
+    });
+
+    it('should return stricter limits for write category', () => {
+      const config = getRateLimitConfig('write');
+
+      expect(config.max).toBe(30);
+      expect(config.timeWindow).toBe(60000);
+    });
+
+    it('should return moderate limits for search category', () => {
+      const config = getRateLimitConfig('search');
+
+      expect(config.max).toBe(20);
+      expect(config.timeWindow).toBe(60000);
+    });
+
+    it('should return strict limits for send category', () => {
+      const config = getRateLimitConfig('send');
+
+      expect(config.max).toBe(10);
+      expect(config.timeWindow).toBe(60000);
+    });
+
+    it('should return strictest limits for admin category', () => {
+      const config = getRateLimitConfig('admin');
+
+      expect(config.max).toBe(5);
+      expect(config.timeWindow).toBe(60000);
+    });
+
+    it('should return higher limits for webhook category', () => {
+      const config = getRateLimitConfig('webhook');
+
+      expect(config.max).toBe(60);
+      expect(config.timeWindow).toBe(60000);
+    });
+
+    it('should allow override via environment variables', () => {
+      process.env.RATE_LIMIT_SEARCH_MAX = '50';
+      process.env.RATE_LIMIT_SEND_MAX = '5';
+
+      expect(getRateLimitConfig('search').max).toBe(50);
+      expect(getRateLimitConfig('send').max).toBe(5);
+    });
+
+    it('should use global window override', () => {
+      process.env.RATE_LIMIT_WINDOW_MS = '30000';
+
+      const config = getRateLimitConfig('read');
+
+      expect(config.timeWindow).toBe(30000);
+    });
+  });
+
+  describe('Rate limit key generation', () => {
+    it('should generate different keys for different users', async () => {
+      const mockGetSessionEmail1 = vi.fn().mockResolvedValue('user1@example.com');
+      const mockGetSessionEmail2 = vi.fn().mockResolvedValue('user2@example.com');
+
+      const req1 = createMockRequest({ ip: '192.168.1.1' });
+      const req2 = createMockRequest({ ip: '192.168.1.1' });
+
+      const key1 = await extractUserIdForRateLimit(req1, mockGetSessionEmail1);
+      const key2 = await extractUserIdForRateLimit(req2, mockGetSessionEmail2);
+
+      expect(key1).not.toBe(key2);
+    });
+
+    it('should generate same key for same user from different IPs', async () => {
+      const email = 'consistent@example.com';
+      const mockGetSessionEmail = vi.fn().mockResolvedValue(email);
+
+      const req1 = createMockRequest({ ip: '192.168.1.1' });
+      const req2 = createMockRequest({ ip: '10.0.0.1' });
+
+      const key1 = await extractUserIdForRateLimit(req1, mockGetSessionEmail);
+      const key2 = await extractUserIdForRateLimit(req2, mockGetSessionEmail);
+
+      expect(key1).toBe(key2);
+      expect(key1).toBe(`user:${email}`);
+    });
+
+    it('should generate different keys for different IPs when unauthenticated', async () => {
+      const mockGetSessionEmail = vi.fn().mockResolvedValue(null);
+
+      const req1 = createMockRequest({ ip: '192.168.1.1' });
+      const req2 = createMockRequest({ ip: '10.0.0.1' });
+
+      const key1 = await extractUserIdForRateLimit(req1, mockGetSessionEmail);
+      const key2 = await extractUserIdForRateLimit(req2, mockGetSessionEmail);
+
+      expect(key1).not.toBe(key2);
+      expect(key1).toBe('ip:192.168.1.1');
+      expect(key2).toBe('ip:10.0.0.1');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements per-user rate limiting that falls back to IP when not authenticated.

- Create per-user rate limit module (`src/api/rate-limit/per-user.ts`)
- Implement `extractUserIdForRateLimit` for session-based user identification
- Add `getEndpointRateLimitCategory` for endpoint categorization
- Support environment variable overrides per category
- Integrate with existing @fastify/rate-limit setup in server.ts
- Enhanced logging includes user context and category

### Rate Limit Categories

| Category | Limit | Endpoints |
|----------|-------|-----------|
| read | 100/min | GET operations |
| write | 30/min | POST/PUT/PATCH/DELETE |
| search | 20/min | /search endpoints |
| send | 10/min | Message sending |
| admin | 5/min | /admin/* endpoints |
| webhook | 60/min | External service webhooks |

### Environment Variables

```bash
RATE_LIMIT_READ_MAX=100
RATE_LIMIT_WRITE_MAX=30
RATE_LIMIT_SEARCH_MAX=20
RATE_LIMIT_SEND_MAX=10
RATE_LIMIT_ADMIN_MAX=5
RATE_LIMIT_WEBHOOK_MAX=60
RATE_LIMIT_WINDOW_MS=60000
```

## Test Plan

- [x] 22 unit tests for rate limit utilities
- [x] Existing rate limit tests pass (29 total)
- [x] Full test suite passes (2444 tests)

Closes #323

🤖 Generated with [Claude Code](https://claude.ai/code)