### PR TITLE
[#381] Implement inline editing for all fields

### DIFF
--- a/src/ui/components/board/board-column.tsx
+++ b/src/ui/components/board/board-column.tsx
@@ -6,7 +6,7 @@ import { cn } from '@/ui/lib/utils';
 import { Button } from '@/ui/components/ui/button';
 import { ScrollArea } from '@/ui/components/ui/scroll-area';
 import { BoardCard } from './board-card';
-import type { BoardColumn as ColumnType, BoardItem, BoardStatus } from './types';
+import type { BoardColumn as ColumnType, BoardItem, BoardStatus, BoardPriority } from './types';
 
 function getStatusColor(status: BoardStatus): string {
   switch (status) {
@@ -27,6 +27,10 @@ export interface BoardColumnProps {
   onAddItem?: (status: BoardStatus) => void;
   isOver?: boolean;
   className?: string;
+  /** Called when card title is edited inline */
+  onTitleChange?: (id: string, newTitle: string) => void;
+  /** Called when card priority is cycled */
+  onPriorityChange?: (id: string, newPriority: BoardPriority) => void;
 }
 
 export function BoardColumn({
@@ -35,6 +39,8 @@ export function BoardColumn({
   onAddItem,
   isOver,
   className,
+  onTitleChange,
+  onPriorityChange,
 }: BoardColumnProps) {
   const { setNodeRef, isOver: isDroppableOver } = useDroppable({
     id: column.id,
@@ -84,7 +90,13 @@ export function BoardColumn({
         <div className="space-y-2 p-2">
           <SortableContext items={itemIds} strategy={verticalListSortingStrategy}>
             {column.items.map((item) => (
-              <BoardCard key={item.id} item={item} onClick={onItemClick} />
+              <BoardCard
+                key={item.id}
+                item={item}
+                onClick={onItemClick}
+                onTitleChange={onTitleChange}
+                onPriorityChange={onPriorityChange}
+              />
             ))}
           </SortableContext>
 

--- a/src/ui/components/board/kanban-board.tsx
+++ b/src/ui/components/board/kanban-board.tsx
@@ -19,7 +19,7 @@ import { Button } from '@/ui/components/ui/button';
 import { ScrollArea, ScrollBar } from '@/ui/components/ui/scroll-area';
 import { BoardColumn } from './board-column';
 import { BoardCardOverlay } from './board-card';
-import type { BoardItem, BoardStatus, BoardColumn as ColumnType } from './types';
+import type { BoardItem, BoardStatus, BoardColumn as ColumnType, BoardPriority } from './types';
 
 const DEFAULT_COLUMNS: ColumnType[] = [
   { id: 'not_started', title: 'To Do', items: [] },
@@ -46,6 +46,10 @@ export interface KanbanBoardProps {
   viewMode?: ViewMode;
   onViewModeChange?: (mode: ViewMode) => void;
   className?: string;
+  /** Called when a card title is edited inline */
+  onTitleChange?: (id: string, newTitle: string) => void;
+  /** Called when a card priority is cycled */
+  onPriorityChange?: (id: string, newPriority: BoardPriority) => void;
 }
 
 export function KanbanBoard({
@@ -56,6 +60,8 @@ export function KanbanBoard({
   viewMode = 'board',
   onViewModeChange,
   className,
+  onTitleChange,
+  onPriorityChange,
 }: KanbanBoardProps) {
   const [activeItem, setActiveItem] = useState<BoardItem | null>(null);
   const [overColumn, setOverColumn] = useState<BoardStatus | null>(null);
@@ -182,6 +188,8 @@ export function KanbanBoard({
                 onItemClick={onItemClick}
                 onAddItem={onAddItem}
                 isOver={overColumn === column.id}
+                onTitleChange={onTitleChange}
+                onPriorityChange={onPriorityChange}
               />
             ))}
             <DragOverlay>

--- a/src/ui/components/inline-edit/index.ts
+++ b/src/ui/components/inline-edit/index.ts
@@ -1,0 +1,7 @@
+export { InlineEdit } from './inline-edit';
+export { InlineEditableText } from './inline-editable-text';
+export type {
+  InlineEditProps,
+  InlineEditableTextProps,
+  InlineEditState,
+} from './types';

--- a/src/ui/components/inline-edit/inline-edit.tsx
+++ b/src/ui/components/inline-edit/inline-edit.tsx
@@ -1,0 +1,124 @@
+import * as React from 'react';
+import { useState, useRef, useCallback, useEffect } from 'react';
+import { cn } from '@/ui/lib/utils';
+import { Input } from '@/ui/components/ui/input';
+import type { InlineEditProps } from './types';
+
+export function InlineEdit({
+  value,
+  onSave,
+  onCancel,
+  validate,
+  saveOnBlur = false,
+  selectOnFocus = false,
+  placeholder,
+  className,
+  disabled = false,
+}: InlineEditProps) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [editValue, setEditValue] = useState(value);
+  const [isSaving, setIsSaving] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Update edit value when prop value changes
+  useEffect(() => {
+    if (!isEditing) {
+      setEditValue(value);
+    }
+  }, [value, isEditing]);
+
+  const startEditing = useCallback(() => {
+    if (disabled) return;
+    setEditValue(value);
+    setIsEditing(true);
+  }, [value, disabled]);
+
+  const handleSave = useCallback(async () => {
+    // Don't save if value unchanged
+    if (editValue === value) {
+      setIsEditing(false);
+      return;
+    }
+
+    // Validate if provided
+    if (validate && !validate(editValue)) {
+      return;
+    }
+
+    setIsSaving(true);
+    try {
+      await onSave(editValue);
+      setIsEditing(false);
+    } catch {
+      // Keep editing on error
+    } finally {
+      setIsSaving(false);
+    }
+  }, [editValue, value, validate, onSave]);
+
+  const handleCancel = useCallback(() => {
+    setEditValue(value);
+    setIsEditing(false);
+    onCancel?.();
+  }, [value, onCancel]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        handleSave();
+      } else if (e.key === 'Escape') {
+        e.preventDefault();
+        handleCancel();
+      }
+    },
+    [handleSave, handleCancel]
+  );
+
+  const handleBlur = useCallback(() => {
+    if (saveOnBlur) {
+      handleSave();
+    }
+  }, [saveOnBlur, handleSave]);
+
+  // Focus and select on edit start
+  useEffect(() => {
+    if (isEditing && inputRef.current) {
+      inputRef.current.focus();
+      if (selectOnFocus) {
+        inputRef.current.select();
+      }
+    }
+  }, [isEditing, selectOnFocus]);
+
+  if (isEditing) {
+    return (
+      <Input
+        ref={inputRef}
+        value={editValue}
+        onChange={(e) => setEditValue(e.target.value)}
+        onKeyDown={handleKeyDown}
+        onBlur={handleBlur}
+        disabled={isSaving}
+        className={cn('h-auto py-0.5', className)}
+        data-testid="inline-edit-input"
+      />
+    );
+  }
+
+  return (
+    <span
+      onClick={startEditing}
+      onDoubleClick={startEditing}
+      className={cn(
+        'cursor-text rounded px-1 -mx-1 hover:bg-muted/50 transition-colors',
+        disabled && 'cursor-default hover:bg-transparent',
+        !value && 'text-muted-foreground',
+        className
+      )}
+      data-testid="inline-edit-display"
+    >
+      {value || placeholder || '\u00A0'}
+    </span>
+  );
+}

--- a/src/ui/components/inline-edit/inline-editable-text.tsx
+++ b/src/ui/components/inline-edit/inline-editable-text.tsx
@@ -1,0 +1,154 @@
+import * as React from 'react';
+import { useState, useRef, useCallback, useEffect } from 'react';
+import { cn } from '@/ui/lib/utils';
+import { Input } from '@/ui/components/ui/input';
+import { Textarea } from '@/ui/components/ui/textarea';
+import type { InlineEditableTextProps } from './types';
+
+export function InlineEditableText({
+  value,
+  onSave,
+  validate,
+  saveOnBlur = true,
+  selectOnFocus = true,
+  placeholder,
+  className,
+  editClassName,
+  disabled = false,
+  multiline = false,
+  doubleClick = false,
+}: InlineEditableTextProps) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [editValue, setEditValue] = useState(value);
+  const [isSaving, setIsSaving] = useState(false);
+  const inputRef = useRef<HTMLInputElement | HTMLTextAreaElement>(null);
+
+  // Update edit value when prop value changes
+  useEffect(() => {
+    if (!isEditing) {
+      setEditValue(value);
+    }
+  }, [value, isEditing]);
+
+  const startEditing = useCallback(() => {
+    if (disabled) return;
+    setEditValue(value);
+    setIsEditing(true);
+  }, [value, disabled]);
+
+  const handleClick = useCallback(() => {
+    if (!doubleClick) {
+      startEditing();
+    }
+  }, [doubleClick, startEditing]);
+
+  const handleDoubleClick = useCallback(() => {
+    startEditing();
+  }, [startEditing]);
+
+  const handleSave = useCallback(async () => {
+    // Don't save if value unchanged
+    if (editValue === value) {
+      setIsEditing(false);
+      return;
+    }
+
+    // Validate if provided
+    if (validate && !validate(editValue)) {
+      return;
+    }
+
+    setIsSaving(true);
+    try {
+      await onSave(editValue);
+      setIsEditing(false);
+    } catch {
+      // Keep editing on error
+    } finally {
+      setIsSaving(false);
+    }
+  }, [editValue, value, validate, onSave]);
+
+  const handleCancel = useCallback(() => {
+    setEditValue(value);
+    setIsEditing(false);
+  }, [value]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter' && !multiline) {
+        e.preventDefault();
+        handleSave();
+      } else if (e.key === 'Enter' && multiline && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        handleSave();
+      } else if (e.key === 'Escape') {
+        e.preventDefault();
+        handleCancel();
+      }
+    },
+    [handleSave, handleCancel, multiline]
+  );
+
+  const handleBlur = useCallback(() => {
+    if (saveOnBlur) {
+      handleSave();
+    }
+  }, [saveOnBlur, handleSave]);
+
+  // Focus and select on edit start
+  useEffect(() => {
+    if (isEditing && inputRef.current) {
+      inputRef.current.focus();
+      if (selectOnFocus && inputRef.current instanceof HTMLInputElement) {
+        inputRef.current.select();
+      }
+    }
+  }, [isEditing, selectOnFocus]);
+
+  if (isEditing) {
+    const commonProps = {
+      value: editValue,
+      onChange: (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) =>
+        setEditValue(e.target.value),
+      onKeyDown: handleKeyDown,
+      onBlur: handleBlur,
+      disabled: isSaving,
+      className: cn('ring-2 ring-primary', editClassName),
+    };
+
+    if (multiline) {
+      return (
+        <Textarea
+          ref={inputRef as React.RefObject<HTMLTextAreaElement>}
+          {...commonProps}
+          data-testid="inline-edit-textarea"
+        />
+      );
+    }
+
+    return (
+      <Input
+        ref={inputRef as React.RefObject<HTMLInputElement>}
+        {...commonProps}
+        data-testid="inline-edit-input"
+      />
+    );
+  }
+
+  return (
+    <span
+      onClick={handleClick}
+      onDoubleClick={handleDoubleClick}
+      className={cn(
+        'cursor-text rounded px-1 -mx-1 hover:bg-muted/50 transition-colors',
+        disabled && 'cursor-default hover:bg-transparent',
+        !value && 'text-muted-foreground italic',
+        className
+      )}
+      data-testid="inline-edit-display"
+    >
+      {value || placeholder || '\u00A0'}
+    </span>
+  );
+}

--- a/src/ui/components/inline-edit/types.ts
+++ b/src/ui/components/inline-edit/types.ts
@@ -1,0 +1,40 @@
+/**
+ * Types for inline edit components
+ */
+
+export interface InlineEditProps {
+  /** Current value */
+  value: string;
+  /** Called when value is saved */
+  onSave: (value: string) => void | Promise<void>;
+  /** Called when editing is cancelled */
+  onCancel?: () => void;
+  /** Validate the value before saving. Returns true if valid. */
+  validate?: (value: string) => boolean;
+  /** Auto-save when input loses focus */
+  saveOnBlur?: boolean;
+  /** Select all text when entering edit mode */
+  selectOnFocus?: boolean;
+  /** Placeholder text for empty value */
+  placeholder?: string;
+  /** Custom className */
+  className?: string;
+  /** Disable editing */
+  disabled?: boolean;
+}
+
+export interface InlineEditableTextProps extends Omit<InlineEditProps, 'onCancel'> {
+  /** Use multiline textarea instead of input */
+  multiline?: boolean;
+  /** Trigger edit mode on double-click instead of single-click */
+  doubleClick?: boolean;
+  /** Custom edit mode className */
+  editClassName?: string;
+}
+
+export interface InlineEditState {
+  isEditing: boolean;
+  editValue: string;
+  isSaving: boolean;
+  error?: string;
+}

--- a/src/ui/components/tree/project-tree.tsx
+++ b/src/ui/components/tree/project-tree.tsx
@@ -120,6 +120,8 @@ export interface ProjectTreeProps {
   onMove?: (itemId: string, newParentId: string | null) => void;
   /** Called when user requests to move an item via the "Move to..." menu */
   onMoveRequest?: (item: TreeItem) => void;
+  /** Called when a title is changed via inline edit */
+  onTitleChange?: (id: string, newTitle: string) => void;
   className?: string;
 }
 
@@ -132,6 +134,7 @@ export function ProjectTree({
   onDelete,
   onMove,
   onMoveRequest,
+  onTitleChange,
   className,
 }: ProjectTreeProps) {
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
@@ -272,6 +275,7 @@ export function ProjectTree({
                   onEdit={onEdit}
                   onDelete={onDelete}
                   onMoveRequest={onMoveRequest}
+                  onTitleChange={onTitleChange}
                 />
               ))}
             </SortableContext>

--- a/src/ui/components/tree/tree-item.tsx
+++ b/src/ui/components/tree/tree-item.tsx
@@ -24,6 +24,7 @@ import {
   DropdownMenuTrigger,
 } from '@/ui/components/ui/dropdown-menu';
 import type { TreeItem, TreeItemKind, TreeItemStatus } from './types';
+import { InlineEditableText } from '@/ui/components/inline-edit';
 
 function getKindIcon(kind: TreeItemKind) {
   switch (kind) {
@@ -78,6 +79,8 @@ export interface TreeItemRowProps {
   onDelete?: (id: string) => void;
   /** Called when user requests to move the item via "Move to..." menu */
   onMoveRequest?: (item: TreeItem) => void;
+  /** Called when title is changed via inline edit */
+  onTitleChange?: (id: string, newTitle: string) => void;
 }
 
 export function TreeItemRow({
@@ -91,6 +94,7 @@ export function TreeItemRow({
   onEdit,
   onDelete,
   onMoveRequest,
+  onTitleChange,
 }: TreeItemRowProps) {
   const {
     attributes,
@@ -203,7 +207,18 @@ export function TreeItemRow({
       <span className="shrink-0 text-muted-foreground">{getKindIcon(item.kind)}</span>
 
       {/* Title */}
-      <span className="min-w-0 flex-1 truncate text-sm">{item.title}</span>
+      {onTitleChange ? (
+        <InlineEditableText
+          value={item.title}
+          onSave={(newTitle) => onTitleChange(item.id, newTitle)}
+          doubleClick
+          selectOnFocus
+          className="min-w-0 flex-1 truncate text-sm"
+          validate={(v) => v.trim().length > 0}
+        />
+      ) : (
+        <span className="min-w-0 flex-1 truncate text-sm">{item.title}</span>
+      )}
 
       {/* Child count badge */}
       {hasChildren && (

--- a/tests/ui/inline-edit.test.tsx
+++ b/tests/ui/inline-edit.test.tsx
@@ -1,0 +1,245 @@
+/**
+ * @vitest-environment jsdom
+ */
+import * as React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { InlineEdit, InlineEditableText } from '@/ui/components/inline-edit';
+
+describe('InlineEdit', () => {
+  const defaultProps = {
+    value: 'Test Value',
+    onSave: vi.fn(),
+    onCancel: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the value when not editing', () => {
+    render(<InlineEdit {...defaultProps} />);
+
+    expect(screen.getByText('Test Value')).toBeInTheDocument();
+  });
+
+  it('shows input when clicking on the value', () => {
+    render(<InlineEdit {...defaultProps} />);
+
+    fireEvent.click(screen.getByText('Test Value'));
+
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+    expect(screen.getByRole('textbox')).toHaveValue('Test Value');
+  });
+
+  it('shows input when double-clicking on the value', () => {
+    render(<InlineEdit {...defaultProps} />);
+
+    fireEvent.doubleClick(screen.getByText('Test Value'));
+
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+  });
+
+  it('calls onSave when pressing Enter', async () => {
+    const onSave = vi.fn();
+    render(<InlineEdit {...defaultProps} onSave={onSave} />);
+
+    fireEvent.click(screen.getByText('Test Value'));
+
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'New Value' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onSave).toHaveBeenCalledWith('New Value');
+  });
+
+  it('calls onCancel when pressing Escape', () => {
+    const onCancel = vi.fn();
+    render(<InlineEdit {...defaultProps} onCancel={onCancel} />);
+
+    fireEvent.click(screen.getByText('Test Value'));
+
+    const input = screen.getByRole('textbox');
+    fireEvent.keyDown(input, { key: 'Escape' });
+
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it('reverts to original value when pressing Escape', () => {
+    render(<InlineEdit {...defaultProps} />);
+
+    fireEvent.click(screen.getByText('Test Value'));
+
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'Changed' } });
+    fireEvent.keyDown(input, { key: 'Escape' });
+
+    expect(screen.getByText('Test Value')).toBeInTheDocument();
+  });
+
+  it('calls onSave when input loses focus', () => {
+    const onSave = vi.fn();
+    render(<InlineEdit {...defaultProps} onSave={onSave} saveOnBlur />);
+
+    fireEvent.click(screen.getByText('Test Value'));
+
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'New Value' } });
+    fireEvent.blur(input);
+
+    expect(onSave).toHaveBeenCalledWith('New Value');
+  });
+
+  it('does not call onSave if value is unchanged', () => {
+    const onSave = vi.fn();
+    render(<InlineEdit {...defaultProps} onSave={onSave} />);
+
+    fireEvent.click(screen.getByText('Test Value'));
+
+    const input = screen.getByRole('textbox');
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it('validates input before saving', () => {
+    const onSave = vi.fn();
+    const validate = (value: string) => value.length >= 3;
+    render(<InlineEdit {...defaultProps} onSave={onSave} validate={validate} />);
+
+    fireEvent.click(screen.getByText('Test Value'));
+
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'AB' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it('shows loading state during async save', async () => {
+    const onSave = vi.fn(() => new Promise((resolve) => setTimeout(resolve, 100)));
+    render(<InlineEdit {...defaultProps} onSave={onSave} />);
+
+    fireEvent.click(screen.getByText('Test Value'));
+
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'New Value' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(input).toBeDisabled();
+  });
+
+  it('focuses input when entering edit mode', () => {
+    render(<InlineEdit {...defaultProps} />);
+
+    fireEvent.click(screen.getByText('Test Value'));
+
+    expect(document.activeElement).toBe(screen.getByRole('textbox'));
+  });
+
+  it('selects all text when entering edit mode', () => {
+    render(<InlineEdit {...defaultProps} selectOnFocus />);
+
+    fireEvent.click(screen.getByText('Test Value'));
+
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+    expect(input.selectionStart).toBe(0);
+    expect(input.selectionEnd).toBe(input.value.length);
+  });
+});
+
+describe('InlineEditableText', () => {
+  const defaultProps = {
+    value: 'Editable Text',
+    onSave: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders as a span by default', () => {
+    render(<InlineEditableText {...defaultProps} />);
+
+    const span = screen.getByText('Editable Text');
+    expect(span.tagName).toBe('SPAN');
+  });
+
+  it('renders with custom className', () => {
+    render(<InlineEditableText {...defaultProps} className="custom-class" />);
+
+    expect(screen.getByText('Editable Text')).toHaveClass('custom-class');
+  });
+
+  it('shows placeholder when value is empty', () => {
+    render(<InlineEditableText {...defaultProps} value="" placeholder="Enter text..." />);
+
+    expect(screen.getByText('Enter text...')).toBeInTheDocument();
+  });
+
+  it('applies edit mode styles when editing', () => {
+    render(<InlineEditableText {...defaultProps} />);
+
+    fireEvent.click(screen.getByText('Editable Text'));
+
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveClass('ring-2');
+  });
+
+  it('supports multiline editing', () => {
+    render(<InlineEditableText {...defaultProps} multiline />);
+
+    fireEvent.click(screen.getByText('Editable Text'));
+
+    expect(screen.getByRole('textbox').tagName).toBe('TEXTAREA');
+  });
+
+  it('requires double-click when doubleClick prop is true', () => {
+    render(<InlineEditableText {...defaultProps} doubleClick />);
+
+    // Single click should not enter edit mode
+    fireEvent.click(screen.getByText('Editable Text'));
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+
+    // Double click should enter edit mode
+    fireEvent.doubleClick(screen.getByText('Editable Text'));
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+  });
+
+  it('validates before saving', () => {
+    const onSave = vi.fn();
+    render(
+      <InlineEditableText
+        {...defaultProps}
+        onSave={onSave}
+        validate={(v) => v.trim().length > 0}
+      />
+    );
+
+    fireEvent.click(screen.getByText('Editable Text'));
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: '   ' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it('calls onSave with valid input', () => {
+    const onSave = vi.fn();
+    render(<InlineEditableText {...defaultProps} onSave={onSave} />);
+
+    fireEvent.click(screen.getByText('Editable Text'));
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'New Title' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onSave).toHaveBeenCalledWith('New Title');
+  });
+
+  it('is disabled when disabled prop is true', () => {
+    render(<InlineEditableText {...defaultProps} disabled />);
+
+    fireEvent.click(screen.getByText('Editable Text'));
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- Creates reusable `InlineEdit` and `InlineEditableText` components for inline text editing
- Adds inline title editing to tree view (double-click to edit)
- Adds inline title editing to Kanban cards (single-click to edit)
- Adds clickable priority badge to cycle priorities in board cards
- Wires up PATCH API calls for persisting changes

## Changes

### New Components
- `src/ui/components/inline-edit/inline-edit.tsx` - Basic inline edit component
- `src/ui/components/inline-edit/inline-editable-text.tsx` - Enhanced text edit with styling
- `src/ui/components/inline-edit/types.ts` - TypeScript interfaces
- `src/ui/components/inline-edit/index.ts` - Module exports

### Modified Files
- `src/ui/components/tree/tree-item.tsx` - Added `onTitleChange` prop, uses InlineEditableText
- `src/ui/components/tree/project-tree.tsx` - Passes `onTitleChange` through
- `src/ui/components/board/board-card.tsx` - Added inline title editing and priority cycling
- `src/ui/components/board/board-column.tsx` - Passes edit callbacks through
- `src/ui/components/board/kanban-board.tsx` - Passes edit callbacks through
- `src/ui/app/main.tsx` - Added handlers for tree and kanban title changes

### Tests
- 21 unit tests for InlineEdit and InlineEditableText components

## Acceptance Criteria

- [x] Tree item titles editable inline (double-click)
- [x] Kanban card titles editable inline (click)
- [x] Detail metadata fields click-to-edit (already existed in MetadataGrid)
- [x] Date fields use date picker component (already existed)
- [x] Enter/Escape keyboard shortcuts work
- [x] Changes persist immediately via PATCH API
- [x] Loading/error states during save

## Test Plan

- [x] Run `pnpm test tests/ui/inline-edit.test.tsx` - 21 tests pass
- [x] Run `pnpm test tests/ui/` - 383 tests pass
- [ ] Manual testing: double-click tree item to edit title
- [ ] Manual testing: click kanban card title to edit
- [ ] Manual testing: click priority badge to cycle priority

Closes #381

🤖 Generated with [Claude Code](https://claude.com/claude-code)