### PR TITLE
[#345] Add Notebook CRUD API

### DIFF
--- a/src/api/notebooks/index.ts
+++ b/src/api/notebooks/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Notebooks API exports
+ * Part of Epic #337, Issue #345
+ */
+
+export * from './types.ts';
+export * from './service.ts';

--- a/src/api/notebooks/service.ts
+++ b/src/api/notebooks/service.ts
@@ -1,0 +1,656 @@
+/**
+ * Notebook service for the notebooks API.
+ * Part of Epic #337, Issue #345
+ */
+
+import type { Pool } from 'pg';
+import type {
+  Notebook,
+  NotebookNote,
+  CreateNotebookInput,
+  UpdateNotebookInput,
+  ListNotebooksOptions,
+  ListNotebooksResult,
+  GetNotebookOptions,
+  NotebookTreeNode,
+  MoveNotesInput,
+  MoveNotesResult,
+} from './types.ts';
+
+/**
+ * Maps database row to Notebook
+ */
+function mapRowToNotebook(row: Record<string, unknown>): Notebook {
+  return {
+    id: row.id as string,
+    userEmail: row.user_email as string,
+    name: row.name as string,
+    description: row.description as string | null,
+    icon: row.icon as string | null,
+    color: row.color as string | null,
+    parentNotebookId: row.parent_notebook_id as string | null,
+    sortOrder: (row.sort_order as number) ?? 0,
+    isArchived: (row.is_archived as boolean) ?? false,
+    deletedAt: row.deleted_at ? new Date(row.deleted_at as string) : null,
+    createdAt: new Date(row.created_at as string),
+    updatedAt: new Date(row.updated_at as string),
+    // Optional fields
+    noteCount: row.note_count !== undefined ? Number(row.note_count) : undefined,
+    childCount: row.child_count !== undefined ? Number(row.child_count) : undefined,
+    parent: row.parent_name
+      ? { id: row.parent_notebook_id as string, name: row.parent_name as string }
+      : null,
+  };
+}
+
+/**
+ * Checks if user owns a notebook
+ */
+export async function userOwnsNotebook(
+  pool: Pool,
+  notebookId: string,
+  userEmail: string
+): Promise<boolean> {
+  const result = await pool.query(
+    'SELECT user_email FROM notebook WHERE id = $1 AND deleted_at IS NULL',
+    [notebookId]
+  );
+  return result.rows[0]?.user_email === userEmail;
+}
+
+/**
+ * Checks if a notebook would create a circular reference
+ */
+async function wouldCreateCircularReference(
+  pool: Pool,
+  notebookId: string,
+  newParentId: string
+): Promise<boolean> {
+  // Check if newParentId is the notebook itself
+  if (notebookId === newParentId) {
+    return true;
+  }
+
+  // Check if newParentId is a descendant of notebookId
+  const result = await pool.query(
+    `WITH RECURSIVE ancestors AS (
+      SELECT id, parent_notebook_id FROM notebook WHERE id = $1
+      UNION ALL
+      SELECT n.id, n.parent_notebook_id
+      FROM notebook n
+      JOIN ancestors a ON n.id = a.parent_notebook_id
+    )
+    SELECT 1 FROM ancestors WHERE id = $2 LIMIT 1`,
+    [newParentId, notebookId]
+  );
+
+  return result.rows.length > 0;
+}
+
+/**
+ * Creates a new notebook
+ */
+export async function createNotebook(
+  pool: Pool,
+  input: CreateNotebookInput,
+  userEmail: string
+): Promise<Notebook> {
+  // Validate parent notebook exists and belongs to user if provided
+  if (input.parentNotebookId) {
+    const parentResult = await pool.query(
+      'SELECT user_email FROM notebook WHERE id = $1 AND deleted_at IS NULL',
+      [input.parentNotebookId]
+    );
+    if (parentResult.rows.length === 0) {
+      throw new Error('Parent notebook not found');
+    }
+    if (parentResult.rows[0].user_email !== userEmail) {
+      throw new Error('Cannot create notebook under a notebook you do not own');
+    }
+  }
+
+  const result = await pool.query(
+    `INSERT INTO notebook (
+      user_email, name, description, icon, color, parent_notebook_id
+    ) VALUES ($1, $2, $3, $4, $5, $6)
+    RETURNING
+      id::text, user_email, name, description, icon, color,
+      parent_notebook_id::text, sort_order, is_archived, deleted_at,
+      created_at, updated_at`,
+    [
+      userEmail,
+      input.name,
+      input.description ?? null,
+      input.icon ?? null,
+      input.color ?? null,
+      input.parentNotebookId ?? null,
+    ]
+  );
+
+  const notebook = mapRowToNotebook(result.rows[0]);
+  notebook.noteCount = 0;
+  notebook.childCount = 0;
+  return notebook;
+}
+
+/**
+ * Gets a notebook by ID
+ */
+export async function getNotebook(
+  pool: Pool,
+  notebookId: string,
+  userEmail: string,
+  options: GetNotebookOptions = {}
+): Promise<Notebook | null> {
+  // Get notebook with optional note count
+  const result = await pool.query(
+    `SELECT
+      nb.id::text, nb.user_email, nb.name, nb.description, nb.icon, nb.color,
+      nb.parent_notebook_id::text, nb.sort_order, nb.is_archived, nb.deleted_at,
+      nb.created_at, nb.updated_at,
+      pnb.name as parent_name,
+      (SELECT COUNT(*) FROM note WHERE notebook_id = nb.id AND deleted_at IS NULL) as note_count,
+      (SELECT COUNT(*) FROM notebook WHERE parent_notebook_id = nb.id AND deleted_at IS NULL) as child_count
+    FROM notebook nb
+    LEFT JOIN notebook pnb ON nb.parent_notebook_id = pnb.id
+    WHERE nb.id = $1 AND nb.deleted_at IS NULL AND nb.user_email = $2`,
+    [notebookId, userEmail]
+  );
+
+  if (result.rows.length === 0) {
+    return null;
+  }
+
+  const notebook = mapRowToNotebook(result.rows[0]);
+
+  // Include notes if requested
+  if (options.includeNotes) {
+    const notesResult = await pool.query(
+      `SELECT id::text, title, updated_at
+       FROM note
+       WHERE notebook_id = $1 AND deleted_at IS NULL
+       ORDER BY sort_order ASC, updated_at DESC
+       LIMIT 100`,
+      [notebookId]
+    );
+    notebook.notes = notesResult.rows.map((n) => ({
+      id: n.id as string,
+      title: n.title as string,
+      updatedAt: new Date(n.updated_at as string),
+    }));
+  }
+
+  // Include children if requested
+  if (options.includeChildren) {
+    const childrenResult = await pool.query(
+      `SELECT
+        nb.id::text, nb.user_email, nb.name, nb.description, nb.icon, nb.color,
+        nb.parent_notebook_id::text, nb.sort_order, nb.is_archived, nb.deleted_at,
+        nb.created_at, nb.updated_at,
+        (SELECT COUNT(*) FROM note WHERE notebook_id = nb.id AND deleted_at IS NULL) as note_count,
+        (SELECT COUNT(*) FROM notebook WHERE parent_notebook_id = nb.id AND deleted_at IS NULL) as child_count
+      FROM notebook nb
+      WHERE nb.parent_notebook_id = $1 AND nb.deleted_at IS NULL
+      ORDER BY nb.sort_order ASC, nb.name ASC`,
+      [notebookId]
+    );
+    notebook.children = childrenResult.rows.map(mapRowToNotebook);
+  }
+
+  return notebook;
+}
+
+/**
+ * Lists notebooks with filters and pagination
+ */
+export async function listNotebooks(
+  pool: Pool,
+  userEmail: string,
+  options: ListNotebooksOptions = {}
+): Promise<ListNotebooksResult> {
+  const limit = Math.min(options.limit ?? 100, 200);
+  const offset = options.offset ?? 0;
+
+  // Build WHERE clause
+  const conditions: string[] = ['nb.deleted_at IS NULL', 'nb.user_email = $1'];
+  const params: (string | boolean | number)[] = [userEmail];
+  let paramIndex = 2;
+
+  // Filter by parent (null means root notebooks)
+  if (options.parentId === null) {
+    conditions.push('nb.parent_notebook_id IS NULL');
+  } else if (options.parentId) {
+    conditions.push(`nb.parent_notebook_id = $${paramIndex}`);
+    params.push(options.parentId);
+    paramIndex++;
+  }
+
+  // Include archived notebooks
+  if (!options.includeArchived) {
+    conditions.push('nb.is_archived = false');
+  }
+
+  const whereClause = `WHERE ${conditions.join(' AND ')}`;
+
+  // Get total count
+  const countResult = await pool.query(
+    `SELECT COUNT(*) as total FROM notebook nb ${whereClause}`,
+    params
+  );
+  const total = parseInt((countResult.rows[0] as { total: string }).total, 10);
+
+  // Build select with optional counts
+  let selectCounts = '';
+  if (options.includeNoteCounts !== false) {
+    selectCounts += ', (SELECT COUNT(*) FROM note WHERE notebook_id = nb.id AND deleted_at IS NULL) as note_count';
+  }
+  if (options.includeChildCounts !== false) {
+    selectCounts += ', (SELECT COUNT(*) FROM notebook WHERE parent_notebook_id = nb.id AND deleted_at IS NULL) as child_count';
+  }
+
+  // Get notebooks
+  params.push(limit);
+  params.push(offset);
+
+  const notebooksResult = await pool.query(
+    `SELECT
+      nb.id::text, nb.user_email, nb.name, nb.description, nb.icon, nb.color,
+      nb.parent_notebook_id::text, nb.sort_order, nb.is_archived, nb.deleted_at,
+      nb.created_at, nb.updated_at
+      ${selectCounts}
+    FROM notebook nb
+    ${whereClause}
+    ORDER BY nb.sort_order ASC, nb.name ASC
+    LIMIT $${paramIndex} OFFSET $${paramIndex + 1}`,
+    params
+  );
+
+  return {
+    notebooks: notebooksResult.rows.map(mapRowToNotebook),
+    total,
+  };
+}
+
+/**
+ * Gets notebooks as a tree structure
+ */
+export async function getNotebooksTree(
+  pool: Pool,
+  userEmail: string,
+  includeNoteCounts = false
+): Promise<NotebookTreeNode[]> {
+  // Get all notebooks for the user
+  let selectCounts = '';
+  if (includeNoteCounts) {
+    selectCounts = ', (SELECT COUNT(*) FROM note WHERE notebook_id = nb.id AND deleted_at IS NULL) as note_count';
+  }
+
+  const result = await pool.query(
+    `SELECT
+      nb.id::text, nb.name, nb.icon, nb.color, nb.parent_notebook_id::text, nb.sort_order
+      ${selectCounts}
+    FROM notebook nb
+    WHERE nb.user_email = $1 AND nb.deleted_at IS NULL AND nb.is_archived = false
+    ORDER BY nb.sort_order ASC, nb.name ASC`,
+    [userEmail]
+  );
+
+  // Build tree structure
+  const notebooksById = new Map<string, NotebookTreeNode & { parentId: string | null }>();
+  const rootNodes: NotebookTreeNode[] = [];
+
+  // First pass: create all nodes
+  for (const row of result.rows) {
+    notebooksById.set(row.id as string, {
+      id: row.id as string,
+      name: row.name as string,
+      icon: row.icon as string | null,
+      color: row.color as string | null,
+      noteCount: row.note_count !== undefined ? Number(row.note_count) : undefined,
+      children: [],
+      parentId: row.parent_notebook_id as string | null,
+    });
+  }
+
+  // Second pass: build tree
+  for (const node of notebooksById.values()) {
+    if (node.parentId === null) {
+      rootNodes.push(node);
+    } else {
+      const parent = notebooksById.get(node.parentId);
+      if (parent) {
+        parent.children.push(node);
+      } else {
+        // Parent not found (maybe deleted), treat as root
+        rootNodes.push(node);
+      }
+    }
+  }
+
+  // Remove parentId from result
+  const cleanNode = (node: NotebookTreeNode & { parentId?: string | null }): NotebookTreeNode => {
+    const { parentId: _, ...clean } = node;
+    return {
+      ...clean,
+      children: node.children.map(cleanNode),
+    };
+  };
+
+  return rootNodes.map(cleanNode);
+}
+
+/**
+ * Updates a notebook
+ */
+export async function updateNotebook(
+  pool: Pool,
+  notebookId: string,
+  input: UpdateNotebookInput,
+  userEmail: string
+): Promise<Notebook | null> {
+  // Check ownership
+  const isOwner = await userOwnsNotebook(pool, notebookId, userEmail);
+  if (!isOwner) {
+    const exists = await pool.query(
+      'SELECT id FROM notebook WHERE id = $1 AND deleted_at IS NULL',
+      [notebookId]
+    );
+    if (exists.rows.length === 0) {
+      return null; // 404
+    }
+    throw new Error('FORBIDDEN');
+  }
+
+  // Validate new parent if provided
+  if (input.parentNotebookId !== undefined && input.parentNotebookId !== null) {
+    // Check parent exists and belongs to user
+    const parentResult = await pool.query(
+      'SELECT user_email FROM notebook WHERE id = $1 AND deleted_at IS NULL',
+      [input.parentNotebookId]
+    );
+    if (parentResult.rows.length === 0) {
+      throw new Error('Parent notebook not found');
+    }
+    if (parentResult.rows[0].user_email !== userEmail) {
+      throw new Error('Cannot move notebook under a notebook you do not own');
+    }
+
+    // Check for circular reference
+    const wouldBeCircular = await wouldCreateCircularReference(pool, notebookId, input.parentNotebookId);
+    if (wouldBeCircular) {
+      throw new Error('Cannot create circular notebook hierarchy');
+    }
+  }
+
+  // Build UPDATE query dynamically
+  const updates: string[] = [];
+  const params: (string | number | null)[] = [];
+  let paramIndex = 1;
+
+  if (input.name !== undefined) {
+    updates.push(`name = $${paramIndex}`);
+    params.push(input.name);
+    paramIndex++;
+  }
+  if (input.description !== undefined) {
+    updates.push(`description = $${paramIndex}`);
+    params.push(input.description);
+    paramIndex++;
+  }
+  if (input.icon !== undefined) {
+    updates.push(`icon = $${paramIndex}`);
+    params.push(input.icon);
+    paramIndex++;
+  }
+  if (input.color !== undefined) {
+    updates.push(`color = $${paramIndex}`);
+    params.push(input.color);
+    paramIndex++;
+  }
+  if (input.parentNotebookId !== undefined) {
+    updates.push(`parent_notebook_id = $${paramIndex}`);
+    params.push(input.parentNotebookId);
+    paramIndex++;
+  }
+  if (input.sortOrder !== undefined) {
+    updates.push(`sort_order = $${paramIndex}`);
+    params.push(input.sortOrder);
+    paramIndex++;
+  }
+
+  if (updates.length === 0) {
+    // Nothing to update, just return current notebook
+    return getNotebook(pool, notebookId, userEmail);
+  }
+
+  params.push(notebookId);
+
+  const result = await pool.query(
+    `UPDATE notebook
+     SET ${updates.join(', ')}
+     WHERE id = $${paramIndex} AND deleted_at IS NULL
+     RETURNING
+       id::text, user_email, name, description, icon, color,
+       parent_notebook_id::text, sort_order, is_archived, deleted_at,
+       created_at, updated_at`,
+    params
+  );
+
+  if (result.rows.length === 0) {
+    return null;
+  }
+
+  return mapRowToNotebook(result.rows[0]);
+}
+
+/**
+ * Archives a notebook
+ */
+export async function archiveNotebook(
+  pool: Pool,
+  notebookId: string,
+  userEmail: string
+): Promise<Notebook | null> {
+  const isOwner = await userOwnsNotebook(pool, notebookId, userEmail);
+  if (!isOwner) {
+    const exists = await pool.query(
+      'SELECT id FROM notebook WHERE id = $1 AND deleted_at IS NULL',
+      [notebookId]
+    );
+    if (exists.rows.length === 0) {
+      return null;
+    }
+    throw new Error('FORBIDDEN');
+  }
+
+  const result = await pool.query(
+    `UPDATE notebook
+     SET is_archived = true
+     WHERE id = $1 AND deleted_at IS NULL
+     RETURNING
+       id::text, user_email, name, description, icon, color,
+       parent_notebook_id::text, sort_order, is_archived, deleted_at,
+       created_at, updated_at`,
+    [notebookId]
+  );
+
+  if (result.rows.length === 0) {
+    return null;
+  }
+
+  return mapRowToNotebook(result.rows[0]);
+}
+
+/**
+ * Unarchives a notebook
+ */
+export async function unarchiveNotebook(
+  pool: Pool,
+  notebookId: string,
+  userEmail: string
+): Promise<Notebook | null> {
+  const isOwner = await userOwnsNotebook(pool, notebookId, userEmail);
+  if (!isOwner) {
+    const exists = await pool.query(
+      'SELECT id FROM notebook WHERE id = $1 AND deleted_at IS NULL',
+      [notebookId]
+    );
+    if (exists.rows.length === 0) {
+      return null;
+    }
+    throw new Error('FORBIDDEN');
+  }
+
+  const result = await pool.query(
+    `UPDATE notebook
+     SET is_archived = false
+     WHERE id = $1 AND deleted_at IS NULL
+     RETURNING
+       id::text, user_email, name, description, icon, color,
+       parent_notebook_id::text, sort_order, is_archived, deleted_at,
+       created_at, updated_at`,
+    [notebookId]
+  );
+
+  if (result.rows.length === 0) {
+    return null;
+  }
+
+  return mapRowToNotebook(result.rows[0]);
+}
+
+/**
+ * Soft deletes a notebook
+ */
+export async function deleteNotebook(
+  pool: Pool,
+  notebookId: string,
+  userEmail: string,
+  deleteNotes = false
+): Promise<boolean> {
+  const isOwner = await userOwnsNotebook(pool, notebookId, userEmail);
+  if (!isOwner) {
+    const exists = await pool.query(
+      'SELECT id FROM notebook WHERE id = $1 AND deleted_at IS NULL',
+      [notebookId]
+    );
+    if (exists.rows.length === 0) {
+      throw new Error('NOT_FOUND');
+    }
+    throw new Error('FORBIDDEN');
+  }
+
+  // Handle notes in the notebook
+  if (deleteNotes) {
+    // Soft delete all notes in the notebook
+    await pool.query(
+      `UPDATE note SET deleted_at = NOW() WHERE notebook_id = $1 AND deleted_at IS NULL`,
+      [notebookId]
+    );
+  } else {
+    // Move notes to root (null notebook)
+    await pool.query(
+      `UPDATE note SET notebook_id = NULL WHERE notebook_id = $1 AND deleted_at IS NULL`,
+      [notebookId]
+    );
+  }
+
+  // Move child notebooks to parent of deleted notebook (or root)
+  const notebookResult = await pool.query(
+    'SELECT parent_notebook_id FROM notebook WHERE id = $1',
+    [notebookId]
+  );
+  const parentId = notebookResult.rows[0]?.parent_notebook_id ?? null;
+
+  await pool.query(
+    `UPDATE notebook SET parent_notebook_id = $1 WHERE parent_notebook_id = $2 AND deleted_at IS NULL`,
+    [parentId, notebookId]
+  );
+
+  // Soft delete the notebook
+  const result = await pool.query(
+    `UPDATE notebook SET deleted_at = NOW() WHERE id = $1 AND deleted_at IS NULL`,
+    [notebookId]
+  );
+
+  return (result.rowCount ?? 0) > 0;
+}
+
+/**
+ * Moves or copies notes to a notebook
+ */
+export async function moveNotesToNotebook(
+  pool: Pool,
+  notebookId: string,
+  input: MoveNotesInput,
+  userEmail: string
+): Promise<MoveNotesResult> {
+  // Verify user owns target notebook
+  const isOwner = await userOwnsNotebook(pool, notebookId, userEmail);
+  if (!isOwner) {
+    const exists = await pool.query(
+      'SELECT id FROM notebook WHERE id = $1 AND deleted_at IS NULL',
+      [notebookId]
+    );
+    if (exists.rows.length === 0) {
+      throw new Error('NOT_FOUND');
+    }
+    throw new Error('FORBIDDEN');
+  }
+
+  const moved: string[] = [];
+  const failed: string[] = [];
+
+  for (const noteId of input.noteIds) {
+    try {
+      // Check if user owns the note
+      const noteResult = await pool.query(
+        'SELECT user_email, title, content, tags, visibility, hide_from_agents, summary, is_pinned FROM note WHERE id = $1 AND deleted_at IS NULL',
+        [noteId]
+      );
+
+      if (noteResult.rows.length === 0) {
+        failed.push(noteId);
+        continue;
+      }
+
+      if (noteResult.rows[0].user_email !== userEmail) {
+        failed.push(noteId);
+        continue;
+      }
+
+      if (input.action === 'move') {
+        // Move: update notebook_id
+        await pool.query(
+          `UPDATE note SET notebook_id = $1 WHERE id = $2`,
+          [notebookId, noteId]
+        );
+        moved.push(noteId);
+      } else {
+        // Copy: insert new note
+        const note = noteResult.rows[0];
+        const copyResult = await pool.query(
+          `INSERT INTO note (user_email, notebook_id, title, content, tags, visibility, hide_from_agents, summary, is_pinned)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+           RETURNING id::text`,
+          [
+            userEmail,
+            notebookId,
+            note.title,
+            note.content,
+            note.tags,
+            note.visibility,
+            note.hide_from_agents,
+            note.summary,
+            note.is_pinned,
+          ]
+        );
+        moved.push(copyResult.rows[0].id);
+      }
+    } catch {
+      failed.push(noteId);
+    }
+  }
+
+  return { moved, failed };
+}

--- a/src/api/notebooks/types.ts
+++ b/src/api/notebooks/types.ts
@@ -1,0 +1,97 @@
+/**
+ * Notebook types for the notebooks API.
+ * Part of Epic #337, Issue #345
+ */
+
+/** A notebook from the database */
+export interface Notebook {
+  id: string;
+  userEmail: string;
+  name: string;
+  description: string | null;
+  icon: string | null;
+  color: string | null;
+  parentNotebookId: string | null;
+  sortOrder: number;
+  isArchived: boolean;
+  deletedAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+  // Optional computed/expanded fields
+  noteCount?: number;
+  childCount?: number;
+  parent?: { id: string; name: string } | null;
+  children?: Notebook[];
+  notes?: NotebookNote[];
+}
+
+/** Minimal note info for notebook expansion */
+export interface NotebookNote {
+  id: string;
+  title: string;
+  updatedAt: Date;
+}
+
+/** Input for creating a new notebook */
+export interface CreateNotebookInput {
+  name: string;
+  description?: string;
+  icon?: string;
+  color?: string;
+  parentNotebookId?: string;
+}
+
+/** Input for updating a notebook */
+export interface UpdateNotebookInput {
+  name?: string;
+  description?: string | null;
+  icon?: string | null;
+  color?: string | null;
+  parentNotebookId?: string | null;
+  sortOrder?: number;
+}
+
+/** Query options for listing notebooks */
+export interface ListNotebooksOptions {
+  parentId?: string | null;
+  includeArchived?: boolean;
+  includeNoteCounts?: boolean;
+  includeChildCounts?: boolean;
+  limit?: number;
+  offset?: number;
+}
+
+/** Result of listing notebooks */
+export interface ListNotebooksResult {
+  notebooks: Notebook[];
+  total: number;
+}
+
+/** Options for getting a single notebook */
+export interface GetNotebookOptions {
+  includeNotes?: boolean;
+  includeChildren?: boolean;
+  includeNoteCounts?: boolean;
+}
+
+/** Tree node for notebook hierarchy */
+export interface NotebookTreeNode {
+  id: string;
+  name: string;
+  icon: string | null;
+  color: string | null;
+  noteCount?: number;
+  children: NotebookTreeNode[];
+}
+
+/** Input for moving notes between notebooks */
+export interface MoveNotesInput {
+  noteIds: string[];
+  action: 'move' | 'copy';
+}
+
+/** Result of moving notes */
+export interface MoveNotesResult {
+  moved: string[];
+  failed: string[];
+}

--- a/tests/notebooks_api.test.ts
+++ b/tests/notebooks_api.test.ts
@@ -1,0 +1,835 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { Pool } from 'pg';
+import { buildServer } from '../src/api/server.ts';
+import { runMigrate } from './helpers/migrate.js';
+import { createTestPool, truncateAllTables } from './helpers/db.js';
+
+describe('Notebooks CRUD API (Epic #337, Issue #345)', () => {
+  const app = buildServer();
+  let pool: Pool;
+  const testUserEmail = 'test@example.com';
+  const otherUserEmail = 'other@example.com';
+
+  beforeAll(async () => {
+    await runMigrate('up');
+    pool = createTestPool();
+    await app.ready();
+  });
+
+  beforeEach(async () => {
+    await truncateAllTables(pool);
+  });
+
+  afterAll(async () => {
+    await app.close();
+    await pool.end();
+  });
+
+  describe('POST /api/notebooks', () => {
+    it('creates a basic notebook', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/notebooks',
+        payload: {
+          user_email: testUserEmail,
+          name: 'My Notebook',
+        },
+      });
+
+      expect(res.statusCode).toBe(201);
+      const body = res.json();
+      expect(body.id).toBeDefined();
+      expect(body.name).toBe('My Notebook');
+      expect(body.userEmail).toBe(testUserEmail);
+      expect(body.isArchived).toBe(false);
+      expect(body.parentNotebookId).toBeNull();
+      expect(body.noteCount).toBe(0);
+    });
+
+    it('creates a notebook with all optional fields', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/notebooks',
+        payload: {
+          user_email: testUserEmail,
+          name: 'Full Notebook',
+          description: 'A detailed description',
+          icon: '📓',
+          color: '#3b82f6',
+        },
+      });
+
+      expect(res.statusCode).toBe(201);
+      const body = res.json();
+      expect(body.description).toBe('A detailed description');
+      expect(body.icon).toBe('📓');
+      expect(body.color).toBe('#3b82f6');
+    });
+
+    it('creates a child notebook', async () => {
+      // Create parent first
+      const parentRes = await app.inject({
+        method: 'POST',
+        url: '/api/notebooks',
+        payload: {
+          user_email: testUserEmail,
+          name: 'Parent',
+        },
+      });
+      const parentId = parentRes.json().id;
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/notebooks',
+        payload: {
+          user_email: testUserEmail,
+          name: 'Child',
+          parent_notebook_id: parentId,
+        },
+      });
+
+      expect(res.statusCode).toBe(201);
+      expect(res.json().parentNotebookId).toBe(parentId);
+    });
+
+    it('returns 400 when user_email is missing', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/notebooks',
+        payload: { name: 'Test' },
+      });
+
+      expect(res.statusCode).toBe(400);
+      expect(res.json().error).toBe('user_email is required');
+    });
+
+    it('returns 400 when name is missing', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/notebooks',
+        payload: { user_email: testUserEmail },
+      });
+
+      expect(res.statusCode).toBe(400);
+      expect(res.json().error).toBe('name is required');
+    });
+
+    it('returns 400 when parent notebook does not exist', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/notebooks',
+        payload: {
+          user_email: testUserEmail,
+          name: 'Test',
+          parent_notebook_id: '00000000-0000-0000-0000-000000000000',
+        },
+      });
+
+      expect(res.statusCode).toBe(400);
+      expect(res.json().error).toBe('Parent notebook not found');
+    });
+
+    it('returns 403 when adding notebook under another user\'s notebook', async () => {
+      // Create notebook owned by another user
+      const otherResult = await pool.query(
+        `INSERT INTO notebook (user_email, name) VALUES ($1, 'Other') RETURNING id::text as id`,
+        [otherUserEmail]
+      );
+      const otherId = (otherResult.rows[0] as { id: string }).id;
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/notebooks',
+        payload: {
+          user_email: testUserEmail,
+          name: 'Test',
+          parent_notebook_id: otherId,
+        },
+      });
+
+      expect(res.statusCode).toBe(403);
+    });
+  });
+
+  describe('GET /api/notebooks', () => {
+    beforeEach(async () => {
+      // Create test notebooks
+      await pool.query(
+        `INSERT INTO notebook (user_email, name, is_archived)
+         VALUES
+           ($1, 'Notebook 1', false),
+           ($1, 'Notebook 2', false),
+           ($1, 'Archived', true)`,
+        [testUserEmail]
+      );
+    });
+
+    it('lists notebooks for a user', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/notebooks',
+        query: { user_email: testUserEmail },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.notebooks).toHaveLength(2); // Excludes archived by default
+      expect(body.total).toBe(2);
+    });
+
+    it('returns 400 when user_email is missing', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/notebooks',
+      });
+
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('includes archived notebooks when requested', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/notebooks',
+        query: { user_email: testUserEmail, include_archived: 'true' },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json().notebooks).toHaveLength(3);
+    });
+
+    it('filters by parent_id=null for root notebooks', async () => {
+      // Create a child notebook
+      const parentResult = await pool.query(
+        `SELECT id::text FROM notebook WHERE name = 'Notebook 1'`
+      );
+      const parentId = (parentResult.rows[0] as { id: string }).id;
+
+      await pool.query(
+        `INSERT INTO notebook (user_email, name, parent_notebook_id) VALUES ($1, 'Child', $2)`,
+        [testUserEmail, parentId]
+      );
+
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/notebooks',
+        query: { user_email: testUserEmail, parent_id: 'null' },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.notebooks.every((n: { parentNotebookId: string | null }) => n.parentNotebookId === null)).toBe(true);
+    });
+
+    it('includes note counts', async () => {
+      // Get first notebook ID
+      const nbResult = await pool.query(
+        `SELECT id::text FROM notebook WHERE name = 'Notebook 1'`
+      );
+      const nbId = (nbResult.rows[0] as { id: string }).id;
+
+      // Add notes to it
+      await pool.query(
+        `INSERT INTO note (user_email, notebook_id, title) VALUES ($1, $2, 'Note 1'), ($1, $2, 'Note 2')`,
+        [testUserEmail, nbId]
+      );
+
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/notebooks',
+        query: { user_email: testUserEmail },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const notebooks = res.json().notebooks;
+      const nb1 = notebooks.find((n: { name: string }) => n.name === 'Notebook 1');
+      expect(nb1.noteCount).toBe(2);
+    });
+  });
+
+  describe('GET /api/notebooks/tree', () => {
+    beforeEach(async () => {
+      // Create hierarchical notebooks
+      const rootResult = await pool.query(
+        `INSERT INTO notebook (user_email, name) VALUES ($1, 'Root') RETURNING id::text as id`,
+        [testUserEmail]
+      );
+      const rootId = (rootResult.rows[0] as { id: string }).id;
+
+      await pool.query(
+        `INSERT INTO notebook (user_email, name, parent_notebook_id)
+         VALUES ($1, 'Child 1', $2), ($1, 'Child 2', $2)`,
+        [testUserEmail, rootId]
+      );
+    });
+
+    it('returns notebooks as tree structure', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/notebooks/tree',
+        query: { user_email: testUserEmail },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.notebooks).toHaveLength(1);
+      expect(body.notebooks[0].name).toBe('Root');
+      expect(body.notebooks[0].children).toHaveLength(2);
+    });
+
+    it('returns 400 when user_email is missing', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/notebooks/tree',
+      });
+
+      expect(res.statusCode).toBe(400);
+    });
+  });
+
+  describe('GET /api/notebooks/:id', () => {
+    it('returns a notebook by ID', async () => {
+      const nbResult = await pool.query(
+        `INSERT INTO notebook (user_email, name) VALUES ($1, 'Test') RETURNING id::text as id`,
+        [testUserEmail]
+      );
+      const nbId = (nbResult.rows[0] as { id: string }).id;
+
+      const res = await app.inject({
+        method: 'GET',
+        url: `/api/notebooks/${nbId}`,
+        query: { user_email: testUserEmail },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json().name).toBe('Test');
+    });
+
+    it('returns 400 when user_email is missing', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/notebooks/some-id',
+      });
+
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('returns 404 for non-existent notebook', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/notebooks/00000000-0000-0000-0000-000000000000',
+        query: { user_email: testUserEmail },
+      });
+
+      expect(res.statusCode).toBe(404);
+    });
+
+    it('returns 404 for another user\'s notebook', async () => {
+      const nbResult = await pool.query(
+        `INSERT INTO notebook (user_email, name) VALUES ($1, 'Other') RETURNING id::text as id`,
+        [otherUserEmail]
+      );
+      const nbId = (nbResult.rows[0] as { id: string }).id;
+
+      const res = await app.inject({
+        method: 'GET',
+        url: `/api/notebooks/${nbId}`,
+        query: { user_email: testUserEmail },
+      });
+
+      expect(res.statusCode).toBe(404);
+    });
+
+    it('includes notes when requested', async () => {
+      const nbResult = await pool.query(
+        `INSERT INTO notebook (user_email, name) VALUES ($1, 'Test') RETURNING id::text as id`,
+        [testUserEmail]
+      );
+      const nbId = (nbResult.rows[0] as { id: string }).id;
+
+      await pool.query(
+        `INSERT INTO note (user_email, notebook_id, title) VALUES ($1, $2, 'Note 1')`,
+        [testUserEmail, nbId]
+      );
+
+      const res = await app.inject({
+        method: 'GET',
+        url: `/api/notebooks/${nbId}`,
+        query: { user_email: testUserEmail, include_notes: 'true' },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json().notes).toHaveLength(1);
+    });
+
+    it('includes children when requested', async () => {
+      const parentResult = await pool.query(
+        `INSERT INTO notebook (user_email, name) VALUES ($1, 'Parent') RETURNING id::text as id`,
+        [testUserEmail]
+      );
+      const parentId = (parentResult.rows[0] as { id: string }).id;
+
+      await pool.query(
+        `INSERT INTO notebook (user_email, name, parent_notebook_id) VALUES ($1, 'Child', $2)`,
+        [testUserEmail, parentId]
+      );
+
+      const res = await app.inject({
+        method: 'GET',
+        url: `/api/notebooks/${parentId}`,
+        query: { user_email: testUserEmail, include_children: 'true' },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json().children).toHaveLength(1);
+    });
+  });
+
+  describe('PUT /api/notebooks/:id', () => {
+    let notebookId: string;
+
+    beforeEach(async () => {
+      const result = await pool.query(
+        `INSERT INTO notebook (user_email, name) VALUES ($1, 'Original') RETURNING id::text as id`,
+        [testUserEmail]
+      );
+      notebookId = (result.rows[0] as { id: string }).id;
+    });
+
+    it('updates notebook fields', async () => {
+      const res = await app.inject({
+        method: 'PUT',
+        url: `/api/notebooks/${notebookId}`,
+        payload: {
+          user_email: testUserEmail,
+          name: 'Updated',
+          description: 'New description',
+          icon: '📁',
+          color: '#ff0000',
+        },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.name).toBe('Updated');
+      expect(body.description).toBe('New description');
+      expect(body.icon).toBe('📁');
+      expect(body.color).toBe('#ff0000');
+    });
+
+    it('returns 400 when user_email is missing', async () => {
+      const res = await app.inject({
+        method: 'PUT',
+        url: `/api/notebooks/${notebookId}`,
+        payload: { name: 'New' },
+      });
+
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('returns 404 for non-existent notebook', async () => {
+      const res = await app.inject({
+        method: 'PUT',
+        url: '/api/notebooks/00000000-0000-0000-0000-000000000000',
+        payload: { user_email: testUserEmail, name: 'New' },
+      });
+
+      expect(res.statusCode).toBe(404);
+    });
+
+    it('returns 403 for another user\'s notebook', async () => {
+      const otherResult = await pool.query(
+        `INSERT INTO notebook (user_email, name) VALUES ($1, 'Other') RETURNING id::text as id`,
+        [otherUserEmail]
+      );
+      const otherId = (otherResult.rows[0] as { id: string }).id;
+
+      const res = await app.inject({
+        method: 'PUT',
+        url: `/api/notebooks/${otherId}`,
+        payload: { user_email: testUserEmail, name: 'Hacked' },
+      });
+
+      expect(res.statusCode).toBe(403);
+    });
+
+    it('prevents circular parent reference', async () => {
+      // Create child notebook
+      const childResult = await pool.query(
+        `INSERT INTO notebook (user_email, name, parent_notebook_id) VALUES ($1, 'Child', $2) RETURNING id::text as id`,
+        [testUserEmail, notebookId]
+      );
+      const childId = (childResult.rows[0] as { id: string }).id;
+
+      // Try to set parent's parent to child
+      const res = await app.inject({
+        method: 'PUT',
+        url: `/api/notebooks/${notebookId}`,
+        payload: {
+          user_email: testUserEmail,
+          parent_notebook_id: childId,
+        },
+      });
+
+      expect(res.statusCode).toBe(400);
+      expect(res.json().error).toContain('circular');
+    });
+
+    it('allows moving notebook to another parent', async () => {
+      const newParentResult = await pool.query(
+        `INSERT INTO notebook (user_email, name) VALUES ($1, 'New Parent') RETURNING id::text as id`,
+        [testUserEmail]
+      );
+      const newParentId = (newParentResult.rows[0] as { id: string }).id;
+
+      const res = await app.inject({
+        method: 'PUT',
+        url: `/api/notebooks/${notebookId}`,
+        payload: {
+          user_email: testUserEmail,
+          parent_notebook_id: newParentId,
+        },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json().parentNotebookId).toBe(newParentId);
+    });
+  });
+
+  describe('POST /api/notebooks/:id/archive', () => {
+    it('archives a notebook', async () => {
+      const nbResult = await pool.query(
+        `INSERT INTO notebook (user_email, name) VALUES ($1, 'Test') RETURNING id::text as id`,
+        [testUserEmail]
+      );
+      const nbId = (nbResult.rows[0] as { id: string }).id;
+
+      const res = await app.inject({
+        method: 'POST',
+        url: `/api/notebooks/${nbId}/archive`,
+        payload: { user_email: testUserEmail },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json().isArchived).toBe(true);
+    });
+
+    it('returns 400 when user_email is missing', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/notebooks/some-id/archive',
+        payload: {},
+      });
+
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('returns 403 for another user\'s notebook', async () => {
+      const nbResult = await pool.query(
+        `INSERT INTO notebook (user_email, name) VALUES ($1, 'Other') RETURNING id::text as id`,
+        [otherUserEmail]
+      );
+      const nbId = (nbResult.rows[0] as { id: string }).id;
+
+      const res = await app.inject({
+        method: 'POST',
+        url: `/api/notebooks/${nbId}/archive`,
+        payload: { user_email: testUserEmail },
+      });
+
+      expect(res.statusCode).toBe(403);
+    });
+  });
+
+  describe('POST /api/notebooks/:id/unarchive', () => {
+    it('unarchives a notebook', async () => {
+      const nbResult = await pool.query(
+        `INSERT INTO notebook (user_email, name, is_archived) VALUES ($1, 'Test', true) RETURNING id::text as id`,
+        [testUserEmail]
+      );
+      const nbId = (nbResult.rows[0] as { id: string }).id;
+
+      const res = await app.inject({
+        method: 'POST',
+        url: `/api/notebooks/${nbId}/unarchive`,
+        payload: { user_email: testUserEmail },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json().isArchived).toBe(false);
+    });
+  });
+
+  describe('DELETE /api/notebooks/:id', () => {
+    it('soft deletes a notebook and moves notes to root', async () => {
+      const nbResult = await pool.query(
+        `INSERT INTO notebook (user_email, name) VALUES ($1, 'Test') RETURNING id::text as id`,
+        [testUserEmail]
+      );
+      const nbId = (nbResult.rows[0] as { id: string }).id;
+
+      // Add a note to the notebook
+      await pool.query(
+        `INSERT INTO note (user_email, notebook_id, title) VALUES ($1, $2, 'Note')`,
+        [testUserEmail, nbId]
+      );
+
+      const res = await app.inject({
+        method: 'DELETE',
+        url: `/api/notebooks/${nbId}`,
+        query: { user_email: testUserEmail },
+      });
+
+      expect(res.statusCode).toBe(204);
+
+      // Verify notebook is deleted
+      const nbCheck = await pool.query(
+        'SELECT deleted_at FROM notebook WHERE id = $1',
+        [nbId]
+      );
+      expect(nbCheck.rows[0].deleted_at).not.toBeNull();
+
+      // Verify note is moved to root
+      const noteCheck = await pool.query(
+        'SELECT notebook_id FROM note WHERE user_email = $1',
+        [testUserEmail]
+      );
+      expect(noteCheck.rows[0].notebook_id).toBeNull();
+    });
+
+    it('deletes notes when delete_notes=true', async () => {
+      const nbResult = await pool.query(
+        `INSERT INTO notebook (user_email, name) VALUES ($1, 'Test') RETURNING id::text as id`,
+        [testUserEmail]
+      );
+      const nbId = (nbResult.rows[0] as { id: string }).id;
+
+      await pool.query(
+        `INSERT INTO note (user_email, notebook_id, title) VALUES ($1, $2, 'Note')`,
+        [testUserEmail, nbId]
+      );
+
+      const res = await app.inject({
+        method: 'DELETE',
+        url: `/api/notebooks/${nbId}`,
+        query: { user_email: testUserEmail, delete_notes: 'true' },
+      });
+
+      expect(res.statusCode).toBe(204);
+
+      // Verify note is deleted
+      const noteCheck = await pool.query(
+        'SELECT deleted_at FROM note WHERE user_email = $1',
+        [testUserEmail]
+      );
+      expect(noteCheck.rows[0].deleted_at).not.toBeNull();
+    });
+
+    it('returns 400 when user_email is missing', async () => {
+      const res = await app.inject({
+        method: 'DELETE',
+        url: '/api/notebooks/some-id',
+      });
+
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('returns 404 for non-existent notebook', async () => {
+      const res = await app.inject({
+        method: 'DELETE',
+        url: '/api/notebooks/00000000-0000-0000-0000-000000000000',
+        query: { user_email: testUserEmail },
+      });
+
+      expect(res.statusCode).toBe(404);
+    });
+
+    it('returns 403 for another user\'s notebook', async () => {
+      const nbResult = await pool.query(
+        `INSERT INTO notebook (user_email, name) VALUES ($1, 'Other') RETURNING id::text as id`,
+        [otherUserEmail]
+      );
+      const nbId = (nbResult.rows[0] as { id: string }).id;
+
+      const res = await app.inject({
+        method: 'DELETE',
+        url: `/api/notebooks/${nbId}`,
+        query: { user_email: testUserEmail },
+      });
+
+      expect(res.statusCode).toBe(403);
+    });
+
+    it('moves child notebooks to parent when deleted', async () => {
+      // Create parent -> child structure
+      const parentResult = await pool.query(
+        `INSERT INTO notebook (user_email, name) VALUES ($1, 'Parent') RETURNING id::text as id`,
+        [testUserEmail]
+      );
+      const parentId = (parentResult.rows[0] as { id: string }).id;
+
+      const childResult = await pool.query(
+        `INSERT INTO notebook (user_email, name, parent_notebook_id) VALUES ($1, 'Child', $2) RETURNING id::text as id`,
+        [testUserEmail, parentId]
+      );
+      const childId = (childResult.rows[0] as { id: string }).id;
+
+      await pool.query(
+        `INSERT INTO notebook (user_email, name, parent_notebook_id) VALUES ($1, 'Grandchild', $2)`,
+        [testUserEmail, childId]
+      );
+
+      // Delete the child
+      await app.inject({
+        method: 'DELETE',
+        url: `/api/notebooks/${childId}`,
+        query: { user_email: testUserEmail },
+      });
+
+      // Verify grandchild is now under parent
+      const gcCheck = await pool.query(
+        `SELECT parent_notebook_id FROM notebook WHERE name = 'Grandchild'`
+      );
+      expect(gcCheck.rows[0].parent_notebook_id).toBe(parentId);
+    });
+  });
+
+  describe('POST /api/notebooks/:id/notes', () => {
+    let notebookId: string;
+    let noteId: string;
+
+    beforeEach(async () => {
+      const nbResult = await pool.query(
+        `INSERT INTO notebook (user_email, name) VALUES ($1, 'Target') RETURNING id::text as id`,
+        [testUserEmail]
+      );
+      notebookId = (nbResult.rows[0] as { id: string }).id;
+
+      const noteResult = await pool.query(
+        `INSERT INTO note (user_email, title, content) VALUES ($1, 'Note', 'Content') RETURNING id::text as id`,
+        [testUserEmail]
+      );
+      noteId = (noteResult.rows[0] as { id: string }).id;
+    });
+
+    it('moves notes to notebook', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: `/api/notebooks/${notebookId}/notes`,
+        payload: {
+          user_email: testUserEmail,
+          note_ids: [noteId],
+          action: 'move',
+        },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json().moved).toContain(noteId);
+      expect(res.json().failed).toHaveLength(0);
+
+      // Verify note is in notebook
+      const check = await pool.query(
+        'SELECT notebook_id FROM note WHERE id = $1',
+        [noteId]
+      );
+      expect(check.rows[0].notebook_id).toBe(notebookId);
+    });
+
+    it('copies notes to notebook', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: `/api/notebooks/${notebookId}/notes`,
+        payload: {
+          user_email: testUserEmail,
+          note_ids: [noteId],
+          action: 'copy',
+        },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json().moved).toHaveLength(1);
+      expect(res.json().moved[0]).not.toBe(noteId); // New ID
+
+      // Verify original note unchanged
+      const check = await pool.query(
+        'SELECT notebook_id FROM note WHERE id = $1',
+        [noteId]
+      );
+      expect(check.rows[0].notebook_id).toBeNull();
+    });
+
+    it('returns 400 when user_email is missing', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: `/api/notebooks/${notebookId}/notes`,
+        payload: { note_ids: [noteId], action: 'move' },
+      });
+
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('returns 400 when note_ids is missing', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: `/api/notebooks/${notebookId}/notes`,
+        payload: { user_email: testUserEmail, action: 'move' },
+      });
+
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('returns 400 for invalid action', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: `/api/notebooks/${notebookId}/notes`,
+        payload: {
+          user_email: testUserEmail,
+          note_ids: [noteId],
+          action: 'invalid',
+        },
+      });
+
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('returns 403 for another user\'s notebook', async () => {
+      const otherNbResult = await pool.query(
+        `INSERT INTO notebook (user_email, name) VALUES ($1, 'Other') RETURNING id::text as id`,
+        [otherUserEmail]
+      );
+      const otherNbId = (otherNbResult.rows[0] as { id: string }).id;
+
+      const res = await app.inject({
+        method: 'POST',
+        url: `/api/notebooks/${otherNbId}/notes`,
+        payload: {
+          user_email: testUserEmail,
+          note_ids: [noteId],
+          action: 'move',
+        },
+      });
+
+      expect(res.statusCode).toBe(403);
+    });
+
+    it('fails for notes user does not own', async () => {
+      const otherNoteResult = await pool.query(
+        `INSERT INTO note (user_email, title) VALUES ($1, 'Other') RETURNING id::text as id`,
+        [otherUserEmail]
+      );
+      const otherNoteId = (otherNoteResult.rows[0] as { id: string }).id;
+
+      const res = await app.inject({
+        method: 'POST',
+        url: `/api/notebooks/${notebookId}/notes`,
+        payload: {
+          user_email: testUserEmail,
+          note_ids: [otherNoteId],
+          action: 'move',
+        },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json().failed).toContain(otherNoteId);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds REST API endpoints for CRUD operations on notebooks (Epic #337, Issue #345)
- Implements service layer with hierarchical notebook support
- Includes 43 integration tests covering all endpoints and edge cases

## Endpoints Added
- `GET /api/notebooks` - List notebooks with filters (parent_id, archived, counts)
- `GET /api/notebooks/tree` - Get notebooks as tree hierarchy
- `GET /api/notebooks/:id` - Get single notebook by ID (with optional notes/children)
- `POST /api/notebooks` - Create new notebook (with optional parent)
- `PUT /api/notebooks/:id` - Update notebook fields
- `POST /api/notebooks/:id/archive` - Archive notebook
- `POST /api/notebooks/:id/unarchive` - Unarchive notebook
- `DELETE /api/notebooks/:id` - Soft delete notebook (optionally delete notes)
- `POST /api/notebooks/:id/notes` - Move or copy notes to notebook

## Features
- Hierarchical notebooks with parent/child relationships
- Circular reference prevention when moving notebooks
- Archive/unarchive support
- Delete handles child notebooks (move to parent) and notes (move to root or delete)
- Move/copy notes between notebooks

## Test plan
- [x] All 43 new tests pass
- [x] Tests cover create, read, list, tree, update, archive, delete operations
- [x] Tests verify ownership checks and forbidden operations
- [x] Tests verify hierarchical operations (circular prevention, child reparenting)
- [x] Tests verify note move/copy operations

Closes #345

🤖 Generated with [Claude Code](https://claude.ai/code)