### PR TITLE
[#359-364] Add note and notebook tools for OpenClaw plugin

### DIFF
--- a/packages/openclaw-plugin/src/api-client.ts
+++ b/packages/openclaw-plugin/src/api-client.ts
@@ -28,6 +28,8 @@ export interface RequestOptions {
   userId?: string
   /** Custom timeout (overrides config) */
   timeout?: number
+  /** Mark request as coming from an agent (adds X-OpenClaw-Agent header) */
+  isAgent?: boolean
 }
 
 /** API client options */
@@ -199,6 +201,11 @@ export class ApiClient {
 
       if (options?.userId) {
         headers['X-Agent-Id'] = options.userId
+      }
+
+      // Mark request as coming from an agent for privacy filtering
+      if (options?.isAgent) {
+        headers['X-OpenClaw-Agent'] = options.userId || 'plugin-agent'
       }
 
       const response = await fetch(url, {

--- a/packages/openclaw-plugin/src/config.ts
+++ b/packages/openclaw-plugin/src/config.ts
@@ -140,6 +140,9 @@ export const RawPluginConfigSchema = z
 
     /** Enable debug logging (never logs secrets) */
     debug: z.boolean().default(false).describe('Enable debug logging'),
+
+    /** Base URL for web app (used for generating note/notebook URLs) */
+    baseUrl: z.string().url().optional().describe('Web app base URL'),
   })
   .refine(
     (data) => data.apiKey || data.apiKeyFile || data.apiKeyCommand,
@@ -203,6 +206,9 @@ export const PluginConfigSchema = z.object({
 
   /** Enable debug logging */
   debug: z.boolean().default(false),
+
+  /** Base URL for web app */
+  baseUrl: z.string().url().optional(),
 })
 
 export type PluginConfig = z.infer<typeof PluginConfigSchema>
@@ -341,6 +347,7 @@ export async function resolveConfigSecrets(rawConfig: RawPluginConfig): Promise<
     timeout: rawConfig.timeout,
     maxRetries: rawConfig.maxRetries,
     debug: rawConfig.debug,
+    baseUrl: rawConfig.baseUrl,
   }
 
   // Validate the resolved config

--- a/packages/openclaw-plugin/src/tools/index.ts
+++ b/packages/openclaw-plugin/src/tools/index.ts
@@ -142,6 +142,59 @@ export {
   type ThreadToolOptions,
 } from './threads.js'
 
+// Note tools
+export {
+  createNoteCreateTool,
+  createNoteGetTool,
+  createNoteUpdateTool,
+  createNoteDeleteTool,
+  createNoteSearchTool,
+  NoteCreateParamsSchema,
+  NoteGetParamsSchema,
+  NoteUpdateParamsSchema,
+  NoteDeleteParamsSchema,
+  NoteSearchParamsSchema,
+  NoteVisibility,
+  type NoteCreateParams,
+  type NoteGetParams,
+  type NoteUpdateParams,
+  type NoteDeleteParams,
+  type NoteSearchParams,
+  type NoteCreateTool,
+  type NoteGetTool,
+  type NoteUpdateTool,
+  type NoteDeleteTool,
+  type NoteSearchTool,
+  type NoteCreateResult,
+  type NoteGetResult,
+  type NoteUpdateResult,
+  type NoteDeleteResult,
+  type NoteSearchToolResult,
+  type Note,
+  type NoteToolOptions,
+} from './notes.js'
+
+// Notebook tools
+export {
+  createNotebookListTool,
+  createNotebookCreateTool,
+  createNotebookGetTool,
+  NotebookListParamsSchema,
+  NotebookCreateParamsSchema,
+  NotebookGetParamsSchema,
+  type NotebookListParams,
+  type NotebookCreateParams,
+  type NotebookGetParams,
+  type NotebookListTool,
+  type NotebookCreateTool,
+  type NotebookGetTool,
+  type NotebookListResult,
+  type NotebookCreateResult,
+  type NotebookGetResult,
+  type Notebook,
+  type NotebookToolOptions,
+} from './notebooks.js'
+
 /** Tool factory types */
 export interface ToolFactoryOptions {
   // Common options for tool factories

--- a/packages/openclaw-plugin/src/tools/notebooks.ts
+++ b/packages/openclaw-plugin/src/tools/notebooks.ts
@@ -1,0 +1,471 @@
+/**
+ * Notebook tools for OpenClaw agents.
+ * Part of Epic #339, Issue #363
+ *
+ * Provides tools for:
+ * - notebook_list: List user's notebooks
+ * - notebook_create: Create a new notebook
+ * - notebook_get: Get a notebook by ID
+ */
+
+import { z } from 'zod'
+import type { ApiClient } from '../api-client.js'
+import type { Logger } from '../logger.js'
+import type { PluginConfig } from '../config.js'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Common Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Notebook from API */
+export interface Notebook {
+  id: string
+  name: string
+  description: string | null
+  userEmail: string
+  isArchived: boolean
+  noteCount?: number
+  createdAt: string
+  updatedAt: string
+}
+
+/** Tool options shared by all notebook tools */
+export interface NotebookToolOptions {
+  client: ApiClient
+  logger: Logger
+  config: PluginConfig
+  userId: string
+}
+
+/**
+ * Sanitize text input to remove control characters.
+ */
+function sanitizeText(text: string): string {
+  const sanitized = text.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, '')
+  return sanitized.trim()
+}
+
+/**
+ * Create a sanitized error message that doesn't expose internal details.
+ */
+function sanitizeErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    const message = error.message
+      .replace(/\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b/g, '[host]')
+      .replace(/:\d{2,5}\b/g, '')
+      .replace(/\b(?:localhost|internal[-\w]*)\b/gi, '[internal]')
+
+    if (message.includes('[internal]') || message.includes('[host]')) {
+      return 'Failed to complete operation. Please try again.'
+    }
+
+    return message
+  }
+  return 'An unexpected error occurred.'
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// notebook_list Tool
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const NotebookListParamsSchema = z.object({
+  includeArchived: z.boolean().optional().default(false),
+  limit: z.number().min(1).max(100).optional().default(50),
+  offset: z.number().min(0).optional().default(0),
+})
+export type NotebookListParams = z.infer<typeof NotebookListParamsSchema>
+
+export interface NotebookListSuccess {
+  success: true
+  data: {
+    notebooks: Array<{
+      id: string
+      name: string
+      description: string | null
+      isArchived: boolean
+      noteCount: number
+      url: string
+    }>
+    total: number
+    limit: number
+    offset: number
+  }
+}
+
+export interface NotebookListFailure {
+  success: false
+  error: string
+}
+
+export type NotebookListResult = NotebookListSuccess | NotebookListFailure
+
+export interface NotebookListTool {
+  name: string
+  description: string
+  parameters: typeof NotebookListParamsSchema
+  execute: (params: NotebookListParams) => Promise<NotebookListResult>
+}
+
+export function createNotebookListTool(options: NotebookToolOptions): NotebookListTool {
+  const { client, logger, config, userId } = options
+
+  return {
+    name: 'notebook_list',
+    description:
+      'List available notebooks for the user. Notebooks are used to organize notes ' +
+      'into collections. Returns notebook IDs that can be used with note_create.',
+    parameters: NotebookListParamsSchema,
+
+    async execute(params: NotebookListParams): Promise<NotebookListResult> {
+      const parseResult = NotebookListParamsSchema.safeParse(params)
+      if (!parseResult.success) {
+        const errorMessage = parseResult.error.errors
+          .map((e) => `${e.path.join('.')}: ${e.message}`)
+          .join(', ')
+        return { success: false, error: errorMessage }
+      }
+
+      const { includeArchived, limit, offset } = parseResult.data
+
+      logger.info('notebook_list invoked', {
+        userId,
+        includeArchived,
+        limit,
+      })
+
+      try {
+        const queryParams = new URLSearchParams({
+          user_email: userId,
+          limit: String(limit),
+          offset: String(offset),
+        })
+
+        if (includeArchived) {
+          queryParams.set('includeArchived', 'true')
+        }
+
+        const response = await client.get<{
+          notebooks: Notebook[]
+          total: number
+          limit: number
+          offset: number
+        }>(`/api/notebooks?${queryParams}`, { userId })
+
+        if (!response.success) {
+          logger.error('notebook_list API error', {
+            userId,
+            status: response.error.status,
+          })
+          return {
+            success: false,
+            error: response.error.message || 'Failed to list notebooks',
+          }
+        }
+
+        const result = response.data
+
+        logger.debug('notebook_list completed', {
+          userId,
+          count: result.notebooks.length,
+        })
+
+        return {
+          success: true,
+          data: {
+            notebooks: result.notebooks.map((nb) => ({
+              id: nb.id,
+              name: nb.name,
+              description: nb.description,
+              isArchived: nb.isArchived,
+              noteCount: nb.noteCount ?? 0,
+              url: `${config.baseUrl}/notebooks/${nb.id}`,
+            })),
+            total: result.total,
+            limit: result.limit,
+            offset: result.offset,
+          },
+        }
+      } catch (error) {
+        logger.error('notebook_list failed', {
+          userId,
+          error: error instanceof Error ? error.message : String(error),
+        })
+        return {
+          success: false,
+          error: sanitizeErrorMessage(error),
+        }
+      }
+    },
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// notebook_create Tool
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const NotebookCreateParamsSchema = z.object({
+  name: z
+    .string()
+    .min(1, 'Name cannot be empty')
+    .max(200, 'Name must be 200 characters or less'),
+  description: z.string().max(1000).optional(),
+})
+export type NotebookCreateParams = z.infer<typeof NotebookCreateParamsSchema>
+
+export interface NotebookCreateSuccess {
+  success: true
+  data: {
+    id: string
+    name: string
+    description: string | null
+    createdAt: string
+    url: string
+  }
+}
+
+export interface NotebookCreateFailure {
+  success: false
+  error: string
+}
+
+export type NotebookCreateResult = NotebookCreateSuccess | NotebookCreateFailure
+
+export interface NotebookCreateTool {
+  name: string
+  description: string
+  parameters: typeof NotebookCreateParamsSchema
+  execute: (params: NotebookCreateParams) => Promise<NotebookCreateResult>
+}
+
+export function createNotebookCreateTool(options: NotebookToolOptions): NotebookCreateTool {
+  const { client, logger, config, userId } = options
+
+  return {
+    name: 'notebook_create',
+    description:
+      'Create a new notebook to organize notes. Use notebooks to group related notes ' +
+      'together (e.g., "Meeting Notes", "Project Documentation", "Research").',
+    parameters: NotebookCreateParamsSchema,
+
+    async execute(params: NotebookCreateParams): Promise<NotebookCreateResult> {
+      const parseResult = NotebookCreateParamsSchema.safeParse(params)
+      if (!parseResult.success) {
+        const errorMessage = parseResult.error.errors
+          .map((e) => `${e.path.join('.')}: ${e.message}`)
+          .join(', ')
+        return { success: false, error: errorMessage }
+      }
+
+      const { name, description } = parseResult.data
+
+      const sanitizedName = sanitizeText(name)
+      if (sanitizedName.length === 0) {
+        return { success: false, error: 'Name cannot be empty after sanitization' }
+      }
+
+      logger.info('notebook_create invoked', {
+        userId,
+        nameLength: sanitizedName.length,
+      })
+
+      try {
+        const response = await client.post<Notebook>(
+          '/api/notebooks',
+          {
+            user_email: userId,
+            name: sanitizedName,
+            description: description ? sanitizeText(description) : undefined,
+          },
+          { userId }
+        )
+
+        if (!response.success) {
+          logger.error('notebook_create API error', {
+            userId,
+            status: response.error.status,
+          })
+          return {
+            success: false,
+            error: response.error.message || 'Failed to create notebook',
+          }
+        }
+
+        const notebook = response.data
+
+        logger.debug('notebook_create completed', {
+          userId,
+          notebookId: notebook.id,
+        })
+
+        return {
+          success: true,
+          data: {
+            id: notebook.id,
+            name: notebook.name,
+            description: notebook.description,
+            createdAt: notebook.createdAt,
+            url: `${config.baseUrl}/notebooks/${notebook.id}`,
+          },
+        }
+      } catch (error) {
+        logger.error('notebook_create failed', {
+          userId,
+          error: error instanceof Error ? error.message : String(error),
+        })
+        return {
+          success: false,
+          error: sanitizeErrorMessage(error),
+        }
+      }
+    },
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// notebook_get Tool
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const NotebookGetParamsSchema = z.object({
+  notebookId: z.string().uuid('Notebook ID must be a valid UUID'),
+  includeNotes: z.boolean().optional().default(false),
+})
+export type NotebookGetParams = z.infer<typeof NotebookGetParamsSchema>
+
+export interface NotebookNote {
+  id: string
+  title: string
+  visibility: string
+  updatedAt: string
+}
+
+export interface NotebookGetSuccess {
+  success: true
+  data: {
+    id: string
+    name: string
+    description: string | null
+    isArchived: boolean
+    noteCount: number
+    createdAt: string
+    updatedAt: string
+    url: string
+    notes?: Array<{
+      id: string
+      title: string
+      visibility: string
+      url: string
+    }>
+  }
+}
+
+export interface NotebookGetFailure {
+  success: false
+  error: string
+}
+
+export type NotebookGetResult = NotebookGetSuccess | NotebookGetFailure
+
+export interface NotebookGetTool {
+  name: string
+  description: string
+  parameters: typeof NotebookGetParamsSchema
+  execute: (params: NotebookGetParams) => Promise<NotebookGetResult>
+}
+
+export function createNotebookGetTool(options: NotebookToolOptions): NotebookGetTool {
+  const { client, logger, config, userId } = options
+
+  return {
+    name: 'notebook_get',
+    description:
+      'Get a notebook by its ID. Optionally include a list of notes in the notebook. ' +
+      'Only accessible if you own the notebook or have shared access.',
+    parameters: NotebookGetParamsSchema,
+
+    async execute(params: NotebookGetParams): Promise<NotebookGetResult> {
+      const parseResult = NotebookGetParamsSchema.safeParse(params)
+      if (!parseResult.success) {
+        const errorMessage = parseResult.error.errors
+          .map((e) => `${e.path.join('.')}: ${e.message}`)
+          .join(', ')
+        return { success: false, error: errorMessage }
+      }
+
+      const { notebookId, includeNotes } = parseResult.data
+
+      logger.info('notebook_get invoked', {
+        userId,
+        notebookId,
+        includeNotes,
+      })
+
+      try {
+        const queryParams = new URLSearchParams({ user_email: userId })
+        if (includeNotes) {
+          queryParams.set('expand', 'notes')
+        }
+
+        const response = await client.get<
+          Notebook & { notes?: NotebookNote[] }
+        >(`/api/notebooks/${notebookId}?${queryParams}`, { userId })
+
+        if (!response.success) {
+          if (response.error.status === 404) {
+            return { success: false, error: 'Notebook not found or access denied' }
+          }
+          logger.error('notebook_get API error', {
+            userId,
+            notebookId,
+            status: response.error.status,
+          })
+          return {
+            success: false,
+            error: response.error.message || 'Failed to get notebook',
+          }
+        }
+
+        const notebook = response.data
+
+        logger.debug('notebook_get completed', {
+          userId,
+          notebookId,
+        })
+
+        const result: NotebookGetSuccess = {
+          success: true,
+          data: {
+            id: notebook.id,
+            name: notebook.name,
+            description: notebook.description,
+            isArchived: notebook.isArchived,
+            noteCount: notebook.noteCount ?? 0,
+            createdAt: notebook.createdAt,
+            updatedAt: notebook.updatedAt,
+            url: `${config.baseUrl}/notebooks/${notebook.id}`,
+          },
+        }
+
+        if (includeNotes && notebook.notes) {
+          result.data.notes = notebook.notes.map((n) => ({
+            id: n.id,
+            title: n.title,
+            visibility: n.visibility,
+            url: `${config.baseUrl}/notes/${n.id}`,
+          }))
+        }
+
+        return result
+      } catch (error) {
+        logger.error('notebook_get failed', {
+          userId,
+          notebookId,
+          error: error instanceof Error ? error.message : String(error),
+        })
+        return {
+          success: false,
+          error: sanitizeErrorMessage(error),
+        }
+      }
+    },
+  }
+}

--- a/packages/openclaw-plugin/src/tools/notes.ts
+++ b/packages/openclaw-plugin/src/tools/notes.ts
@@ -1,0 +1,808 @@
+/**
+ * Note tools for OpenClaw agents.
+ * Part of Epic #339, Issues #359, #360, #361, #362
+ *
+ * Provides tools for:
+ * - note_create: Create a new note
+ * - note_get: Get a note by ID
+ * - note_update: Update a note
+ * - note_delete: Delete a note
+ * - note_search: Search notes
+ */
+
+import { z } from 'zod'
+import type { ApiClient } from '../api-client.js'
+import type { Logger } from '../logger.js'
+import type { PluginConfig } from '../config.js'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Common Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Note visibility levels */
+export const NoteVisibility = z.enum(['private', 'shared', 'public'])
+export type NoteVisibility = z.infer<typeof NoteVisibility>
+
+/** Note from API */
+export interface Note {
+  id: string
+  title: string
+  content: string
+  notebookId: string | null
+  userEmail: string
+  tags: string[]
+  visibility: NoteVisibility
+  hideFromAgents: boolean
+  summary: string | null
+  isPinned: boolean
+  createdAt: string
+  updatedAt: string
+}
+
+/** Tool options shared by all note tools */
+export interface NoteToolOptions {
+  client: ApiClient
+  logger: Logger
+  config: PluginConfig
+  userId: string
+}
+
+/**
+ * Sanitize text input to remove control characters.
+ */
+function sanitizeText(text: string): string {
+  const sanitized = text.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, '')
+  return sanitized.trim()
+}
+
+/**
+ * Create a sanitized error message that doesn't expose internal details.
+ */
+function sanitizeErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    const message = error.message
+      .replace(/\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b/g, '[host]')
+      .replace(/:\d{2,5}\b/g, '')
+      .replace(/\b(?:localhost|internal[-\w]*)\b/gi, '[internal]')
+
+    if (message.includes('[internal]') || message.includes('[host]')) {
+      return 'Failed to complete operation. Please try again.'
+    }
+
+    return message
+  }
+  return 'An unexpected error occurred.'
+}
+
+/**
+ * Truncate text for display preview.
+ */
+function truncateForPreview(text: string, maxLength = 100): string {
+  if (text.length <= maxLength) {
+    return text
+  }
+  return text.substring(0, maxLength) + '...'
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// note_create Tool
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const NoteCreateParamsSchema = z.object({
+  title: z
+    .string()
+    .min(1, 'Title cannot be empty')
+    .max(500, 'Title must be 500 characters or less'),
+  content: z
+    .string()
+    .min(1, 'Content cannot be empty')
+    .max(100000, 'Content must be 100,000 characters or less'),
+  notebookId: z.string().uuid().optional(),
+  tags: z.array(z.string()).max(20).optional(),
+  visibility: NoteVisibility.optional().default('private'),
+  summary: z.string().max(1000).optional(),
+})
+export type NoteCreateParams = z.infer<typeof NoteCreateParamsSchema>
+
+export interface NoteCreateSuccess {
+  success: true
+  data: {
+    id: string
+    title: string
+    notebookId: string | null
+    visibility: string
+    createdAt: string
+    url: string
+  }
+}
+
+export interface NoteCreateFailure {
+  success: false
+  error: string
+}
+
+export type NoteCreateResult = NoteCreateSuccess | NoteCreateFailure
+
+export interface NoteCreateTool {
+  name: string
+  description: string
+  parameters: typeof NoteCreateParamsSchema
+  execute: (params: NoteCreateParams) => Promise<NoteCreateResult>
+}
+
+export function createNoteCreateTool(options: NoteToolOptions): NoteCreateTool {
+  const { client, logger, config, userId } = options
+
+  return {
+    name: 'note_create',
+    description:
+      'Create a new note with markdown content. Use for meeting notes, documentation, ' +
+      'research, or any information worth preserving as a document.',
+    parameters: NoteCreateParamsSchema,
+
+    async execute(params: NoteCreateParams): Promise<NoteCreateResult> {
+      const parseResult = NoteCreateParamsSchema.safeParse(params)
+      if (!parseResult.success) {
+        const errorMessage = parseResult.error.errors
+          .map((e) => `${e.path.join('.')}: ${e.message}`)
+          .join(', ')
+        return { success: false, error: errorMessage }
+      }
+
+      const { title, content, notebookId, tags, visibility, summary } = parseResult.data
+
+      const sanitizedTitle = sanitizeText(title)
+      const sanitizedContent = sanitizeText(content)
+
+      if (sanitizedTitle.length === 0) {
+        return { success: false, error: 'Title cannot be empty after sanitization' }
+      }
+      if (sanitizedContent.length === 0) {
+        return { success: false, error: 'Content cannot be empty after sanitization' }
+      }
+
+      logger.info('note_create invoked', {
+        userId,
+        titleLength: sanitizedTitle.length,
+        contentLength: sanitizedContent.length,
+        notebookId,
+        visibility,
+      })
+
+      try {
+        const response = await client.post<Note>(
+          '/api/notes',
+          {
+            title: sanitizedTitle,
+            content: sanitizedContent,
+            notebook_id: notebookId,
+            tags,
+            visibility,
+            summary,
+          },
+          { userId }
+        )
+
+        if (!response.success) {
+          logger.error('note_create API error', {
+            userId,
+            status: response.error.status,
+            code: response.error.code,
+          })
+          return {
+            success: false,
+            error: response.error.message || 'Failed to create note',
+          }
+        }
+
+        const note = response.data
+
+        logger.debug('note_create completed', {
+          userId,
+          noteId: note.id,
+        })
+
+        return {
+          success: true,
+          data: {
+            id: note.id,
+            title: note.title,
+            notebookId: note.notebookId,
+            visibility: note.visibility,
+            createdAt: note.createdAt,
+            url: `${config.baseUrl}/notes/${note.id}`,
+          },
+        }
+      } catch (error) {
+        logger.error('note_create failed', {
+          userId,
+          error: error instanceof Error ? error.message : String(error),
+        })
+        return {
+          success: false,
+          error: sanitizeErrorMessage(error),
+        }
+      }
+    },
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// note_get Tool
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const NoteGetParamsSchema = z.object({
+  noteId: z.string().uuid('Note ID must be a valid UUID'),
+  includeVersions: z.boolean().optional().default(false),
+})
+export type NoteGetParams = z.infer<typeof NoteGetParamsSchema>
+
+export interface NoteGetSuccess {
+  success: true
+  data: {
+    id: string
+    title: string
+    content: string
+    notebookId: string | null
+    tags: string[]
+    visibility: string
+    summary: string | null
+    isPinned: boolean
+    createdAt: string
+    updatedAt: string
+    url: string
+    versionCount?: number
+  }
+}
+
+export interface NoteGetFailure {
+  success: false
+  error: string
+}
+
+export type NoteGetResult = NoteGetSuccess | NoteGetFailure
+
+export interface NoteGetTool {
+  name: string
+  description: string
+  parameters: typeof NoteGetParamsSchema
+  execute: (params: NoteGetParams) => Promise<NoteGetResult>
+}
+
+export function createNoteGetTool(options: NoteToolOptions): NoteGetTool {
+  const { client, logger, config, userId } = options
+
+  return {
+    name: 'note_get',
+    description:
+      'Get a note by its ID. Returns the full content and metadata of the note. ' +
+      'Only accessible if you have permission to view the note.',
+    parameters: NoteGetParamsSchema,
+
+    async execute(params: NoteGetParams): Promise<NoteGetResult> {
+      const parseResult = NoteGetParamsSchema.safeParse(params)
+      if (!parseResult.success) {
+        const errorMessage = parseResult.error.errors
+          .map((e) => `${e.path.join('.')}: ${e.message}`)
+          .join(', ')
+        return { success: false, error: errorMessage }
+      }
+
+      const { noteId, includeVersions } = parseResult.data
+
+      logger.info('note_get invoked', {
+        userId,
+        noteId,
+        includeVersions,
+      })
+
+      try {
+        const queryParams = new URLSearchParams({ user_email: userId })
+        if (includeVersions) {
+          queryParams.set('includeVersions', 'true')
+        }
+
+        const response = await client.get<Note>(
+          `/api/notes/${noteId}?${queryParams}`,
+          { userId }
+        )
+
+        if (!response.success) {
+          if (response.error.status === 404) {
+            return { success: false, error: 'Note not found or access denied' }
+          }
+          logger.error('note_get API error', {
+            userId,
+            noteId,
+            status: response.error.status,
+          })
+          return {
+            success: false,
+            error: response.error.message || 'Failed to get note',
+          }
+        }
+
+        const note = response.data
+
+        logger.debug('note_get completed', {
+          userId,
+          noteId,
+        })
+
+        return {
+          success: true,
+          data: {
+            id: note.id,
+            title: note.title,
+            content: note.content,
+            notebookId: note.notebookId,
+            tags: note.tags,
+            visibility: note.visibility,
+            summary: note.summary,
+            isPinned: note.isPinned,
+            createdAt: note.createdAt,
+            updatedAt: note.updatedAt,
+            url: `${config.baseUrl}/notes/${note.id}`,
+            versionCount: (note as Note & { versionCount?: number }).versionCount,
+          },
+        }
+      } catch (error) {
+        logger.error('note_get failed', {
+          userId,
+          noteId,
+          error: error instanceof Error ? error.message : String(error),
+        })
+        return {
+          success: false,
+          error: sanitizeErrorMessage(error),
+        }
+      }
+    },
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// note_update Tool
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const NoteUpdateParamsSchema = z.object({
+  noteId: z.string().uuid('Note ID must be a valid UUID'),
+  title: z.string().min(1).max(500).optional(),
+  content: z.string().min(1).max(100000).optional(),
+  notebookId: z.string().uuid().nullable().optional(),
+  tags: z.array(z.string()).max(20).optional(),
+  visibility: NoteVisibility.optional(),
+  summary: z.string().max(1000).nullable().optional(),
+  isPinned: z.boolean().optional(),
+})
+export type NoteUpdateParams = z.infer<typeof NoteUpdateParamsSchema>
+
+export interface NoteUpdateSuccess {
+  success: true
+  data: {
+    id: string
+    title: string
+    visibility: string
+    updatedAt: string
+    url: string
+    changes: string[]
+  }
+}
+
+export interface NoteUpdateFailure {
+  success: false
+  error: string
+}
+
+export type NoteUpdateResult = NoteUpdateSuccess | NoteUpdateFailure
+
+export interface NoteUpdateTool {
+  name: string
+  description: string
+  parameters: typeof NoteUpdateParamsSchema
+  execute: (params: NoteUpdateParams) => Promise<NoteUpdateResult>
+}
+
+export function createNoteUpdateTool(options: NoteToolOptions): NoteUpdateTool {
+  const { client, logger, config, userId } = options
+
+  return {
+    name: 'note_update',
+    description:
+      'Update an existing note. Can update title, content, tags, visibility, or move to a different notebook. ' +
+      'Creates a version in history when content changes.',
+    parameters: NoteUpdateParamsSchema,
+
+    async execute(params: NoteUpdateParams): Promise<NoteUpdateResult> {
+      const parseResult = NoteUpdateParamsSchema.safeParse(params)
+      if (!parseResult.success) {
+        const errorMessage = parseResult.error.errors
+          .map((e) => `${e.path.join('.')}: ${e.message}`)
+          .join(', ')
+        return { success: false, error: errorMessage }
+      }
+
+      const { noteId, title, content, notebookId, tags, visibility, summary, isPinned } =
+        parseResult.data
+
+      // Track what's being changed
+      const changes: string[] = []
+      const updateData: Record<string, unknown> = { user_email: userId }
+
+      if (title !== undefined) {
+        const sanitizedTitle = sanitizeText(title)
+        if (sanitizedTitle.length === 0) {
+          return { success: false, error: 'Title cannot be empty after sanitization' }
+        }
+        updateData.title = sanitizedTitle
+        changes.push('title')
+      }
+
+      if (content !== undefined) {
+        const sanitizedContent = sanitizeText(content)
+        if (sanitizedContent.length === 0) {
+          return { success: false, error: 'Content cannot be empty after sanitization' }
+        }
+        updateData.content = sanitizedContent
+        changes.push('content')
+      }
+
+      if (notebookId !== undefined) {
+        updateData.notebook_id = notebookId
+        changes.push('notebook')
+      }
+
+      if (tags !== undefined) {
+        updateData.tags = tags
+        changes.push('tags')
+      }
+
+      if (visibility !== undefined) {
+        updateData.visibility = visibility
+        changes.push('visibility')
+      }
+
+      if (summary !== undefined) {
+        updateData.summary = summary
+        changes.push('summary')
+      }
+
+      if (isPinned !== undefined) {
+        updateData.is_pinned = isPinned
+        changes.push('isPinned')
+      }
+
+      if (changes.length === 0) {
+        return { success: false, error: 'No changes specified' }
+      }
+
+      logger.info('note_update invoked', {
+        userId,
+        noteId,
+        changes,
+      })
+
+      try {
+        const response = await client.put<Note>(`/api/notes/${noteId}`, updateData, { userId })
+
+        if (!response.success) {
+          if (response.error.status === 404) {
+            return { success: false, error: 'Note not found or access denied' }
+          }
+          if (response.error.status === 403) {
+            return { success: false, error: 'You do not have permission to update this note' }
+          }
+          logger.error('note_update API error', {
+            userId,
+            noteId,
+            status: response.error.status,
+          })
+          return {
+            success: false,
+            error: response.error.message || 'Failed to update note',
+          }
+        }
+
+        const note = response.data
+
+        logger.debug('note_update completed', {
+          userId,
+          noteId,
+          changes,
+        })
+
+        return {
+          success: true,
+          data: {
+            id: note.id,
+            title: note.title,
+            visibility: note.visibility,
+            updatedAt: note.updatedAt,
+            url: `${config.baseUrl}/notes/${note.id}`,
+            changes,
+          },
+        }
+      } catch (error) {
+        logger.error('note_update failed', {
+          userId,
+          noteId,
+          error: error instanceof Error ? error.message : String(error),
+        })
+        return {
+          success: false,
+          error: sanitizeErrorMessage(error),
+        }
+      }
+    },
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// note_delete Tool
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const NoteDeleteParamsSchema = z.object({
+  noteId: z.string().uuid('Note ID must be a valid UUID'),
+})
+export type NoteDeleteParams = z.infer<typeof NoteDeleteParamsSchema>
+
+export interface NoteDeleteSuccess {
+  success: true
+  data: {
+    id: string
+    message: string
+  }
+}
+
+export interface NoteDeleteFailure {
+  success: false
+  error: string
+}
+
+export type NoteDeleteResult = NoteDeleteSuccess | NoteDeleteFailure
+
+export interface NoteDeleteTool {
+  name: string
+  description: string
+  parameters: typeof NoteDeleteParamsSchema
+  execute: (params: NoteDeleteParams) => Promise<NoteDeleteResult>
+}
+
+export function createNoteDeleteTool(options: NoteToolOptions): NoteDeleteTool {
+  const { client, logger, userId } = options
+
+  return {
+    name: 'note_delete',
+    description:
+      'Delete a note. This soft-deletes the note, which can be restored later. ' +
+      'Only the note owner can delete a note.',
+    parameters: NoteDeleteParamsSchema,
+
+    async execute(params: NoteDeleteParams): Promise<NoteDeleteResult> {
+      const parseResult = NoteDeleteParamsSchema.safeParse(params)
+      if (!parseResult.success) {
+        const errorMessage = parseResult.error.errors
+          .map((e) => `${e.path.join('.')}: ${e.message}`)
+          .join(', ')
+        return { success: false, error: errorMessage }
+      }
+
+      const { noteId } = parseResult.data
+
+      logger.info('note_delete invoked', {
+        userId,
+        noteId,
+      })
+
+      try {
+        const response = await client.delete<void>(
+          `/api/notes/${noteId}?user_email=${encodeURIComponent(userId)}`,
+          { userId }
+        )
+
+        if (!response.success) {
+          if (response.error.status === 404) {
+            return { success: false, error: 'Note not found' }
+          }
+          if (response.error.status === 403) {
+            return { success: false, error: 'Only the note owner can delete this note' }
+          }
+          logger.error('note_delete API error', {
+            userId,
+            noteId,
+            status: response.error.status,
+          })
+          return {
+            success: false,
+            error: response.error.message || 'Failed to delete note',
+          }
+        }
+
+        logger.debug('note_delete completed', {
+          userId,
+          noteId,
+        })
+
+        return {
+          success: true,
+          data: {
+            id: noteId,
+            message: 'Note deleted successfully',
+          },
+        }
+      } catch (error) {
+        logger.error('note_delete failed', {
+          userId,
+          noteId,
+          error: error instanceof Error ? error.message : String(error),
+        })
+        return {
+          success: false,
+          error: sanitizeErrorMessage(error),
+        }
+      }
+    },
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// note_search Tool
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const NoteSearchParamsSchema = z.object({
+  query: z.string().min(1, 'Search query cannot be empty').max(500),
+  searchType: z.enum(['hybrid', 'text', 'semantic']).optional().default('hybrid'),
+  notebookId: z.string().uuid().optional(),
+  tags: z.array(z.string()).optional(),
+  visibility: NoteVisibility.optional(),
+  limit: z.number().min(1).max(50).optional().default(20),
+  offset: z.number().min(0).optional().default(0),
+})
+export type NoteSearchParams = z.infer<typeof NoteSearchParamsSchema>
+
+export interface NoteSearchResult {
+  id: string
+  title: string
+  snippet: string
+  score: number
+  tags: string[]
+  visibility: string
+  updatedAt: string
+}
+
+export interface NoteSearchSuccess {
+  success: true
+  data: {
+    query: string
+    searchType: string
+    results: Array<{
+      id: string
+      title: string
+      snippet: string
+      score: number
+      tags: string[]
+      visibility: string
+      url: string
+    }>
+    total: number
+    limit: number
+    offset: number
+  }
+}
+
+export interface NoteSearchFailure {
+  success: false
+  error: string
+}
+
+export type NoteSearchToolResult = NoteSearchSuccess | NoteSearchFailure
+
+export interface NoteSearchTool {
+  name: string
+  description: string
+  parameters: typeof NoteSearchParamsSchema
+  execute: (params: NoteSearchParams) => Promise<NoteSearchToolResult>
+}
+
+export function createNoteSearchTool(options: NoteToolOptions): NoteSearchTool {
+  const { client, logger, config, userId } = options
+
+  return {
+    name: 'note_search',
+    description:
+      'Search notes using text search, semantic search, or hybrid (combines both). ' +
+      'Respects privacy settings - private notes are only visible to their owner.',
+    parameters: NoteSearchParamsSchema,
+
+    async execute(params: NoteSearchParams): Promise<NoteSearchToolResult> {
+      const parseResult = NoteSearchParamsSchema.safeParse(params)
+      if (!parseResult.success) {
+        const errorMessage = parseResult.error.errors
+          .map((e) => `${e.path.join('.')}: ${e.message}`)
+          .join(', ')
+        return { success: false, error: errorMessage }
+      }
+
+      const { query, searchType, notebookId, tags, visibility, limit, offset } = parseResult.data
+
+      logger.info('note_search invoked', {
+        userId,
+        queryLength: query.length,
+        searchType,
+        notebookId,
+        limit,
+      })
+
+      try {
+        const queryParams = new URLSearchParams({
+          user_email: userId,
+          q: query,
+          searchType,
+          limit: String(limit),
+          offset: String(offset),
+        })
+
+        if (notebookId) queryParams.set('notebookId', notebookId)
+        if (tags && tags.length > 0) queryParams.set('tags', tags.join(','))
+        if (visibility) queryParams.set('visibility', visibility)
+
+        const response = await client.get<{
+          query: string
+          searchType: string
+          results: NoteSearchResult[]
+          total: number
+          limit: number
+          offset: number
+        }>(`/api/notes/search?${queryParams}`, { userId, isAgent: true })
+
+        if (!response.success) {
+          logger.error('note_search API error', {
+            userId,
+            status: response.error.status,
+          })
+          return {
+            success: false,
+            error: response.error.message || 'Failed to search notes',
+          }
+        }
+
+        const searchResult = response.data
+
+        logger.debug('note_search completed', {
+          userId,
+          resultsCount: searchResult.results.length,
+          total: searchResult.total,
+        })
+
+        return {
+          success: true,
+          data: {
+            query: searchResult.query,
+            searchType: searchResult.searchType,
+            results: searchResult.results.map((r) => ({
+              id: r.id,
+              title: r.title,
+              snippet: truncateForPreview(r.snippet, 200),
+              score: r.score,
+              tags: r.tags,
+              visibility: r.visibility,
+              url: `${config.baseUrl}/notes/${r.id}`,
+            })),
+            total: searchResult.total,
+            limit: searchResult.limit,
+            offset: searchResult.offset,
+          },
+        }
+      } catch (error) {
+        logger.error('note_search failed', {
+          userId,
+          error: error instanceof Error ? error.message : String(error),
+        })
+        return {
+          success: false,
+          error: sanitizeErrorMessage(error),
+        }
+      }
+    },
+  }
+}

--- a/packages/openclaw-plugin/tests/tools/notebooks.test.ts
+++ b/packages/openclaw-plugin/tests/tools/notebooks.test.ts
@@ -1,0 +1,426 @@
+/**
+ * Tests for notebook tools.
+ * Part of Epic #339, Issue #363
+ */
+
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import {
+  createNotebookListTool,
+  createNotebookCreateTool,
+  createNotebookGetTool,
+  type NotebookListParams,
+  type NotebookCreateParams,
+  type NotebookGetParams,
+} from '../../src/tools/notebooks.js'
+import type { ApiClient } from '../../src/api-client.js'
+import type { Logger } from '../../src/logger.js'
+import type { PluginConfig } from '../../src/config.js'
+
+describe('notebook tools', () => {
+  const mockLogger: Logger = {
+    namespace: 'test',
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }
+
+  const mockConfig: PluginConfig = {
+    apiUrl: 'https://api.example.com',
+    apiKey: 'test-key',
+    autoRecall: true,
+    autoCapture: true,
+    userScoping: 'agent',
+    maxRecallMemories: 5,
+    minRecallScore: 0.7,
+    timeout: 30000,
+    maxRetries: 3,
+    debug: false,
+    baseUrl: 'https://app.example.com',
+  }
+
+  const mockApiClient = {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    healthCheck: vi.fn(),
+  } as unknown as ApiClient
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('notebook_list tool', () => {
+    describe('tool metadata', () => {
+      it('should have correct name', () => {
+        const tool = createNotebookListTool({
+          client: mockApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'user@example.com',
+        })
+        expect(tool.name).toBe('notebook_list')
+      })
+
+      it('should have description', () => {
+        const tool = createNotebookListTool({
+          client: mockApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'user@example.com',
+        })
+        expect(tool.description).toBeDefined()
+        expect(tool.description).toContain('notebook')
+      })
+
+      it('should have parameter schema', () => {
+        const tool = createNotebookListTool({
+          client: mockApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'user@example.com',
+        })
+        expect(tool.parameters).toBeDefined()
+      })
+    })
+
+    describe('execution', () => {
+      it('should list notebooks successfully', async () => {
+        const mockNotebooks = {
+          notebooks: [
+            {
+              id: '123e4567-e89b-12d3-a456-426614174000',
+              name: 'Work Notes',
+              description: 'Notes for work',
+              isArchived: false,
+              noteCount: 5,
+              createdAt: '2024-01-01T00:00:00Z',
+              updatedAt: '2024-01-01T00:00:00Z',
+            },
+            {
+              id: '223e4567-e89b-12d3-a456-426614174001',
+              name: 'Personal',
+              description: null,
+              isArchived: false,
+              noteCount: 10,
+              createdAt: '2024-01-01T00:00:00Z',
+              updatedAt: '2024-01-01T00:00:00Z',
+            },
+          ],
+          total: 2,
+          limit: 50,
+          offset: 0,
+        }
+
+        ;(mockApiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+          success: true,
+          data: mockNotebooks,
+        })
+
+        const tool = createNotebookListTool({
+          client: mockApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'user@example.com',
+        })
+
+        const result = await tool.execute({})
+
+        expect(result.success).toBe(true)
+        if (result.success) {
+          expect(result.data.notebooks.length).toBe(2)
+          expect(result.data.notebooks[0].name).toBe('Work Notes')
+          expect(result.data.notebooks[0].url).toContain(mockNotebooks.notebooks[0].id)
+        }
+      })
+
+      it('should handle API errors', async () => {
+        ;(mockApiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+          success: false,
+          error: { status: 500, message: 'Server error' },
+        })
+
+        const tool = createNotebookListTool({
+          client: mockApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'user@example.com',
+        })
+
+        const result = await tool.execute({})
+
+        expect(result.success).toBe(false)
+      })
+
+      it('should pass pagination parameters', async () => {
+        ;(mockApiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+          success: true,
+          data: { notebooks: [], total: 0, limit: 10, offset: 5 },
+        })
+
+        const tool = createNotebookListTool({
+          client: mockApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'user@example.com',
+        })
+
+        await tool.execute({ limit: 10, offset: 5 })
+
+        expect(mockApiClient.get).toHaveBeenCalledWith(
+          expect.stringContaining('limit=10'),
+          expect.anything()
+        )
+        expect(mockApiClient.get).toHaveBeenCalledWith(
+          expect.stringContaining('offset=5'),
+          expect.anything()
+        )
+      })
+    })
+  })
+
+  describe('notebook_create tool', () => {
+    describe('tool metadata', () => {
+      it('should have correct name', () => {
+        const tool = createNotebookCreateTool({
+          client: mockApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'user@example.com',
+        })
+        expect(tool.name).toBe('notebook_create')
+      })
+    })
+
+    describe('parameter validation', () => {
+      it('should require name', async () => {
+        const tool = createNotebookCreateTool({
+          client: mockApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'user@example.com',
+        })
+
+        const result = await tool.execute({} as NotebookCreateParams)
+        expect(result.success).toBe(false)
+        if (!result.success) {
+          expect(result.error).toContain('name')
+        }
+      })
+
+      it('should reject too long name', async () => {
+        const tool = createNotebookCreateTool({
+          client: mockApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'user@example.com',
+        })
+
+        const result = await tool.execute({ name: 'a'.repeat(201) })
+        expect(result.success).toBe(false)
+      })
+    })
+
+    describe('execution', () => {
+      it('should create notebook successfully', async () => {
+        const mockNotebook = {
+          id: '123e4567-e89b-12d3-a456-426614174000',
+          name: 'New Notebook',
+          description: 'A test notebook',
+          createdAt: '2024-01-01T00:00:00Z',
+        }
+
+        ;(mockApiClient.post as ReturnType<typeof vi.fn>).mockResolvedValue({
+          success: true,
+          data: mockNotebook,
+        })
+
+        const tool = createNotebookCreateTool({
+          client: mockApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'user@example.com',
+        })
+
+        const result = await tool.execute({
+          name: 'New Notebook',
+          description: 'A test notebook',
+        })
+
+        expect(result.success).toBe(true)
+        if (result.success) {
+          expect(result.data.id).toBe(mockNotebook.id)
+          expect(result.data.name).toBe(mockNotebook.name)
+          expect(result.data.url).toContain(mockNotebook.id)
+        }
+      })
+
+      it('should sanitize name', async () => {
+        ;(mockApiClient.post as ReturnType<typeof vi.fn>).mockResolvedValue({
+          success: true,
+          data: {
+            id: '123e4567-e89b-12d3-a456-426614174000',
+            name: 'Test Notebook',
+            description: null,
+            createdAt: '2024-01-01T00:00:00Z',
+          },
+        })
+
+        const tool = createNotebookCreateTool({
+          client: mockApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'user@example.com',
+        })
+
+        await tool.execute({ name: 'Test\x00Notebook' })
+
+        expect(mockApiClient.post).toHaveBeenCalledWith(
+          '/api/notebooks',
+          expect.objectContaining({
+            name: 'TestNotebook',
+          }),
+          expect.anything()
+        )
+      })
+    })
+  })
+
+  describe('notebook_get tool', () => {
+    describe('tool metadata', () => {
+      it('should have correct name', () => {
+        const tool = createNotebookGetTool({
+          client: mockApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'user@example.com',
+        })
+        expect(tool.name).toBe('notebook_get')
+      })
+    })
+
+    describe('parameter validation', () => {
+      it('should require valid UUID for notebookId', async () => {
+        const tool = createNotebookGetTool({
+          client: mockApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'user@example.com',
+        })
+
+        const result = await tool.execute({ notebookId: 'invalid' } as NotebookGetParams)
+        expect(result.success).toBe(false)
+        if (!result.success) {
+          expect(result.error).toContain('UUID')
+        }
+      })
+    })
+
+    describe('execution', () => {
+      it('should get notebook successfully', async () => {
+        const mockNotebook = {
+          id: '123e4567-e89b-12d3-a456-426614174000',
+          name: 'Work Notes',
+          description: 'Notes for work',
+          isArchived: false,
+          noteCount: 5,
+          createdAt: '2024-01-01T00:00:00Z',
+          updatedAt: '2024-01-01T00:00:00Z',
+        }
+
+        ;(mockApiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+          success: true,
+          data: mockNotebook,
+        })
+
+        const tool = createNotebookGetTool({
+          client: mockApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'user@example.com',
+        })
+
+        const result = await tool.execute({
+          notebookId: '123e4567-e89b-12d3-a456-426614174000',
+        })
+
+        expect(result.success).toBe(true)
+        if (result.success) {
+          expect(result.data.id).toBe(mockNotebook.id)
+          expect(result.data.name).toBe(mockNotebook.name)
+          expect(result.data.noteCount).toBe(5)
+        }
+      })
+
+      it('should handle not found', async () => {
+        ;(mockApiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+          success: false,
+          error: { status: 404, message: 'Not found' },
+        })
+
+        const tool = createNotebookGetTool({
+          client: mockApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'user@example.com',
+        })
+
+        const result = await tool.execute({
+          notebookId: '123e4567-e89b-12d3-a456-426614174000',
+        })
+
+        expect(result.success).toBe(false)
+        if (!result.success) {
+          expect(result.error).toContain('not found')
+        }
+      })
+
+      it('should include notes when requested', async () => {
+        const mockNotebook = {
+          id: '123e4567-e89b-12d3-a456-426614174000',
+          name: 'Work Notes',
+          description: null,
+          isArchived: false,
+          noteCount: 2,
+          createdAt: '2024-01-01T00:00:00Z',
+          updatedAt: '2024-01-01T00:00:00Z',
+          notes: [
+            { id: 'note-1', title: 'Note 1', visibility: 'private', updatedAt: '2024-01-01' },
+            { id: 'note-2', title: 'Note 2', visibility: 'public', updatedAt: '2024-01-01' },
+          ],
+        }
+
+        ;(mockApiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+          success: true,
+          data: mockNotebook,
+        })
+
+        const tool = createNotebookGetTool({
+          client: mockApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'user@example.com',
+        })
+
+        const result = await tool.execute({
+          notebookId: '123e4567-e89b-12d3-a456-426614174000',
+          includeNotes: true,
+        })
+
+        expect(result.success).toBe(true)
+        if (result.success) {
+          expect(result.data.notes).toBeDefined()
+          expect(result.data.notes?.length).toBe(2)
+          expect(result.data.notes?.[0].url).toContain('note-1')
+        }
+
+        expect(mockApiClient.get).toHaveBeenCalledWith(
+          expect.stringContaining('expand=notes'),
+          expect.anything()
+        )
+      })
+    })
+  })
+})

--- a/packages/openclaw-plugin/tests/tools/notes.test.ts
+++ b/packages/openclaw-plugin/tests/tools/notes.test.ts
@@ -1,0 +1,595 @@
+/**
+ * Tests for note tools.
+ * Part of Epic #339, Issues #359, #360, #361, #362
+ */
+
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import {
+  createNoteCreateTool,
+  createNoteGetTool,
+  createNoteUpdateTool,
+  createNoteDeleteTool,
+  createNoteSearchTool,
+  type NoteCreateParams,
+  type NoteGetParams,
+  type NoteUpdateParams,
+  type NoteDeleteParams,
+  type NoteSearchParams,
+} from '../../src/tools/notes.js'
+import type { ApiClient } from '../../src/api-client.js'
+import type { Logger } from '../../src/logger.js'
+import type { PluginConfig } from '../../src/config.js'
+
+describe('note tools', () => {
+  const mockLogger: Logger = {
+    namespace: 'test',
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }
+
+  const mockConfig: PluginConfig = {
+    apiUrl: 'https://api.example.com',
+    apiKey: 'test-key',
+    autoRecall: true,
+    autoCapture: true,
+    userScoping: 'agent',
+    maxRecallMemories: 5,
+    minRecallScore: 0.7,
+    timeout: 30000,
+    maxRetries: 3,
+    debug: false,
+    baseUrl: 'https://app.example.com',
+  }
+
+  const mockApiClient = {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    healthCheck: vi.fn(),
+  } as unknown as ApiClient
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('note_create tool', () => {
+    describe('tool metadata', () => {
+      it('should have correct name', () => {
+        const tool = createNoteCreateTool({
+          client: mockApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'user@example.com',
+        })
+        expect(tool.name).toBe('note_create')
+      })
+
+      it('should have description', () => {
+        const tool = createNoteCreateTool({
+          client: mockApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'user@example.com',
+        })
+        expect(tool.description).toBeDefined()
+        expect(tool.description).toContain('note')
+      })
+
+      it('should have parameter schema', () => {
+        const tool = createNoteCreateTool({
+          client: mockApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'user@example.com',
+        })
+        expect(tool.parameters).toBeDefined()
+      })
+    })
+
+    describe('parameter validation', () => {
+      it('should require title', async () => {
+        const tool = createNoteCreateTool({
+          client: mockApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'user@example.com',
+        })
+
+        const result = await tool.execute({ content: 'test' } as NoteCreateParams)
+        expect(result.success).toBe(false)
+        if (!result.success) {
+          expect(result.error).toContain('title')
+        }
+      })
+
+      it('should require content', async () => {
+        const tool = createNoteCreateTool({
+          client: mockApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'user@example.com',
+        })
+
+        const result = await tool.execute({ title: 'Test' } as NoteCreateParams)
+        expect(result.success).toBe(false)
+        if (!result.success) {
+          expect(result.error).toContain('content')
+        }
+      })
+
+      it('should reject too long title', async () => {
+        const tool = createNoteCreateTool({
+          client: mockApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'user@example.com',
+        })
+
+        const result = await tool.execute({
+          title: 'a'.repeat(501),
+          content: 'test',
+        })
+        expect(result.success).toBe(false)
+      })
+    })
+
+    describe('execution', () => {
+      it('should create note successfully', async () => {
+        const mockNote = {
+          id: '123e4567-e89b-12d3-a456-426614174000',
+          title: 'Test Note',
+          content: 'Test content',
+          notebookId: null,
+          visibility: 'private',
+          createdAt: '2024-01-01T00:00:00Z',
+        }
+
+        ;(mockApiClient.post as ReturnType<typeof vi.fn>).mockResolvedValue({
+          success: true,
+          data: mockNote,
+        })
+
+        const tool = createNoteCreateTool({
+          client: mockApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'user@example.com',
+        })
+
+        const result = await tool.execute({
+          title: 'Test Note',
+          content: 'Test content',
+        })
+
+        expect(result.success).toBe(true)
+        if (result.success) {
+          expect(result.data.id).toBe(mockNote.id)
+          expect(result.data.title).toBe(mockNote.title)
+          expect(result.data.url).toContain(mockNote.id)
+        }
+      })
+
+      it('should handle API errors', async () => {
+        ;(mockApiClient.post as ReturnType<typeof vi.fn>).mockResolvedValue({
+          success: false,
+          error: { status: 500, message: 'Server error' },
+        })
+
+        const tool = createNoteCreateTool({
+          client: mockApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'user@example.com',
+        })
+
+        const result = await tool.execute({
+          title: 'Test Note',
+          content: 'Test content',
+        })
+
+        expect(result.success).toBe(false)
+      })
+
+      it('should sanitize text', async () => {
+        ;(mockApiClient.post as ReturnType<typeof vi.fn>).mockResolvedValue({
+          success: true,
+          data: {
+            id: '123e4567-e89b-12d3-a456-426614174000',
+            title: 'Test Note',
+            content: 'Test content',
+            notebookId: null,
+            visibility: 'private',
+            createdAt: '2024-01-01T00:00:00Z',
+          },
+        })
+
+        const tool = createNoteCreateTool({
+          client: mockApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'user@example.com',
+        })
+
+        await tool.execute({
+          title: 'Test\x00Note',
+          content: 'Test\x0Bcontent',
+        })
+
+        expect(mockApiClient.post).toHaveBeenCalledWith(
+          '/api/notes',
+          expect.objectContaining({
+            title: 'TestNote',
+            content: 'Testcontent',
+          }),
+          expect.anything()
+        )
+      })
+    })
+  })
+
+  describe('note_get tool', () => {
+    describe('tool metadata', () => {
+      it('should have correct name', () => {
+        const tool = createNoteGetTool({
+          client: mockApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'user@example.com',
+        })
+        expect(tool.name).toBe('note_get')
+      })
+    })
+
+    describe('parameter validation', () => {
+      it('should require valid UUID for noteId', async () => {
+        const tool = createNoteGetTool({
+          client: mockApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'user@example.com',
+        })
+
+        const result = await tool.execute({ noteId: 'invalid' } as NoteGetParams)
+        expect(result.success).toBe(false)
+        if (!result.success) {
+          expect(result.error).toContain('UUID')
+        }
+      })
+    })
+
+    describe('execution', () => {
+      it('should get note successfully', async () => {
+        const mockNote = {
+          id: '123e4567-e89b-12d3-a456-426614174000',
+          title: 'Test Note',
+          content: 'Test content',
+          notebookId: null,
+          tags: ['tag1'],
+          visibility: 'private',
+          summary: null,
+          isPinned: false,
+          createdAt: '2024-01-01T00:00:00Z',
+          updatedAt: '2024-01-01T00:00:00Z',
+        }
+
+        ;(mockApiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+          success: true,
+          data: mockNote,
+        })
+
+        const tool = createNoteGetTool({
+          client: mockApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'user@example.com',
+        })
+
+        const result = await tool.execute({
+          noteId: '123e4567-e89b-12d3-a456-426614174000',
+        })
+
+        expect(result.success).toBe(true)
+        if (result.success) {
+          expect(result.data.id).toBe(mockNote.id)
+          expect(result.data.content).toBe(mockNote.content)
+        }
+      })
+
+      it('should handle not found', async () => {
+        ;(mockApiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+          success: false,
+          error: { status: 404, message: 'Not found' },
+        })
+
+        const tool = createNoteGetTool({
+          client: mockApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'user@example.com',
+        })
+
+        const result = await tool.execute({
+          noteId: '123e4567-e89b-12d3-a456-426614174000',
+        })
+
+        expect(result.success).toBe(false)
+        if (!result.success) {
+          expect(result.error).toContain('not found')
+        }
+      })
+    })
+  })
+
+  describe('note_update tool', () => {
+    describe('tool metadata', () => {
+      it('should have correct name', () => {
+        const tool = createNoteUpdateTool({
+          client: mockApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'user@example.com',
+        })
+        expect(tool.name).toBe('note_update')
+      })
+    })
+
+    describe('parameter validation', () => {
+      it('should require noteId', async () => {
+        const tool = createNoteUpdateTool({
+          client: mockApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'user@example.com',
+        })
+
+        const result = await tool.execute({ title: 'New' } as NoteUpdateParams)
+        expect(result.success).toBe(false)
+      })
+
+      it('should require at least one change', async () => {
+        const tool = createNoteUpdateTool({
+          client: mockApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'user@example.com',
+        })
+
+        const result = await tool.execute({
+          noteId: '123e4567-e89b-12d3-a456-426614174000',
+        })
+
+        expect(result.success).toBe(false)
+        if (!result.success) {
+          expect(result.error).toContain('No changes')
+        }
+      })
+    })
+
+    describe('execution', () => {
+      it('should update note successfully', async () => {
+        const mockNote = {
+          id: '123e4567-e89b-12d3-a456-426614174000',
+          title: 'Updated Title',
+          visibility: 'private',
+          updatedAt: '2024-01-01T00:00:00Z',
+        }
+
+        ;(mockApiClient.put as ReturnType<typeof vi.fn>).mockResolvedValue({
+          success: true,
+          data: mockNote,
+        })
+
+        const tool = createNoteUpdateTool({
+          client: mockApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'user@example.com',
+        })
+
+        const result = await tool.execute({
+          noteId: '123e4567-e89b-12d3-a456-426614174000',
+          title: 'Updated Title',
+        })
+
+        expect(result.success).toBe(true)
+        if (result.success) {
+          expect(result.data.title).toBe(mockNote.title)
+          expect(result.data.changes).toContain('title')
+        }
+      })
+
+      it('should handle 403 forbidden', async () => {
+        ;(mockApiClient.put as ReturnType<typeof vi.fn>).mockResolvedValue({
+          success: false,
+          error: { status: 403, message: 'Forbidden' },
+        })
+
+        const tool = createNoteUpdateTool({
+          client: mockApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'user@example.com',
+        })
+
+        const result = await tool.execute({
+          noteId: '123e4567-e89b-12d3-a456-426614174000',
+          title: 'New Title',
+        })
+
+        expect(result.success).toBe(false)
+        if (!result.success) {
+          expect(result.error).toContain('permission')
+        }
+      })
+    })
+  })
+
+  describe('note_delete tool', () => {
+    describe('tool metadata', () => {
+      it('should have correct name', () => {
+        const tool = createNoteDeleteTool({
+          client: mockApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'user@example.com',
+        })
+        expect(tool.name).toBe('note_delete')
+      })
+    })
+
+    describe('execution', () => {
+      it('should delete note successfully', async () => {
+        ;(mockApiClient.delete as ReturnType<typeof vi.fn>).mockResolvedValue({
+          success: true,
+          data: undefined,
+        })
+
+        const tool = createNoteDeleteTool({
+          client: mockApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'user@example.com',
+        })
+
+        const result = await tool.execute({
+          noteId: '123e4567-e89b-12d3-a456-426614174000',
+        })
+
+        expect(result.success).toBe(true)
+        if (result.success) {
+          expect(result.data.message).toContain('deleted')
+        }
+      })
+
+      it('should handle 404 not found', async () => {
+        ;(mockApiClient.delete as ReturnType<typeof vi.fn>).mockResolvedValue({
+          success: false,
+          error: { status: 404, message: 'Not found' },
+        })
+
+        const tool = createNoteDeleteTool({
+          client: mockApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'user@example.com',
+        })
+
+        const result = await tool.execute({
+          noteId: '123e4567-e89b-12d3-a456-426614174000',
+        })
+
+        expect(result.success).toBe(false)
+        if (!result.success) {
+          expect(result.error).toContain('not found')
+        }
+      })
+    })
+  })
+
+  describe('note_search tool', () => {
+    describe('tool metadata', () => {
+      it('should have correct name', () => {
+        const tool = createNoteSearchTool({
+          client: mockApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'user@example.com',
+        })
+        expect(tool.name).toBe('note_search')
+      })
+    })
+
+    describe('parameter validation', () => {
+      it('should require query', async () => {
+        const tool = createNoteSearchTool({
+          client: mockApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'user@example.com',
+        })
+
+        const result = await tool.execute({} as NoteSearchParams)
+        expect(result.success).toBe(false)
+        if (!result.success) {
+          expect(result.error).toContain('query')
+        }
+      })
+    })
+
+    describe('execution', () => {
+      it('should search notes successfully', async () => {
+        const mockResults = {
+          query: 'test',
+          searchType: 'hybrid',
+          results: [
+            {
+              id: '123e4567-e89b-12d3-a456-426614174000',
+              title: 'Test Note',
+              snippet: 'Test content...',
+              score: 0.95,
+              tags: ['test'],
+              visibility: 'private',
+              updatedAt: '2024-01-01T00:00:00Z',
+            },
+          ],
+          total: 1,
+          limit: 20,
+          offset: 0,
+        }
+
+        ;(mockApiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+          success: true,
+          data: mockResults,
+        })
+
+        const tool = createNoteSearchTool({
+          client: mockApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'user@example.com',
+        })
+
+        const result = await tool.execute({ query: 'test' })
+
+        expect(result.success).toBe(true)
+        if (result.success) {
+          expect(result.data.query).toBe('test')
+          expect(result.data.results.length).toBe(1)
+          expect(result.data.results[0].url).toContain(mockResults.results[0].id)
+        }
+      })
+
+      it('should pass isAgent flag', async () => {
+        ;(mockApiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+          success: true,
+          data: {
+            query: 'test',
+            searchType: 'hybrid',
+            results: [],
+            total: 0,
+            limit: 20,
+            offset: 0,
+          },
+        })
+
+        const tool = createNoteSearchTool({
+          client: mockApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'user@example.com',
+        })
+
+        await tool.execute({ query: 'test' })
+
+        expect(mockApiClient.get).toHaveBeenCalledWith(
+          expect.stringContaining('/api/notes/search'),
+          expect.objectContaining({ isAgent: true })
+        )
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Implements OpenClaw plugin tools for Notes & Notebooks:
- Issues #359, #360, #361, #362: Note tools
- Issue #363: Notebook tools
- Issue #364: Exports and tests

## New Files

### Note Tools (`packages/openclaw-plugin/src/tools/notes.ts`)
- `note_create`: Create notes with markdown content, tags, visibility
- `note_get`: Get note by ID with optional version history
- `note_update`: Update title, content, tags, visibility, notebook
- `note_delete`: Soft-delete notes (owner only)
- `note_search`: Hybrid/text/semantic search with privacy filtering

### Notebook Tools (`packages/openclaw-plugin/src/tools/notebooks.ts`)
- `notebook_list`: List user's notebooks with pagination
- `notebook_create`: Create new notebook
- `notebook_get`: Get notebook details with optional notes list

### Tests
- `tests/tools/notes.test.ts`: 25 tests
- `tests/tools/notebooks.test.ts`: 16 tests

## Modified Files

### `packages/openclaw-plugin/src/api-client.ts`
- Add `isAgent` option to `RequestOptions`
- Sets `X-OpenClaw-Agent` header for privacy filtering

### `packages/openclaw-plugin/src/config.ts`
- Add `baseUrl` option for generating note/notebook URLs

### `packages/openclaw-plugin/src/tools/index.ts`
- Export all new note and notebook tools

## Features

### Tool Capabilities
| Tool | Description |
|------|-------------|
| `note_create` | Create markdown notes with visibility controls |
| `note_get` | Retrieve notes with full content |
| `note_update` | Update title, content, tags, visibility |
| `note_delete` | Soft-delete (owner only) |
| `note_search` | Hybrid search (text + semantic) |
| `notebook_list` | List notebooks with pagination |
| `notebook_create` | Create new notebooks |
| `notebook_get` | Get notebook details |

### Privacy Model
- Agents use `X-OpenClaw-Agent` header via `isAgent` option
- `note_search` respects `hideFromAgents` flag
- Private notes only visible to owner

## Test Plan

- [x] Run plugin tests: `pnpm test -- tests/tools/notes.test.ts tests/tools/notebooks.test.ts`
- [x] 41 tests passing (25 note + 16 notebook)
- [x] All existing tests still pass (708 total)

Closes #359, #360, #361, #362, #363, #364

🤖 Generated with [Claude Code](https://claude.com/claude-code)