### PR TITLE
[#346] Add note search with privacy filtering

### DIFF
--- a/src/api/notes/index.ts
+++ b/src/api/notes/index.ts
@@ -7,3 +7,4 @@ export * from './types.ts';
 export * from './service.ts';
 export * from './versions.ts';
 export * from './sharing.ts';
+export * from './search.ts';

--- a/src/api/notes/search.ts
+++ b/src/api/notes/search.ts
@@ -1,0 +1,541 @@
+/**
+ * Note search with privacy filtering.
+ * Part of Epic #337, Issue #346
+ *
+ * Implements:
+ * - Text search with ts_vector
+ * - Semantic search with embeddings
+ * - Hybrid search using Reciprocal Rank Fusion (RRF)
+ * - Privacy-aware filtering (owner, shared, public)
+ * - Agent visibility control (hideFromAgents)
+ */
+
+import type { Pool } from 'pg';
+import type { NoteVisibility } from './types.ts';
+
+export interface SearchResult {
+  id: string;
+  title: string;
+  snippet: string;
+  score: number;
+  notebookId: string | null;
+  notebookName: string | null;
+  tags: string[];
+  visibility: NoteVisibility;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface SearchOptions {
+  searchType?: 'hybrid' | 'text' | 'semantic';
+  notebookId?: string;
+  tags?: string[];
+  visibility?: NoteVisibility;
+  limit?: number;
+  offset?: number;
+  minSimilarity?: number;
+  isAgent?: boolean;
+}
+
+export interface SearchResponse {
+  query: string;
+  searchType: 'hybrid' | 'text' | 'semantic';
+  results: SearchResult[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export interface SimilarNote {
+  id: string;
+  title: string;
+  similarity: number;
+  snippet: string;
+}
+
+export interface SimilarNotesResponse {
+  note: { id: string; title: string };
+  similar: SimilarNote[];
+}
+
+/**
+ * Build the privacy-aware WHERE clause for note access.
+ * Handles owner, shared, public visibility and agent filtering.
+ */
+function buildAccessConditions(
+  userEmail: string,
+  isAgent: boolean,
+  paramIndex: number
+): { conditions: string[]; params: (string | boolean)[]; nextIndex: number } {
+  const conditions: string[] = [];
+  const params: (string | boolean)[] = [];
+
+  // Base condition: not deleted
+  conditions.push('n.deleted_at IS NULL');
+
+  // Access control: owner OR public OR shared
+  conditions.push(`(
+    n.user_email = $${paramIndex}
+    OR n.visibility = 'public'
+    OR (n.visibility = 'shared' AND EXISTS (
+      SELECT 1 FROM note_share ns
+      WHERE ns.note_id = n.id
+        AND ns.shared_with_email = $${paramIndex}
+        AND (ns.expires_at IS NULL OR ns.expires_at > NOW())
+    ))
+    OR (n.visibility = 'shared' AND n.notebook_id IS NOT NULL AND EXISTS (
+      SELECT 1 FROM notebook_share nbs
+      WHERE nbs.notebook_id = n.notebook_id
+        AND nbs.shared_with_email = $${paramIndex}
+        AND (nbs.expires_at IS NULL OR nbs.expires_at > NOW())
+    ))
+  )`);
+  params.push(userEmail);
+  paramIndex++;
+
+  // Agent filtering: agents cannot see private notes or notes with hideFromAgents
+  if (isAgent) {
+    conditions.push(`(n.visibility != 'private' AND n.hide_from_agents = false)`);
+  }
+
+  return { conditions, params, nextIndex: paramIndex };
+}
+
+/**
+ * Perform full-text search using PostgreSQL tsvector.
+ */
+export async function textSearch(
+  pool: Pool,
+  query: string,
+  userEmail: string,
+  options: SearchOptions = {}
+): Promise<{ results: SearchResult[]; total: number }> {
+  const { notebookId, tags, visibility, limit = 20, offset = 0, isAgent = false } = options;
+
+  const { conditions, params, nextIndex } = buildAccessConditions(userEmail, isAgent, 1);
+  let paramIndex = nextIndex;
+
+  // Add query parameter
+  params.push(query);
+  const queryParamIndex = paramIndex++;
+
+  // Add optional filters
+  if (notebookId) {
+    conditions.push(`n.notebook_id = $${paramIndex}`);
+    params.push(notebookId);
+    paramIndex++;
+  }
+
+  if (tags && tags.length > 0) {
+    conditions.push(`n.tags && $${paramIndex}`);
+    params.push(tags as unknown as string);
+    paramIndex++;
+  }
+
+  if (visibility) {
+    conditions.push(`n.visibility = $${paramIndex}`);
+    params.push(visibility);
+    paramIndex++;
+  }
+
+  // Add text search condition
+  conditions.push(`n.search_vector @@ websearch_to_tsquery('english', $${queryParamIndex})`);
+
+  const whereClause = conditions.join(' AND ');
+
+  // Get total count
+  const countResult = await pool.query(
+    `SELECT COUNT(*) as total
+     FROM note n
+     WHERE ${whereClause}`,
+    params
+  );
+  const total = parseInt(countResult.rows[0].total, 10);
+
+  // Add pagination params
+  params.push(limit as unknown as string);
+  const limitParamIndex = paramIndex++;
+  params.push(offset as unknown as string);
+  const offsetParamIndex = paramIndex++;
+
+  // Execute search with ranking and highlighting
+  const result = await pool.query(
+    `SELECT
+      n.id::text,
+      n.title,
+      n.content,
+      n.notebook_id::text as "notebookId",
+      nb.name as "notebookName",
+      n.tags,
+      n.visibility,
+      n.created_at as "createdAt",
+      n.updated_at as "updatedAt",
+      ts_rank_cd(n.search_vector, websearch_to_tsquery('english', $${queryParamIndex}), 32) as score,
+      ts_headline('english', n.content, websearch_to_tsquery('english', $${queryParamIndex}),
+        'StartSel=<mark>, StopSel=</mark>, MaxWords=50, MinWords=25, MaxFragments=2'
+      ) as snippet
+    FROM note n
+    LEFT JOIN notebook nb ON n.notebook_id = nb.id
+    WHERE ${whereClause}
+    ORDER BY score DESC
+    LIMIT $${limitParamIndex} OFFSET $${offsetParamIndex}`,
+    params
+  );
+
+  return {
+    results: result.rows.map((row) => ({
+      id: row.id,
+      title: row.title,
+      snippet: row.snippet || row.content?.substring(0, 200) || '',
+      score: parseFloat(row.score) || 0,
+      notebookId: row.notebookId,
+      notebookName: row.notebookName,
+      tags: row.tags || [],
+      visibility: row.visibility,
+      createdAt: new Date(row.createdAt),
+      updatedAt: new Date(row.updatedAt),
+    })),
+    total,
+  };
+}
+
+/**
+ * Perform semantic search using vector embeddings.
+ */
+export async function semanticSearch(
+  pool: Pool,
+  query: string,
+  userEmail: string,
+  options: SearchOptions = {}
+): Promise<{ results: SearchResult[]; total: number }> {
+  const {
+    notebookId,
+    tags,
+    visibility,
+    limit = 20,
+    offset = 0,
+    minSimilarity = 0.3,
+    isAgent = false,
+  } = options;
+
+  // Import embedding service lazily
+  const { embeddingService } = await import('../embeddings/service.js');
+
+  // Check if embedding service is configured
+  if (!embeddingService.isConfigured()) {
+    // Fall back to text search
+    return textSearch(pool, query, userEmail, options);
+  }
+
+  // Generate embedding for query
+  let queryEmbedding: number[] | null = null;
+  try {
+    const result = await embeddingService.embed(query);
+    if (result) {
+      queryEmbedding = result.embedding;
+    }
+  } catch (error) {
+    console.warn('[Search] Query embedding failed, falling back to text search');
+    return textSearch(pool, query, userEmail, options);
+  }
+
+  if (!queryEmbedding) {
+    return textSearch(pool, query, userEmail, options);
+  }
+
+  const { conditions, params, nextIndex } = buildAccessConditions(userEmail, isAgent, 1);
+  let paramIndex = nextIndex;
+
+  // Add embedding condition
+  conditions.push(`n.embedding IS NOT NULL AND n.embedding_status = 'complete'`);
+
+  // Add optional filters
+  if (notebookId) {
+    conditions.push(`n.notebook_id = $${paramIndex}`);
+    params.push(notebookId);
+    paramIndex++;
+  }
+
+  if (tags && tags.length > 0) {
+    conditions.push(`n.tags && $${paramIndex}`);
+    params.push(tags as unknown as string);
+    paramIndex++;
+  }
+
+  if (visibility) {
+    conditions.push(`n.visibility = $${paramIndex}`);
+    params.push(visibility);
+    paramIndex++;
+  }
+
+  // Add embedding parameter
+  const embeddingStr = `[${queryEmbedding.join(',')}]`;
+  params.push(embeddingStr);
+  const embeddingParamIndex = paramIndex++;
+
+  // Add similarity threshold
+  params.push(minSimilarity as unknown as string);
+  const minSimParamIndex = paramIndex++;
+
+  const whereClause = conditions.join(' AND ');
+  const similarityCondition = `1 - (n.embedding <=> $${embeddingParamIndex}::vector) >= $${minSimParamIndex}`;
+
+  // Get total count (with similarity threshold)
+  const countResult = await pool.query(
+    `SELECT COUNT(*) as total
+     FROM note n
+     WHERE ${whereClause} AND ${similarityCondition}`,
+    params
+  );
+  const total = parseInt(countResult.rows[0].total, 10);
+
+  // Add pagination params
+  params.push(limit as unknown as string);
+  const limitParamIndex = paramIndex++;
+  params.push(offset as unknown as string);
+  const offsetParamIndex = paramIndex++;
+
+  // Execute semantic search
+  const result = await pool.query(
+    `SELECT
+      n.id::text,
+      n.title,
+      n.content,
+      n.notebook_id::text as "notebookId",
+      nb.name as "notebookName",
+      n.tags,
+      n.visibility,
+      n.created_at as "createdAt",
+      n.updated_at as "updatedAt",
+      1 - (n.embedding <=> $${embeddingParamIndex}::vector) as score,
+      LEFT(n.content, 200) as snippet
+    FROM note n
+    LEFT JOIN notebook nb ON n.notebook_id = nb.id
+    WHERE ${whereClause} AND ${similarityCondition}
+    ORDER BY n.embedding <=> $${embeddingParamIndex}::vector
+    LIMIT $${limitParamIndex} OFFSET $${offsetParamIndex}`,
+    params
+  );
+
+  return {
+    results: result.rows.map((row) => ({
+      id: row.id,
+      title: row.title,
+      snippet: row.snippet || '',
+      score: parseFloat(row.score) || 0,
+      notebookId: row.notebookId,
+      notebookName: row.notebookName,
+      tags: row.tags || [],
+      visibility: row.visibility,
+      createdAt: new Date(row.createdAt),
+      updatedAt: new Date(row.updatedAt),
+    })),
+    total,
+  };
+}
+
+/**
+ * Reciprocal Rank Fusion combines results from multiple search methods.
+ * RRF(d) = Σ 1 / (k + rank(d)) for each ranking
+ * k=60 is a common constant that reduces the impact of high rankings
+ */
+function reciprocalRankFusion(
+  textResults: SearchResult[],
+  semanticResults: SearchResult[],
+  k = 60
+): SearchResult[] {
+  const scores = new Map<string, { score: number; result: SearchResult; hasTextSnippet: boolean }>();
+
+  // Score from text search (prefer these snippets as they have highlights)
+  textResults.forEach((result, index) => {
+    const rrf = 1 / (k + index + 1);
+    scores.set(result.id, { score: rrf, result, hasTextSnippet: true });
+  });
+
+  // Score from semantic search
+  semanticResults.forEach((result, index) => {
+    const rrf = 1 / (k + index + 1);
+    const existing = scores.get(result.id);
+    if (existing) {
+      existing.score += rrf;
+      // Keep text snippet if available (has highlights)
+    } else {
+      scores.set(result.id, { score: rrf, result, hasTextSnippet: false });
+    }
+  });
+
+  // Sort by combined RRF score
+  return Array.from(scores.values())
+    .sort((a, b) => b.score - a.score)
+    .map(({ result, score }) => ({ ...result, score }));
+}
+
+/**
+ * Perform hybrid search combining text and semantic search with RRF.
+ */
+export async function hybridSearch(
+  pool: Pool,
+  query: string,
+  userEmail: string,
+  options: SearchOptions = {}
+): Promise<{ results: SearchResult[]; total: number }> {
+  const { limit = 20, offset = 0 } = options;
+
+  // Run both searches in parallel, fetching more results for fusion
+  const fetchLimit = Math.max(limit * 2, 40);
+  const [textResult, semanticResult] = await Promise.all([
+    textSearch(pool, query, userEmail, { ...options, limit: fetchLimit, offset: 0 }),
+    semanticSearch(pool, query, userEmail, { ...options, limit: fetchLimit, offset: 0 }),
+  ]);
+
+  // Combine with RRF
+  const combined = reciprocalRankFusion(textResult.results, semanticResult.results);
+
+  // Apply pagination
+  const paginatedResults = combined.slice(offset, offset + limit);
+
+  // Total is approximate (max of both searches)
+  const total = Math.max(textResult.total, semanticResult.total);
+
+  return {
+    results: paginatedResults,
+    total,
+  };
+}
+
+/**
+ * Main search function that routes to appropriate search method.
+ */
+export async function searchNotes(
+  pool: Pool,
+  query: string,
+  userEmail: string,
+  options: SearchOptions = {}
+): Promise<SearchResponse> {
+  const { searchType = 'hybrid', limit = 20, offset = 0 } = options;
+
+  let result: { results: SearchResult[]; total: number };
+
+  switch (searchType) {
+    case 'text':
+      result = await textSearch(pool, query, userEmail, options);
+      break;
+    case 'semantic':
+      result = await semanticSearch(pool, query, userEmail, options);
+      break;
+    case 'hybrid':
+    default:
+      result = await hybridSearch(pool, query, userEmail, options);
+      break;
+  }
+
+  return {
+    query,
+    searchType,
+    results: result.results,
+    total: result.total,
+    limit,
+    offset,
+  };
+}
+
+/**
+ * Find notes similar to a given note using embedding similarity.
+ */
+export async function findSimilarNotes(
+  pool: Pool,
+  noteId: string,
+  userEmail: string,
+  options: { limit?: number; minSimilarity?: number; isAgent?: boolean } = {}
+): Promise<SimilarNotesResponse | null> {
+  const { limit = 5, minSimilarity = 0.5, isAgent = false } = options;
+
+  // First, get the source note and verify access
+  const noteResult = await pool.query(
+    `SELECT
+      n.id::text, n.title, n.embedding, n.visibility, n.user_email
+    FROM note n
+    WHERE n.id = $1 AND n.deleted_at IS NULL`,
+    [noteId]
+  );
+
+  if (noteResult.rows.length === 0) {
+    return null;
+  }
+
+  const sourceNote = noteResult.rows[0];
+
+  // Check if user can access the note
+  const canAccess =
+    sourceNote.user_email === userEmail ||
+    sourceNote.visibility === 'public' ||
+    sourceNote.visibility === 'shared';
+
+  if (!canAccess) {
+    // Check for shares
+    const shareResult = await pool.query(
+      `SELECT 1 FROM note_share
+       WHERE note_id = $1 AND shared_with_email = $2
+         AND (expires_at IS NULL OR expires_at > NOW())
+       LIMIT 1`,
+      [noteId, userEmail]
+    );
+    if (shareResult.rows.length === 0) {
+      return null;
+    }
+  }
+
+  // If source note has no embedding, return empty similar list
+  if (!sourceNote.embedding) {
+    return {
+      note: { id: sourceNote.id, title: sourceNote.title },
+      similar: [],
+    };
+  }
+
+  // Build access conditions for similar notes
+  const { conditions, params, nextIndex } = buildAccessConditions(userEmail, isAgent, 1);
+  let paramIndex = nextIndex;
+
+  // Exclude the source note
+  conditions.push(`n.id != $${paramIndex}`);
+  params.push(noteId);
+  paramIndex++;
+
+  // Only notes with embeddings
+  conditions.push(`n.embedding IS NOT NULL AND n.embedding_status = 'complete'`);
+
+  // Add similarity threshold
+  params.push(minSimilarity as unknown as string);
+  const minSimParamIndex = paramIndex++;
+
+  params.push(limit as unknown as string);
+  const limitParamIndex = paramIndex++;
+
+  const whereClause = conditions.join(' AND ');
+
+  // Find similar notes using the source note's embedding
+  const result = await pool.query(
+    `SELECT
+      n.id::text,
+      n.title,
+      LEFT(n.content, 200) as snippet,
+      1 - (n.embedding <=> (SELECT embedding FROM note WHERE id = $${paramIndex})) as similarity
+    FROM note n
+    WHERE ${whereClause}
+      AND 1 - (n.embedding <=> (SELECT embedding FROM note WHERE id = $${paramIndex})) >= $${minSimParamIndex}
+    ORDER BY n.embedding <=> (SELECT embedding FROM note WHERE id = $${paramIndex})
+    LIMIT $${limitParamIndex}`,
+    [...params, noteId]
+  );
+
+  return {
+    note: { id: sourceNote.id, title: sourceNote.title },
+    similar: result.rows.map((row) => ({
+      id: row.id,
+      title: row.title,
+      similarity: parseFloat(row.similarity) || 0,
+      snippet: row.snippet || '',
+    })),
+  };
+}

--- a/tests/note_search_api.test.ts
+++ b/tests/note_search_api.test.ts
@@ -1,0 +1,587 @@
+/**
+ * Tests for note search with privacy filtering.
+ * Part of Epic #337, Issue #346
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import type { Pool } from 'pg';
+import { buildServer } from '../src/api/server.ts';
+import { createPool } from '../src/db.ts';
+
+// Mock the embedding service module
+vi.mock('../src/api/embeddings/service.ts', () => ({
+  embeddingService: {
+    isConfigured: vi.fn(() => true),
+    embed: vi.fn(async (text: string) => ({
+      embedding: new Array(1024).fill(0).map((_, i) => Math.sin(i + text.length * 0.1)),
+      model: 'test-model',
+      provider: 'test-provider',
+    })),
+    getConfig: vi.fn(() => ({
+      provider: 'test-provider',
+      model: 'test-model',
+    })),
+  },
+}));
+
+describe('Note Search API', () => {
+  let app: FastifyInstance;
+  let pool: Pool;
+  const ownerEmail = 'search-owner@example.com';
+  const sharedUserEmail = 'search-shared@example.com';
+  const otherUserEmail = 'search-other@example.com';
+
+  // Track created notes for cleanup
+  const createdNoteIds: string[] = [];
+  const createdNotebookIds: string[] = [];
+
+  beforeAll(async () => {
+    app = await buildServer();
+    pool = createPool();
+
+    // Clean up any existing test data
+    await pool.query(`DELETE FROM note WHERE user_email LIKE 'search-%@example.com'`);
+    await pool.query(`DELETE FROM notebook WHERE user_email LIKE 'search-%@example.com'`);
+
+    // Create test notebook
+    const notebookResult = await pool.query(
+      `INSERT INTO notebook (user_email, name) VALUES ($1, $2) RETURNING id::text`,
+      [ownerEmail, 'Test Search Notebook']
+    );
+    createdNotebookIds.push(notebookResult.rows[0].id);
+
+    // Create various test notes for search testing
+    const notes = [
+      {
+        title: 'TypeScript Programming Guide',
+        content: 'A comprehensive guide to TypeScript programming language with examples',
+        visibility: 'public',
+        hideFromAgents: false,
+        tags: ['programming', 'typescript'],
+      },
+      {
+        title: 'Python Data Science',
+        content: 'Learn Python for data science and machine learning applications',
+        visibility: 'public',
+        hideFromAgents: false,
+        tags: ['programming', 'python', 'data-science'],
+      },
+      {
+        title: 'Private Shopping List',
+        content: 'Milk, bread, eggs, and vegetables',
+        visibility: 'private',
+        hideFromAgents: false,
+        tags: ['personal'],
+      },
+      {
+        title: 'Hidden Agent Note',
+        content: 'This note contains private information hidden from agents',
+        visibility: 'private',
+        hideFromAgents: true,
+        tags: ['private'],
+      },
+      {
+        title: 'Shared Team Notes',
+        content: 'Meeting notes and action items for the team',
+        visibility: 'shared',
+        hideFromAgents: false,
+        tags: ['work', 'meetings'],
+      },
+      {
+        title: 'React Components',
+        content: 'Building reusable React components with TypeScript',
+        visibility: 'public',
+        hideFromAgents: false,
+        tags: ['programming', 'react', 'typescript'],
+      },
+    ];
+
+    for (const note of notes) {
+      const result = await pool.query(
+        `INSERT INTO note (
+          user_email, title, content, visibility, hide_from_agents, tags, notebook_id
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7)
+        RETURNING id::text`,
+        [
+          ownerEmail,
+          note.title,
+          note.content,
+          note.visibility,
+          note.hideFromAgents,
+          note.tags,
+          note.visibility === 'public' ? createdNotebookIds[0] : null,
+        ]
+      );
+      createdNoteIds.push(result.rows[0].id);
+    }
+
+    // Create a share for the shared note
+    const sharedNoteId = createdNoteIds[4]; // 'Shared Team Notes'
+    await pool.query(
+      `INSERT INTO note_share (note_id, shared_with_email, permission, created_by_email)
+       VALUES ($1, $2, $3, $4)`,
+      [sharedNoteId, sharedUserEmail, 'read', ownerEmail]
+    );
+
+    // Wait for search index to update
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  });
+
+  afterAll(async () => {
+    // Clean up test data
+    await pool.query(`DELETE FROM note WHERE user_email LIKE 'search-%@example.com'`);
+    await pool.query(`DELETE FROM notebook WHERE user_email LIKE 'search-%@example.com'`);
+
+    await pool.end();
+    await app.close();
+  });
+
+  describe('GET /api/notes/search', () => {
+    it('should require user_email', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/notes/search?q=test',
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(JSON.parse(response.payload).error).toBe('user_email is required');
+    });
+
+    it('should require search query', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/notes/search?user_email=${ownerEmail}`,
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(JSON.parse(response.payload).error).toBe('q (search query) is required');
+    });
+
+    it('should search notes with text search', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/notes/search?user_email=${ownerEmail}&q=TypeScript&searchType=text`,
+      });
+
+      expect(response.statusCode).toBe(200);
+
+      const result = JSON.parse(response.payload);
+      expect(result.query).toBe('TypeScript');
+      expect(result.searchType).toBe('text');
+      expect(result.results.length).toBeGreaterThan(0);
+
+      // Should find TypeScript related notes
+      const titles = result.results.map((r: { title: string }) => r.title);
+      expect(titles).toContain('TypeScript Programming Guide');
+    });
+
+    it('should search notes with semantic search', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/notes/search?user_email=${ownerEmail}&q=programming%20languages&searchType=semantic`,
+      });
+
+      expect(response.statusCode).toBe(200);
+
+      const result = JSON.parse(response.payload);
+      expect(result.searchType).toBe('semantic');
+      expect(Array.isArray(result.results)).toBe(true);
+    });
+
+    it('should search notes with hybrid search (default)', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/notes/search?user_email=${ownerEmail}&q=programming`,
+      });
+
+      expect(response.statusCode).toBe(200);
+
+      const result = JSON.parse(response.payload);
+      expect(result.searchType).toBe('hybrid');
+      expect(result.results.length).toBeGreaterThan(0);
+    });
+
+    it('should return search result fields', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/notes/search?user_email=${ownerEmail}&q=TypeScript&searchType=text`,
+      });
+
+      expect(response.statusCode).toBe(200);
+
+      const result = JSON.parse(response.payload);
+      expect(result).toHaveProperty('query');
+      expect(result).toHaveProperty('searchType');
+      expect(result).toHaveProperty('results');
+      expect(result).toHaveProperty('total');
+      expect(result).toHaveProperty('limit');
+      expect(result).toHaveProperty('offset');
+
+      if (result.results.length > 0) {
+        const firstResult = result.results[0];
+        expect(firstResult).toHaveProperty('id');
+        expect(firstResult).toHaveProperty('title');
+        expect(firstResult).toHaveProperty('snippet');
+        expect(firstResult).toHaveProperty('score');
+        expect(firstResult).toHaveProperty('tags');
+        expect(firstResult).toHaveProperty('visibility');
+      }
+    });
+
+    it('should filter by notebook', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/notes/search?user_email=${ownerEmail}&q=programming&notebookId=${createdNotebookIds[0]}`,
+      });
+
+      expect(response.statusCode).toBe(200);
+
+      const result = JSON.parse(response.payload);
+      // All results should be in the specified notebook
+      for (const r of result.results) {
+        expect(r.notebookId).toBe(createdNotebookIds[0]);
+      }
+    });
+
+    it('should filter by tags', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/notes/search?user_email=${ownerEmail}&q=programming&tags=typescript`,
+      });
+
+      expect(response.statusCode).toBe(200);
+
+      const result = JSON.parse(response.payload);
+      // All results should have the typescript tag
+      for (const r of result.results) {
+        expect(r.tags).toContain('typescript');
+      }
+    });
+
+    it('should filter by visibility', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/notes/search?user_email=${ownerEmail}&q=*&visibility=public&searchType=text`,
+      });
+
+      expect(response.statusCode).toBe(200);
+
+      const result = JSON.parse(response.payload);
+      // All results should be public
+      for (const r of result.results) {
+        expect(r.visibility).toBe('public');
+      }
+    });
+
+    it('should respect pagination', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/notes/search?user_email=${ownerEmail}&q=programming&limit=2&offset=0`,
+      });
+
+      expect(response.statusCode).toBe(200);
+
+      const result = JSON.parse(response.payload);
+      expect(result.limit).toBe(2);
+      expect(result.offset).toBe(0);
+      expect(result.results.length).toBeLessThanOrEqual(2);
+    });
+
+    it('should enforce max limit of 50', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/notes/search?user_email=${ownerEmail}&q=programming&limit=100`,
+      });
+
+      expect(response.statusCode).toBe(200);
+
+      const result = JSON.parse(response.payload);
+      expect(result.limit).toBeLessThanOrEqual(50);
+    });
+  });
+
+  describe('Privacy Filtering', () => {
+    it('should allow owner to see their private notes', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/notes/search?user_email=${ownerEmail}&q=shopping&searchType=text`,
+      });
+
+      expect(response.statusCode).toBe(200);
+
+      const result = JSON.parse(response.payload);
+      const titles = result.results.map((r: { title: string }) => r.title);
+      expect(titles).toContain('Private Shopping List');
+    });
+
+    it('should not show private notes to other users', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/notes/search?user_email=${otherUserEmail}&q=shopping&searchType=text`,
+      });
+
+      expect(response.statusCode).toBe(200);
+
+      const result = JSON.parse(response.payload);
+      const titles = result.results.map((r: { title: string }) => r.title);
+      expect(titles).not.toContain('Private Shopping List');
+    });
+
+    it('should show public notes to any user', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/notes/search?user_email=${otherUserEmail}&q=TypeScript&searchType=text`,
+      });
+
+      expect(response.statusCode).toBe(200);
+
+      const result = JSON.parse(response.payload);
+      const titles = result.results.map((r: { title: string }) => r.title);
+      expect(titles).toContain('TypeScript Programming Guide');
+    });
+
+    it('should show shared notes to users with share access', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/notes/search?user_email=${sharedUserEmail}&q=team&searchType=text`,
+      });
+
+      expect(response.statusCode).toBe(200);
+
+      const result = JSON.parse(response.payload);
+      const titles = result.results.map((r: { title: string }) => r.title);
+      expect(titles).toContain('Shared Team Notes');
+    });
+
+    it('should not show shared notes to users without share access', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/notes/search?user_email=${otherUserEmail}&q=team&searchType=text`,
+      });
+
+      expect(response.statusCode).toBe(200);
+
+      const result = JSON.parse(response.payload);
+      const titles = result.results.map((r: { title: string }) => r.title);
+      expect(titles).not.toContain('Shared Team Notes');
+    });
+  });
+
+  describe('Agent Filtering', () => {
+    it('should hide private notes from agents', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/notes/search?user_email=${ownerEmail}&q=shopping&searchType=text`,
+        headers: {
+          'X-OpenClaw-Agent': 'test-agent-123',
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+
+      const result = JSON.parse(response.payload);
+      const titles = result.results.map((r: { title: string }) => r.title);
+      // Private notes should be hidden from agents
+      expect(titles).not.toContain('Private Shopping List');
+    });
+
+    it('should hide notes with hideFromAgents flag from agents', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/notes/search?user_email=${ownerEmail}&q=private&searchType=text`,
+        headers: {
+          'X-OpenClaw-Agent': 'test-agent-123',
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+
+      const result = JSON.parse(response.payload);
+      const titles = result.results.map((r: { title: string }) => r.title);
+      expect(titles).not.toContain('Hidden Agent Note');
+    });
+
+    it('should show public notes to agents', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/notes/search?user_email=${ownerEmail}&q=TypeScript&searchType=text`,
+        headers: {
+          'X-OpenClaw-Agent': 'test-agent-123',
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+
+      const result = JSON.parse(response.payload);
+      const titles = result.results.map((r: { title: string }) => r.title);
+      expect(titles).toContain('TypeScript Programming Guide');
+    });
+
+    it('should detect agent via authorization header', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/notes/search?user_email=${ownerEmail}&q=shopping&searchType=text`,
+        headers: {
+          Authorization: 'Bearer agent:test-token',
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+
+      const result = JSON.parse(response.payload);
+      const titles = result.results.map((r: { title: string }) => r.title);
+      // Private notes should be hidden from agents
+      expect(titles).not.toContain('Private Shopping List');
+    });
+  });
+
+  describe('GET /api/notes/:id/similar', () => {
+    it('should require user_email', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/notes/${createdNoteIds[0]}/similar`,
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(JSON.parse(response.payload).error).toBe('user_email is required');
+    });
+
+    it('should return 404 for non-existent note', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/notes/00000000-0000-0000-0000-000000000000/similar?user_email=${ownerEmail}`,
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+
+    it('should return 404 if user does not have access', async () => {
+      // Try to access owner's private note as other user
+      const privateNoteId = createdNoteIds[2]; // 'Private Shopping List'
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/notes/${privateNoteId}/similar?user_email=${otherUserEmail}`,
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+
+    it('should find similar notes for accessible note', async () => {
+      const publicNoteId = createdNoteIds[0]; // 'TypeScript Programming Guide'
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/notes/${publicNoteId}/similar?user_email=${ownerEmail}`,
+      });
+
+      expect(response.statusCode).toBe(200);
+
+      const result = JSON.parse(response.payload);
+      expect(result).toHaveProperty('note');
+      expect(result).toHaveProperty('similar');
+      expect(result.note.id).toBe(publicNoteId);
+      expect(result.note.title).toBe('TypeScript Programming Guide');
+      expect(Array.isArray(result.similar)).toBe(true);
+    });
+
+    it('should respect limit parameter', async () => {
+      const publicNoteId = createdNoteIds[0];
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/notes/${publicNoteId}/similar?user_email=${ownerEmail}&limit=2`,
+      });
+
+      expect(response.statusCode).toBe(200);
+
+      const result = JSON.parse(response.payload);
+      expect(result.similar.length).toBeLessThanOrEqual(2);
+    });
+
+    it('should enforce max limit of 20', async () => {
+      const publicNoteId = createdNoteIds[0];
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/notes/${publicNoteId}/similar?user_email=${ownerEmail}&limit=100`,
+      });
+
+      expect(response.statusCode).toBe(200);
+      // The limit should be capped at 20
+    });
+
+    it('should respect minSimilarity parameter', async () => {
+      const publicNoteId = createdNoteIds[0];
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/notes/${publicNoteId}/similar?user_email=${ownerEmail}&minSimilarity=0.9`,
+      });
+
+      expect(response.statusCode).toBe(200);
+
+      const result = JSON.parse(response.payload);
+      // All similar notes should have similarity >= 0.9
+      for (const similar of result.similar) {
+        expect(similar.similarity).toBeGreaterThanOrEqual(0.9);
+      }
+    });
+
+    it('should filter similar notes based on agent access', async () => {
+      const publicNoteId = createdNoteIds[0];
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/notes/${publicNoteId}/similar?user_email=${ownerEmail}`,
+        headers: {
+          'X-OpenClaw-Agent': 'test-agent-123',
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+
+      const result = JSON.parse(response.payload);
+      // Should not include any private notes or hideFromAgents notes in similar
+      const titles = result.similar.map((s: { title: string }) => s.title);
+      expect(titles).not.toContain('Private Shopping List');
+      expect(titles).not.toContain('Hidden Agent Note');
+    });
+  });
+
+  describe('Search Result Snippets', () => {
+    it('should include highlighted snippets in text search', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/notes/search?user_email=${ownerEmail}&q=TypeScript&searchType=text`,
+      });
+
+      expect(response.statusCode).toBe(200);
+
+      const result = JSON.parse(response.payload);
+      if (result.results.length > 0) {
+        const firstResult = result.results[0];
+        expect(firstResult.snippet).toBeDefined();
+        // Text search snippets may contain <mark> tags
+        if (firstResult.snippet.includes('TypeScript')) {
+          // Either has mark tags or contains the search term
+          expect(
+            firstResult.snippet.includes('<mark>') ||
+              firstResult.snippet.toLowerCase().includes('typescript')
+          ).toBe(true);
+        }
+      }
+    });
+  });
+
+  describe('Reciprocal Rank Fusion', () => {
+    it('should combine text and semantic results in hybrid search', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/notes/search?user_email=${ownerEmail}&q=programming%20guide`,
+      });
+
+      expect(response.statusCode).toBe(200);
+
+      const result = JSON.parse(response.payload);
+      expect(result.searchType).toBe('hybrid');
+      // RRF should produce results even if one search type fails
+      expect(result.results).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Implements Issue #346: Note search with privacy filtering
- Adds text search, semantic search, and hybrid search (RRF)
- Implements comprehensive privacy controls for owner/shared/public visibility
- Adds agent detection and filtering (hideFromAgents)

## Changes

### New Files
- `src/api/notes/search.ts` - Search implementation with RRF
- `tests/note_search_api.test.ts` - Comprehensive test suite (30 tests)

### Modified Files
- `src/api/notes/index.ts` - Export search module
- `src/api/server.ts` - Add search endpoints

## Features

### Search Types
- **Text Search**: Full-text using PostgreSQL tsvector with ts_rank_cd ranking
- **Semantic Search**: Vector similarity using embeddings with pgvector
- **Hybrid Search**: Reciprocal Rank Fusion (RRF) combining both methods

### API Endpoints
- `GET /api/notes/search` - Full search with filters
  - `q` - Search query (required)
  - `searchType` - hybrid, text, or semantic (default: hybrid)
  - `notebookId` - Filter by notebook
  - `tags` - Filter by tags (comma-separated)
  - `visibility` - Filter by visibility
  - `limit` - Results limit (max 50)
  - `offset` - Pagination offset
  - `minSimilarity` - Threshold for semantic search

- `GET /api/notes/:id/similar` - Find similar notes
  - `limit` - Results limit (max 20)
  - `minSimilarity` - Similarity threshold (default 0.5)

### Privacy Model
- Owner always sees their notes
- Public notes visible to all users
- Shared notes visible to users with active shares (direct or via notebook)
- Expired shares do not grant access

### Agent Filtering
- Detect agents via `X-OpenClaw-Agent` header
- Detect agents via `agent:` prefix in Authorization header
- Agents cannot see private notes
- Agents cannot see notes with `hideFromAgents=true`

## Test Plan

- [x] Run note search tests: `npm test tests/note_search_api.test.ts`
- [x] 30 tests passing covering:
  - Search endpoint validation
  - Text, semantic, and hybrid search
  - Filter by notebook, tags, visibility
  - Pagination
  - Privacy filtering (owner/shared/public)
  - Agent filtering (hideFromAgents)
  - Similar notes endpoint

Closes #346

🤖 Generated with [Claude Code](https://claude.com/claude-code)