### PR TITLE
[#340] Create notes and notebooks database schema

### DIFF
--- a/migrations/040_notes_notebooks_schema.down.sql
+++ b/migrations/040_notes_notebooks_schema.down.sql
@@ -1,0 +1,41 @@
+-- Migration 040: Notes and Notebooks Schema (DOWN)
+-- Part of Epic #337, Issue #340
+-- Reverses all changes from the up migration
+
+-- Drop views first
+DROP VIEW IF EXISTS notebook_trash;
+DROP VIEW IF EXISTS note_trash;
+DROP VIEW IF EXISTS notebook_active;
+DROP VIEW IF EXISTS note_active;
+
+-- Drop triggers
+DROP TRIGGER IF EXISTS note_embedding_pending_trigger ON note;
+DROP TRIGGER IF EXISTS note_search_vector_trigger ON note;
+DROP TRIGGER IF EXISTS note_updated_at_trigger ON note;
+DROP TRIGGER IF EXISTS notebook_updated_at_trigger ON notebook;
+
+-- Drop functions
+DROP FUNCTION IF EXISTS note_embedding_pending_on_change();
+DROP FUNCTION IF EXISTS note_search_vector_update();
+DROP FUNCTION IF EXISTS update_note_updated_at();
+DROP FUNCTION IF EXISTS update_notebook_updated_at();
+
+-- Drop indexes
+DROP INDEX IF EXISTS idx_note_embedding_pending;
+DROP INDEX IF EXISTS idx_note_embedding;
+DROP INDEX IF EXISTS idx_note_search_vector;
+DROP INDEX IF EXISTS idx_note_tags;
+DROP INDEX IF EXISTS idx_note_pinned;
+DROP INDEX IF EXISTS idx_note_updated_at;
+DROP INDEX IF EXISTS idx_note_created_at;
+DROP INDEX IF EXISTS idx_note_user_not_deleted;
+DROP INDEX IF EXISTS idx_note_visibility;
+DROP INDEX IF EXISTS idx_note_user_email;
+DROP INDEX IF EXISTS idx_note_notebook_id;
+DROP INDEX IF EXISTS idx_notebook_user_not_deleted;
+DROP INDEX IF EXISTS idx_notebook_parent;
+DROP INDEX IF EXISTS idx_notebook_user_email;
+
+-- Drop tables (note first due to FK dependency)
+DROP TABLE IF EXISTS note;
+DROP TABLE IF EXISTS notebook;

--- a/migrations/040_notes_notebooks_schema.up.sql
+++ b/migrations/040_notes_notebooks_schema.up.sql
@@ -1,0 +1,201 @@
+-- Migration 040: Notes and Notebooks Schema
+-- Part of Epic #337, Issue #340
+-- Creates foundation for full-featured note-taking system
+
+-- ============================================================================
+-- NOTEBOOK TABLE
+-- ============================================================================
+-- Hierarchical containers for organizing notes
+
+CREATE TABLE IF NOT EXISTS notebook (
+  id uuid PRIMARY KEY DEFAULT new_uuid(),
+  user_email text NOT NULL,
+
+  -- Content
+  name text NOT NULL,
+  description text,
+  icon text,  -- emoji or icon identifier (e.g., "📓", "work")
+  color text, -- hex color for UI (e.g., "#3b82f6")
+
+  -- Organization
+  parent_notebook_id uuid REFERENCES notebook(id) ON DELETE SET NULL,
+  sort_order integer DEFAULT 0,
+
+  -- Settings
+  is_archived boolean DEFAULT false,
+
+  -- Soft delete
+  deleted_at timestamptz,
+
+  -- Timestamps
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE notebook IS 'Hierarchical containers for organizing notes';
+COMMENT ON COLUMN notebook.icon IS 'Emoji or icon identifier for visual display';
+COMMENT ON COLUMN notebook.color IS 'Hex color code (e.g., #3b82f6) for UI theming';
+COMMENT ON COLUMN notebook.parent_notebook_id IS 'Self-referential FK for nested notebooks';
+
+-- ============================================================================
+-- NOTE TABLE
+-- ============================================================================
+-- Rich markdown notes with privacy controls and search integration
+
+CREATE TABLE IF NOT EXISTS note (
+  id uuid PRIMARY KEY DEFAULT new_uuid(),
+  notebook_id uuid REFERENCES notebook(id) ON DELETE SET NULL,
+  user_email text NOT NULL,
+
+  -- Content
+  title text NOT NULL,
+  content text NOT NULL DEFAULT '', -- markdown content
+  summary text,          -- AI-generated or manual summary for previews
+
+  -- Metadata
+  tags text[] DEFAULT '{}',
+  is_pinned boolean DEFAULT false,
+  sort_order integer DEFAULT 0,
+
+  -- Privacy (critical for agent access control)
+  visibility text NOT NULL DEFAULT 'private'
+    CHECK (visibility IN ('private', 'shared', 'public')),
+  hide_from_agents boolean DEFAULT false, -- explicit agent exclusion even if shared/public
+
+  -- Search - pgvector for semantic, tsvector for full-text
+  embedding vector(1024),
+  embedding_model text,
+  embedding_provider text,
+  embedding_status text DEFAULT 'pending'
+    CHECK (embedding_status IN ('complete', 'pending', 'failed', 'skipped')),
+  search_vector tsvector,
+
+  -- Soft delete
+  deleted_at timestamptz,
+
+  -- Timestamps
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE note IS 'Rich markdown notes with privacy controls and search integration';
+COMMENT ON COLUMN note.visibility IS 'private=owner only, shared=explicit shares, public=anyone';
+COMMENT ON COLUMN note.hide_from_agents IS 'When true, note excluded from agent searches even if shared/public';
+COMMENT ON COLUMN note.embedding_status IS 'skipped means privacy settings prevent embedding';
+
+-- ============================================================================
+-- INDEXES
+-- ============================================================================
+
+-- Notebook indexes
+CREATE INDEX IF NOT EXISTS idx_notebook_user_email ON notebook(user_email);
+CREATE INDEX IF NOT EXISTS idx_notebook_parent ON notebook(parent_notebook_id) WHERE parent_notebook_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_notebook_user_not_deleted ON notebook(user_email) WHERE deleted_at IS NULL;
+
+-- Note indexes for common queries
+CREATE INDEX IF NOT EXISTS idx_note_notebook_id ON note(notebook_id) WHERE notebook_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_note_user_email ON note(user_email);
+CREATE INDEX IF NOT EXISTS idx_note_visibility ON note(visibility);
+CREATE INDEX IF NOT EXISTS idx_note_user_not_deleted ON note(user_email) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_note_created_at ON note(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_note_updated_at ON note(updated_at DESC);
+CREATE INDEX IF NOT EXISTS idx_note_pinned ON note(user_email, is_pinned) WHERE is_pinned = true;
+
+-- Tag search (GIN for array containment)
+CREATE INDEX IF NOT EXISTS idx_note_tags ON note USING GIN(tags);
+
+-- Full-text search
+CREATE INDEX IF NOT EXISTS idx_note_search_vector ON note USING GIN(search_vector);
+
+-- Semantic search (HNSW for fast approximate nearest neighbor)
+CREATE INDEX IF NOT EXISTS idx_note_embedding ON note USING hnsw (embedding vector_cosine_ops)
+  WHERE embedding IS NOT NULL;
+
+-- Embedding backfill query optimization
+CREATE INDEX IF NOT EXISTS idx_note_embedding_pending ON note(embedding_status)
+  WHERE embedding_status = 'pending';
+
+-- ============================================================================
+-- TRIGGERS
+-- ============================================================================
+
+-- Auto-update notebook updated_at timestamp
+CREATE OR REPLACE FUNCTION update_notebook_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS notebook_updated_at_trigger ON notebook;
+CREATE TRIGGER notebook_updated_at_trigger
+  BEFORE UPDATE ON notebook
+  FOR EACH ROW EXECUTE FUNCTION update_notebook_updated_at();
+
+-- Auto-update note updated_at timestamp
+CREATE OR REPLACE FUNCTION update_note_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS note_updated_at_trigger ON note;
+CREATE TRIGGER note_updated_at_trigger
+  BEFORE UPDATE ON note
+  FOR EACH ROW EXECUTE FUNCTION update_note_updated_at();
+
+-- Auto-update search_vector for full-text search
+CREATE OR REPLACE FUNCTION note_search_vector_update()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.search_vector :=
+    setweight(to_tsvector('english', COALESCE(NEW.title, '')), 'A') ||
+    setweight(to_tsvector('english', COALESCE(NEW.summary, '')), 'B') ||
+    setweight(to_tsvector('english', COALESCE(NEW.content, '')), 'C');
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS note_search_vector_trigger ON note;
+CREATE TRIGGER note_search_vector_trigger
+  BEFORE INSERT OR UPDATE OF title, summary, content ON note
+  FOR EACH ROW EXECUTE FUNCTION note_search_vector_update();
+
+-- Mark embedding as pending when content changes
+CREATE OR REPLACE FUNCTION note_embedding_pending_on_change()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF OLD.title IS DISTINCT FROM NEW.title
+     OR OLD.content IS DISTINCT FROM NEW.content THEN
+    NEW.embedding_status = 'pending';
+    NEW.embedding = NULL;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS note_embedding_pending_trigger ON note;
+CREATE TRIGGER note_embedding_pending_trigger
+  BEFORE UPDATE OF title, content ON note
+  FOR EACH ROW EXECUTE FUNCTION note_embedding_pending_on_change();
+
+-- ============================================================================
+-- VIEWS
+-- ============================================================================
+
+-- Active views (exclude soft-deleted)
+CREATE OR REPLACE VIEW note_active AS
+SELECT * FROM note WHERE deleted_at IS NULL;
+
+CREATE OR REPLACE VIEW notebook_active AS
+SELECT * FROM notebook WHERE deleted_at IS NULL;
+
+-- Trash views (soft-deleted items)
+CREATE OR REPLACE VIEW note_trash AS
+SELECT * FROM note WHERE deleted_at IS NOT NULL;
+
+CREATE OR REPLACE VIEW notebook_trash AS
+SELECT * FROM notebook WHERE deleted_at IS NOT NULL;

--- a/tests/notes_schema.test.ts
+++ b/tests/notes_schema.test.ts
@@ -1,0 +1,358 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { Pool } from 'pg';
+import { existsSync } from 'fs';
+import { runMigrate, migrationCount } from './helpers/migrate.js';
+
+/**
+ * Tests for Issue #340 - Notes and Notebooks Database Schema
+ * Validates migration 040_notes_notebooks_schema
+ */
+describe('Notes and Notebooks Schema (Migration 040)', () => {
+  let pool: Pool;
+
+  beforeAll(async () => {
+    const defaultHost = existsSync('/.dockerenv') ? 'postgres' : 'localhost';
+    const host = process.env.PGHOST || defaultHost;
+
+    pool = new Pool({
+      host,
+      port: parseInt(process.env.PGPORT || '5432', 10),
+      user: process.env.PGUSER || 'openclaw',
+      password: process.env.PGPASSWORD || 'openclaw',
+      database: process.env.PGDATABASE || 'openclaw',
+    });
+
+    // Ensure migrations are applied
+    await runMigrate('up');
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  describe('notebook table', () => {
+    it('exists with all required columns', async () => {
+      const result = await pool.query(`
+        SELECT column_name, data_type, is_nullable, column_default
+        FROM information_schema.columns
+        WHERE table_name = 'notebook'
+        ORDER BY ordinal_position
+      `);
+
+      const columns = result.rows.map((r) => r.column_name);
+      expect(columns).toContain('id');
+      expect(columns).toContain('user_email');
+      expect(columns).toContain('name');
+      expect(columns).toContain('description');
+      expect(columns).toContain('icon');
+      expect(columns).toContain('color');
+      expect(columns).toContain('parent_notebook_id');
+      expect(columns).toContain('sort_order');
+      expect(columns).toContain('is_archived');
+      expect(columns).toContain('deleted_at');
+      expect(columns).toContain('created_at');
+      expect(columns).toContain('updated_at');
+    });
+
+    it('supports hierarchical structure via parent_notebook_id', async () => {
+      // Create parent notebook
+      const parent = await pool.query(`
+        INSERT INTO notebook (user_email, name)
+        VALUES ('test@example.com', 'Parent Notebook')
+        RETURNING id
+      `);
+      const parentId = parent.rows[0].id;
+
+      // Create child notebook
+      const child = await pool.query(`
+        INSERT INTO notebook (user_email, name, parent_notebook_id)
+        VALUES ('test@example.com', 'Child Notebook', $1)
+        RETURNING id, parent_notebook_id
+      `, [parentId]);
+
+      expect(child.rows[0].parent_notebook_id).toBe(parentId);
+
+      // Cleanup
+      await pool.query('DELETE FROM notebook WHERE user_email = $1', ['test@example.com']);
+    });
+
+    it('auto-updates updated_at timestamp on modification', async () => {
+      // Create notebook
+      const created = await pool.query(`
+        INSERT INTO notebook (user_email, name)
+        VALUES ('test@example.com', 'Test Notebook')
+        RETURNING id, created_at, updated_at
+      `);
+      const id = created.rows[0].id;
+      const originalUpdatedAt = created.rows[0].updated_at;
+
+      // Wait a moment then update
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      await pool.query(`
+        UPDATE notebook SET name = 'Updated Name' WHERE id = $1
+      `, [id]);
+
+      // Check updated_at changed
+      const updated = await pool.query('SELECT updated_at FROM notebook WHERE id = $1', [id]);
+      expect(updated.rows[0].updated_at.getTime()).toBeGreaterThan(originalUpdatedAt.getTime());
+
+      // Cleanup
+      await pool.query('DELETE FROM notebook WHERE id = $1', [id]);
+    });
+  });
+
+  describe('note table', () => {
+    let notebookId: string;
+
+    beforeAll(async () => {
+      // Create a test notebook for note tests
+      const result = await pool.query(`
+        INSERT INTO notebook (user_email, name)
+        VALUES ('test@example.com', 'Test Notebook for Notes')
+        RETURNING id
+      `);
+      notebookId = result.rows[0].id;
+    });
+
+    afterAll(async () => {
+      // Cleanup test data
+      await pool.query('DELETE FROM note WHERE user_email = $1', ['test@example.com']);
+      await pool.query('DELETE FROM notebook WHERE user_email = $1', ['test@example.com']);
+    });
+
+    it('exists with all required columns', async () => {
+      const result = await pool.query(`
+        SELECT column_name, data_type, is_nullable
+        FROM information_schema.columns
+        WHERE table_name = 'note'
+        ORDER BY ordinal_position
+      `);
+
+      const columns = result.rows.map((r) => r.column_name);
+      expect(columns).toContain('id');
+      expect(columns).toContain('notebook_id');
+      expect(columns).toContain('user_email');
+      expect(columns).toContain('title');
+      expect(columns).toContain('content');
+      expect(columns).toContain('summary');
+      expect(columns).toContain('tags');
+      expect(columns).toContain('is_pinned');
+      expect(columns).toContain('sort_order');
+      expect(columns).toContain('visibility');
+      expect(columns).toContain('hide_from_agents');
+      expect(columns).toContain('embedding');
+      expect(columns).toContain('embedding_model');
+      expect(columns).toContain('embedding_provider');
+      expect(columns).toContain('embedding_status');
+      expect(columns).toContain('search_vector');
+      expect(columns).toContain('deleted_at');
+      expect(columns).toContain('created_at');
+      expect(columns).toContain('updated_at');
+    });
+
+    it('enforces visibility CHECK constraint', async () => {
+      // Valid values should work
+      const valid = await pool.query(`
+        INSERT INTO note (user_email, title, visibility)
+        VALUES ('test@example.com', 'Private Note', 'private')
+        RETURNING id
+      `);
+      expect(valid.rows[0].id).toBeDefined();
+
+      // Invalid value should fail
+      await expect(
+        pool.query(`
+          INSERT INTO note (user_email, title, visibility)
+          VALUES ('test@example.com', 'Bad Note', 'invalid_visibility')
+        `)
+      ).rejects.toThrow();
+    });
+
+    it('enforces embedding_status CHECK constraint', async () => {
+      // Valid status should work
+      const valid = await pool.query(`
+        INSERT INTO note (user_email, title, embedding_status)
+        VALUES ('test@example.com', 'Pending Note', 'pending')
+        RETURNING id
+      `);
+      expect(valid.rows[0].id).toBeDefined();
+
+      // Invalid status should fail
+      await expect(
+        pool.query(`
+          INSERT INTO note (user_email, title, embedding_status)
+          VALUES ('test@example.com', 'Bad Note', 'invalid_status')
+        `)
+      ).rejects.toThrow();
+    });
+
+    it('auto-updates search_vector on insert and update', async () => {
+      const created = await pool.query(`
+        INSERT INTO note (user_email, title, content, summary)
+        VALUES ('test@example.com', 'Search Test', 'This is the content', 'Brief summary')
+        RETURNING id, search_vector
+      `);
+      const id = created.rows[0].id;
+
+      // search_vector should be populated
+      expect(created.rows[0].search_vector).not.toBeNull();
+
+      // Verify it's searchable
+      const search = await pool.query(`
+        SELECT id FROM note
+        WHERE search_vector @@ to_tsquery('english', 'Search')
+        AND id = $1
+      `, [id]);
+      expect(search.rows.length).toBe(1);
+    });
+
+    it('auto-updates updated_at timestamp on modification', async () => {
+      const created = await pool.query(`
+        INSERT INTO note (user_email, title, content)
+        VALUES ('test@example.com', 'Update Test', 'Initial content')
+        RETURNING id, updated_at
+      `);
+      const id = created.rows[0].id;
+      const originalUpdatedAt = created.rows[0].updated_at;
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      await pool.query('UPDATE note SET title = $1 WHERE id = $2', ['New Title', id]);
+
+      const updated = await pool.query('SELECT updated_at FROM note WHERE id = $1', [id]);
+      expect(updated.rows[0].updated_at.getTime()).toBeGreaterThan(originalUpdatedAt.getTime());
+    });
+
+    it('resets embedding to pending when content changes', async () => {
+      // Create note with complete embedding
+      const created = await pool.query(`
+        INSERT INTO note (user_email, title, content, embedding_status)
+        VALUES ('test@example.com', 'Embedding Test', 'Initial content', 'complete')
+        RETURNING id
+      `);
+      const id = created.rows[0].id;
+
+      // Update content
+      await pool.query('UPDATE note SET content = $1 WHERE id = $2', ['Changed content', id]);
+
+      // Check embedding_status is reset to pending
+      const updated = await pool.query('SELECT embedding_status, embedding FROM note WHERE id = $1', [id]);
+      expect(updated.rows[0].embedding_status).toBe('pending');
+      expect(updated.rows[0].embedding).toBeNull();
+    });
+
+    it('can associate note with notebook', async () => {
+      const created = await pool.query(`
+        INSERT INTO note (user_email, title, notebook_id)
+        VALUES ('test@example.com', 'Notebook Note', $1)
+        RETURNING id, notebook_id
+      `, [notebookId]);
+
+      expect(created.rows[0].notebook_id).toBe(notebookId);
+    });
+
+    it('supports tags array', async () => {
+      const created = await pool.query(`
+        INSERT INTO note (user_email, title, tags)
+        VALUES ('test@example.com', 'Tagged Note', ARRAY['work', 'important', 'meeting'])
+        RETURNING id, tags
+      `);
+
+      expect(created.rows[0].tags).toEqual(['work', 'important', 'meeting']);
+
+      // Test GIN index with containment query
+      const search = await pool.query(`
+        SELECT id FROM note WHERE tags @> ARRAY['work', 'meeting']
+      `);
+      expect(search.rows.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('active views', () => {
+    let noteId: string;
+    let notebookId: string;
+
+    beforeAll(async () => {
+      // Create test data
+      const notebook = await pool.query(`
+        INSERT INTO notebook (user_email, name)
+        VALUES ('test@example.com', 'View Test Notebook')
+        RETURNING id
+      `);
+      notebookId = notebook.rows[0].id;
+
+      const note = await pool.query(`
+        INSERT INTO note (user_email, title)
+        VALUES ('test@example.com', 'View Test Note')
+        RETURNING id
+      `);
+      noteId = note.rows[0].id;
+    });
+
+    afterAll(async () => {
+      await pool.query('DELETE FROM note WHERE user_email = $1', ['test@example.com']);
+      await pool.query('DELETE FROM notebook WHERE user_email = $1', ['test@example.com']);
+    });
+
+    it('note_active excludes soft-deleted notes', async () => {
+      // Soft delete the note
+      await pool.query('UPDATE note SET deleted_at = NOW() WHERE id = $1', [noteId]);
+
+      // note_active should not contain it
+      const active = await pool.query('SELECT id FROM note_active WHERE id = $1', [noteId]);
+      expect(active.rows.length).toBe(0);
+
+      // note_trash should contain it
+      const trash = await pool.query('SELECT id FROM note_trash WHERE id = $1', [noteId]);
+      expect(trash.rows.length).toBe(1);
+
+      // Restore
+      await pool.query('UPDATE note SET deleted_at = NULL WHERE id = $1', [noteId]);
+    });
+
+    it('notebook_active excludes soft-deleted notebooks', async () => {
+      // Soft delete
+      await pool.query('UPDATE notebook SET deleted_at = NOW() WHERE id = $1', [notebookId]);
+
+      // notebook_active should not contain it
+      const active = await pool.query('SELECT id FROM notebook_active WHERE id = $1', [notebookId]);
+      expect(active.rows.length).toBe(0);
+
+      // notebook_trash should contain it
+      const trash = await pool.query('SELECT id FROM notebook_trash WHERE id = $1', [notebookId]);
+      expect(trash.rows.length).toBe(1);
+
+      // Restore
+      await pool.query('UPDATE notebook SET deleted_at = NULL WHERE id = $1', [notebookId]);
+    });
+  });
+
+  describe('indexes', () => {
+    it('has required indexes', async () => {
+      const result = await pool.query(`
+        SELECT indexname FROM pg_indexes
+        WHERE tablename IN ('note', 'notebook')
+        ORDER BY indexname
+      `);
+
+      const indexes = result.rows.map((r) => r.indexname);
+
+      // Notebook indexes
+      expect(indexes).toContain('idx_notebook_user_email');
+      expect(indexes).toContain('idx_notebook_parent');
+      expect(indexes).toContain('idx_notebook_user_not_deleted');
+
+      // Note indexes
+      expect(indexes).toContain('idx_note_notebook_id');
+      expect(indexes).toContain('idx_note_user_email');
+      expect(indexes).toContain('idx_note_visibility');
+      expect(indexes).toContain('idx_note_user_not_deleted');
+      expect(indexes).toContain('idx_note_created_at');
+      expect(indexes).toContain('idx_note_updated_at');
+      expect(indexes).toContain('idx_note_pinned');
+      expect(indexes).toContain('idx_note_tags');
+      expect(indexes).toContain('idx_note_search_vector');
+      expect(indexes).toContain('idx_note_embedding');
+      expect(indexes).toContain('idx_note_embedding_pending');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Creates the foundational database schema for the notes and notebooks feature:
- `notebook` table with hierarchical structure support
- `note` table with markdown content, privacy controls, and full search integration

## Changes

- Add migration 040 with `notebook` and `note` tables
- Both tables include soft delete support via `deleted_at` column
- `note` includes:
  - pgvector embedding column (1024 dimensions) for semantic search
  - tsvector search_vector with automatic trigger for full-text search
  - Privacy controls (`visibility`, `hide_from_agents`)
  - Tags array with GIN index
- Triggers for: `updated_at`, search vector updates, embedding status reset on content change
- Active/trash views for soft delete filtering
- Comprehensive indexes for all common query patterns

## Test plan

- [x] All 14 new schema tests pass
- [x] Migration up/down tests pass
- [x] Tables created with correct columns
- [x] Triggers work correctly (updated_at, search_vector, embedding_status)
- [x] Indexes created for all query patterns
- [x] Views correctly filter by deleted_at

Closes #340

🤖 Generated with [Claude Code](https://claude.com/claude-code)