### PR TITLE
[#341] Create note sharing and permissions database schema

### DIFF
--- a/migrations/041_note_sharing_schema.down.sql
+++ b/migrations/041_note_sharing_schema.down.sql
@@ -1,0 +1,27 @@
+-- Migration 041: Note Sharing and Permissions Schema (DOWN)
+-- Part of Epic #337, Issue #341
+-- Reverses all changes from the up migration
+
+-- Drop functions
+DROP FUNCTION IF EXISTS cleanup_expired_shares();
+DROP FUNCTION IF EXISTS generate_share_token();
+DROP FUNCTION IF EXISTS validate_share_link(text, boolean);
+DROP FUNCTION IF EXISTS agent_can_access_note(uuid);
+DROP FUNCTION IF EXISTS user_can_access_note(uuid, text, text);
+
+-- Drop indexes
+DROP INDEX IF EXISTS idx_note_collaborator_last_seen;
+DROP INDEX IF EXISTS idx_note_collaborator_user;
+DROP INDEX IF EXISTS idx_note_collaborator_note;
+DROP INDEX IF EXISTS idx_notebook_share_token;
+DROP INDEX IF EXISTS idx_notebook_share_shared_with_email;
+DROP INDEX IF EXISTS idx_notebook_share_notebook_id;
+DROP INDEX IF EXISTS idx_note_share_expires_at;
+DROP INDEX IF EXISTS idx_note_share_token;
+DROP INDEX IF EXISTS idx_note_share_shared_with_email;
+DROP INDEX IF EXISTS idx_note_share_note_id;
+
+-- Drop tables
+DROP TABLE IF EXISTS note_collaborator;
+DROP TABLE IF EXISTS notebook_share;
+DROP TABLE IF EXISTS note_share;

--- a/migrations/041_note_sharing_schema.up.sql
+++ b/migrations/041_note_sharing_schema.up.sql
@@ -1,0 +1,328 @@
+-- Migration 041: Note Sharing and Permissions Schema
+-- Part of Epic #337, Issue #341
+-- Creates sharing system for notes and notebooks
+
+-- ============================================================================
+-- NOTE_SHARE TABLE
+-- ============================================================================
+-- Direct note sharing with users or via share links
+
+CREATE TABLE IF NOT EXISTS note_share (
+  id uuid PRIMARY KEY DEFAULT new_uuid(),
+  note_id uuid NOT NULL REFERENCES note(id) ON DELETE CASCADE,
+
+  -- Share target (one of these should be set)
+  shared_with_email text,        -- Specific user
+  share_link_token text UNIQUE,  -- Public link token
+
+  -- Permissions
+  permission text NOT NULL DEFAULT 'read'
+    CHECK (permission IN ('read', 'read_write')),
+
+  -- Access controls
+  is_single_view boolean DEFAULT false,  -- Link dies after first view
+  view_count integer DEFAULT 0,
+  max_views integer,                     -- Optional view limit
+  expires_at timestamptz,                -- Optional expiration
+
+  -- Metadata
+  created_by_email text NOT NULL,
+  note_title_snapshot text,  -- Title at time of share for display
+
+  -- Timestamps
+  created_at timestamptz NOT NULL DEFAULT now(),
+  last_accessed_at timestamptz,
+
+  -- Ensure at least one target is set
+  CONSTRAINT note_share_target_check CHECK (
+    shared_with_email IS NOT NULL OR share_link_token IS NOT NULL
+  )
+);
+
+COMMENT ON TABLE note_share IS 'Shares granting access to individual notes';
+COMMENT ON COLUMN note_share.share_link_token IS 'URL-safe token for anonymous access';
+COMMENT ON COLUMN note_share.is_single_view IS 'When true, link is invalidated after first view';
+COMMENT ON COLUMN note_share.note_title_snapshot IS 'Cached title at share creation for display';
+
+-- ============================================================================
+-- NOTEBOOK_SHARE TABLE
+-- ============================================================================
+-- Notebook-level sharing (inherited by all notes in notebook)
+
+CREATE TABLE IF NOT EXISTS notebook_share (
+  id uuid PRIMARY KEY DEFAULT new_uuid(),
+  notebook_id uuid NOT NULL REFERENCES notebook(id) ON DELETE CASCADE,
+
+  -- Share target
+  shared_with_email text,
+  share_link_token text UNIQUE,
+
+  -- Permissions (applied to all notes in notebook)
+  permission text NOT NULL DEFAULT 'read'
+    CHECK (permission IN ('read', 'read_write')),
+
+  -- Access controls
+  expires_at timestamptz,
+
+  -- Metadata
+  created_by_email text NOT NULL,
+
+  -- Timestamps
+  created_at timestamptz NOT NULL DEFAULT now(),
+  last_accessed_at timestamptz,
+
+  -- Ensure at least one target is set
+  CONSTRAINT notebook_share_target_check CHECK (
+    shared_with_email IS NOT NULL OR share_link_token IS NOT NULL
+  )
+);
+
+COMMENT ON TABLE notebook_share IS 'Shares granting access to all notes in a notebook';
+
+-- ============================================================================
+-- NOTE_COLLABORATOR TABLE
+-- ============================================================================
+-- Active collaborators for presence and real-time features
+
+CREATE TABLE IF NOT EXISTS note_collaborator (
+  id uuid PRIMARY KEY DEFAULT new_uuid(),
+  note_id uuid NOT NULL REFERENCES note(id) ON DELETE CASCADE,
+  user_email text NOT NULL,
+
+  -- Presence
+  last_seen_at timestamptz NOT NULL DEFAULT now(),
+  cursor_position jsonb,  -- For collaborative editing: {"line": 10, "column": 5}
+
+  UNIQUE(note_id, user_email)
+);
+
+COMMENT ON TABLE note_collaborator IS 'Tracks active collaborators for presence features';
+COMMENT ON COLUMN note_collaborator.cursor_position IS 'JSON with line/column for cursor display';
+
+-- ============================================================================
+-- INDEXES
+-- ============================================================================
+
+-- note_share indexes
+CREATE INDEX IF NOT EXISTS idx_note_share_note_id ON note_share(note_id);
+CREATE INDEX IF NOT EXISTS idx_note_share_shared_with_email ON note_share(shared_with_email)
+  WHERE shared_with_email IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_note_share_token ON note_share(share_link_token)
+  WHERE share_link_token IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_note_share_expires_at ON note_share(expires_at)
+  WHERE expires_at IS NOT NULL;
+
+-- notebook_share indexes
+CREATE INDEX IF NOT EXISTS idx_notebook_share_notebook_id ON notebook_share(notebook_id);
+CREATE INDEX IF NOT EXISTS idx_notebook_share_shared_with_email ON notebook_share(shared_with_email)
+  WHERE shared_with_email IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_notebook_share_token ON notebook_share(share_link_token)
+  WHERE share_link_token IS NOT NULL;
+
+-- note_collaborator indexes
+CREATE INDEX IF NOT EXISTS idx_note_collaborator_note ON note_collaborator(note_id);
+CREATE INDEX IF NOT EXISTS idx_note_collaborator_user ON note_collaborator(user_email);
+-- Note: Stale collaborator cleanup uses last_seen_at column - index on that for cleanup queries
+CREATE INDEX IF NOT EXISTS idx_note_collaborator_last_seen ON note_collaborator(last_seen_at);
+
+-- ============================================================================
+-- HELPER FUNCTIONS
+-- ============================================================================
+
+-- Check if user has access to note with specified permission
+CREATE OR REPLACE FUNCTION user_can_access_note(
+  p_note_id uuid,
+  p_user_email text,
+  p_required_permission text DEFAULT 'read'
+) RETURNS boolean AS $$
+DECLARE
+  v_note RECORD;
+  v_has_access boolean := false;
+BEGIN
+  -- Get the note
+  SELECT n.user_email, n.visibility, n.notebook_id, n.deleted_at
+  INTO v_note
+  FROM note n
+  WHERE n.id = p_note_id;
+
+  -- Note doesn't exist or is deleted
+  IF v_note IS NULL OR v_note.deleted_at IS NOT NULL THEN
+    RETURN false;
+  END IF;
+
+  -- Owner always has full access
+  IF v_note.user_email = p_user_email THEN
+    RETURN true;
+  END IF;
+
+  -- Public notes allow read access to everyone
+  IF v_note.visibility = 'public' AND p_required_permission = 'read' THEN
+    RETURN true;
+  END IF;
+
+  -- Check direct note share
+  SELECT EXISTS (
+    SELECT 1 FROM note_share ns
+    WHERE ns.note_id = p_note_id
+      AND ns.shared_with_email = p_user_email
+      AND (ns.expires_at IS NULL OR ns.expires_at > NOW())
+      AND (
+        p_required_permission = 'read'
+        OR ns.permission = 'read_write'
+      )
+  ) INTO v_has_access;
+
+  IF v_has_access THEN
+    RETURN true;
+  END IF;
+
+  -- Check notebook-level share (if note is in a notebook)
+  IF v_note.notebook_id IS NOT NULL THEN
+    SELECT EXISTS (
+      SELECT 1 FROM notebook_share nbs
+      WHERE nbs.notebook_id = v_note.notebook_id
+        AND nbs.shared_with_email = p_user_email
+        AND (nbs.expires_at IS NULL OR nbs.expires_at > NOW())
+        AND (
+          p_required_permission = 'read'
+          OR nbs.permission = 'read_write'
+        )
+    ) INTO v_has_access;
+  END IF;
+
+  RETURN v_has_access;
+END;
+$$ LANGUAGE plpgsql STABLE;
+
+COMMENT ON FUNCTION user_can_access_note IS 'Check if user has specified permission on note via ownership, direct share, or notebook share';
+
+-- Check if agent can access note (for OpenClaw plugin)
+CREATE OR REPLACE FUNCTION agent_can_access_note(
+  p_note_id uuid
+) RETURNS boolean AS $$
+DECLARE
+  v_visibility text;
+  v_hide_from_agents boolean;
+  v_deleted_at timestamptz;
+BEGIN
+  SELECT visibility, hide_from_agents, deleted_at
+  INTO v_visibility, v_hide_from_agents, v_deleted_at
+  FROM note
+  WHERE id = p_note_id;
+
+  -- Note doesn't exist or is deleted
+  IF v_visibility IS NULL OR v_deleted_at IS NOT NULL THEN
+    RETURN false;
+  END IF;
+
+  -- Private notes are never accessible to agents
+  IF v_visibility = 'private' THEN
+    RETURN false;
+  END IF;
+
+  -- Explicit agent exclusion
+  IF v_hide_from_agents THEN
+    RETURN false;
+  END IF;
+
+  RETURN true;
+END;
+$$ LANGUAGE plpgsql STABLE;
+
+COMMENT ON FUNCTION agent_can_access_note IS 'Check if OpenClaw agent can access note based on visibility and hide_from_agents flag';
+
+-- Validate and consume share link token
+CREATE OR REPLACE FUNCTION validate_share_link(
+  p_token text,
+  p_increment_view boolean DEFAULT true
+) RETURNS TABLE (
+  note_id uuid,
+  permission text,
+  is_valid boolean,
+  error_message text
+) AS $$
+DECLARE
+  v_share RECORD;
+BEGIN
+  -- Find the share
+  SELECT ns.note_id, ns.permission, ns.is_single_view, ns.view_count,
+         ns.max_views, ns.expires_at
+  INTO v_share
+  FROM note_share ns
+  WHERE ns.share_link_token = p_token;
+
+  IF v_share IS NULL THEN
+    RETURN QUERY SELECT NULL::uuid, NULL::text, false, 'Invalid or expired link'::text;
+    RETURN;
+  END IF;
+
+  -- Check expiration
+  IF v_share.expires_at IS NOT NULL AND v_share.expires_at < NOW() THEN
+    RETURN QUERY SELECT v_share.note_id, NULL::text, false, 'Link has expired'::text;
+    RETURN;
+  END IF;
+
+  -- Check single view
+  IF v_share.is_single_view AND v_share.view_count > 0 THEN
+    RETURN QUERY SELECT v_share.note_id, NULL::text, false,
+      'This link can only be viewed once'::text;
+    RETURN;
+  END IF;
+
+  -- Check max views
+  IF v_share.max_views IS NOT NULL AND v_share.view_count >= v_share.max_views THEN
+    RETURN QUERY SELECT v_share.note_id, NULL::text, false,
+      'Maximum views reached for this link'::text;
+    RETURN;
+  END IF;
+
+  -- Increment view count and update last accessed
+  IF p_increment_view THEN
+    UPDATE note_share
+    SET view_count = view_count + 1,
+        last_accessed_at = NOW()
+    WHERE share_link_token = p_token;
+  END IF;
+
+  RETURN QUERY SELECT v_share.note_id, v_share.permission, true, NULL::text;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION validate_share_link IS 'Validate share token, check limits, optionally increment view count';
+
+-- Generate secure share token using multiple UUIDs for sufficient entropy
+CREATE OR REPLACE FUNCTION generate_share_token() RETURNS text AS $$
+BEGIN
+  -- Combine two UUIDv4s (256 bits total) and remove hyphens for a compact URL-safe token
+  RETURN replace(gen_random_uuid()::text || gen_random_uuid()::text, '-', '');
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION generate_share_token IS 'Generate cryptographically secure URL-safe share token';
+
+-- Cleanup expired and stale data
+CREATE OR REPLACE FUNCTION cleanup_expired_shares() RETURNS integer AS $$
+DECLARE
+  v_deleted integer := 0;
+BEGIN
+  -- Delete expired share links (keep user shares for audit)
+  DELETE FROM note_share
+  WHERE share_link_token IS NOT NULL
+    AND expires_at IS NOT NULL
+    AND expires_at < NOW() - INTERVAL '7 days';
+  GET DIAGNOSTICS v_deleted = ROW_COUNT;
+
+  DELETE FROM notebook_share
+  WHERE share_link_token IS NOT NULL
+    AND expires_at IS NOT NULL
+    AND expires_at < NOW() - INTERVAL '7 days';
+
+  -- Delete stale collaborator presence (older than 1 hour)
+  DELETE FROM note_collaborator
+  WHERE last_seen_at < NOW() - INTERVAL '1 hour';
+
+  RETURN v_deleted;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION cleanup_expired_shares IS 'Remove expired link shares (7+ days old) and stale collaborator presence';

--- a/tests/note_sharing_schema.test.ts
+++ b/tests/note_sharing_schema.test.ts
@@ -1,0 +1,494 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
+import { Pool } from 'pg';
+import { existsSync } from 'fs';
+import { runMigrate } from './helpers/migrate.js';
+
+/**
+ * Tests for Issue #341 - Note Sharing and Permissions Schema
+ * Validates migration 041_note_sharing_schema
+ */
+describe('Note Sharing Schema (Migration 041)', () => {
+  let pool: Pool;
+  let testNoteId: string;
+  let testNotebookId: string;
+
+  beforeAll(async () => {
+    const defaultHost = existsSync('/.dockerenv') ? 'postgres' : 'localhost';
+    const host = process.env.PGHOST || defaultHost;
+
+    pool = new Pool({
+      host,
+      port: parseInt(process.env.PGPORT || '5432', 10),
+      user: process.env.PGUSER || 'openclaw',
+      password: process.env.PGPASSWORD || 'openclaw',
+      database: process.env.PGDATABASE || 'openclaw',
+    });
+
+    // Ensure migrations are applied
+    await runMigrate('up');
+
+    // Create test notebook and note for sharing tests
+    const notebook = await pool.query(`
+      INSERT INTO notebook (user_email, name)
+      VALUES ('owner@example.com', 'Test Notebook for Sharing')
+      RETURNING id
+    `);
+    testNotebookId = notebook.rows[0].id;
+
+    const note = await pool.query(`
+      INSERT INTO note (user_email, title, content, notebook_id, visibility)
+      VALUES ('owner@example.com', 'Test Note', 'Test content', $1, 'shared')
+      RETURNING id
+    `, [testNotebookId]);
+    testNoteId = note.rows[0].id;
+  });
+
+  afterAll(async () => {
+    // Cleanup test data
+    await pool.query('DELETE FROM note_collaborator WHERE note_id = $1', [testNoteId]);
+    await pool.query('DELETE FROM note_share WHERE note_id = $1', [testNoteId]);
+    await pool.query('DELETE FROM notebook_share WHERE notebook_id = $1', [testNotebookId]);
+    await pool.query('DELETE FROM note WHERE user_email = $1', ['owner@example.com']);
+    await pool.query('DELETE FROM notebook WHERE user_email = $1', ['owner@example.com']);
+    await pool.end();
+  });
+
+  describe('note_share table', () => {
+    afterEach(async () => {
+      // Clean up shares after each test
+      await pool.query('DELETE FROM note_share WHERE note_id = $1', [testNoteId]);
+    });
+
+    it('exists with all required columns', async () => {
+      const result = await pool.query(`
+        SELECT column_name, data_type, is_nullable
+        FROM information_schema.columns
+        WHERE table_name = 'note_share'
+        ORDER BY ordinal_position
+      `);
+
+      const columns = result.rows.map((r) => r.column_name);
+      expect(columns).toContain('id');
+      expect(columns).toContain('note_id');
+      expect(columns).toContain('shared_with_email');
+      expect(columns).toContain('share_link_token');
+      expect(columns).toContain('permission');
+      expect(columns).toContain('is_single_view');
+      expect(columns).toContain('view_count');
+      expect(columns).toContain('max_views');
+      expect(columns).toContain('expires_at');
+      expect(columns).toContain('created_by_email');
+      expect(columns).toContain('note_title_snapshot');
+      expect(columns).toContain('created_at');
+      expect(columns).toContain('last_accessed_at');
+    });
+
+    it('enforces permission CHECK constraint', async () => {
+      // Valid permission should work
+      const valid = await pool.query(`
+        INSERT INTO note_share (note_id, shared_with_email, permission, created_by_email)
+        VALUES ($1, 'reader@example.com', 'read', 'owner@example.com')
+        RETURNING id
+      `, [testNoteId]);
+      expect(valid.rows[0].id).toBeDefined();
+
+      // Invalid permission should fail
+      await expect(
+        pool.query(`
+          INSERT INTO note_share (note_id, shared_with_email, permission, created_by_email)
+          VALUES ($1, 'bad@example.com', 'admin', 'owner@example.com')
+        `, [testNoteId])
+      ).rejects.toThrow();
+    });
+
+    it('requires at least one target (shared_with_email or share_link_token)', async () => {
+      // Should fail without either target
+      await expect(
+        pool.query(`
+          INSERT INTO note_share (note_id, permission, created_by_email)
+          VALUES ($1, 'read', 'owner@example.com')
+        `, [testNoteId])
+      ).rejects.toThrow();
+
+      // Should succeed with email
+      const withEmail = await pool.query(`
+        INSERT INTO note_share (note_id, shared_with_email, permission, created_by_email)
+        VALUES ($1, 'user@example.com', 'read', 'owner@example.com')
+        RETURNING id
+      `, [testNoteId]);
+      expect(withEmail.rows[0].id).toBeDefined();
+
+      // Should succeed with token
+      const withToken = await pool.query(`
+        INSERT INTO note_share (note_id, share_link_token, permission, created_by_email)
+        VALUES ($1, 'unique-token-123', 'read', 'owner@example.com')
+        RETURNING id
+      `, [testNoteId]);
+      expect(withToken.rows[0].id).toBeDefined();
+    });
+
+    it('cascades delete when note is deleted', async () => {
+      // Create a temporary note
+      const tempNote = await pool.query(`
+        INSERT INTO note (user_email, title)
+        VALUES ('owner@example.com', 'Temp Note for Cascade Test')
+        RETURNING id
+      `);
+      const tempNoteId = tempNote.rows[0].id;
+
+      // Create a share
+      await pool.query(`
+        INSERT INTO note_share (note_id, shared_with_email, permission, created_by_email)
+        VALUES ($1, 'user@example.com', 'read', 'owner@example.com')
+      `, [tempNoteId]);
+
+      // Delete the note
+      await pool.query('DELETE FROM note WHERE id = $1', [tempNoteId]);
+
+      // Share should be gone
+      const shares = await pool.query('SELECT id FROM note_share WHERE note_id = $1', [tempNoteId]);
+      expect(shares.rows.length).toBe(0);
+    });
+  });
+
+  describe('notebook_share table', () => {
+    afterEach(async () => {
+      await pool.query('DELETE FROM notebook_share WHERE notebook_id = $1', [testNotebookId]);
+    });
+
+    it('exists with all required columns', async () => {
+      const result = await pool.query(`
+        SELECT column_name FROM information_schema.columns
+        WHERE table_name = 'notebook_share'
+        ORDER BY ordinal_position
+      `);
+
+      const columns = result.rows.map((r) => r.column_name);
+      expect(columns).toContain('id');
+      expect(columns).toContain('notebook_id');
+      expect(columns).toContain('shared_with_email');
+      expect(columns).toContain('share_link_token');
+      expect(columns).toContain('permission');
+      expect(columns).toContain('expires_at');
+      expect(columns).toContain('created_by_email');
+    });
+
+    it('cascades delete when notebook is deleted', async () => {
+      // Create temp notebook
+      const tempNotebook = await pool.query(`
+        INSERT INTO notebook (user_email, name)
+        VALUES ('owner@example.com', 'Temp Notebook for Cascade')
+        RETURNING id
+      `);
+      const tempNotebookId = tempNotebook.rows[0].id;
+
+      // Create share
+      await pool.query(`
+        INSERT INTO notebook_share (notebook_id, shared_with_email, permission, created_by_email)
+        VALUES ($1, 'user@example.com', 'read', 'owner@example.com')
+      `, [tempNotebookId]);
+
+      // Delete notebook
+      await pool.query('DELETE FROM notebook WHERE id = $1', [tempNotebookId]);
+
+      // Share should be gone
+      const shares = await pool.query('SELECT id FROM notebook_share WHERE notebook_id = $1', [tempNotebookId]);
+      expect(shares.rows.length).toBe(0);
+    });
+  });
+
+  describe('note_collaborator table', () => {
+    afterEach(async () => {
+      await pool.query('DELETE FROM note_collaborator WHERE note_id = $1', [testNoteId]);
+    });
+
+    it('exists with required columns', async () => {
+      const result = await pool.query(`
+        SELECT column_name FROM information_schema.columns
+        WHERE table_name = 'note_collaborator'
+        ORDER BY ordinal_position
+      `);
+
+      const columns = result.rows.map((r) => r.column_name);
+      expect(columns).toContain('id');
+      expect(columns).toContain('note_id');
+      expect(columns).toContain('user_email');
+      expect(columns).toContain('last_seen_at');
+      expect(columns).toContain('cursor_position');
+    });
+
+    it('enforces unique constraint on note_id + user_email', async () => {
+      await pool.query(`
+        INSERT INTO note_collaborator (note_id, user_email)
+        VALUES ($1, 'collab@example.com')
+      `, [testNoteId]);
+
+      // Duplicate should fail
+      await expect(
+        pool.query(`
+          INSERT INTO note_collaborator (note_id, user_email)
+          VALUES ($1, 'collab@example.com')
+        `, [testNoteId])
+      ).rejects.toThrow();
+    });
+
+    it('stores cursor position as JSONB', async () => {
+      const cursorPos = { line: 10, column: 25 };
+      const result = await pool.query(`
+        INSERT INTO note_collaborator (note_id, user_email, cursor_position)
+        VALUES ($1, 'editor@example.com', $2)
+        RETURNING cursor_position
+      `, [testNoteId, JSON.stringify(cursorPos)]);
+
+      expect(result.rows[0].cursor_position).toEqual(cursorPos);
+    });
+  });
+
+  describe('user_can_access_note() function', () => {
+    beforeEach(async () => {
+      // Update test note visibility to shared
+      await pool.query(`UPDATE note SET visibility = 'shared' WHERE id = $1`, [testNoteId]);
+    });
+
+    afterEach(async () => {
+      await pool.query('DELETE FROM note_share WHERE note_id = $1', [testNoteId]);
+      await pool.query('DELETE FROM notebook_share WHERE notebook_id = $1', [testNotebookId]);
+    });
+
+    it('returns true for note owner', async () => {
+      const result = await pool.query(`
+        SELECT user_can_access_note($1, 'owner@example.com', 'read_write')
+      `, [testNoteId]);
+      expect(result.rows[0].user_can_access_note).toBe(true);
+    });
+
+    it('returns false for unshared note', async () => {
+      const result = await pool.query(`
+        SELECT user_can_access_note($1, 'stranger@example.com', 'read')
+      `, [testNoteId]);
+      expect(result.rows[0].user_can_access_note).toBe(false);
+    });
+
+    it('returns true when note is directly shared with user', async () => {
+      await pool.query(`
+        INSERT INTO note_share (note_id, shared_with_email, permission, created_by_email)
+        VALUES ($1, 'reader@example.com', 'read', 'owner@example.com')
+      `, [testNoteId]);
+
+      const result = await pool.query(`
+        SELECT user_can_access_note($1, 'reader@example.com', 'read')
+      `, [testNoteId]);
+      expect(result.rows[0].user_can_access_note).toBe(true);
+    });
+
+    it('returns false when user only has read but needs read_write', async () => {
+      await pool.query(`
+        INSERT INTO note_share (note_id, shared_with_email, permission, created_by_email)
+        VALUES ($1, 'reader@example.com', 'read', 'owner@example.com')
+      `, [testNoteId]);
+
+      const result = await pool.query(`
+        SELECT user_can_access_note($1, 'reader@example.com', 'read_write')
+      `, [testNoteId]);
+      expect(result.rows[0].user_can_access_note).toBe(false);
+    });
+
+    it('returns true when notebook is shared with user', async () => {
+      await pool.query(`
+        INSERT INTO notebook_share (notebook_id, shared_with_email, permission, created_by_email)
+        VALUES ($1, 'nb-reader@example.com', 'read', 'owner@example.com')
+      `, [testNotebookId]);
+
+      const result = await pool.query(`
+        SELECT user_can_access_note($1, 'nb-reader@example.com', 'read')
+      `, [testNoteId]);
+      expect(result.rows[0].user_can_access_note).toBe(true);
+    });
+
+    it('respects share expiration', async () => {
+      // Create expired share
+      await pool.query(`
+        INSERT INTO note_share (note_id, shared_with_email, permission, created_by_email, expires_at)
+        VALUES ($1, 'expired@example.com', 'read', 'owner@example.com', NOW() - INTERVAL '1 day')
+      `, [testNoteId]);
+
+      const result = await pool.query(`
+        SELECT user_can_access_note($1, 'expired@example.com', 'read')
+      `, [testNoteId]);
+      expect(result.rows[0].user_can_access_note).toBe(false);
+    });
+
+    it('grants read access to public notes', async () => {
+      // Make note public
+      await pool.query(`UPDATE note SET visibility = 'public' WHERE id = $1`, [testNoteId]);
+
+      const result = await pool.query(`
+        SELECT user_can_access_note($1, 'anyone@example.com', 'read')
+      `, [testNoteId]);
+      expect(result.rows[0].user_can_access_note).toBe(true);
+    });
+  });
+
+  describe('agent_can_access_note() function', () => {
+    afterEach(async () => {
+      await pool.query(`
+        UPDATE note SET visibility = 'shared', hide_from_agents = false WHERE id = $1
+      `, [testNoteId]);
+    });
+
+    it('returns false for private notes', async () => {
+      await pool.query(`UPDATE note SET visibility = 'private' WHERE id = $1`, [testNoteId]);
+
+      const result = await pool.query(`SELECT agent_can_access_note($1)`, [testNoteId]);
+      expect(result.rows[0].agent_can_access_note).toBe(false);
+    });
+
+    it('returns true for shared notes without hide_from_agents', async () => {
+      await pool.query(`UPDATE note SET visibility = 'shared' WHERE id = $1`, [testNoteId]);
+
+      const result = await pool.query(`SELECT agent_can_access_note($1)`, [testNoteId]);
+      expect(result.rows[0].agent_can_access_note).toBe(true);
+    });
+
+    it('returns false when hide_from_agents is true', async () => {
+      await pool.query(`
+        UPDATE note SET visibility = 'public', hide_from_agents = true WHERE id = $1
+      `, [testNoteId]);
+
+      const result = await pool.query(`SELECT agent_can_access_note($1)`, [testNoteId]);
+      expect(result.rows[0].agent_can_access_note).toBe(false);
+    });
+  });
+
+  describe('validate_share_link() function', () => {
+    afterEach(async () => {
+      await pool.query('DELETE FROM note_share WHERE note_id = $1', [testNoteId]);
+    });
+
+    it('returns is_valid=false for non-existent token', async () => {
+      const result = await pool.query(`SELECT * FROM validate_share_link('nonexistent-token')`);
+      expect(result.rows[0].is_valid).toBe(false);
+      expect(result.rows[0].error_message).toBe('Invalid or expired link');
+    });
+
+    it('returns is_valid=true for valid token', async () => {
+      await pool.query(`
+        INSERT INTO note_share (note_id, share_link_token, permission, created_by_email)
+        VALUES ($1, 'valid-token', 'read', 'owner@example.com')
+      `, [testNoteId]);
+
+      const result = await pool.query(`SELECT * FROM validate_share_link('valid-token')`);
+      expect(result.rows[0].is_valid).toBe(true);
+      expect(result.rows[0].note_id).toBe(testNoteId);
+      expect(result.rows[0].permission).toBe('read');
+    });
+
+    it('increments view count', async () => {
+      await pool.query(`
+        INSERT INTO note_share (note_id, share_link_token, permission, created_by_email)
+        VALUES ($1, 'count-token', 'read', 'owner@example.com')
+      `, [testNoteId]);
+
+      await pool.query(`SELECT * FROM validate_share_link('count-token')`);
+      await pool.query(`SELECT * FROM validate_share_link('count-token')`);
+
+      const share = await pool.query(`
+        SELECT view_count FROM note_share WHERE share_link_token = 'count-token'
+      `);
+      expect(share.rows[0].view_count).toBe(2);
+    });
+
+    it('rejects single-view links after first view', async () => {
+      await pool.query(`
+        INSERT INTO note_share (note_id, share_link_token, permission, created_by_email, is_single_view)
+        VALUES ($1, 'single-view-token', 'read', 'owner@example.com', true)
+      `, [testNoteId]);
+
+      // First view should work
+      const first = await pool.query(`SELECT * FROM validate_share_link('single-view-token')`);
+      expect(first.rows[0].is_valid).toBe(true);
+
+      // Second view should fail
+      const second = await pool.query(`SELECT * FROM validate_share_link('single-view-token')`);
+      expect(second.rows[0].is_valid).toBe(false);
+      expect(second.rows[0].error_message).toBe('This link can only be viewed once');
+    });
+
+    it('rejects expired links', async () => {
+      await pool.query(`
+        INSERT INTO note_share (note_id, share_link_token, permission, created_by_email, expires_at)
+        VALUES ($1, 'expired-token', 'read', 'owner@example.com', NOW() - INTERVAL '1 hour')
+      `, [testNoteId]);
+
+      const result = await pool.query(`SELECT * FROM validate_share_link('expired-token')`);
+      expect(result.rows[0].is_valid).toBe(false);
+      expect(result.rows[0].error_message).toBe('Link has expired');
+    });
+
+    it('rejects max-views exceeded links', async () => {
+      await pool.query(`
+        INSERT INTO note_share (note_id, share_link_token, permission, created_by_email, max_views, view_count)
+        VALUES ($1, 'max-views-token', 'read', 'owner@example.com', 3, 3)
+      `, [testNoteId]);
+
+      const result = await pool.query(`SELECT * FROM validate_share_link('max-views-token')`);
+      expect(result.rows[0].is_valid).toBe(false);
+      expect(result.rows[0].error_message).toBe('Maximum views reached for this link');
+    });
+  });
+
+  describe('generate_share_token() function', () => {
+    it('generates URL-safe tokens', async () => {
+      const result = await pool.query(`SELECT generate_share_token() as token`);
+      const token = result.rows[0].token;
+
+      // Should be non-empty
+      expect(token.length).toBeGreaterThan(0);
+
+      // Should be URL-safe (no hyphens, plus, or slash)
+      expect(token).not.toContain('+');
+      expect(token).not.toContain('/');
+      expect(token).not.toContain('-');
+
+      // Should be 64 chars (two UUIDs without hyphens)
+      expect(token.length).toBe(64);
+
+      // Should only contain hex characters
+      expect(token).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it('generates unique tokens', async () => {
+      const result = await pool.query(`
+        SELECT generate_share_token() as t1, generate_share_token() as t2
+      `);
+      expect(result.rows[0].t1).not.toBe(result.rows[0].t2);
+    });
+  });
+
+  describe('indexes', () => {
+    it('has required indexes', async () => {
+      const result = await pool.query(`
+        SELECT indexname FROM pg_indexes
+        WHERE tablename IN ('note_share', 'notebook_share', 'note_collaborator')
+        ORDER BY indexname
+      `);
+
+      const indexes = result.rows.map((r) => r.indexname);
+
+      // note_share indexes
+      expect(indexes).toContain('idx_note_share_note_id');
+      expect(indexes).toContain('idx_note_share_shared_with_email');
+      expect(indexes).toContain('idx_note_share_token');
+      expect(indexes).toContain('idx_note_share_expires_at');
+
+      // notebook_share indexes
+      expect(indexes).toContain('idx_notebook_share_notebook_id');
+      expect(indexes).toContain('idx_notebook_share_shared_with_email');
+      expect(indexes).toContain('idx_notebook_share_token');
+
+      // note_collaborator indexes
+      expect(indexes).toContain('idx_note_collaborator_note');
+      expect(indexes).toContain('idx_note_collaborator_user');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Creates the sharing and permissions system for notes and notebooks:
- Direct user sharing via email
- Share links with configurable access controls
- Notebook-level sharing (inherited by all notes)
- Real-time collaborator presence tracking

## Changes

- Add migration 041 with three new tables:
  - `note_share` - direct note sharing and share links
  - `notebook_share` - notebook-level sharing
  - `note_collaborator` - presence tracking for real-time collaboration
- Add helper functions:
  - `user_can_access_note()` - checks ownership, direct share, notebook share, public visibility
  - `agent_can_access_note()` - enforces privacy for OpenClaw agents
  - `validate_share_link()` - validates tokens with expiration, single-view, and max-views support
  - `generate_share_token()` - generates secure URL-safe tokens
  - `cleanup_expired_shares()` - maintenance function for stale data
- Comprehensive indexes for all query patterns

## Test plan

- [x] All 28 new schema tests pass
- [x] Migration up/down tests pass
- [x] Permission CHECK constraints enforced
- [x] Target CHECK constraint (email OR token required) works
- [x] CASCADE deletes work when note/notebook deleted
- [x] user_can_access_note() correctly checks all access paths
- [x] agent_can_access_note() enforces privacy settings
- [x] validate_share_link() handles all edge cases
- [x] generate_share_token() produces unique URL-safe tokens

Closes #341

🤖 Generated with [Claude Code](https://claude.com/claude-code)