### PR TITLE
[#349] Add note embeddings integration

### DIFF
--- a/src/api/embeddings/index.ts
+++ b/src/api/embeddings/index.ts
@@ -8,6 +8,7 @@ export * from './config.js';
 export * from './service.js';
 export * from './memory-integration.js';
 export * from './message-integration.js';
+export * from './note-integration.js';
 export * from './health.js';
 export * from './settings.js';
 export { createProvider, VoyageAIProvider, OpenAIProvider, GeminiProvider } from './providers/index.js';

--- a/src/api/embeddings/note-integration.ts
+++ b/src/api/embeddings/note-integration.ts
@@ -1,0 +1,491 @@
+/**
+ * Note embedding integration with embedding service.
+ * Part of Epic #337, Issue #349
+ *
+ * This module provides functions to generate and update embeddings
+ * for notes, with privacy-aware filtering and graceful degradation.
+ */
+
+import type { Pool } from 'pg';
+import { embeddingService } from './service.js';
+import { EmbeddingError } from './errors.js';
+
+/** Embedding status for note records. */
+export type NoteEmbeddingStatus = 'complete' | 'pending' | 'failed' | 'skipped';
+
+/** Note visibility type */
+export type NoteVisibility = 'private' | 'shared' | 'public';
+
+export interface NoteForEmbedding {
+  id: string;
+  title: string;
+  content: string;
+  visibility: NoteVisibility;
+  hideFromAgents: boolean;
+}
+
+export interface BackfillOptions {
+  limit?: number;
+  onlyPending?: boolean;
+  batchSize?: number;
+}
+
+export interface BackfillResult {
+  processed: number;
+  succeeded: number;
+  failed: number;
+  skipped: number;
+  errors: Array<{ noteId: string; error: string }>;
+}
+
+export interface EmbeddingStatsResult {
+  total: number;
+  byStatus: {
+    complete: number;
+    pending: number;
+    failed: number;
+    skipped: number;
+  };
+  provider: string | null;
+  model: string | null;
+}
+
+/**
+ * Determine if a note should be embedded based on privacy settings.
+ *
+ * Embedding rules:
+ * - Private notes with hideFromAgents: SKIP (no semantic search needed)
+ * - Private notes without hideFromAgents: EMBED (owner can search)
+ * - Shared/public notes: EMBED (searchable by authorized users)
+ */
+export function shouldEmbed(note: NoteForEmbedding): boolean {
+  if (note.visibility === 'private' && note.hideFromAgents) {
+    // Completely private - no semantic search needed
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Update just the embedding status.
+ */
+async function updateEmbeddingStatus(
+  pool: Pool,
+  noteId: string,
+  status: NoteEmbeddingStatus
+): Promise<void> {
+  await pool.query(`UPDATE note SET embedding_status = $2 WHERE id = $1`, [
+    noteId,
+    status,
+  ]);
+}
+
+/**
+ * Generate and store embedding for a single note.
+ *
+ * @param pool Database pool
+ * @param noteId The note ID
+ * @returns The embedding status
+ */
+export async function embedNote(
+  pool: Pool,
+  noteId: string
+): Promise<NoteEmbeddingStatus> {
+  // Fetch note data
+  const result = await pool.query(
+    `SELECT
+      id::text as id, title, content, visibility,
+      hide_from_agents as "hideFromAgents"
+    FROM note
+    WHERE id = $1 AND deleted_at IS NULL`,
+    [noteId]
+  );
+
+  if (result.rows.length === 0) {
+    return 'failed'; // Note not found
+  }
+
+  const note = result.rows[0] as NoteForEmbedding;
+
+  // Check if note should be embedded based on privacy
+  if (!shouldEmbed(note)) {
+    await updateEmbeddingStatus(pool, noteId, 'skipped');
+    return 'skipped';
+  }
+
+  // Check if embedding service is configured
+  if (!embeddingService.isConfigured()) {
+    // Mark as pending - can be backfilled later
+    await updateEmbeddingStatus(pool, noteId, 'pending');
+    return 'pending';
+  }
+
+  try {
+    // Prepare text for embedding
+    // Title is repeated to increase its weight in the embedding
+    const text = `${note.title}\n\n${note.title}\n\n${note.content}`.slice(
+      0,
+      8000
+    );
+
+    const embeddingResult = await embeddingService.embed(text);
+
+    if (!embeddingResult) {
+      await updateEmbeddingStatus(pool, noteId, 'pending');
+      return 'pending';
+    }
+
+    // Store embedding in database
+    await pool.query(
+      `UPDATE note
+       SET embedding = $1::vector,
+           embedding_model = $2,
+           embedding_provider = $3,
+           embedding_status = 'complete'
+       WHERE id = $4`,
+      [
+        `[${embeddingResult.embedding.join(',')}]`,
+        embeddingResult.model,
+        embeddingResult.provider,
+        noteId,
+      ]
+    );
+
+    return 'complete';
+  } catch (error) {
+    // Log error but don't fail the request
+    console.error(
+      `[Embeddings] Failed to embed note ${noteId}:`,
+      error instanceof EmbeddingError
+        ? error.toSafeString()
+        : (error as Error).message
+    );
+
+    // Mark as failed
+    await updateEmbeddingStatus(pool, noteId, 'failed');
+    return 'failed';
+  }
+}
+
+/**
+ * Trigger embedding for a note asynchronously (non-blocking).
+ * This is called from note create/update operations.
+ *
+ * @param pool Database pool
+ * @param noteId The note ID
+ */
+export function triggerNoteEmbedding(pool: Pool, noteId: string): void {
+  // Run async, don't wait for result
+  embedNote(pool, noteId).catch((err) =>
+    console.error(`[Embeddings] Background embedding failed for note ${noteId}:`, err)
+  );
+}
+
+/**
+ * Backfill embeddings for notes missing them.
+ *
+ * @param pool Database pool
+ * @param options Backfill options
+ * @returns Backfill results
+ */
+export async function backfillNoteEmbeddings(
+  pool: Pool,
+  options: BackfillOptions = {}
+): Promise<BackfillResult> {
+  const { limit = 100, onlyPending = true, batchSize = 10 } = options;
+
+  if (!embeddingService.isConfigured()) {
+    throw new Error('No embedding provider configured');
+  }
+
+  // Find notes needing embeddings
+  const statusFilter = onlyPending
+    ? "embedding_status IN ('pending', 'failed')"
+    : "embedding IS NULL OR embedding_status != 'complete'";
+
+  const notesResult = await pool.query(
+    `SELECT
+      id::text as id, title, content, visibility,
+      hide_from_agents as "hideFromAgents"
+    FROM note
+    WHERE deleted_at IS NULL AND (${statusFilter})
+    ORDER BY updated_at DESC
+    LIMIT $1`,
+    [limit]
+  );
+
+  const notes = notesResult.rows as NoteForEmbedding[];
+
+  const result: BackfillResult = {
+    processed: 0,
+    succeeded: 0,
+    failed: 0,
+    skipped: 0,
+    errors: [],
+  };
+
+  // Process in batches to respect rate limits
+  for (let i = 0; i < notes.length; i += batchSize) {
+    const batch = notes.slice(i, i + batchSize);
+
+    await Promise.all(
+      batch.map(async (note) => {
+        result.processed++;
+
+        // Check if should skip due to privacy
+        if (!shouldEmbed(note)) {
+          await updateEmbeddingStatus(pool, note.id, 'skipped');
+          result.skipped++;
+          return;
+        }
+
+        try {
+          const status = await embedNote(pool, note.id);
+
+          if (status === 'complete') {
+            result.succeeded++;
+          } else if (status === 'skipped') {
+            result.skipped++;
+          } else {
+            result.failed++;
+            result.errors.push({ noteId: note.id, error: `Status: ${status}` });
+          }
+        } catch (error) {
+          result.failed++;
+          result.errors.push({
+            noteId: note.id,
+            error: error instanceof Error ? error.message : 'Unknown error',
+          });
+        }
+      })
+    );
+
+    // Rate limit: wait between batches
+    if (i + batchSize < notes.length) {
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Get embedding statistics for notes.
+ *
+ * @param pool Database pool
+ * @returns Embedding statistics
+ */
+export async function getNoteEmbeddingStats(
+  pool: Pool
+): Promise<EmbeddingStatsResult> {
+  // Get counts by status
+  const statusResult = await pool.query(`
+    SELECT
+      embedding_status,
+      COUNT(*) as count
+    FROM note
+    WHERE deleted_at IS NULL
+    GROUP BY embedding_status
+  `);
+
+  const byStatus = {
+    complete: 0,
+    pending: 0,
+    failed: 0,
+    skipped: 0,
+  };
+
+  let total = 0;
+  for (const row of statusResult.rows) {
+    const status = row.embedding_status as NoteEmbeddingStatus | null;
+    const count = parseInt(row.count, 10);
+    total += count;
+
+    if (status === 'complete') {
+      byStatus.complete = count;
+    } else if (status === 'failed') {
+      byStatus.failed = count;
+    } else if (status === 'skipped') {
+      byStatus.skipped = count;
+    } else {
+      // null or 'pending'
+      byStatus.pending += count;
+    }
+  }
+
+  // Get current provider/model info
+  const configSummary = embeddingService.getConfig();
+
+  return {
+    total,
+    byStatus,
+    provider: configSummary?.provider ?? null,
+    model: configSummary?.model ?? null,
+  };
+}
+
+/**
+ * Search notes using semantic similarity.
+ *
+ * If embedding fails for the query, falls back to text search.
+ *
+ * @param pool Database pool
+ * @param query Search query text
+ * @param userEmail User making the query (for access control)
+ * @param options Search options
+ * @returns Search results with similarity scores
+ */
+export async function searchNotesSemantic(
+  pool: Pool,
+  query: string,
+  userEmail: string,
+  options: {
+    limit?: number;
+    offset?: number;
+    notebookId?: string;
+    tags?: string[];
+  } = {}
+): Promise<{
+  results: Array<{
+    id: string;
+    title: string;
+    content: string;
+    similarity: number;
+    updatedAt: Date;
+  }>;
+  searchType: 'semantic' | 'text';
+  queryEmbeddingProvider?: string;
+}> {
+  const { limit = 20, offset = 0, notebookId, tags } = options;
+
+  // Try to generate embedding for query
+  let queryEmbedding: number[] | null = null;
+  let queryProvider: string | undefined;
+
+  if (embeddingService.isConfigured()) {
+    try {
+      const result = await embeddingService.embed(query);
+      if (result) {
+        queryEmbedding = result.embedding;
+        queryProvider = result.provider;
+      }
+    } catch (error) {
+      console.warn(
+        '[Embeddings] Query embedding failed, falling back to text search:',
+        error instanceof EmbeddingError
+          ? error.toSafeString()
+          : (error as Error).message
+      );
+    }
+  }
+
+  // Build access control condition
+  // User can see: own notes OR shared with them OR public
+  const accessCondition = `(
+    n.user_email = $1
+    OR n.visibility = 'public'
+    OR EXISTS (
+      SELECT 1 FROM note_share ns
+      WHERE ns.note_id = n.id
+      AND ns.shared_with_email = $1
+      AND (ns.expires_at IS NULL OR ns.expires_at > NOW())
+    )
+  )`;
+
+  // Build dynamic WHERE clause
+  const conditions: string[] = ['n.deleted_at IS NULL', accessCondition];
+  const params: (string | string[] | number)[] = [userEmail];
+  let paramIndex = 2;
+
+  if (notebookId) {
+    conditions.push(`n.notebook_id = $${paramIndex}`);
+    params.push(notebookId);
+    paramIndex++;
+  }
+
+  if (tags && tags.length > 0) {
+    conditions.push(`n.tags && $${paramIndex}`);
+    params.push(tags);
+    paramIndex++;
+  }
+
+  // Semantic search with embedding
+  if (queryEmbedding) {
+    conditions.push(`n.embedding IS NOT NULL AND n.embedding_status = 'complete'`);
+
+    const embeddingParam = `[${queryEmbedding.join(',')}]`;
+    params.push(embeddingParam);
+    const embeddingParamIndex = paramIndex++;
+
+    params.push(limit);
+    const limitParamIndex = paramIndex++;
+    params.push(offset);
+    const offsetParamIndex = paramIndex++;
+
+    const whereClause = conditions.join(' AND ');
+
+    const result = await pool.query(
+      `SELECT
+        n.id::text as id,
+        n.title,
+        n.content,
+        n.updated_at as "updatedAt",
+        1 - (n.embedding <=> $${embeddingParamIndex}::vector) as similarity
+      FROM note n
+      WHERE ${whereClause}
+      ORDER BY n.embedding <=> $${embeddingParamIndex}::vector
+      LIMIT $${limitParamIndex} OFFSET $${offsetParamIndex}`,
+      params
+    );
+
+    return {
+      results: result.rows.map((row) => ({
+        id: row.id,
+        title: row.title,
+        content: row.content,
+        similarity: parseFloat(row.similarity),
+        updatedAt: new Date(row.updatedAt),
+      })),
+      searchType: 'semantic',
+      queryEmbeddingProvider: queryProvider,
+    };
+  }
+
+  // Fall back to text search
+  params.push(`%${query}%`);
+  const searchParamIndex = paramIndex++;
+
+  conditions.push(`(n.title ILIKE $${searchParamIndex} OR n.content ILIKE $${searchParamIndex})`);
+
+  params.push(limit);
+  const limitParamIndex = paramIndex++;
+  params.push(offset);
+  const offsetParamIndex = paramIndex++;
+
+  const whereClause = conditions.join(' AND ');
+
+  const result = await pool.query(
+    `SELECT
+      n.id::text as id,
+      n.title,
+      n.content,
+      n.updated_at as "updatedAt",
+      0.5 as similarity
+    FROM note n
+    WHERE ${whereClause}
+    ORDER BY n.updated_at DESC
+    LIMIT $${limitParamIndex} OFFSET $${offsetParamIndex}`,
+    params
+  );
+
+  return {
+    results: result.rows.map((row) => ({
+      id: row.id,
+      title: row.title,
+      content: row.content,
+      similarity: parseFloat(row.similarity),
+      updatedAt: new Date(row.updatedAt),
+    })),
+    searchType: 'text',
+  };
+}

--- a/tests/note_embeddings_api.test.ts
+++ b/tests/note_embeddings_api.test.ts
@@ -1,0 +1,572 @@
+/**
+ * Tests for note embeddings integration.
+ * Part of Epic #337, Issue #349
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import type { Pool } from 'pg';
+import { buildServer } from '../src/api/server.ts';
+import { createPool } from '../src/db.ts';
+
+// Mock the embedding service module
+vi.mock('../src/api/embeddings/service.ts', () => ({
+  embeddingService: {
+    isConfigured: vi.fn(() => true),
+    embed: vi.fn(async (text: string) => ({
+      embedding: new Array(1536).fill(0).map((_, i) => Math.sin(i + text.length)),
+      model: 'test-model',
+      provider: 'test-provider',
+    })),
+    getConfig: vi.fn(() => ({
+      provider: 'test-provider',
+      model: 'test-model',
+    })),
+  },
+}));
+
+describe('Note Embeddings API', () => {
+  let app: FastifyInstance;
+  let pool: Pool;
+  const testUserEmail = 'embed-test@example.com';
+  const otherUserEmail = 'embed-other@example.com';
+
+  beforeAll(async () => {
+    app = await buildServer();
+    pool = createPool();
+
+    // Clean up any existing test data
+    await pool.query(`DELETE FROM note WHERE user_email LIKE 'embed-%@example.com'`);
+    await pool.query(`DELETE FROM notebook WHERE user_email LIKE 'embed-%@example.com'`);
+  });
+
+  afterAll(async () => {
+    // Clean up test data
+    await pool.query(`DELETE FROM note WHERE user_email LIKE 'embed-%@example.com'`);
+    await pool.query(`DELETE FROM notebook WHERE user_email LIKE 'embed-%@example.com'`);
+
+    await pool.end();
+    await app.close();
+  });
+
+  // Helper functions
+  async function createNote(overrides: Partial<{
+    title: string;
+    content: string;
+    visibility: string;
+    hideFromAgents: boolean;
+    tags: string[];
+    userEmail: string;
+  }> = {}) {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/notes',
+      payload: {
+        user_email: overrides.userEmail ?? testUserEmail,
+        title: overrides.title ?? 'Test Note',
+        content: overrides.content ?? 'Test content for embedding',
+        visibility: overrides.visibility ?? 'private',
+        hide_from_agents: overrides.hideFromAgents ?? false,
+        tags: overrides.tags ?? [],
+      },
+    });
+    expect(response.statusCode).toBe(201);
+    return JSON.parse(response.payload);
+  }
+
+  async function getNote(noteId: string, userEmail: string = testUserEmail) {
+    const response = await app.inject({
+      method: 'GET',
+      url: `/api/notes/${noteId}?user_email=${userEmail}`,
+    });
+    if (response.statusCode === 200) {
+      return JSON.parse(response.payload);
+    }
+    return null;
+  }
+
+  describe('Embedding Status on Note Operations', () => {
+    it('should trigger embedding when creating a note', async () => {
+      const note = await createNote({
+        title: 'Embedding Test Note',
+        content: 'This note should be embedded',
+      });
+
+      // The embedding is triggered asynchronously, so we check the note exists
+      expect(note.id).toBeDefined();
+      expect(note.title).toBe('Embedding Test Note');
+    });
+
+    it('should mark private+hideFromAgents notes as skipped', async () => {
+      const note = await createNote({
+        title: 'Hidden Note',
+        content: 'This note should not be embedded',
+        visibility: 'private',
+        hideFromAgents: true,
+      });
+
+      // Wait a bit for async embedding to process
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // Fetch the note directly from DB to check embedding status
+      const result = await pool.query(
+        `SELECT embedding_status FROM note WHERE id = $1`,
+        [note.id]
+      );
+
+      // The note should be skipped due to privacy settings
+      expect(['skipped', 'pending']).toContain(result.rows[0].embedding_status);
+    });
+
+    it('should embed public notes', async () => {
+      const note = await createNote({
+        title: 'Public Note',
+        content: 'This public note should be embedded',
+        visibility: 'public',
+      });
+
+      // Wait for async embedding
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      const result = await pool.query(
+        `SELECT embedding_status FROM note WHERE id = $1`,
+        [note.id]
+      );
+
+      // Should be complete or pending (depending on timing)
+      expect(['complete', 'pending']).toContain(result.rows[0].embedding_status);
+    });
+
+    it('should embed shared notes', async () => {
+      const note = await createNote({
+        title: 'Shared Note',
+        content: 'This shared note should be embedded',
+        visibility: 'shared',
+      });
+
+      expect(note.visibility).toBe('shared');
+    });
+  });
+
+  describe('GET /api/admin/embeddings/status/notes', () => {
+    it('should return embedding statistics', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/admin/embeddings/status/notes',
+      });
+
+      expect(response.statusCode).toBe(200);
+
+      const stats = JSON.parse(response.payload);
+      expect(stats).toHaveProperty('total');
+      expect(stats).toHaveProperty('byStatus');
+      expect(stats.byStatus).toHaveProperty('complete');
+      expect(stats.byStatus).toHaveProperty('pending');
+      expect(stats.byStatus).toHaveProperty('failed');
+      expect(stats.byStatus).toHaveProperty('skipped');
+      expect(stats).toHaveProperty('provider');
+      expect(stats).toHaveProperty('model');
+    });
+  });
+
+  describe('POST /api/admin/embeddings/backfill/notes', () => {
+    it('should backfill pending notes', async () => {
+      // Create some notes first
+      await createNote({ title: 'Backfill Note 1', content: 'Content 1' });
+      await createNote({ title: 'Backfill Note 2', content: 'Content 2' });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/admin/embeddings/backfill/notes',
+        payload: {
+          limit: 10,
+          onlyPending: true,
+          batchSize: 5,
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+
+      const result = JSON.parse(response.payload);
+      expect(result).toHaveProperty('processed');
+      expect(result).toHaveProperty('succeeded');
+      expect(result).toHaveProperty('failed');
+      expect(result).toHaveProperty('skipped');
+      expect(result).toHaveProperty('errors');
+      expect(Array.isArray(result.errors)).toBe(true);
+    });
+
+    it('should accept default parameters', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/admin/embeddings/backfill/notes',
+        payload: {},
+      });
+
+      expect(response.statusCode).toBe(200);
+    });
+  });
+
+  describe('POST /api/notes/search/semantic', () => {
+    beforeEach(async () => {
+      // Create test notes with distinct content for search
+      await createNote({
+        title: 'TypeScript Guide',
+        content: 'A comprehensive guide to TypeScript programming',
+        visibility: 'public',
+      });
+      await createNote({
+        title: 'Python Tutorial',
+        content: 'Learn Python programming from scratch',
+        visibility: 'public',
+      });
+      await createNote({
+        title: 'Private Secret',
+        content: 'This is a private note that should only be found by owner',
+        visibility: 'private',
+      });
+
+      // Wait for embeddings to process
+      await new Promise((resolve) => setTimeout(resolve, 200));
+    });
+
+    it('should require user_email', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/notes/search/semantic',
+        payload: {
+          query: 'programming',
+        },
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(JSON.parse(response.payload).error).toBe('user_email is required');
+    });
+
+    it('should require query', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/notes/search/semantic',
+        payload: {
+          user_email: testUserEmail,
+        },
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(JSON.parse(response.payload).error).toBe('query is required');
+    });
+
+    it('should search notes semantically', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/notes/search/semantic',
+        payload: {
+          user_email: testUserEmail,
+          query: 'programming languages',
+          limit: 10,
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+
+      const result = JSON.parse(response.payload);
+      expect(result).toHaveProperty('results');
+      expect(result).toHaveProperty('searchType');
+      expect(['semantic', 'text']).toContain(result.searchType);
+      expect(Array.isArray(result.results)).toBe(true);
+    });
+
+    it('should return similarity scores', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/notes/search/semantic',
+        payload: {
+          user_email: testUserEmail,
+          query: 'TypeScript',
+          limit: 5,
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+
+      const result = JSON.parse(response.payload);
+      if (result.results.length > 0) {
+        expect(result.results[0]).toHaveProperty('id');
+        expect(result.results[0]).toHaveProperty('title');
+        expect(result.results[0]).toHaveProperty('content');
+        expect(result.results[0]).toHaveProperty('similarity');
+        expect(typeof result.results[0].similarity).toBe('number');
+      }
+    });
+
+    it('should filter by notebookId', async () => {
+      // Create a notebook and note in it
+      const notebookResponse = await app.inject({
+        method: 'POST',
+        url: '/api/notebooks',
+        payload: {
+          user_email: testUserEmail,
+          name: 'Search Test Notebook',
+        },
+      });
+      const notebook = JSON.parse(notebookResponse.payload);
+
+      await createNote({
+        title: 'Notebook Note',
+        content: 'This note is in a specific notebook',
+        visibility: 'private',
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/notes/search/semantic',
+        payload: {
+          user_email: testUserEmail,
+          query: 'notebook',
+          notebookId: notebook.id,
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+    });
+
+    it('should filter by tags', async () => {
+      await createNote({
+        title: 'Tagged Note',
+        content: 'This note has specific tags',
+        tags: ['test-tag', 'search-tag'],
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/notes/search/semantic',
+        payload: {
+          user_email: testUserEmail,
+          query: 'tagged',
+          tags: ['test-tag'],
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+    });
+
+    it('should respect visibility/access control', async () => {
+      // Create a private note for test user
+      const privateNote = await createNote({
+        title: 'Owner Only Note',
+        content: 'This note should only be visible to owner',
+        visibility: 'private',
+      });
+
+      // Search as owner - should find
+      const ownerResponse = await app.inject({
+        method: 'POST',
+        url: '/api/notes/search/semantic',
+        payload: {
+          user_email: testUserEmail,
+          query: 'Owner Only',
+        },
+      });
+
+      expect(ownerResponse.statusCode).toBe(200);
+
+      // Search as other user - should not find the private note
+      const otherResponse = await app.inject({
+        method: 'POST',
+        url: '/api/notes/search/semantic',
+        payload: {
+          user_email: otherUserEmail,
+          query: 'Owner Only',
+        },
+      });
+
+      expect(otherResponse.statusCode).toBe(200);
+      const otherResult = JSON.parse(otherResponse.payload);
+
+      // The other user should not see the private note
+      const foundPrivate = otherResult.results.find(
+        (r: { id: string }) => r.id === privateNote.id
+      );
+      expect(foundPrivate).toBeUndefined();
+    });
+
+    it('should handle pagination', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/notes/search/semantic',
+        payload: {
+          user_email: testUserEmail,
+          query: 'test',
+          limit: 5,
+          offset: 0,
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+
+      const result = JSON.parse(response.payload);
+      expect(result.results.length).toBeLessThanOrEqual(5);
+    });
+  });
+
+  describe('shouldEmbed function', () => {
+    it('should export shouldEmbed function', async () => {
+      const { shouldEmbed } = await import('../src/api/embeddings/note-integration.ts');
+      expect(typeof shouldEmbed).toBe('function');
+    });
+
+    it('should return false for private+hideFromAgents', async () => {
+      const { shouldEmbed } = await import('../src/api/embeddings/note-integration.ts');
+
+      const result = shouldEmbed({
+        id: 'test',
+        title: 'Test',
+        content: 'Test',
+        visibility: 'private',
+        hideFromAgents: true,
+      });
+
+      expect(result).toBe(false);
+    });
+
+    it('should return true for private notes without hideFromAgents', async () => {
+      const { shouldEmbed } = await import('../src/api/embeddings/note-integration.ts');
+
+      const result = shouldEmbed({
+        id: 'test',
+        title: 'Test',
+        content: 'Test',
+        visibility: 'private',
+        hideFromAgents: false,
+      });
+
+      expect(result).toBe(true);
+    });
+
+    it('should return true for public notes', async () => {
+      const { shouldEmbed } = await import('../src/api/embeddings/note-integration.ts');
+
+      const result = shouldEmbed({
+        id: 'test',
+        title: 'Test',
+        content: 'Test',
+        visibility: 'public',
+        hideFromAgents: false,
+      });
+
+      expect(result).toBe(true);
+    });
+
+    it('should return true for shared notes', async () => {
+      const { shouldEmbed } = await import('../src/api/embeddings/note-integration.ts');
+
+      const result = shouldEmbed({
+        id: 'test',
+        title: 'Test',
+        content: 'Test',
+        visibility: 'shared',
+        hideFromAgents: false,
+      });
+
+      expect(result).toBe(true);
+    });
+
+    it('should return true for public notes even with hideFromAgents', async () => {
+      const { shouldEmbed } = await import('../src/api/embeddings/note-integration.ts');
+
+      // Public notes are always searchable regardless of hideFromAgents
+      // (hideFromAgents is meant for private content only)
+      const result = shouldEmbed({
+        id: 'test',
+        title: 'Test',
+        content: 'Test',
+        visibility: 'public',
+        hideFromAgents: true,
+      });
+
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('Re-embedding on updates', () => {
+    it('should trigger re-embedding when title changes', async () => {
+      const note = await createNote({
+        title: 'Original Title',
+        content: 'Original content',
+      });
+
+      const updateResponse = await app.inject({
+        method: 'PUT',
+        url: `/api/notes/${note.id}`,
+        payload: {
+          user_email: testUserEmail,
+          title: 'Updated Title',
+        },
+      });
+
+      expect(updateResponse.statusCode).toBe(200);
+      const updatedNote = JSON.parse(updateResponse.payload);
+      expect(updatedNote.title).toBe('Updated Title');
+    });
+
+    it('should trigger re-embedding when content changes', async () => {
+      const note = await createNote({
+        title: 'Content Update Test',
+        content: 'Original content',
+      });
+
+      const updateResponse = await app.inject({
+        method: 'PUT',
+        url: `/api/notes/${note.id}`,
+        payload: {
+          user_email: testUserEmail,
+          content: 'Updated content for embedding',
+        },
+      });
+
+      expect(updateResponse.statusCode).toBe(200);
+    });
+
+    it('should trigger re-embedding when visibility changes', async () => {
+      const note = await createNote({
+        title: 'Visibility Update Test',
+        content: 'Content',
+        visibility: 'private',
+      });
+
+      const updateResponse = await app.inject({
+        method: 'PUT',
+        url: `/api/notes/${note.id}`,
+        payload: {
+          user_email: testUserEmail,
+          visibility: 'public',
+        },
+      });
+
+      expect(updateResponse.statusCode).toBe(200);
+      const updatedNote = JSON.parse(updateResponse.payload);
+      expect(updatedNote.visibility).toBe('public');
+    });
+
+    it('should trigger re-embedding when hideFromAgents changes', async () => {
+      const note = await createNote({
+        title: 'HideFromAgents Update Test',
+        content: 'Content',
+        hideFromAgents: false,
+      });
+
+      const updateResponse = await app.inject({
+        method: 'PUT',
+        url: `/api/notes/${note.id}`,
+        payload: {
+          user_email: testUserEmail,
+          hide_from_agents: true,  // API uses snake_case input
+        },
+      });
+
+      expect(updateResponse.statusCode).toBe(200);
+      const updatedNote = JSON.parse(updateResponse.payload);
+      expect(updatedNote.hideFromAgents).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Implements Issue #349: Note embeddings for semantic search
- Creates privacy-aware embedding system for notes
- Adds admin endpoints for backfill and status monitoring
- Adds semantic search endpoint with text fallback

## Changes

### New Files
- `src/api/embeddings/note-integration.ts` - Core embedding functions
- `tests/note_embeddings_api.test.ts` - Comprehensive test suite (25 tests)

### Modified Files  
- `src/api/embeddings/index.ts` - Export new module
- `src/api/notes/service.ts` - Trigger embeddings on create/update
- `src/api/server.ts` - Add admin and search endpoints

## Features

### Embedding Logic
- **shouldEmbed()**: Privacy-aware decision - skips private notes with hideFromAgents
- **embedNote()**: Generates and stores embedding for a single note
- **triggerNoteEmbedding()**: Async non-blocking trigger for background processing
- **backfillNoteEmbeddings()**: Bulk embedding generation with rate limiting
- **getNoteEmbeddingStats()**: Embedding status statistics
- **searchNotesSemantic()**: Semantic search with automatic text fallback

### API Endpoints
- `GET /api/admin/embeddings/status/notes` - View embedding statistics
- `POST /api/admin/embeddings/backfill/notes` - Backfill pending embeddings
- `POST /api/notes/search/semantic` - Search notes semantically with access control

### Privacy Model
- Private notes with `hideFromAgents=true` are skipped (status: 'skipped')
- Private notes without `hideFromAgents` are embedded (owner can search)
- Shared/public notes are always embedded

## Test Plan

- [x] Run note embedding tests: `npm test tests/note_embeddings_api.test.ts`
- [x] 25 tests passing covering:
  - Embedding status on create/update
  - Admin endpoints (status, backfill)
  - Semantic search with validation
  - Privacy/access control
  - shouldEmbed function logic
  - Re-embedding triggers

Closes #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)