### PR TITLE
[#344] Add Note CRUD API

### DIFF
--- a/src/api/notes/index.ts
+++ b/src/api/notes/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Notes API exports
+ * Part of Epic #337, Issue #344
+ */
+
+export * from './types.ts';
+export * from './service.ts';

--- a/src/api/notes/service.ts
+++ b/src/api/notes/service.ts
@@ -1,0 +1,513 @@
+/**
+ * Note service for the notes API.
+ * Part of Epic #337, Issue #344
+ */
+
+import type { Pool } from 'pg';
+import type {
+  Note,
+  NoteVisibility,
+  EmbeddingStatus,
+  CreateNoteInput,
+  UpdateNoteInput,
+  ListNotesOptions,
+  ListNotesResult,
+  GetNoteOptions,
+} from './types.ts';
+
+/** Valid visibility values */
+const VALID_VISIBILITY: NoteVisibility[] = ['private', 'shared', 'public'];
+
+/**
+ * Maps database row to Note
+ */
+function mapRowToNote(row: Record<string, unknown>): Note {
+  return {
+    id: row.id as string,
+    notebookId: row.notebook_id as string | null,
+    userEmail: row.user_email as string,
+    title: row.title as string,
+    content: row.content as string,
+    summary: row.summary as string | null,
+    tags: (row.tags as string[]) ?? [],
+    isPinned: (row.is_pinned as boolean) ?? false,
+    sortOrder: (row.sort_order as number) ?? 0,
+    visibility: row.visibility as NoteVisibility,
+    hideFromAgents: (row.hide_from_agents as boolean) ?? false,
+    embeddingStatus: row.embedding_status as EmbeddingStatus,
+    deletedAt: row.deleted_at ? new Date(row.deleted_at as string) : null,
+    createdAt: new Date(row.created_at as string),
+    updatedAt: new Date(row.updated_at as string),
+    // Optional notebook expand
+    notebook: row.notebook_name
+      ? { id: row.notebook_id as string, name: row.notebook_name as string }
+      : null,
+    versionCount: row.version_count !== undefined ? Number(row.version_count) : undefined,
+  };
+}
+
+/**
+ * Validates visibility value
+ */
+export function isValidVisibility(value: string): value is NoteVisibility {
+  return VALID_VISIBILITY.includes(value as NoteVisibility);
+}
+
+/**
+ * Checks if user can access a note (read permission)
+ */
+export async function userCanAccessNote(
+  pool: Pool,
+  noteId: string,
+  userEmail: string,
+  requiredPermission: 'read' | 'read_write' = 'read'
+): Promise<boolean> {
+  const result = await pool.query(
+    'SELECT user_can_access_note($1, $2, $3) as can_access',
+    [noteId, userEmail, requiredPermission]
+  );
+  return result.rows[0]?.can_access ?? false;
+}
+
+/**
+ * Checks if user owns a note
+ */
+export async function userOwnsNote(
+  pool: Pool,
+  noteId: string,
+  userEmail: string
+): Promise<boolean> {
+  const result = await pool.query(
+    'SELECT user_email FROM note WHERE id = $1 AND deleted_at IS NULL',
+    [noteId]
+  );
+  return result.rows[0]?.user_email === userEmail;
+}
+
+/**
+ * Creates a new note
+ */
+export async function createNote(
+  pool: Pool,
+  input: CreateNoteInput,
+  userEmail: string
+): Promise<Note> {
+  const visibility = input.visibility ?? 'private';
+
+  if (!isValidVisibility(visibility)) {
+    throw new Error(`Invalid visibility: ${visibility}. Valid values are: ${VALID_VISIBILITY.join(', ')}`);
+  }
+
+  // Validate notebook exists and belongs to user if provided
+  if (input.notebookId) {
+    const nbResult = await pool.query(
+      'SELECT user_email FROM notebook WHERE id = $1 AND deleted_at IS NULL',
+      [input.notebookId]
+    );
+    if (nbResult.rows.length === 0) {
+      throw new Error('Notebook not found');
+    }
+    if (nbResult.rows[0].user_email !== userEmail) {
+      throw new Error('Cannot add note to notebook you do not own');
+    }
+  }
+
+  const result = await pool.query(
+    `INSERT INTO note (
+      user_email, title, content, notebook_id,
+      tags, visibility, hide_from_agents, summary, is_pinned
+    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+    RETURNING
+      id::text, notebook_id::text, user_email, title, content,
+      summary, tags, is_pinned, sort_order, visibility,
+      hide_from_agents, embedding_status, deleted_at,
+      created_at, updated_at`,
+    [
+      userEmail,
+      input.title,
+      input.content ?? '',
+      input.notebookId ?? null,
+      input.tags ?? [],
+      visibility,
+      input.hideFromAgents ?? false,
+      input.summary ?? null,
+      input.isPinned ?? false,
+    ]
+  );
+
+  return mapRowToNote(result.rows[0]);
+}
+
+/**
+ * Gets a note by ID with access check
+ */
+export async function getNote(
+  pool: Pool,
+  noteId: string,
+  userEmail: string,
+  options: GetNoteOptions = {}
+): Promise<Note | null> {
+  // Check access
+  const canAccess = await userCanAccessNote(pool, noteId, userEmail, 'read');
+  if (!canAccess) {
+    return null;
+  }
+
+  // Get note with optional notebook expansion
+  const result = await pool.query(
+    `SELECT
+      n.id::text, n.notebook_id::text, n.user_email, n.title, n.content,
+      n.summary, n.tags, n.is_pinned, n.sort_order, n.visibility,
+      n.hide_from_agents, n.embedding_status, n.deleted_at,
+      n.created_at, n.updated_at,
+      nb.name as notebook_name,
+      (SELECT COUNT(*) FROM note_version WHERE note_id = n.id) as version_count
+    FROM note n
+    LEFT JOIN notebook nb ON n.notebook_id = nb.id
+    WHERE n.id = $1 AND n.deleted_at IS NULL`,
+    [noteId]
+  );
+
+  if (result.rows.length === 0) {
+    return null;
+  }
+
+  const note = mapRowToNote(result.rows[0]);
+
+  // Include versions if requested
+  if (options.includeVersions) {
+    const versionsResult = await pool.query(
+      `SELECT version_number, title, changed_by_email, change_type, created_at
+       FROM note_version
+       WHERE note_id = $1
+       ORDER BY version_number DESC
+       LIMIT 50`,
+      [noteId]
+    );
+    (note as Note & { versions: unknown[] }).versions = versionsResult.rows.map((v) => ({
+      versionNumber: v.version_number,
+      title: v.title,
+      changedByEmail: v.changed_by_email,
+      changeType: v.change_type,
+      createdAt: v.created_at,
+    }));
+  }
+
+  // Include references if requested
+  if (options.includeReferences) {
+    const refsResult = await pool.query(
+      `SELECT r.id::text, r.work_item_id::text, r.reference_type, r.created_at,
+              w.title as work_item_title, w.work_item_kind, w.status
+       FROM note_work_item_reference r
+       JOIN work_item w ON r.work_item_id = w.id AND w.deleted_at IS NULL
+       WHERE r.note_id = $1`,
+      [noteId]
+    );
+    (note as Note & { references: unknown[] }).references = refsResult.rows.map((r) => ({
+      id: r.id,
+      workItemId: r.work_item_id,
+      referenceType: r.reference_type,
+      createdAt: r.created_at,
+      workItem: {
+        id: r.work_item_id,
+        title: r.work_item_title,
+        kind: r.work_item_kind,
+        status: r.status,
+      },
+    }));
+  }
+
+  return note;
+}
+
+/**
+ * Lists notes with filters and pagination
+ */
+export async function listNotes(
+  pool: Pool,
+  userEmail: string,
+  options: ListNotesOptions = {}
+): Promise<ListNotesResult> {
+  const limit = Math.min(options.limit ?? 50, 100);
+  const offset = options.offset ?? 0;
+  const sortBy = options.sortBy ?? 'updatedAt';
+  const sortOrder = options.sortOrder ?? 'desc';
+
+  // Map sort field to column
+  const sortColumn = {
+    createdAt: 'n.created_at',
+    updatedAt: 'n.updated_at',
+    title: 'n.title',
+  }[sortBy];
+
+  // Build dynamic WHERE clause
+  const conditions: string[] = ['n.deleted_at IS NULL'];
+  const params: (string | string[] | boolean | number)[] = [];
+  let paramIndex = 1;
+
+  // User can see: own notes OR shared with them OR public
+  conditions.push(`(
+    n.user_email = $${paramIndex}
+    OR n.visibility = 'public'
+    OR EXISTS (SELECT 1 FROM note_share ns WHERE ns.note_id = n.id AND ns.shared_with_email = $${paramIndex} AND (ns.expires_at IS NULL OR ns.expires_at > NOW()))
+    OR EXISTS (SELECT 1 FROM notebook_share nbs WHERE nbs.notebook_id = n.notebook_id AND nbs.shared_with_email = $${paramIndex} AND (nbs.expires_at IS NULL OR nbs.expires_at > NOW()))
+  )`);
+  params.push(userEmail);
+  paramIndex++;
+
+  if (options.notebookId) {
+    conditions.push(`n.notebook_id = $${paramIndex}`);
+    params.push(options.notebookId);
+    paramIndex++;
+  }
+
+  if (options.visibility) {
+    conditions.push(`n.visibility = $${paramIndex}`);
+    params.push(options.visibility);
+    paramIndex++;
+  }
+
+  if (options.tags && options.tags.length > 0) {
+    conditions.push(`n.tags @> $${paramIndex}`);
+    params.push(options.tags);
+    paramIndex++;
+  }
+
+  if (options.isPinned !== undefined) {
+    conditions.push(`n.is_pinned = $${paramIndex}`);
+    params.push(options.isPinned);
+    paramIndex++;
+  }
+
+  if (options.search) {
+    conditions.push(`n.search_vector @@ plainto_tsquery('english', $${paramIndex})`);
+    params.push(options.search);
+    paramIndex++;
+  }
+
+  const whereClause = `WHERE ${conditions.join(' AND ')}`;
+
+  // Get total count
+  const countResult = await pool.query(
+    `SELECT COUNT(*) as total FROM note n ${whereClause}`,
+    params
+  );
+  const total = parseInt((countResult.rows[0] as { total: string }).total, 10);
+
+  // Get notes
+  const notesResult = await pool.query(
+    `SELECT
+      n.id::text, n.notebook_id::text, n.user_email, n.title, n.content,
+      n.summary, n.tags, n.is_pinned, n.sort_order, n.visibility,
+      n.hide_from_agents, n.embedding_status, n.deleted_at,
+      n.created_at, n.updated_at,
+      nb.name as notebook_name
+    FROM note n
+    LEFT JOIN notebook nb ON n.notebook_id = nb.id
+    ${whereClause}
+    ORDER BY ${sortColumn} ${sortOrder === 'asc' ? 'ASC' : 'DESC'}
+    LIMIT $${paramIndex} OFFSET $${paramIndex + 1}`,
+    [...params, limit, offset]
+  );
+
+  return {
+    notes: notesResult.rows.map(mapRowToNote),
+    total,
+    limit,
+    offset,
+  };
+}
+
+/**
+ * Updates a note with write permission check
+ */
+export async function updateNote(
+  pool: Pool,
+  noteId: string,
+  input: UpdateNoteInput,
+  userEmail: string
+): Promise<Note | null> {
+  // Check write access
+  const canWrite = await userCanAccessNote(pool, noteId, userEmail, 'read_write');
+  if (!canWrite) {
+    // Check if note exists but user lacks permission (403) vs not found (404)
+    const exists = await pool.query(
+      'SELECT id FROM note WHERE id = $1 AND deleted_at IS NULL',
+      [noteId]
+    );
+    if (exists.rows.length === 0) {
+      return null; // 404
+    }
+    throw new Error('FORBIDDEN'); // 403
+  }
+
+  // Validate visibility if provided
+  if (input.visibility && !isValidVisibility(input.visibility)) {
+    throw new Error(`Invalid visibility: ${input.visibility}`);
+  }
+
+  // Validate notebook if provided
+  if (input.notebookId) {
+    const nbResult = await pool.query(
+      'SELECT user_email FROM notebook WHERE id = $1 AND deleted_at IS NULL',
+      [input.notebookId]
+    );
+    if (nbResult.rows.length === 0) {
+      throw new Error('Notebook not found');
+    }
+    // Note: only owner can change notebook
+    const isOwner = await userOwnsNote(pool, noteId, userEmail);
+    if (!isOwner && nbResult.rows[0].user_email !== userEmail) {
+      throw new Error('Only note owner can change notebook');
+    }
+  }
+
+  // Set session user for version tracking
+  await pool.query(`SELECT set_config('app.current_user_email', $1, true)`, [userEmail]);
+
+  // Build UPDATE query dynamically
+  const updates: string[] = [];
+  const params: (string | string[] | boolean | number | null)[] = [];
+  let paramIndex = 1;
+
+  if (input.title !== undefined) {
+    updates.push(`title = $${paramIndex}`);
+    params.push(input.title);
+    paramIndex++;
+  }
+  if (input.content !== undefined) {
+    updates.push(`content = $${paramIndex}`);
+    params.push(input.content);
+    paramIndex++;
+  }
+  if (input.notebookId !== undefined) {
+    updates.push(`notebook_id = $${paramIndex}`);
+    params.push(input.notebookId);
+    paramIndex++;
+  }
+  if (input.tags !== undefined) {
+    updates.push(`tags = $${paramIndex}`);
+    params.push(input.tags);
+    paramIndex++;
+  }
+  if (input.visibility !== undefined) {
+    updates.push(`visibility = $${paramIndex}`);
+    params.push(input.visibility);
+    paramIndex++;
+  }
+  if (input.hideFromAgents !== undefined) {
+    updates.push(`hide_from_agents = $${paramIndex}`);
+    params.push(input.hideFromAgents);
+    paramIndex++;
+  }
+  if (input.summary !== undefined) {
+    updates.push(`summary = $${paramIndex}`);
+    params.push(input.summary);
+    paramIndex++;
+  }
+  if (input.isPinned !== undefined) {
+    updates.push(`is_pinned = $${paramIndex}`);
+    params.push(input.isPinned);
+    paramIndex++;
+  }
+  if (input.sortOrder !== undefined) {
+    updates.push(`sort_order = $${paramIndex}`);
+    params.push(input.sortOrder);
+    paramIndex++;
+  }
+
+  if (updates.length === 0) {
+    // Nothing to update, just return current note
+    return getNote(pool, noteId, userEmail);
+  }
+
+  params.push(noteId);
+
+  const result = await pool.query(
+    `UPDATE note
+     SET ${updates.join(', ')}
+     WHERE id = $${paramIndex} AND deleted_at IS NULL
+     RETURNING
+       id::text, notebook_id::text, user_email, title, content,
+       summary, tags, is_pinned, sort_order, visibility,
+       hide_from_agents, embedding_status, deleted_at,
+       created_at, updated_at`,
+    params
+  );
+
+  if (result.rows.length === 0) {
+    return null;
+  }
+
+  return mapRowToNote(result.rows[0]);
+}
+
+/**
+ * Soft deletes a note (only owner can delete)
+ */
+export async function deleteNote(
+  pool: Pool,
+  noteId: string,
+  userEmail: string
+): Promise<boolean> {
+  // Only owner can delete
+  const isOwner = await userOwnsNote(pool, noteId, userEmail);
+  if (!isOwner) {
+    const exists = await pool.query(
+      'SELECT id FROM note WHERE id = $1 AND deleted_at IS NULL',
+      [noteId]
+    );
+    if (exists.rows.length === 0) {
+      throw new Error('NOT_FOUND');
+    }
+    throw new Error('FORBIDDEN');
+  }
+
+  const result = await pool.query(
+    `UPDATE note SET deleted_at = NOW() WHERE id = $1 AND deleted_at IS NULL`,
+    [noteId]
+  );
+
+  return (result.rowCount ?? 0) > 0;
+}
+
+/**
+ * Restores a soft-deleted note (only owner can restore)
+ */
+export async function restoreNote(
+  pool: Pool,
+  noteId: string,
+  userEmail: string
+): Promise<Note | null> {
+  // Check if note exists (even if deleted) and user owns it
+  const noteResult = await pool.query(
+    'SELECT user_email FROM note WHERE id = $1',
+    [noteId]
+  );
+
+  if (noteResult.rows.length === 0) {
+    return null; // 404
+  }
+
+  if (noteResult.rows[0].user_email !== userEmail) {
+    throw new Error('FORBIDDEN');
+  }
+
+  const result = await pool.query(
+    `UPDATE note
+     SET deleted_at = NULL
+     WHERE id = $1 AND deleted_at IS NOT NULL
+     RETURNING
+       id::text, notebook_id::text, user_email, title, content,
+       summary, tags, is_pinned, sort_order, visibility,
+       hide_from_agents, embedding_status, deleted_at,
+       created_at, updated_at`,
+    [noteId]
+  );
+
+  if (result.rows.length === 0) {
+    return null; // Already restored or never deleted
+  }
+
+  return mapRowToNote(result.rows[0]);
+}

--- a/src/api/notes/types.ts
+++ b/src/api/notes/types.ts
@@ -1,0 +1,85 @@
+/**
+ * Note types for the notes API.
+ * Part of Epic #337, Issue #344
+ */
+
+/** Valid note visibility levels */
+export type NoteVisibility = 'private' | 'shared' | 'public';
+
+/** Valid embedding statuses */
+export type EmbeddingStatus = 'pending' | 'complete' | 'failed' | 'skipped';
+
+/** A note entry from the database */
+export interface Note {
+  id: string;
+  notebookId: string | null;
+  userEmail: string;
+  title: string;
+  content: string;
+  summary: string | null;
+  tags: string[];
+  isPinned: boolean;
+  sortOrder: number;
+  visibility: NoteVisibility;
+  hideFromAgents: boolean;
+  embeddingStatus: EmbeddingStatus;
+  deletedAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+  // Optional expanded fields
+  notebook?: { id: string; name: string } | null;
+  versionCount?: number;
+}
+
+/** Input for creating a new note */
+export interface CreateNoteInput {
+  title: string;
+  content?: string;
+  notebookId?: string;
+  tags?: string[];
+  visibility?: NoteVisibility;
+  hideFromAgents?: boolean;
+  summary?: string;
+  isPinned?: boolean;
+}
+
+/** Input for updating a note */
+export interface UpdateNoteInput {
+  title?: string;
+  content?: string;
+  notebookId?: string | null;
+  tags?: string[];
+  visibility?: NoteVisibility;
+  hideFromAgents?: boolean;
+  summary?: string | null;
+  isPinned?: boolean;
+  sortOrder?: number;
+}
+
+/** Query options for listing notes */
+export interface ListNotesOptions {
+  notebookId?: string;
+  tags?: string[];
+  visibility?: NoteVisibility;
+  search?: string;
+  isPinned?: boolean;
+  includeDeleted?: boolean;
+  limit?: number;
+  offset?: number;
+  sortBy?: 'createdAt' | 'updatedAt' | 'title';
+  sortOrder?: 'asc' | 'desc';
+}
+
+/** Result of listing notes */
+export interface ListNotesResult {
+  notes: Note[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+/** Options for getting a single note */
+export interface GetNoteOptions {
+  includeVersions?: boolean;
+  includeReferences?: boolean;
+}

--- a/tests/helpers/db.ts
+++ b/tests/helpers/db.ts
@@ -58,6 +58,14 @@ const APPLICATION_TABLES = [
   'user_presence',
   'calendar_event',
   'oauth_connection',
+  // Note/notebook tables (Epic #337)
+  'note_work_item_reference',
+  'note_version',
+  'note_collaborator',
+  'note_share',
+  'notebook_share',
+  'note',
+  'notebook',
   // Async/queue tables (no FKs today, but still want consistent cleanup)
   'webhook_outbox',
   'internal_job',

--- a/tests/notes_api.test.ts
+++ b/tests/notes_api.test.ts
@@ -1,0 +1,735 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { Pool } from 'pg';
+import { buildServer } from '../src/api/server.ts';
+import { runMigrate } from './helpers/migrate.js';
+import { createTestPool, truncateAllTables } from './helpers/db.js';
+
+describe('Notes CRUD API (Epic #337, Issue #344)', () => {
+  const app = buildServer();
+  let pool: Pool;
+  const testUserEmail = 'test@example.com';
+  const otherUserEmail = 'other@example.com';
+
+  beforeAll(async () => {
+    await runMigrate('up');
+    pool = createTestPool();
+    await app.ready();
+  });
+
+  beforeEach(async () => {
+    await truncateAllTables(pool);
+  });
+
+  afterAll(async () => {
+    await app.close();
+    await pool.end();
+  });
+
+  describe('POST /api/notes', () => {
+    it('creates a basic note', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/notes',
+        payload: {
+          user_email: testUserEmail,
+          title: 'My First Note',
+          content: 'This is the content of my note.',
+        },
+      });
+
+      expect(res.statusCode).toBe(201);
+      const body = res.json();
+      expect(body.id).toBeDefined();
+      expect(body.title).toBe('My First Note');
+      expect(body.content).toBe('This is the content of my note.');
+      expect(body.userEmail).toBe(testUserEmail);
+      expect(body.visibility).toBe('private');
+      expect(body.isPinned).toBe(false);
+      expect(body.tags).toEqual([]);
+      expect(body.embeddingStatus).toBe('pending');
+    });
+
+    it('creates a note with all optional fields', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/notes',
+        payload: {
+          user_email: testUserEmail,
+          title: 'Full Note',
+          content: 'Content here',
+          tags: ['work', 'important'],
+          visibility: 'public',
+          hide_from_agents: true,
+          summary: 'A brief summary',
+          is_pinned: true,
+        },
+      });
+
+      expect(res.statusCode).toBe(201);
+      const body = res.json();
+      expect(body.tags).toEqual(['work', 'important']);
+      expect(body.visibility).toBe('public');
+      expect(body.hideFromAgents).toBe(true);
+      expect(body.summary).toBe('A brief summary');
+      expect(body.isPinned).toBe(true);
+    });
+
+    it('creates a note in a notebook', async () => {
+      // Create a notebook first
+      const nbResult = await pool.query(
+        `INSERT INTO notebook (user_email, name) VALUES ($1, 'Work Notebook') RETURNING id::text as id`,
+        [testUserEmail]
+      );
+      const notebookId = (nbResult.rows[0] as { id: string }).id;
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/notes',
+        payload: {
+          user_email: testUserEmail,
+          title: 'Notebook Note',
+          notebook_id: notebookId,
+        },
+      });
+
+      expect(res.statusCode).toBe(201);
+      const body = res.json();
+      expect(body.notebookId).toBe(notebookId);
+    });
+
+    it('returns 400 when user_email is missing', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/notes',
+        payload: {
+          title: 'No User',
+        },
+      });
+
+      expect(res.statusCode).toBe(400);
+      expect(res.json().error).toBe('user_email is required');
+    });
+
+    it('returns 400 when title is missing', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/notes',
+        payload: {
+          user_email: testUserEmail,
+        },
+      });
+
+      expect(res.statusCode).toBe(400);
+      expect(res.json().error).toBe('title is required');
+    });
+
+    it('returns 400 for invalid visibility', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/notes',
+        payload: {
+          user_email: testUserEmail,
+          title: 'Test',
+          visibility: 'invalid',
+        },
+      });
+
+      expect(res.statusCode).toBe(400);
+      expect(res.json().error).toContain('Invalid visibility');
+    });
+
+    it('returns 400 when notebook does not exist', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/notes',
+        payload: {
+          user_email: testUserEmail,
+          title: 'Test',
+          notebook_id: '00000000-0000-0000-0000-000000000000',
+        },
+      });
+
+      expect(res.statusCode).toBe(400);
+      expect(res.json().error).toBe('Notebook not found');
+    });
+
+    it('returns 403 when adding note to someone else\'s notebook', async () => {
+      // Create a notebook owned by another user
+      const nbResult = await pool.query(
+        `INSERT INTO notebook (user_email, name) VALUES ($1, 'Other Notebook') RETURNING id::text as id`,
+        [otherUserEmail]
+      );
+      const notebookId = (nbResult.rows[0] as { id: string }).id;
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/notes',
+        payload: {
+          user_email: testUserEmail,
+          title: 'Test',
+          notebook_id: notebookId,
+        },
+      });
+
+      expect(res.statusCode).toBe(403);
+      expect(res.json().error).toContain('do not own');
+    });
+  });
+
+  describe('GET /api/notes', () => {
+    beforeEach(async () => {
+      // Create some test notes
+      await pool.query(
+        `INSERT INTO note (user_email, title, content, tags, visibility, is_pinned)
+         VALUES
+           ($1, 'Note 1', 'Content 1', ARRAY['work'], 'private', false),
+           ($1, 'Note 2', 'Content 2', ARRAY['personal'], 'public', true),
+           ($1, 'Note 3', 'Content 3', ARRAY['work', 'important'], 'private', false)`,
+        [testUserEmail]
+      );
+    });
+
+    it('lists notes for a user', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/notes',
+        query: { user_email: testUserEmail },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.notes).toHaveLength(3);
+      expect(body.total).toBe(3);
+    });
+
+    it('returns 400 when user_email is missing', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/notes',
+      });
+
+      expect(res.statusCode).toBe(400);
+      expect(res.json().error).toBe('user_email is required');
+    });
+
+    it('filters notes by visibility', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/notes',
+        query: { user_email: testUserEmail, visibility: 'public' },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.notes).toHaveLength(1);
+      expect(body.notes[0].title).toBe('Note 2');
+    });
+
+    it('filters notes by tags', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/notes',
+        query: { user_email: testUserEmail, tags: 'work' },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.notes).toHaveLength(2);
+    });
+
+    it('filters notes by isPinned', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/notes',
+        query: { user_email: testUserEmail, is_pinned: 'true' },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.notes).toHaveLength(1);
+      expect(body.notes[0].title).toBe('Note 2');
+    });
+
+    it('paginates results', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/notes',
+        query: { user_email: testUserEmail, limit: '2', offset: '0' },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.notes).toHaveLength(2);
+      expect(body.total).toBe(3);
+      expect(body.limit).toBe(2);
+      expect(body.offset).toBe(0);
+    });
+
+    it('sorts notes by title ascending', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/notes',
+        query: { user_email: testUserEmail, sort_by: 'title', sort_order: 'asc' },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.notes[0].title).toBe('Note 1');
+      expect(body.notes[2].title).toBe('Note 3');
+    });
+
+    it('can see public notes from other users', async () => {
+      // Create a public note from another user
+      await pool.query(
+        `INSERT INTO note (user_email, title, visibility) VALUES ($1, 'Public Note', 'public')`,
+        [otherUserEmail]
+      );
+
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/notes',
+        query: { user_email: testUserEmail, visibility: 'public' },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      // Should see both our public note and the other user's public note
+      expect(body.notes.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('filters notes by notebook', async () => {
+      // Create a notebook and a note in it
+      const nbResult = await pool.query(
+        `INSERT INTO notebook (user_email, name) VALUES ($1, 'Test Notebook') RETURNING id::text as id`,
+        [testUserEmail]
+      );
+      const notebookId = (nbResult.rows[0] as { id: string }).id;
+
+      await pool.query(
+        `INSERT INTO note (user_email, title, notebook_id) VALUES ($1, 'Notebook Note', $2)`,
+        [testUserEmail, notebookId]
+      );
+
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/notes',
+        query: { user_email: testUserEmail, notebook_id: notebookId },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.notes).toHaveLength(1);
+      expect(body.notes[0].title).toBe('Notebook Note');
+    });
+  });
+
+  describe('GET /api/notes/:id', () => {
+    it('returns a note by ID', async () => {
+      const noteResult = await pool.query(
+        `INSERT INTO note (user_email, title, content) VALUES ($1, 'Test Note', 'Content') RETURNING id::text as id`,
+        [testUserEmail]
+      );
+      const noteId = (noteResult.rows[0] as { id: string }).id;
+
+      const res = await app.inject({
+        method: 'GET',
+        url: `/api/notes/${noteId}`,
+        query: { user_email: testUserEmail },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.id).toBe(noteId);
+      expect(body.title).toBe('Test Note');
+    });
+
+    it('returns 400 when user_email is missing', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/notes/some-id',
+      });
+
+      expect(res.statusCode).toBe(400);
+      expect(res.json().error).toBe('user_email is required');
+    });
+
+    it('returns 404 for non-existent note', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/notes/00000000-0000-0000-0000-000000000000',
+        query: { user_email: testUserEmail },
+      });
+
+      expect(res.statusCode).toBe(404);
+    });
+
+    it('returns 404 when user cannot access note', async () => {
+      // Create a private note from another user
+      const noteResult = await pool.query(
+        `INSERT INTO note (user_email, title, visibility) VALUES ($1, 'Private', 'private') RETURNING id::text as id`,
+        [otherUserEmail]
+      );
+      const noteId = (noteResult.rows[0] as { id: string }).id;
+
+      const res = await app.inject({
+        method: 'GET',
+        url: `/api/notes/${noteId}`,
+        query: { user_email: testUserEmail },
+      });
+
+      expect(res.statusCode).toBe(404);
+    });
+
+    it('allows accessing public notes from other users', async () => {
+      const noteResult = await pool.query(
+        `INSERT INTO note (user_email, title, visibility) VALUES ($1, 'Public', 'public') RETURNING id::text as id`,
+        [otherUserEmail]
+      );
+      const noteId = (noteResult.rows[0] as { id: string }).id;
+
+      const res = await app.inject({
+        method: 'GET',
+        url: `/api/notes/${noteId}`,
+        query: { user_email: testUserEmail },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json().visibility).toBe('public');
+    });
+
+    it('includes version count', async () => {
+      const noteResult = await pool.query(
+        `INSERT INTO note (user_email, title) VALUES ($1, 'Test') RETURNING id::text as id`,
+        [testUserEmail]
+      );
+      const noteId = (noteResult.rows[0] as { id: string }).id;
+
+      const res = await app.inject({
+        method: 'GET',
+        url: `/api/notes/${noteId}`,
+        query: { user_email: testUserEmail },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json().versionCount).toBeDefined();
+    });
+  });
+
+  describe('PUT /api/notes/:id', () => {
+    let noteId: string;
+
+    beforeEach(async () => {
+      const result = await pool.query(
+        `INSERT INTO note (user_email, title, content, tags)
+         VALUES ($1, 'Original Title', 'Original Content', ARRAY['tag1'])
+         RETURNING id::text as id`,
+        [testUserEmail]
+      );
+      noteId = (result.rows[0] as { id: string }).id;
+    });
+
+    it('updates note fields', async () => {
+      const res = await app.inject({
+        method: 'PUT',
+        url: `/api/notes/${noteId}`,
+        payload: {
+          user_email: testUserEmail,
+          title: 'Updated Title',
+          content: 'Updated Content',
+          tags: ['tag2', 'tag3'],
+        },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.title).toBe('Updated Title');
+      expect(body.content).toBe('Updated Content');
+      expect(body.tags).toEqual(['tag2', 'tag3']);
+    });
+
+    it('returns 400 when user_email is missing', async () => {
+      const res = await app.inject({
+        method: 'PUT',
+        url: `/api/notes/${noteId}`,
+        payload: { title: 'New Title' },
+      });
+
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('returns 404 for non-existent note', async () => {
+      const res = await app.inject({
+        method: 'PUT',
+        url: '/api/notes/00000000-0000-0000-0000-000000000000',
+        payload: { user_email: testUserEmail, title: 'New' },
+      });
+
+      expect(res.statusCode).toBe(404);
+    });
+
+    it('returns 403 when user cannot edit note', async () => {
+      // Create a private note from another user
+      const otherNoteResult = await pool.query(
+        `INSERT INTO note (user_email, title, visibility) VALUES ($1, 'Private', 'private') RETURNING id::text as id`,
+        [otherUserEmail]
+      );
+      const otherNoteId = (otherNoteResult.rows[0] as { id: string }).id;
+
+      const res = await app.inject({
+        method: 'PUT',
+        url: `/api/notes/${otherNoteId}`,
+        payload: { user_email: testUserEmail, title: 'Hacked' },
+      });
+
+      expect(res.statusCode).toBe(403);
+    });
+
+    it('allows partial updates', async () => {
+      const res = await app.inject({
+        method: 'PUT',
+        url: `/api/notes/${noteId}`,
+        payload: {
+          user_email: testUserEmail,
+          is_pinned: true,
+        },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.isPinned).toBe(true);
+      expect(body.title).toBe('Original Title'); // Unchanged
+    });
+
+    it('returns 400 for invalid visibility', async () => {
+      const res = await app.inject({
+        method: 'PUT',
+        url: `/api/notes/${noteId}`,
+        payload: {
+          user_email: testUserEmail,
+          visibility: 'invalid',
+        },
+      });
+
+      expect(res.statusCode).toBe(400);
+    });
+  });
+
+  describe('DELETE /api/notes/:id', () => {
+    it('soft deletes a note', async () => {
+      const noteResult = await pool.query(
+        `INSERT INTO note (user_email, title) VALUES ($1, 'To Delete') RETURNING id::text as id`,
+        [testUserEmail]
+      );
+      const noteId = (noteResult.rows[0] as { id: string }).id;
+
+      const res = await app.inject({
+        method: 'DELETE',
+        url: `/api/notes/${noteId}`,
+        query: { user_email: testUserEmail },
+      });
+
+      expect(res.statusCode).toBe(204);
+
+      // Verify it's soft deleted
+      const check = await pool.query(
+        'SELECT deleted_at FROM note WHERE id = $1',
+        [noteId]
+      );
+      expect(check.rows[0].deleted_at).not.toBeNull();
+    });
+
+    it('returns 400 when user_email is missing', async () => {
+      const res = await app.inject({
+        method: 'DELETE',
+        url: '/api/notes/some-id',
+      });
+
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('returns 404 for non-existent note', async () => {
+      const res = await app.inject({
+        method: 'DELETE',
+        url: '/api/notes/00000000-0000-0000-0000-000000000000',
+        query: { user_email: testUserEmail },
+      });
+
+      expect(res.statusCode).toBe(404);
+    });
+
+    it('returns 403 when non-owner tries to delete', async () => {
+      const noteResult = await pool.query(
+        `INSERT INTO note (user_email, title) VALUES ($1, 'Other Note') RETURNING id::text as id`,
+        [otherUserEmail]
+      );
+      const noteId = (noteResult.rows[0] as { id: string }).id;
+
+      const res = await app.inject({
+        method: 'DELETE',
+        url: `/api/notes/${noteId}`,
+        query: { user_email: testUserEmail },
+      });
+
+      expect(res.statusCode).toBe(403);
+    });
+  });
+
+  describe('POST /api/notes/:id/restore', () => {
+    it('restores a soft-deleted note', async () => {
+      const noteResult = await pool.query(
+        `INSERT INTO note (user_email, title, deleted_at) VALUES ($1, 'Deleted Note', NOW()) RETURNING id::text as id`,
+        [testUserEmail]
+      );
+      const noteId = (noteResult.rows[0] as { id: string }).id;
+
+      const res = await app.inject({
+        method: 'POST',
+        url: `/api/notes/${noteId}/restore`,
+        payload: { user_email: testUserEmail },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.id).toBe(noteId);
+      expect(body.deletedAt).toBeNull();
+    });
+
+    it('returns 400 when user_email is missing', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/notes/some-id/restore',
+        payload: {},
+      });
+
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('returns 404 for non-existent note', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/notes/00000000-0000-0000-0000-000000000000/restore',
+        payload: { user_email: testUserEmail },
+      });
+
+      expect(res.statusCode).toBe(404);
+    });
+
+    it('returns 403 when non-owner tries to restore', async () => {
+      const noteResult = await pool.query(
+        `INSERT INTO note (user_email, title, deleted_at) VALUES ($1, 'Other Deleted', NOW()) RETURNING id::text as id`,
+        [otherUserEmail]
+      );
+      const noteId = (noteResult.rows[0] as { id: string }).id;
+
+      const res = await app.inject({
+        method: 'POST',
+        url: `/api/notes/${noteId}/restore`,
+        payload: { user_email: testUserEmail },
+      });
+
+      expect(res.statusCode).toBe(403);
+    });
+
+    it('returns 404 when note is not deleted', async () => {
+      const noteResult = await pool.query(
+        `INSERT INTO note (user_email, title) VALUES ($1, 'Not Deleted') RETURNING id::text as id`,
+        [testUserEmail]
+      );
+      const noteId = (noteResult.rows[0] as { id: string }).id;
+
+      const res = await app.inject({
+        method: 'POST',
+        url: `/api/notes/${noteId}/restore`,
+        payload: { user_email: testUserEmail },
+      });
+
+      expect(res.statusCode).toBe(404);
+    });
+  });
+
+  describe('Note sharing access', () => {
+    it('allows access to shared notes', async () => {
+      // Create a private note and share it
+      const noteResult = await pool.query(
+        `INSERT INTO note (user_email, title, visibility)
+         VALUES ($1, 'Shared Note', 'shared')
+         RETURNING id::text as id`,
+        [otherUserEmail]
+      );
+      const noteId = (noteResult.rows[0] as { id: string }).id;
+
+      // Create a share (must include created_by_email)
+      await pool.query(
+        `INSERT INTO note_share (note_id, shared_with_email, permission, created_by_email)
+         VALUES ($1, $2, 'read', $3)`,
+        [noteId, testUserEmail, otherUserEmail]
+      );
+
+      const res = await app.inject({
+        method: 'GET',
+        url: `/api/notes/${noteId}`,
+        query: { user_email: testUserEmail },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json().title).toBe('Shared Note');
+    });
+
+    it('allows editing shared notes with write permission', async () => {
+      // Create a private note and share with write access
+      const noteResult = await pool.query(
+        `INSERT INTO note (user_email, title, visibility)
+         VALUES ($1, 'Editable Shared', 'shared')
+         RETURNING id::text as id`,
+        [otherUserEmail]
+      );
+      const noteId = (noteResult.rows[0] as { id: string }).id;
+
+      await pool.query(
+        `INSERT INTO note_share (note_id, shared_with_email, permission, created_by_email)
+         VALUES ($1, $2, 'read_write', $3)`,
+        [noteId, testUserEmail, otherUserEmail]
+      );
+
+      const res = await app.inject({
+        method: 'PUT',
+        url: `/api/notes/${noteId}`,
+        payload: {
+          user_email: testUserEmail,
+          title: 'Updated by Collaborator',
+        },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json().title).toBe('Updated by Collaborator');
+    });
+
+    it('prevents editing shared notes with read-only permission', async () => {
+      // Create a private note and share with read-only access
+      const noteResult = await pool.query(
+        `INSERT INTO note (user_email, title, visibility)
+         VALUES ($1, 'Read Only Shared', 'shared')
+         RETURNING id::text as id`,
+        [otherUserEmail]
+      );
+      const noteId = (noteResult.rows[0] as { id: string }).id;
+
+      await pool.query(
+        `INSERT INTO note_share (note_id, shared_with_email, permission, created_by_email)
+         VALUES ($1, $2, 'read', $3)`,
+        [noteId, testUserEmail, otherUserEmail]
+      );
+
+      const res = await app.inject({
+        method: 'PUT',
+        url: `/api/notes/${noteId}`,
+        payload: {
+          user_email: testUserEmail,
+          title: 'Attempted Edit',
+        },
+      });
+
+      expect(res.statusCode).toBe(403);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds REST API endpoints for CRUD operations on notes (Epic #337, Issue #344)
- Implements service layer with proper access control using `user_can_access_note` DB function
- Includes 41 integration tests covering all endpoints and edge cases

## Endpoints Added
- `GET /api/notes` - List notes with filters (tags, visibility, notebook, search, pagination)
- `GET /api/notes/:id` - Get single note by ID (with optional versions/references expansion)
- `POST /api/notes` - Create new note
- `PUT /api/notes/:id` - Update note fields
- `DELETE /api/notes/:id` - Soft delete note (owner only)
- `POST /api/notes/:id/restore` - Restore soft-deleted note (owner only)

## Access Control
- Uses `user_can_access_note()` DB function from #341 for permission checks
- Supports visibility levels: private, shared, public
- Respects note_share and notebook_share permissions

## Test plan
- [x] All 41 new tests pass
- [x] Tests cover create, read, list, update, delete, restore operations
- [x] Tests verify access control (owner-only operations, sharing permissions)
- [x] Tests verify error cases (400, 403, 404 responses)

Closes #344

🤖 Generated with [Claude Code](https://claude.ai/code)