### PR TITLE
[#380] Implement move/reparent work items

### DIFF
--- a/src/ui/components/tree/tree-item.tsx
+++ b/src/ui/components/tree/tree-item.tsx
@@ -12,6 +12,7 @@ import {
   Pencil,
   Trash2,
   GripVertical,
+  FolderInput,
 } from 'lucide-react';
 import { cn } from '@/ui/lib/utils';
 import { Button } from '@/ui/components/ui/button';
@@ -75,6 +76,8 @@ export interface TreeItemRowProps {
   onAddChild?: (parentId: string, kind: TreeItemKind) => void;
   onEdit?: (id: string) => void;
   onDelete?: (id: string) => void;
+  /** Called when user requests to move the item via "Move to..." menu */
+  onMoveRequest?: (item: TreeItem) => void;
 }
 
 export function TreeItemRow({
@@ -87,6 +90,7 @@ export function TreeItemRow({
   onAddChild,
   onEdit,
   onDelete,
+  onMoveRequest,
 }: TreeItemRowProps) {
   const {
     attributes,
@@ -232,6 +236,12 @@ export function TreeItemRow({
             <DropdownMenuItem onClick={() => onEdit(item.id)}>
               <Pencil className="mr-2 size-4" />
               Edit
+            </DropdownMenuItem>
+          )}
+          {onMoveRequest && item.kind !== 'project' && (
+            <DropdownMenuItem onClick={() => onMoveRequest(item)}>
+              <FolderInput className="mr-2 size-4" />
+              Move to...
             </DropdownMenuItem>
           )}
           {onDelete && (

--- a/src/ui/components/work-item-move/hierarchy-validation.ts
+++ b/src/ui/components/work-item-move/hierarchy-validation.ts
@@ -1,0 +1,99 @@
+/**
+ * Hierarchy validation utilities for work item moves
+ *
+ * Hierarchy rules:
+ * - Project: can only be root (no parent)
+ * - Initiative: parent must be project
+ * - Epic: parent must be project or initiative
+ * - Issue: parent must be project, initiative, or epic
+ */
+
+import type { TreeItemKind } from '@/ui/components/tree/types';
+
+/**
+ * Returns the valid parent kinds for a given item kind.
+ * If the array is empty, the item must be at root level.
+ */
+export function getValidParentKinds(kind: TreeItemKind): TreeItemKind[] {
+  switch (kind) {
+    case 'project':
+      // Projects must be root - no parent allowed
+      return [];
+    case 'initiative':
+      // Initiatives can only be under projects
+      return ['project'];
+    case 'epic':
+      // Epics can be under projects or initiatives
+      return ['project', 'initiative'];
+    case 'issue':
+      // Issues can be under projects, initiatives, or epics
+      return ['project', 'initiative', 'epic'];
+  }
+}
+
+/**
+ * Check if an item can be moved to a specific parent.
+ *
+ * @param item - The item being moved
+ * @param targetParent - The potential new parent (null for root)
+ * @returns true if the move is valid
+ */
+export function canMoveToParent(
+  item: { id: string; kind: TreeItemKind },
+  targetParent: { id: string; kind: TreeItemKind } | null
+): boolean {
+  // Can't move item to itself
+  if (targetParent && item.id === targetParent.id) {
+    return false;
+  }
+
+  const validParentKinds = getValidParentKinds(item.kind);
+
+  // If no valid parent kinds, item must be root
+  if (validParentKinds.length === 0) {
+    return targetParent === null;
+  }
+
+  // Item cannot be root if it requires a parent
+  if (targetParent === null) {
+    return false;
+  }
+
+  // Check if target parent's kind is in the valid list
+  return validParentKinds.includes(targetParent.kind);
+}
+
+/**
+ * Check if moving an item would create a circular dependency.
+ * This happens when the target parent is a descendant of the item being moved.
+ *
+ * @param itemId - The ID of the item being moved
+ * @param targetParentId - The ID of the target parent
+ * @param getChildren - Function to get children of an item
+ * @returns true if the move would create a cycle
+ */
+export function wouldCreateCycle(
+  itemId: string,
+  targetParentId: string,
+  getChildren: (id: string) => string[]
+): boolean {
+  // Check if targetParentId is a descendant of itemId
+  const visited = new Set<string>();
+  const queue = [itemId];
+
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    if (visited.has(current)) continue;
+    visited.add(current);
+
+    const children = getChildren(current);
+    for (const childId of children) {
+      if (childId === targetParentId) {
+        return true;
+      }
+      queue.push(childId);
+    }
+  }
+
+  return false;
+}

--- a/src/ui/components/work-item-move/index.ts
+++ b/src/ui/components/work-item-move/index.ts
@@ -1,0 +1,14 @@
+export { MoveToDialog } from './move-to-dialog';
+export { useWorkItemMove } from './use-work-item-move';
+export {
+  canMoveToParent,
+  getValidParentKinds,
+  wouldCreateCycle,
+} from './hierarchy-validation';
+export type {
+  MoveItem,
+  PotentialParent,
+  MoveToDialogProps,
+  UseWorkItemMoveOptions,
+  UseWorkItemMoveReturn,
+} from './types';

--- a/src/ui/components/work-item-move/move-to-dialog.tsx
+++ b/src/ui/components/work-item-move/move-to-dialog.tsx
@@ -1,0 +1,203 @@
+import * as React from 'react';
+import { useState, useMemo } from 'react';
+import { Search, FolderTree, ChevronRight } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/ui/components/ui/dialog';
+import { Button } from '@/ui/components/ui/button';
+import { Input } from '@/ui/components/ui/input';
+import { ScrollArea } from '@/ui/components/ui/scroll-area';
+import { Badge } from '@/ui/components/ui/badge';
+import { cn } from '@/ui/lib/utils';
+import { canMoveToParent, getValidParentKinds } from './hierarchy-validation';
+import type { MoveToDialogProps, PotentialParent } from './types';
+import type { TreeItemKind } from '@/ui/components/tree/types';
+
+const kindIcons: Record<TreeItemKind, string> = {
+  project: '📁',
+  initiative: '🎯',
+  epic: '📚',
+  issue: '📄',
+};
+
+const kindColors: Record<TreeItemKind, string> = {
+  project: 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200',
+  initiative: 'bg-violet-100 text-violet-800 dark:bg-violet-900 dark:text-violet-200',
+  epic: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900 dark:text-emerald-200',
+  issue: 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200',
+};
+
+export function MoveToDialog({
+  open,
+  onOpenChange,
+  item,
+  items,
+  potentialParents,
+  onMove,
+  isMoving,
+}: MoveToDialogProps) {
+  const [searchQuery, setSearchQuery] = useState('');
+  const [selectedParentId, setSelectedParentId] = useState<string | null>(null);
+
+  const isBulk = items && items.length > 0;
+  const movingItem = item;
+  const itemKind = movingItem?.kind;
+  const currentParentId = movingItem?.currentParentId;
+
+  // Filter parents based on hierarchy rules and search
+  const filteredParents = useMemo(() => {
+    if (!itemKind) return [];
+
+    const validKinds = getValidParentKinds(itemKind);
+
+    return potentialParents.filter((parent) => {
+      // Must be a valid kind
+      if (!validKinds.includes(parent.kind)) return false;
+
+      // Search filter
+      if (searchQuery) {
+        const query = searchQuery.toLowerCase();
+        return parent.title.toLowerCase().includes(query);
+      }
+
+      return true;
+    });
+  }, [potentialParents, itemKind, searchQuery]);
+
+  const handleSelect = (parentId: string) => {
+    setSelectedParentId(parentId);
+  };
+
+  const handleMove = () => {
+    if (selectedParentId !== null) {
+      onMove(selectedParentId);
+    }
+  };
+
+  const handleCancel = () => {
+    setSearchQuery('');
+    setSelectedParentId(null);
+    onOpenChange(false);
+  };
+
+  // Reset state when dialog opens/closes
+  React.useEffect(() => {
+    if (!open) {
+      setSearchQuery('');
+      setSelectedParentId(null);
+    }
+  }, [open]);
+
+  const getTitle = () => {
+    if (isBulk) {
+      return `Move ${items.length} items`;
+    }
+    return `Move "${movingItem?.title}"`;
+  };
+
+  const getDescription = () => {
+    if (isBulk) {
+      return `Select a new parent for ${items.length} items.`;
+    }
+    if (movingItem?.currentParentTitle) {
+      return `Currently under "${movingItem.currentParentTitle}". Select a new parent.`;
+    }
+    return 'Select a new parent for this item.';
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>{getTitle()}</DialogTitle>
+          <DialogDescription>{getDescription()}</DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          {/* Search input */}
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              placeholder="Search parents..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="pl-9"
+            />
+          </div>
+
+          {/* Parent list */}
+          <ScrollArea className="h-64">
+            <div className="space-y-1">
+              {filteredParents.map((parent) => {
+                const isCurrent = parent.id === currentParentId;
+                const isSelected = parent.id === selectedParentId;
+
+                return (
+                  <button
+                    key={parent.id}
+                    data-current={isCurrent ? 'true' : undefined}
+                    onClick={() => handleSelect(parent.id)}
+                    disabled={isCurrent || isMoving}
+                    className={cn(
+                      'flex w-full items-center gap-3 rounded-md px-3 py-2 text-left text-sm transition-colors',
+                      'hover:bg-accent hover:text-accent-foreground',
+                      isSelected && 'bg-primary/10 ring-1 ring-primary',
+                      isCurrent && 'opacity-50 cursor-not-allowed'
+                    )}
+                  >
+                    <span className="text-lg">{kindIcons[parent.kind]}</span>
+                    <div className="flex-1 min-w-0">
+                      <div className="truncate font-medium">{parent.title}</div>
+                      <div className="flex items-center gap-2 mt-0.5">
+                        <Badge
+                          variant="secondary"
+                          className={cn('text-xs', kindColors[parent.kind])}
+                        >
+                          {parent.kind}
+                        </Badge>
+                        {isCurrent && (
+                          <span className="text-xs text-muted-foreground">
+                            (current)
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                    {isSelected && <ChevronRight className="size-4 text-primary" />}
+                  </button>
+                );
+              })}
+
+              {filteredParents.length === 0 && (
+                <div className="py-8 text-center text-muted-foreground">
+                  <FolderTree className="mx-auto mb-2 size-8 opacity-50" />
+                  <p className="text-sm">
+                    {searchQuery
+                      ? 'No matching parents found'
+                      : 'No valid parents available'}
+                  </p>
+                </div>
+              )}
+            </div>
+          </ScrollArea>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={handleCancel} disabled={isMoving}>
+            Cancel
+          </Button>
+          <Button
+            onClick={handleMove}
+            disabled={selectedParentId === null || isMoving}
+          >
+            {isMoving ? 'Moving...' : 'Move'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/ui/components/work-item-move/types.ts
+++ b/src/ui/components/work-item-move/types.ts
@@ -1,0 +1,43 @@
+/**
+ * Types for work item move/reparent components
+ */
+
+import type { TreeItemKind } from '@/ui/components/tree/types';
+
+export interface MoveItem {
+  id: string;
+  title: string;
+  kind: TreeItemKind;
+  currentParentId?: string | null;
+  currentParentTitle?: string;
+}
+
+export interface PotentialParent {
+  id: string;
+  title: string;
+  kind: TreeItemKind;
+}
+
+export interface MoveToDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Single item to move */
+  item?: MoveItem;
+  /** Multiple items for bulk move */
+  items?: MoveItem[];
+  /** List of potential parent items */
+  potentialParents: PotentialParent[];
+  onMove: (newParentId: string | null) => void;
+  isMoving: boolean;
+}
+
+export interface UseWorkItemMoveOptions {
+  onMoved?: () => void;
+  onError?: (error: Error) => void;
+}
+
+export interface UseWorkItemMoveReturn {
+  moveItem: (item: { id: string; title: string }, newParentId: string | null) => Promise<void>;
+  moveItems: (items: { id: string; title: string }[], newParentId: string | null) => Promise<void>;
+  isMoving: boolean;
+}

--- a/src/ui/components/work-item-move/use-work-item-move.ts
+++ b/src/ui/components/work-item-move/use-work-item-move.ts
@@ -1,0 +1,76 @@
+import * as React from 'react';
+import type {
+  UseWorkItemMoveOptions,
+  UseWorkItemMoveReturn,
+} from './types';
+
+export function useWorkItemMove(
+  options: UseWorkItemMoveOptions = {}
+): UseWorkItemMoveReturn {
+  const { onMoved, onError } = options;
+
+  const [isMoving, setIsMoving] = React.useState(false);
+
+  const moveItem = React.useCallback(
+    async (item: { id: string; title: string }, newParentId: string | null) => {
+      setIsMoving(true);
+      try {
+        const response = await fetch(`/api/work-items/${item.id}`, {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            parent_id: newParentId,
+          }),
+        });
+
+        if (!response.ok) {
+          throw new Error('Failed to move item');
+        }
+
+        onMoved?.();
+      } catch (error) {
+        onError?.(error instanceof Error ? error : new Error('Unknown error'));
+      } finally {
+        setIsMoving(false);
+      }
+    },
+    [onMoved, onError]
+  );
+
+  const moveItems = React.useCallback(
+    async (items: { id: string; title: string }[], newParentId: string | null) => {
+      setIsMoving(true);
+      try {
+        // Move items in parallel
+        await Promise.all(
+          items.map((item) =>
+            fetch(`/api/work-items/${item.id}`, {
+              method: 'PATCH',
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              body: JSON.stringify({
+                parent_id: newParentId,
+              }),
+            })
+          )
+        );
+
+        onMoved?.();
+      } catch (error) {
+        onError?.(error instanceof Error ? error : new Error('Unknown error'));
+      } finally {
+        setIsMoving(false);
+      }
+    },
+    [onMoved, onError]
+  );
+
+  return {
+    moveItem,
+    moveItems,
+    isMoving,
+  };
+}

--- a/tests/ui/work-item-move.test.tsx
+++ b/tests/ui/work-item-move.test.tsx
@@ -1,0 +1,298 @@
+/**
+ * @vitest-environment jsdom
+ */
+import * as React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import {
+  MoveToDialog,
+  useWorkItemMove,
+  canMoveToParent,
+  getValidParentKinds,
+} from '@/ui/components/work-item-move';
+import type { TreeItemKind } from '@/ui/components/tree/types';
+
+// Mock fetch globally
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+describe('Hierarchy validation', () => {
+  describe('getValidParentKinds', () => {
+    it('returns empty array for project (must be root)', () => {
+      expect(getValidParentKinds('project')).toEqual([]);
+    });
+
+    it('returns [project] for initiative', () => {
+      expect(getValidParentKinds('initiative')).toEqual(['project']);
+    });
+
+    it('returns [project, initiative] for epic', () => {
+      expect(getValidParentKinds('epic')).toEqual(['project', 'initiative']);
+    });
+
+    it('returns [project, initiative, epic] for issue', () => {
+      expect(getValidParentKinds('issue')).toEqual([
+        'project',
+        'initiative',
+        'epic',
+      ]);
+    });
+  });
+
+  describe('canMoveToParent', () => {
+    it('allows moving initiative under project', () => {
+      expect(
+        canMoveToParent(
+          { id: '1', kind: 'initiative' },
+          { id: '2', kind: 'project' }
+        )
+      ).toBe(true);
+    });
+
+    it('disallows moving project under anything', () => {
+      expect(
+        canMoveToParent(
+          { id: '1', kind: 'project' },
+          { id: '2', kind: 'project' }
+        )
+      ).toBe(false);
+    });
+
+    it('disallows moving epic under issue', () => {
+      expect(
+        canMoveToParent(
+          { id: '1', kind: 'epic' },
+          { id: '2', kind: 'issue' }
+        )
+      ).toBe(false);
+    });
+
+    it('allows moving epic under project', () => {
+      expect(
+        canMoveToParent(
+          { id: '1', kind: 'epic' },
+          { id: '2', kind: 'project' }
+        )
+      ).toBe(true);
+    });
+
+    it('allows moving epic under initiative', () => {
+      expect(
+        canMoveToParent(
+          { id: '1', kind: 'epic' },
+          { id: '2', kind: 'initiative' }
+        )
+      ).toBe(true);
+    });
+
+    it('allows moving issue under epic', () => {
+      expect(
+        canMoveToParent(
+          { id: '1', kind: 'issue' },
+          { id: '2', kind: 'epic' }
+        )
+      ).toBe(true);
+    });
+
+    it('disallows moving item under itself', () => {
+      expect(
+        canMoveToParent(
+          { id: '1', kind: 'issue' },
+          { id: '1', kind: 'epic' }
+        )
+      ).toBe(false);
+    });
+
+    it('allows moving to null parent (root) for project', () => {
+      expect(
+        canMoveToParent({ id: '1', kind: 'project' }, null)
+      ).toBe(true);
+    });
+
+    it('disallows moving to null parent (root) for non-project', () => {
+      expect(
+        canMoveToParent({ id: '1', kind: 'issue' }, null)
+      ).toBe(false);
+    });
+  });
+});
+
+describe('MoveToDialog', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  const mockPotentialParents = [
+    { id: 'proj-1', title: 'Project Alpha', kind: 'project' as TreeItemKind },
+    { id: 'init-1', title: 'Initiative Beta', kind: 'initiative' as TreeItemKind },
+    { id: 'epic-1', title: 'Epic Gamma', kind: 'epic' as TreeItemKind },
+  ];
+
+  const defaultProps = {
+    open: true,
+    onOpenChange: vi.fn(),
+    item: {
+      id: 'item-1',
+      title: 'Test Issue',
+      kind: 'issue' as TreeItemKind,
+      currentParentId: 'epic-1',
+      currentParentTitle: 'Epic Gamma',
+    },
+    potentialParents: mockPotentialParents,
+    onMove: vi.fn(),
+    isMoving: false,
+  };
+
+  it('renders dialog with item title', () => {
+    render(<MoveToDialog {...defaultProps} />);
+
+    expect(screen.getByText(/move.*test issue/i)).toBeInTheDocument();
+  });
+
+  it('shows current parent', () => {
+    render(<MoveToDialog {...defaultProps} />);
+
+    // Current parent is shown in the description
+    expect(screen.getByText(/currently under.*epic gamma/i)).toBeInTheDocument();
+  });
+
+  it('shows searchable list of potential parents', () => {
+    render(<MoveToDialog {...defaultProps} />);
+
+    expect(screen.getByText('Project Alpha')).toBeInTheDocument();
+    expect(screen.getByText('Initiative Beta')).toBeInTheDocument();
+  });
+
+  it('filters out invalid parent kinds', () => {
+    // Issue can be under project, initiative, or epic - all should show
+    render(<MoveToDialog {...defaultProps} />);
+
+    expect(screen.getByText('Project Alpha')).toBeInTheDocument();
+    expect(screen.getByText('Initiative Beta')).toBeInTheDocument();
+    expect(screen.getByText('Epic Gamma')).toBeInTheDocument();
+  });
+
+  it('filters parents when searching', () => {
+    render(<MoveToDialog {...defaultProps} />);
+
+    const searchInput = screen.getByPlaceholderText(/search/i);
+    fireEvent.change(searchInput, { target: { value: 'Alpha' } });
+
+    expect(screen.getByText('Project Alpha')).toBeInTheDocument();
+    expect(screen.queryByText('Initiative Beta')).not.toBeInTheDocument();
+  });
+
+  it('calls onMove when parent is selected', async () => {
+    const onMove = vi.fn();
+    render(<MoveToDialog {...defaultProps} onMove={onMove} />);
+
+    const projectOption = screen.getByText('Project Alpha');
+    fireEvent.click(projectOption);
+
+    const moveButton = screen.getByRole('button', { name: /move/i });
+    fireEvent.click(moveButton);
+
+    expect(onMove).toHaveBeenCalledWith('proj-1');
+  });
+
+  it('disables move button when no parent selected', () => {
+    render(<MoveToDialog {...defaultProps} />);
+
+    const moveButton = screen.getByRole('button', { name: /move/i });
+    expect(moveButton).toBeDisabled();
+  });
+
+  it('disables buttons when isMoving is true', () => {
+    render(<MoveToDialog {...defaultProps} isMoving={true} />);
+
+    const moveButton = screen.getByRole('button', { name: /mov/i });
+    expect(moveButton).toBeDisabled();
+  });
+
+  it('filters out current parent from options', () => {
+    render(<MoveToDialog {...defaultProps} />);
+
+    // Epic Gamma is the current parent, so it should be marked or filtered
+    const epicOption = screen.getByText('Epic Gamma');
+    expect(epicOption.closest('[data-current="true"]')).toBeInTheDocument();
+  });
+});
+
+describe('useWorkItemMove hook', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  function TestComponent({
+    onMoved,
+  }: {
+    onMoved?: () => void;
+  }) {
+    const { moveItem, isMoving } = useWorkItemMove({
+      onMoved,
+    });
+
+    return (
+      <div>
+        <button
+          onClick={() => moveItem({ id: 'test-1', title: 'Test Item' }, 'new-parent-id')}
+          disabled={isMoving}
+          data-testid="move-btn"
+        >
+          Move
+        </button>
+        <span data-testid="is-moving">{isMoving ? 'true' : 'false'}</span>
+      </div>
+    );
+  }
+
+  it('calls PATCH API to move item', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true });
+
+    render(<TestComponent />);
+
+    fireEvent.click(screen.getByTestId('move-btn'));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/api/work-items/test-1',
+        expect.objectContaining({
+          method: 'PATCH',
+          body: expect.stringContaining('new-parent-id'),
+        })
+      );
+    });
+  });
+
+  it('sets isMoving while API call is in progress', async () => {
+    mockFetch.mockImplementation(
+      () =>
+        new Promise((resolve) =>
+          setTimeout(() => resolve({ ok: true }), 100)
+        )
+    );
+
+    render(<TestComponent />);
+
+    expect(screen.getByTestId('is-moving').textContent).toBe('false');
+
+    fireEvent.click(screen.getByTestId('move-btn'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('is-moving').textContent).toBe('true');
+    });
+  });
+
+  it('calls onMoved callback after successful move', async () => {
+    const onMoved = vi.fn();
+    mockFetch.mockResolvedValueOnce({ ok: true });
+
+    render(<TestComponent onMoved={onMoved} />);
+
+    fireEvent.click(screen.getByTestId('move-btn'));
+
+    await waitFor(() => {
+      expect(onMoved).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `getValidParentKinds` and `canMoveToParent` utilities for hierarchy validation
- Adds `MoveToDialog` component with searchable parent selector that respects hierarchy rules
- Adds `useWorkItemMove` hook for PATCH API integration (`parent_id` field)
- Updates `ProjectTree` to support drag-drop reparenting with hierarchy validation
- Adds "Move to..." option in tree item context menu (via `FolderInput` icon)
- Wires up move handlers in `WorkItemsListPage` for both drag-drop and dialog moves

### Hierarchy Rules Enforced
- **Project**: root only (no parent allowed)
- **Initiative**: parent must be project
- **Epic**: parent must be project or initiative
- **Issue**: parent must be project, initiative, or epic

## Test plan

- [x] Run `pnpm test tests/ui/work-item-move.test.tsx` - 25 tests pass
- [x] Run `pnpm test tests/ui/` - all 362 UI tests pass
- [ ] Manual test: Drag issue onto epic to move it
- [ ] Manual test: Drag epic onto initiative to move it
- [ ] Manual test: Drag epic onto issue (should NOT move - invalid hierarchy)
- [ ] Manual test: Right-click item → "Move to..." → Select new parent → Move
- [ ] Manual test: Search for parent in Move dialog
- [ ] Manual test: Verify current parent is marked in dialog

Closes #380

🤖 Generated with [Claude Code](https://claude.com/claude-code)