### PR TITLE
docs: add git worktree discipline to ralph-templates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,6 +158,24 @@ If you have not read them in this environment, stop and read them.
 - For long-running autonomous work across multiple issues, use **ralph-loop** per the runbook:
   - always set `--max-iterations`
   - only emit the completion promise when the work is truly complete
+  - use templates from `docs/ralph-templates/` (issue, epic, iteration, initiative)
+
+### Worktree Discipline (MANDATORY)
+
+**Never work in the root repository directly.** All work MUST happen in isolated git worktrees in `/tmp`.
+
+```bash
+# Create worktree
+git worktree add /tmp/worktree-issue-<NUMBER>-<slug> -b issue/<NUMBER>-<slug>
+cd /tmp/worktree-issue-<NUMBER>-<slug>
+
+# After PR merged, clean up
+cd <REPO_ROOT>
+git worktree remove /tmp/worktree-issue-<NUMBER>-<slug>
+git branch -d issue/<NUMBER>-<slug>
+```
+
+This enables parallel agents and prevents filesystem conflicts. See `AGENTS.md` for full worktree policy.
 
 ---
 

--- a/docs/ralph-templates/epic.md
+++ b/docs/ralph-templates/epic.md
@@ -2,7 +2,16 @@
 
 Use this template for autonomous work on an epic - a group of related issues that form a cohesive feature.
 
-## Command
+## Execution Modes
+
+Epics can run in two modes:
+
+| Mode                       | When to Use                     | How                                                     |
+| -------------------------- | ------------------------------- | ------------------------------------------------------- |
+| **Sequential**             | Issues have strict dependencies | Single Ralph instance processes issues in order         |
+| **Parallel Orchestration** | Independent issues exist        | Orchestrator spawns worker agents in separate worktrees |
+
+## Command (Sequential Mode)
 
 ```bash
 /ralph-loop:ralph-loop "
@@ -20,30 +29,49 @@ Use this template for autonomous work on an epic - a group of related issues tha
 
 Follow CODING.md without exception.
 
-For EACH issue in order:
+**CRITICAL: Never work in <REPO_ROOT> directly.**
+
+For EACH issue in dependency order:
+
+#### Phase: Workspace Setup
+1. Create isolated worktree:
+   \`\`\`bash
+   git worktree add /tmp/worktree-issue-<number>-<slug> -b issue/<number>-<slug>
+   cd /tmp/worktree-issue-<number>-<slug>
+   \`\`\`
 
 #### Phase: Issue Work
 1. Read issue for full acceptance criteria
-2. Create branch \`issue/<number>-<slug>\`
-3. Implement with TDD (tests first, real services)
-4. Update issue with progress as you work
-5. Commit atomically: \`[#<number>] description\`
-6. Local validation: typecheck, lint, test, build
-7. Create PR with clear description
-8. Self-review (security + blind spots)
-9. Monitor CI until green
-10. Merge and update issue
+2. Implement with TDD (tests first, real services)
+3. Update issue with progress as you work
+4. Commit atomically: \`[#<number>] description\`
+5. Local validation: typecheck, lint, test, build
+6. Create PR with clear description
+7. Self-review (security + blind spots)
+8. Monitor CI until green
+9. Merge and update issue
+
+#### Phase: Cleanup
+After each issue's PR is merged:
+\`\`\`bash
+cd <REPO_ROOT>
+git worktree remove /tmp/worktree-issue-<number>-<slug>
+git branch -d issue/<number>-<slug>
+git fetch origin main && git pull origin main
+\`\`\`
 
 #### Between Issues
-- Fetch latest main
-- Create new branch for next issue
+- Verify main is stable (CI green)
 - Reference previous work in issue comments
+- Create new worktree for next issue
 
 ### Constraints
+- NEVER work in <REPO_ROOT> directly
 - Complete issues in dependency order
-- Each issue gets its own branch and PR
+- Each issue gets its own worktree, branch, and PR
 - Never batch multiple issues into one PR
-- Update each issue independently
+- Clean up worktree immediately after each merge
+- Workers use REST-only GitHub API (no GraphQL)
 
 ### Completion
 
@@ -51,7 +79,92 @@ Output <promise>EPIC COMPLETE</promise> when:
 - ALL listed issues are merged to main
 - ALL acceptance criteria verified
 - ALL issues updated with completion status
+- ALL worktrees cleaned up
 - Main branch is stable (CI green)
+" --completion-promise "EPIC COMPLETE" --max-iterations 100
+```
+
+## Command (Parallel Orchestration Mode)
+
+Use when multiple issues can be worked on simultaneously (no dependencies between them).
+
+```bash
+/ralph-loop:ralph-loop "
+## Epic: <EPIC TITLE> (Orchestrated)
+
+### Overview
+<What this epic delivers, why it matters>
+
+### Issues in Scope
+
+#### Sequential (must complete first)
+1. #<ISSUE1> - <Title> (foundation - do first)
+
+#### Parallel Batch 1 (after #<ISSUE1> complete)
+- #<ISSUE2> - <Title>
+- #<ISSUE3> - <Title>
+- #<ISSUE4> - <Title>
+
+#### Sequential (after Batch 1)
+5. #<ISSUE5> - <Title> (depends on #2-#4)
+
+### Process
+
+Follow CODING.md without exception.
+
+**You are the ORCHESTRATOR.** You coordinate work but delegate implementation.
+
+#### Orchestrator Rules
+- You remain in <REPO_ROOT> (coordination only)
+- You are the ONLY agent allowed to use GitHub Projects/GraphQL
+- You spawn worker agents for parallel issues
+- You serialize project board updates
+
+#### Sequential Issues
+Handle these yourself using the standard worktree flow:
+1. Create worktree in /tmp/worktree-issue-<number>-<slug>
+2. Implement, test, PR, merge
+3. Clean up worktree
+4. Update project board status
+
+#### Parallel Batches
+Spawn Claude Code workers for independent issues:
+
+\`\`\`bash
+# Spawn workers for parallel batch (each in separate terminal/process)
+claude --worktree /tmp/worktree-issue-<ISSUE2>-<slug> \"
+  Work on issue #<ISSUE2>.
+  Follow CODING.md.
+  REST-only GitHub API (no GraphQL).
+  Exit when PR merged or blocked.
+\"
+\`\`\`
+
+Each worker:
+- Gets its own worktree in /tmp/worktree-issue-<number>-<slug>
+- Works on exactly ONE issue
+- Uses REST-only GitHub API
+- Reports completion via PR merge
+- Cleans up its worktree after merge
+
+#### Coordination
+- Wait for all parallel workers to complete before next batch
+- Aggregate any blockers before proceeding
+- Update project board after each batch completes
+
+### Constraints
+- Orchestrator stays in <REPO_ROOT> (no direct code changes)
+- Workers MUST use isolated worktrees in /tmp
+- Workers MUST NOT use GraphQL or gh project commands
+- One worker = one issue = one worktree = one branch = one PR
+- Clean up all worktrees after merges
+
+### Completion
+
+Output <promise>EPIC COMPLETE</promise> when:
+- ALL issues merged to main
+- ALL worktrees cleaned up
+- Main branch stable (CI green)
 " --completion-promise "EPIC COMPLETE" --max-iterations 100
 ```
 
@@ -59,13 +172,26 @@ Output <promise>EPIC COMPLETE</promise> when:
 
 Replace:
 
+- `<REPO_ROOT>` - Your repository's root directory (e.g., `/workspaces/myproject`)
 - `<EPIC TITLE>` - Descriptive epic name
-- `<ISSUE1>`, `<ISSUE2>`, etc. - Issue numbers in dependency order
-- Add/remove issues as needed
+- `<ISSUE1>`, `<ISSUE2>`, etc. - Issue numbers
+- `<slug>` - Short lowercase hyphenated descriptor
+- Organize issues by dependencies (sequential vs parallel batches)
 
 ## Notes
 
 - Higher `--max-iterations` needed (100+ for 3-5 issues)
-- Order issues by dependencies
-- Each issue = separate branch + PR (never combine)
+- Order issues by dependencies in sequential mode
+- Group independent issues into parallel batches for orchestration
+- Each issue = separate worktree + branch + PR (never combine)
 - Epic may span multiple hours of autonomous work
+- Parallel orchestration significantly reduces total time for independent work
+
+## Choosing Sequential vs Parallel
+
+| Scenario                              | Mode                   |
+| ------------------------------------- | ---------------------- |
+| All issues depend on each other       | Sequential             |
+| Some issues can run independently     | Parallel Orchestration |
+| Simple 2-3 issue epic                 | Sequential (simpler)   |
+| 5+ issues with parallel opportunities | Parallel Orchestration |

--- a/docs/ralph-templates/initiative.md
+++ b/docs/ralph-templates/initiative.md
@@ -2,7 +2,16 @@
 
 Use this template for autonomous work on an initiative - a strategic goal spanning multiple iterations or phases, typically representing a significant product capability.
 
-## Command
+## Execution Modes
+
+| Mode             | When to Use                                    | Scale         |
+| ---------------- | ---------------------------------------------- | ------------- |
+| **Sequential**   | Strict phase dependencies, limited parallelism | Days          |
+| **Orchestrated** | Multiple independent iterations/phases         | Days to weeks |
+
+Initiatives almost always benefit from orchestration due to their scale.
+
+## Command (Sequential Mode)
 
 ```bash
 /ralph-loop:ralph-loop "
@@ -35,21 +44,38 @@ Use this template for autonomous work on an initiative - a strategic goal spanni
 
 Follow CODING.md without exception.
 
+**CRITICAL: Never work in <REPO_ROOT> directly.**
+
 #### For Each Issue:
+
+**Setup:**
+\`\`\`bash
+git worktree add /tmp/worktree-issue-<number>-<slug> -b issue/<number>-<slug>
+cd /tmp/worktree-issue-<number>-<slug>
+\`\`\`
+
+**Implementation:**
 1. Read issue for acceptance criteria
-2. Branch: \`feature/<number>-<slug>\`
-3. TDD: failing tests first, then implement
-4. Real services: PostgreSQL/Redis in devcontainer
-5. Commits: \`[#<number>] description\`
-6. Issue updates: progress at milestones
-7. Local validation: typecheck, lint, test, build
-8. PR with description
-9. Self-review: security + blind spots
-10. CI green, then merge
+2. TDD: failing tests first, then implement
+3. Real services: PostgreSQL/Redis in devcontainer
+4. Commits: \`[#<number>] description\`
+5. Issue updates: progress at milestones
+6. Local validation: typecheck, lint, test, build
+7. PR with description
+8. Self-review: security + blind spots
+9. CI green, then merge
+
+**Cleanup (after merge):**
+\`\`\`bash
+cd <REPO_ROOT>
+git worktree remove /tmp/worktree-issue-<number>-<slug>
+git branch -d issue/<number>-<slug>
+git fetch origin main && git pull origin main
+\`\`\`
 
 #### Between Issues:
-- git fetch origin main && git rebase origin/main
-- Verify main is stable before next issue (check CI status)
+- Verify main is stable before next issue (check CI)
+- Reference previous work in issue comments
 
 #### Phase Transitions:
 After completing each phase:
@@ -63,15 +89,18 @@ After each iteration, report:
 - Phase: X of Y
 - Iteration: X.Y
 - Issues completed: N/M in current iteration
-- Overall progress: total issues completed / total issues
+- Overall progress: total completed / total issues
 - Blockers or risks identified
 
 ### Constraints
-- One issue = one branch = one PR
+- NEVER work in <REPO_ROOT> directly
+- One issue = one worktree = one branch = one PR
+- Clean up worktree immediately after each merge
 - Complete phases in order (phases have dependencies)
 - Iterations within a phase may parallelize if independent
 - Never skip issue updates or phase summaries
 - Escalate blockers that affect strategic timeline
+- Workers use REST-only GitHub API (no GraphQL)
 
 ### Completion
 
@@ -81,9 +110,162 @@ Output <promise>INITIATIVE COMPLETE</promise> when:
 - ALL issues merged to main
 - ALL acceptance criteria verified
 - ALL issues updated with final status
+- ALL worktrees cleaned up
 - Main branch stable and CI green
 - Initiative tracking issue updated with final summary
 - No critical technical debt deferred
+" --completion-promise "INITIATIVE COMPLETE" --max-iterations 500
+```
+
+## Command (Orchestrated Mode)
+
+Use for large initiatives with parallel iteration opportunities.
+
+```bash
+/ralph-loop:ralph-loop "
+## Initiative: <INITIATIVE NAME> (Orchestrated)
+
+### Strategic Goal
+<Business objective this initiative achieves, success metrics>
+
+### Phase Structure
+
+#### Phase 1: Foundation (Sequential)
+Must complete before any parallel work.
+- #<ISSUE1> - Core infrastructure
+- #<ISSUE2> - Base dependencies
+
+#### Phase 2: Feature Development (Parallel Iterations)
+
+**Iteration 2A: <Name>** (Worker 1)
+- Epic: <Name>
+  - #<ISSUE3> - <Title>
+  - #<ISSUE4> - <Title>
+
+**Iteration 2B: <Name>** (Worker 2)
+- Epic: <Name>
+  - #<ISSUE5> - <Title>
+  - #<ISSUE6> - <Title>
+
+**Iteration 2C: <Name>** (Worker 3)
+- Standalone issues:
+  - #<ISSUE7> - <Title>
+  - #<ISSUE8> - <Title>
+
+#### Phase 3: Integration (Sequential)
+After all Phase 2 iterations complete.
+- #<ISSUE9> - Integration testing
+- #<ISSUE10> - Final polish
+
+### Process
+
+Follow CODING.md without exception.
+
+**You are the ORCHESTRATOR.** You coordinate the strategic initiative.
+
+#### Orchestrator Responsibilities
+- Remain in <REPO_ROOT> (coordination only)
+- ONLY agent allowed to use GitHub Projects/GraphQL
+- Spawn and monitor worker agents
+- Serialize project board updates
+- Manage phase transitions
+- Track overall initiative progress
+- Escalate blockers that affect timeline
+
+#### Phase 1: Foundation (You Execute)
+Handle foundation issues yourself:
+1. Create worktree: /tmp/worktree-issue-<number>-<slug>
+2. Implement, test, PR, merge
+3. Clean up worktree
+4. Document phase completion
+5. Proceed to Phase 2
+
+#### Phase 2: Parallel Iterations
+Spawn workers for independent iterations:
+
+\`\`\`bash
+# Worker 1: Iteration 2A
+claude --worktree /tmp/worktree-iteration-2a \"
+  ## Iteration 2A: <Name>
+
+  Complete these issues sequentially:
+  - #<ISSUE3>
+  - #<ISSUE4>
+
+  For each issue:
+  1. Create worktree: /tmp/worktree-issue-<num>-<slug>
+  2. TDD, implement, PR, merge
+  3. Clean up worktree
+  4. Update issue
+
+  Constraints:
+  - Follow CODING.md
+  - REST-only GitHub API (no GraphQL)
+  - One worktree per issue
+
+  Exit when all issues merged or blocked.
+\"
+
+# Worker 2: Iteration 2B
+claude --worktree /tmp/worktree-iteration-2b \"
+  ## Iteration 2B: <Name>
+
+  Complete these issues sequentially:
+  - #<ISSUE5>
+  - #<ISSUE6>
+
+  [Same constraints as Worker 1]
+\"
+
+# Worker 3: Iteration 2C
+claude --worktree /tmp/worktree-iteration-2c \"
+  ## Iteration 2C: <Name>
+
+  Complete these issues:
+  - #<ISSUE7>
+  - #<ISSUE8>
+
+  [Same constraints as Worker 1]
+\"
+\`\`\`
+
+**Monitor workers. Wait for ALL to complete before Phase 3.**
+
+#### Phase 3: Integration (You Execute)
+After Phase 2 completes:
+1. Verify all Phase 2 PRs merged
+2. Run integration testing
+3. Handle integration issues in worktrees
+4. Final polish
+
+#### Progress Tracking
+Maintain initiative status:
+\`\`\`
+Phase: X/Y
+Active workers: N
+Issues completed: X/Y total
+Blockers: [list]
+Next milestone: [description]
+\`\`\`
+
+### Constraints
+- Orchestrator stays in <REPO_ROOT> (no direct code changes)
+- Workers MUST use isolated worktrees in /tmp
+- Workers MUST NOT use GraphQL or gh project commands
+- One issue = one worktree = one branch = one PR
+- Clean up all worktrees after merges
+- Phase boundaries are synchronization points
+- Never proceed to next phase until current phase fully complete
+
+### Completion
+
+Output <promise>INITIATIVE COMPLETE</promise> when:
+- ALL phases completed
+- ALL workers finished
+- ALL issues merged to main
+- ALL worktrees cleaned up
+- Main branch stable (CI green)
+- Initiative tracking issue updated
 " --completion-promise "INITIATIVE COMPLETE" --max-iterations 500
 ```
 
@@ -91,10 +273,12 @@ Output <promise>INITIATIVE COMPLETE</promise> when:
 
 Replace:
 
+- `<REPO_ROOT>` - Your repository's root directory (e.g., `/workspaces/myproject`)
 - `<INITIATIVE NAME>` - Strategic capability being delivered
-- Phase structure - Organize by delivery milestones
+- Phase structure - Organize by delivery milestones and dependencies
 - Iterations - Group related work within phases
 - Issue list - All issues in scope
+- Worker assignments - Group by independence and skill area
 
 ## Notes
 
@@ -104,55 +288,13 @@ Replace:
 - Can `/ralph-loop:cancel-ralph` and resume with remaining work
 - Consider creating a GitHub tracking issue for the initiative itself
 - Phase boundaries are natural checkpoints for `/ralph-loop:cancel-ralph`
+- Orchestrated mode can reduce total time by 60%+ for large initiatives
 
-## When to Use Initiative vs Iteration
+## Template Selection Guide
 
-| Scope                               | Template      | Typical Duration |
-| ----------------------------------- | ------------- | ---------------- |
-| 1 issue                             | issue.md      | Hours            |
-| 3-5 related issues                  | epic.md       | Half day         |
-| Multiple epics (sprint-sized)       | iteration.md  | Day              |
-| Strategic capability (multi-sprint) | initiative.md | Multiple days    |
-
-## Example
-
-```bash
-/ralph-loop:ralph-loop "
-## Initiative: Multi-Currency Support
-
-### Strategic Goal
-Enable users to manage budgets in multiple currencies with real-time exchange rates.
-Success: Users can create budgets in 10+ currencies with daily rate updates.
-
-### Phases
-
-#### Phase 1: Foundation
-**Iteration 1.1: Currency Infrastructure**
-- Epic: Exchange Rate System
-  - #201 - Add currency table and seed data
-  - #202 - Integrate exchange rate API
-  - #203 - Create rate caching layer
-
-**Iteration 1.2: Data Model Updates**
-- Epic: Multi-Currency Schema
-  - #204 - Add currency field to budgets
-  - #205 - Add currency field to transactions
-  - #206 - Migration for existing data
-
-#### Phase 2: User Experience
-**Iteration 2.1: Currency Selection**
-- Epic: Currency UI
-  - #207 - Currency picker component
-  - #208 - Budget creation with currency
-  - #209 - Transaction entry with currency
-
-**Iteration 2.2: Conversion Display**
-- Epic: Rate Display
-  - #210 - Show converted totals
-  - #211 - Historical rate viewing
-  - #212 - Rate alerts
-
-### Process
-...
-" --completion-promise "INITIATIVE COMPLETE" --max-iterations 500
-```
+| Scope                               | Template      | Typical Duration | Max Iterations |
+| ----------------------------------- | ------------- | ---------------- | -------------- |
+| 1 issue                             | issue.md      | Hours            | 50             |
+| 3-5 related issues                  | epic.md       | Half day         | 100            |
+| Multiple epics (sprint-sized)       | iteration.md  | Day              | 200            |
+| Strategic capability (multi-sprint) | initiative.md | Multiple days    | 500+           |

--- a/docs/ralph-templates/issue.md
+++ b/docs/ralph-templates/issue.md
@@ -21,22 +21,48 @@ Use this template for autonomous work on a single GitHub issue.
 
 Follow CODING.md without exception.
 
-1. **Branch**: Create \`issue/<NUMBER>-<slug>\` from main
-2. **TDD**: Write failing tests first, then implement
-3. **Real services**: Test against PostgreSQL/Redis in devcontainer
-4. **Commits**: Atomic, tested, format: \`[#<NUMBER>] description\`
-5. **Issue updates**: Post progress after each milestone (not at end)
+#### Workspace Setup (MANDATORY)
+**Never work in the root repository.** All work MUST happen in an isolated git worktree.
 
-Local validation before PR:
+1. Create worktree:
+   \`\`\`bash
+   git worktree add /tmp/worktree-issue-<NUMBER>-<slug> -b issue/<NUMBER>-<slug>
+   cd /tmp/worktree-issue-<NUMBER>-<slug>
+   \`\`\`
+2. All subsequent work happens in this worktree directory
+3. The worktree isolates your work from other parallel agents
+
+#### Implementation
+1. **TDD**: Write failing tests first, then implement
+2. **Real services**: Test against PostgreSQL/Redis in devcontainer
+3. **Commits**: Atomic, tested, format: \`[#<NUMBER>] description\`
+4. **Issue updates**: Post progress after each milestone (not at end)
+
+#### Local Validation (before PR)
 - \`pnpm typecheck\`
 - \`pnpm lint\`
 - \`pnpm test\`
 - \`pnpm build\`
 
-6. **PR**: Create with clear description
-7. **Self-review**: Security + blind spot review
-8. **CI**: Monitor until green, fix any failures
-9. **Merge**: After CI green and review complete
+#### Ship
+1. **PR**: Create with clear description
+2. **Self-review**: Security + blind spot review
+3. **CI**: Monitor until green, fix any failures
+4. **Merge**: After CI green and review complete
+
+#### Cleanup (MANDATORY)
+After PR is merged:
+\`\`\`bash
+cd <REPO_ROOT>
+git worktree remove /tmp/worktree-issue-<NUMBER>-<slug>
+git branch -d issue/<NUMBER>-<slug>
+\`\`\`
+
+### Constraints
+- NEVER work in the root repository directly
+- One worktree per issue, one branch per issue
+- Clean up worktree immediately after merge
+- Workers use REST-only GitHub API (no GraphQL)
 
 ### Completion
 
@@ -46,6 +72,7 @@ Output <promise>ISSUE <NUMBER> COMPLETE</promise> when:
 - CI green
 - Issue updated with completion status
 - PR merged to main
+- Worktree cleaned up
 " --completion-promise "ISSUE <NUMBER> COMPLETE" --max-iterations 50
 ```
 
@@ -53,9 +80,10 @@ Output <promise>ISSUE <NUMBER> COMPLETE</promise> when:
 
 Replace:
 
+- `<REPO_ROOT>` - Your repository's root directory (e.g., `/workspaces/myproject`)
 - `<NUMBER>` - GitHub issue number
 - `<TITLE>` - Issue title
-- `<slug>` - Short branch name descriptor
+- `<slug>` - Short branch name descriptor (lowercase, hyphenated)
 - Acceptance criteria - Copy from issue
 
 ## Notes
@@ -63,3 +91,5 @@ Replace:
 - Adjust `--max-iterations` based on complexity (30-100 typical)
 - For database changes, add `pnpm db:reset && pnpm db:migrate && pnpm db:seed` to validation
 - For API changes, add runtime testing step
+- Worktrees in `/tmp` prevent filesystem conflicts with other agents
+- The worktree cleanup step is part of the completion criteria

--- a/docs/ralph-templates/iteration.md
+++ b/docs/ralph-templates/iteration.md
@@ -1,8 +1,15 @@
-# Ralph Template: Iteration (Large Initiative)
+# Ralph Template: Iteration (Sprint-Sized Work)
 
-Use this template for autonomous work on an iteration - a large initiative spanning multiple epics or a significant body of work.
+Use this template for autonomous work on an iteration - a sprint-sized body of work spanning multiple epics or a significant number of related issues.
 
-## Command
+## Execution Modes
+
+| Mode             | When to Use                           | How                                           |
+| ---------------- | ------------------------------------- | --------------------------------------------- |
+| **Sequential**   | Limited parallelization opportunities | Single Ralph processes epics/issues in order  |
+| **Orchestrated** | Multiple independent epics or issues  | Orchestrator spawns workers for parallel work |
+
+## Command (Sequential Mode)
 
 ```bash
 /ralph-loop:ralph-loop "
@@ -28,21 +35,38 @@ Use this template for autonomous work on an iteration - a large initiative spann
 
 Follow CODING.md without exception.
 
+**CRITICAL: Never work in <REPO_ROOT> directly.**
+
 #### For Each Issue:
+
+**Setup:**
+\`\`\`bash
+git worktree add /tmp/worktree-issue-<number>-<slug> -b issue/<number>-<slug>
+cd /tmp/worktree-issue-<number>-<slug>
+\`\`\`
+
+**Implementation:**
 1. Read issue for acceptance criteria
-2. Branch: \`issue/<number>-<slug>\`
-3. TDD: failing tests first, then implement
-4. Real services: PostgreSQL/Redis in devcontainer
-5. Commits: \`[#<number>] description\`
-6. Issue updates: progress at milestones
-7. Local validation: typecheck, lint, test, build
-8. PR with description
-9. Self-review: security + blind spots
-10. CI green, then merge
+2. TDD: failing tests first, then implement
+3. Real services: PostgreSQL/Redis in devcontainer
+4. Commits: \`[#<number>] description\`
+5. Issue updates: progress at milestones
+6. Local validation: typecheck, lint, test, build
+7. PR with description
+8. Self-review: security + blind spots
+9. CI green, then merge
+
+**Cleanup (after merge):**
+\`\`\`bash
+cd <REPO_ROOT>
+git worktree remove /tmp/worktree-issue-<number>-<slug>
+git branch -d issue/<number>-<slug>
+git fetch origin main && git pull origin main
+\`\`\`
 
 #### Between Issues:
-- git fetch && git checkout main && git pull
-- Verify main is stable before next issue
+- Verify main is stable before next issue (check CI)
+- Reference previous work in issue comments
 
 #### Progress Tracking:
 After completing each issue, summarize:
@@ -51,10 +75,12 @@ After completing each issue, summarize:
 - Any blockers encountered
 
 ### Constraints
-- One issue = one branch = one PR
+- NEVER work in <REPO_ROOT> directly
+- One issue = one worktree = one branch = one PR
+- Clean up worktree immediately after each merge
 - Complete epics in order when dependencies exist
-- Parallelize only when explicitly safe
 - Never skip issue updates
+- Workers use REST-only GitHub API (no GraphQL)
 
 ### Completion
 
@@ -62,8 +88,121 @@ Output <promise>ITERATION COMPLETE</promise> when:
 - ALL issues in scope are merged
 - ALL acceptance criteria verified
 - ALL issues updated with final status
+- ALL worktrees cleaned up
 - Main branch stable and CI green
 - No open blockers or deferred work
+" --completion-promise "ITERATION COMPLETE" --max-iterations 200
+```
+
+## Command (Orchestrated Mode)
+
+Use when epics or issues within the iteration can be parallelized.
+
+```bash
+/ralph-loop:ralph-loop "
+## Iteration: <ITERATION NAME> (Orchestrated)
+
+### Goal
+<High-level objective for this iteration>
+
+### Scope
+
+#### Phase 1: Foundation (Sequential)
+- #<ISSUE1> - <Title> (must complete first)
+
+#### Phase 2: Parallel Epics
+**Epic A** (assign to Worker 1):
+- #<ISSUE2> - <Title>
+- #<ISSUE3> - <Title>
+
+**Epic B** (assign to Worker 2):
+- #<ISSUE4> - <Title>
+- #<ISSUE5> - <Title>
+
+**Standalone** (assign to Worker 3):
+- #<ISSUE6> - <Title>
+
+#### Phase 3: Integration (Sequential)
+- #<ISSUE7> - <Title> (depends on Phase 2)
+
+### Process
+
+Follow CODING.md without exception.
+
+**You are the ORCHESTRATOR.** You coordinate work but delegate implementation.
+
+#### Orchestrator Rules
+- Remain in <REPO_ROOT> (coordination only)
+- You are the ONLY agent allowed to use GitHub Projects/GraphQL
+- Spawn worker agents for parallel work
+- Serialize project board updates
+- Aggregate blockers and coordinate resolution
+
+#### Phase 1: Foundation (You Execute)
+Handle foundation issues yourself:
+1. Create worktree: /tmp/worktree-issue-<number>-<slug>
+2. Implement, test, PR, merge
+3. Clean up worktree
+4. Proceed to Phase 2
+
+#### Phase 2: Parallel Execution
+Spawn workers for independent epics/issues:
+
+\`\`\`bash
+# Worker 1: Epic A
+claude --worktree /tmp/worktree-epic-a \"
+  Complete Epic A issues (#<ISSUE2>, #<ISSUE3>) sequentially.
+  Each issue: own worktree in /tmp, own branch, own PR.
+  Follow CODING.md. REST-only GitHub API.
+  Clean up worktrees after each merge.
+  Exit when all Epic A issues merged or blocked.
+\"
+
+# Worker 2: Epic B
+claude --worktree /tmp/worktree-epic-b \"
+  Complete Epic B issues (#<ISSUE4>, #<ISSUE5>) sequentially.
+  Each issue: own worktree in /tmp, own branch, own PR.
+  Follow CODING.md. REST-only GitHub API.
+  Clean up worktrees after each merge.
+  Exit when all Epic B issues merged or blocked.
+\"
+
+# Worker 3: Standalone
+claude --worktree /tmp/worktree-issue-<ISSUE6>-<slug> \"
+  Complete issue #<ISSUE6>.
+  Follow CODING.md. REST-only GitHub API.
+  Clean up worktree after merge.
+  Exit when PR merged or blocked.
+\"
+\`\`\`
+
+**Wait for all Phase 2 workers to complete before Phase 3.**
+
+#### Phase 3: Integration (You Execute)
+Handle integration issues yourself after Phase 2 completes.
+
+#### Progress Tracking
+After each phase:
+- Issues completed: X/Y total
+- Epics completed: X/Y
+- Blockers identified
+- Time in phase
+
+### Constraints
+- Orchestrator stays in <REPO_ROOT> (no direct code changes)
+- Workers MUST use isolated worktrees in /tmp
+- Workers MUST NOT use GraphQL or gh project commands
+- One issue = one worktree = one branch = one PR
+- Clean up all worktrees after merges
+- Never skip progress tracking between phases
+
+### Completion
+
+Output <promise>ITERATION COMPLETE</promise> when:
+- ALL phases completed
+- ALL issues merged to main
+- ALL worktrees cleaned up
+- Main branch stable (CI green)
 " --completion-promise "ITERATION COMPLETE" --max-iterations 200
 ```
 
@@ -71,9 +210,11 @@ Output <promise>ITERATION COMPLETE</promise> when:
 
 Replace:
 
+- `<REPO_ROOT>` - Your repository's root directory (e.g., `/workspaces/myproject`)
 - `<ITERATION NAME>` - Sprint/iteration identifier
-- Epic groupings - Organize by feature area
+- Epic groupings - Organize by feature area and dependencies
 - Issue list - All issues in scope
+- Phase structure - Group by dependencies (foundation → parallel → integration)
 
 ## Notes
 
@@ -82,3 +223,14 @@ Replace:
 - Monitor periodically: `grep '^iteration:' .claude/ralph-loop.local.md`
 - Can `/ralph-loop:cancel-ralph` and resume later with remaining issues
 - Consider breaking into smaller epics if iteration is too large
+- Orchestrated mode can reduce total time by 50%+ with parallel epics
+
+## When to Use Orchestrated Mode
+
+| Scenario                               | Recommendation |
+| -------------------------------------- | -------------- |
+| 3-5 issues, all dependent              | Sequential     |
+| 5+ issues, 2+ independent epics        | Orchestrated   |
+| Multiple standalone issues             | Orchestrated   |
+| Tight deadline, parallel opportunities | Orchestrated   |
+| Simple linear work                     | Sequential     |


### PR DESCRIPTION
## Summary

- Add mandatory worktree isolation requirement to all ralph-templates
- Worktrees must be created in `/tmp/worktree-issue-<number>-<slug>`
- Add cleanup step after PR merge to completion criteria
- Add parallel orchestration mode to epic, iteration, initiative templates
- Use generic `<REPO_ROOT>` placeholder for portability
- Update AGENTS.md with full worktree discipline section
- Update CLAUDE.md with worktree quick reference

## Why

Enables parallel agent work without filesystem conflicts. Multiple agents can now work on independent issues simultaneously, each in their own isolated worktree.

## Test plan

- [ ] Review template changes for consistency
- [ ] Verify `<REPO_ROOT>` placeholder is documented in customization sections
- [ ] Confirm orchestrator/worker patterns are clear

🤖 Generated with [Claude Code](https://claude.ai/code)