### PR TITLE
[#384] Implement project templates and cloning

### DIFF
--- a/src/ui/components/clone-dialog/clone-dialog.tsx
+++ b/src/ui/components/clone-dialog/clone-dialog.tsx
@@ -1,0 +1,143 @@
+/**
+ * Clone Dialog component for duplicating work items
+ */
+import * as React from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/ui/components/ui/dialog';
+import { Button } from '@/ui/components/ui/button';
+import { Input } from '@/ui/components/ui/input';
+import { Checkbox } from '@/ui/components/ui/checkbox';
+import { Label } from '@/ui/components/ui/label';
+import type { CloneDialogProps, CloneOptions } from './types';
+
+export function CloneDialog({
+  open,
+  item,
+  onClone,
+  onCancel,
+  isCloning = false,
+}: CloneDialogProps) {
+  const [title, setTitle] = React.useState(`${item.title} (Copy)`);
+  const [includeChildren, setIncludeChildren] = React.useState(false);
+  const [includeTodos, setIncludeTodos] = React.useState(false);
+
+  // Reset state when item changes
+  React.useEffect(() => {
+    setTitle(`${item.title} (Copy)`);
+    setIncludeChildren(false);
+    setIncludeTodos(false);
+  }, [item.id, item.title]);
+
+  const canClone = title.trim().length > 0 && !isCloning;
+
+  const handleClone = React.useCallback(() => {
+    if (!canClone) return;
+    const options: CloneOptions = {
+      title: title.trim(),
+      includeChildren,
+      includeTodos,
+    };
+    onClone(options);
+  }, [canClone, title, includeChildren, includeTodos, onClone]);
+
+  const handleKeyDown = React.useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter' && canClone) {
+        e.preventDefault();
+        handleClone();
+      }
+    },
+    [canClone, handleClone]
+  );
+
+  const handleDialogKeyDown = React.useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onCancel();
+      }
+    },
+    [onCancel]
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onCancel()}>
+      <DialogContent onKeyDown={handleDialogKeyDown}>
+        <DialogHeader>
+          <DialogTitle>Clone {item.kind}</DialogTitle>
+          <DialogDescription>
+            Create a copy of this {item.kind} with optional children and todos.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-4">
+          {/* Title input */}
+          <div className="space-y-2">
+            <Label htmlFor="clone-title">Title</Label>
+            <Input
+              id="clone-title"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="Enter title for cloned item"
+            />
+          </div>
+
+          {/* Clone options */}
+          <div className="space-y-3">
+            <p className="text-sm text-muted-foreground">Clone item only</p>
+
+            <div className="flex items-center space-x-2">
+              <Checkbox
+                id="include-children"
+                checked={includeChildren}
+                onCheckedChange={(checked) =>
+                  setIncludeChildren(checked === true)
+                }
+                disabled={!item.hasChildren}
+                aria-label="Include children"
+              />
+              <Label
+                htmlFor="include-children"
+                className={!item.hasChildren ? 'text-muted-foreground' : ''}
+              >
+                Include children
+              </Label>
+            </div>
+
+            <div className="flex items-center space-x-2">
+              <Checkbox
+                id="include-todos"
+                checked={includeTodos}
+                onCheckedChange={(checked) => setIncludeTodos(checked === true)}
+                disabled={!item.hasTodos}
+                aria-label="Include todos"
+              />
+              <Label
+                htmlFor="include-todos"
+                className={!item.hasTodos ? 'text-muted-foreground' : ''}
+              >
+                Include todos
+              </Label>
+            </div>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onCancel} disabled={isCloning}>
+            Cancel
+          </Button>
+          <Button onClick={handleClone} disabled={!canClone}>
+            {isCloning ? 'Cloning...' : 'Clone'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/ui/components/clone-dialog/index.ts
+++ b/src/ui/components/clone-dialog/index.ts
@@ -1,0 +1,2 @@
+export { CloneDialog } from './clone-dialog';
+export type { CloneDialogProps, CloneOptions, WorkItemForClone } from './types';

--- a/src/ui/components/clone-dialog/types.ts
+++ b/src/ui/components/clone-dialog/types.ts
@@ -1,0 +1,39 @@
+/**
+ * Types for Clone Dialog component
+ */
+
+/**
+ * Work item data needed for cloning
+ */
+export interface WorkItemForClone {
+  id: string;
+  title: string;
+  kind: string;
+  hasChildren: boolean;
+  hasTodos: boolean;
+}
+
+/**
+ * Options selected by user for cloning
+ */
+export interface CloneOptions {
+  title: string;
+  includeChildren: boolean;
+  includeTodos: boolean;
+}
+
+/**
+ * Props for CloneDialog component
+ */
+export interface CloneDialogProps {
+  /** Whether the dialog is open */
+  open: boolean;
+  /** The work item to clone */
+  item: WorkItemForClone;
+  /** Callback when user confirms clone */
+  onClone: (options: CloneOptions) => void;
+  /** Callback when user cancels */
+  onCancel: () => void;
+  /** Whether clone operation is in progress */
+  isCloning?: boolean;
+}

--- a/src/ui/components/templates/index.ts
+++ b/src/ui/components/templates/index.ts
@@ -1,0 +1,12 @@
+export { useTemplates } from './use-templates';
+export { TemplateSelector } from './template-selector';
+export { TemplateManager } from './template-manager';
+export { SaveTemplateDialog } from './save-template-dialog';
+export type {
+  WorkItemTemplate,
+  TemplateCategory,
+  TemplateStructure,
+  TemplateSelectorProps,
+  SaveTemplateDialogProps,
+  UseTemplatesReturn,
+} from './types';

--- a/src/ui/components/templates/save-template-dialog.tsx
+++ b/src/ui/components/templates/save-template-dialog.tsx
@@ -1,0 +1,155 @@
+/**
+ * Dialog for saving a work item as a template
+ */
+import * as React from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/ui/components/ui/dialog';
+import { Button } from '@/ui/components/ui/button';
+import { Input } from '@/ui/components/ui/input';
+import { Label } from '@/ui/components/ui/label';
+import { Textarea } from '@/ui/components/ui/textarea';
+import { Checkbox } from '@/ui/components/ui/checkbox';
+import type {
+  SaveTemplateDialogProps,
+  WorkItemTemplate,
+  TemplateCategory,
+  TemplateStructure,
+} from './types';
+
+const CATEGORIES: { value: TemplateCategory; label: string }[] = [
+  { value: 'sprint', label: 'Sprint' },
+  { value: 'feature', label: 'Feature' },
+  { value: 'bugfix', label: 'Bug Fix' },
+  { value: 'project', label: 'Project' },
+  { value: 'custom', label: 'Custom' },
+];
+
+export function SaveTemplateDialog({
+  open,
+  item,
+  onSave,
+  onCancel,
+}: SaveTemplateDialogProps) {
+  const [name, setName] = React.useState(item.title);
+  const [description, setDescription] = React.useState('');
+  const [category, setCategory] = React.useState<TemplateCategory>('custom');
+  const [includeChildren, setIncludeChildren] = React.useState(true);
+
+  React.useEffect(() => {
+    setName(item.title);
+    setDescription('');
+    setCategory('custom');
+    setIncludeChildren(true);
+  }, [item.id, item.title]);
+
+  const hasChildren = item.children && item.children.length > 0;
+  const canSave = name.trim().length > 0;
+
+  const handleSave = () => {
+    if (!canSave) return;
+
+    const structure: TemplateStructure = {
+      kind: item.kind as TemplateStructure['kind'],
+      title: name.trim(),
+      description: description.trim() || undefined,
+      children:
+        includeChildren && item.children
+          ? item.children.map((child) => ({
+              kind: child.kind as TemplateStructure['kind'],
+              title: child.title,
+            }))
+          : undefined,
+    };
+
+    const template: Omit<WorkItemTemplate, 'id' | 'createdAt'> = {
+      name: name.trim(),
+      description: description.trim(),
+      category,
+      structure,
+    };
+
+    onSave(template);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onCancel()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Save as Template</DialogTitle>
+          <DialogDescription>
+            Create a reusable template from this {item.kind}.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-4">
+          <div className="space-y-2">
+            <Label htmlFor="template-name">Template Name</Label>
+            <Input
+              id="template-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Enter template name"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="template-description">Description</Label>
+            <Textarea
+              id="template-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Describe this template..."
+              rows={3}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="template-category">Category</Label>
+            <select
+              id="template-category"
+              value={category}
+              onChange={(e) => setCategory(e.target.value as TemplateCategory)}
+              className="w-full h-9 rounded-md border border-input bg-background px-3 text-sm"
+              aria-label="Category"
+            >
+              {CATEGORIES.map((cat) => (
+                <option key={cat.value} value={cat.value}>
+                  {cat.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {hasChildren && (
+            <div className="flex items-center space-x-2">
+              <Checkbox
+                id="include-children"
+                checked={includeChildren}
+                onCheckedChange={(checked) => setIncludeChildren(checked === true)}
+                aria-label="Include children"
+              />
+              <Label htmlFor="include-children">
+                Include children ({item.children?.length} items)
+              </Label>
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button onClick={handleSave} disabled={!canSave}>
+            Save Template
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/ui/components/templates/template-manager.tsx
+++ b/src/ui/components/templates/template-manager.tsx
@@ -1,0 +1,164 @@
+/**
+ * Template manager component for viewing, editing, and deleting templates
+ */
+import * as React from 'react';
+import { TrashIcon, SearchIcon } from 'lucide-react';
+import { Input } from '@/ui/components/ui/input';
+import { Button } from '@/ui/components/ui/button';
+import { ScrollArea } from '@/ui/components/ui/scroll-area';
+import { cn } from '@/ui/lib/utils';
+import { useTemplates } from './use-templates';
+import type { WorkItemTemplate, TemplateCategory } from './types';
+
+const CATEGORY_LABELS: Record<TemplateCategory, string> = {
+  sprint: 'Sprint',
+  feature: 'Feature',
+  bugfix: 'Bug Fix',
+  project: 'Project',
+  custom: 'Custom',
+};
+
+interface TemplateManagerProps {
+  className?: string;
+}
+
+export function TemplateManager({ className }: TemplateManagerProps) {
+  const { templates, deleteTemplate } = useTemplates();
+  const [search, setSearch] = React.useState('');
+  const [selectedCategory, setSelectedCategory] =
+    React.useState<TemplateCategory | 'all'>('all');
+
+  const filteredTemplates = React.useMemo(() => {
+    let result = templates;
+
+    if (selectedCategory !== 'all') {
+      result = result.filter((t) => t.category === selectedCategory);
+    }
+
+    if (search.trim()) {
+      const searchLower = search.toLowerCase();
+      result = result.filter(
+        (t) =>
+          t.name.toLowerCase().includes(searchLower) ||
+          t.description.toLowerCase().includes(searchLower)
+      );
+    }
+
+    return result;
+  }, [templates, selectedCategory, search]);
+
+  const handleDelete = (template: WorkItemTemplate) => {
+    if (template.isBuiltIn) return;
+    if (
+      window.confirm(`Delete template "${template.name}"? This cannot be undone.`)
+    ) {
+      deleteTemplate(template.id);
+    }
+  };
+
+  return (
+    <div className={cn('flex flex-col h-full', className)}>
+      <div className="flex items-center gap-4 p-4 border-b">
+        <div className="relative flex-1">
+          <SearchIcon className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <Input
+            placeholder="Search templates..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="pl-9"
+          />
+        </div>
+        <select
+          value={selectedCategory}
+          onChange={(e) =>
+            setSelectedCategory(e.target.value as TemplateCategory | 'all')
+          }
+          className="h-9 rounded-md border border-input bg-background px-3 text-sm"
+          aria-label="Filter by category"
+        >
+          <option value="all">All Categories</option>
+          {Object.entries(CATEGORY_LABELS).map(([value, label]) => (
+            <option key={value} value={value}>
+              {label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <ScrollArea className="flex-1">
+        <div className="p-4 space-y-3">
+          {filteredTemplates.length === 0 ? (
+            <p className="text-center text-muted-foreground py-8">
+              No templates found
+            </p>
+          ) : (
+            filteredTemplates.map((template) => (
+              <div
+                key={template.id}
+                data-template={template.id}
+                className="p-4 rounded-lg border bg-card"
+              >
+                <div className="flex items-start justify-between">
+                  <div>
+                    <div className="flex items-center gap-2">
+                      <h4 className="font-medium">{template.name}</h4>
+                      <span className="text-xs bg-muted px-2 py-0.5 rounded">
+                        {CATEGORY_LABELS[template.category]}
+                      </span>
+                      {template.isBuiltIn && (
+                        <span className="text-xs bg-primary/10 text-primary px-2 py-0.5 rounded">
+                          Built-in
+                        </span>
+                      )}
+                    </div>
+                    <p className="text-sm text-muted-foreground mt-1">
+                      {template.description}
+                    </p>
+                  </div>
+                  {!template.isBuiltIn && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => handleDelete(template)}
+                      aria-label="Delete template"
+                      className="text-destructive hover:text-destructive hover:bg-destructive/10"
+                    >
+                      <TrashIcon className="h-4 w-4" />
+                    </Button>
+                  )}
+                </div>
+                <div className="mt-3 text-xs text-muted-foreground">
+                  <span>Root: {template.structure.kind}</span>
+                  {template.structure.children &&
+                    template.structure.children.length > 0 && (
+                      <span className="ml-2">
+                        • {countTotalItems(template.structure)} items total
+                      </span>
+                    )}
+                  {template.structure.todos &&
+                    template.structure.todos.length > 0 && (
+                      <span className="ml-2">
+                        • {template.structure.todos.length} todos
+                      </span>
+                    )}
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+      </ScrollArea>
+    </div>
+  );
+}
+
+function countTotalItems(
+  structure: WorkItemTemplate['structure'],
+  count = 1
+): number {
+  if (structure.children) {
+    for (const child of structure.children) {
+      count = countTotalItems(child, count + 1);
+    }
+  }
+  return count;
+}

--- a/src/ui/components/templates/template-selector.tsx
+++ b/src/ui/components/templates/template-selector.tsx
@@ -1,0 +1,147 @@
+/**
+ * Template selector component for choosing a template when creating new items
+ */
+import * as React from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/ui/components/ui/dialog';
+import { Button } from '@/ui/components/ui/button';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/ui/components/ui/tabs';
+import { ScrollArea } from '@/ui/components/ui/scroll-area';
+import { cn } from '@/ui/lib/utils';
+import { useTemplates } from './use-templates';
+import type { WorkItemTemplate, TemplateSelectorProps, TemplateCategory } from './types';
+
+const CATEGORIES: { value: TemplateCategory; label: string }[] = [
+  { value: 'sprint', label: 'Sprint' },
+  { value: 'feature', label: 'Feature' },
+  { value: 'bugfix', label: 'Bug Fix' },
+  { value: 'project', label: 'Project' },
+  { value: 'custom', label: 'Custom' },
+];
+
+interface TemplateCardProps {
+  template: WorkItemTemplate;
+  selected: boolean;
+  onSelect: () => void;
+}
+
+function TemplateCard({ template, selected, onSelect }: TemplateCardProps) {
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className={cn(
+        'w-full text-left p-4 rounded-lg border transition-colors',
+        'hover:bg-muted/50 focus:outline-none focus:ring-2 focus:ring-ring',
+        selected && 'border-primary bg-primary/5'
+      )}
+    >
+      <div className="flex items-start justify-between">
+        <div>
+          <h4 className="font-medium">{template.name}</h4>
+          <p className="text-sm text-muted-foreground mt-1">
+            {template.description}
+          </p>
+        </div>
+        {template.isBuiltIn && (
+          <span className="text-xs bg-muted px-2 py-0.5 rounded">Built-in</span>
+        )}
+      </div>
+      <div className="mt-2 text-xs text-muted-foreground">
+        Root: {template.structure.kind}
+        {template.structure.children && template.structure.children.length > 0 && (
+          <span> • {template.structure.children.length} children</span>
+        )}
+      </div>
+    </button>
+  );
+}
+
+export function TemplateSelector({
+  open,
+  onSelect,
+  onCancel,
+  filterCategory,
+}: TemplateSelectorProps) {
+  const { templates, getTemplatesByCategory } = useTemplates();
+  const [selectedTemplate, setSelectedTemplate] =
+    React.useState<WorkItemTemplate | null>(null);
+  const [activeCategory, setActiveCategory] = React.useState<TemplateCategory>(
+    filterCategory || 'sprint'
+  );
+
+  const displayedTemplates = React.useMemo(() => {
+    if (filterCategory) {
+      return getTemplatesByCategory(filterCategory);
+    }
+    return getTemplatesByCategory(activeCategory);
+  }, [filterCategory, activeCategory, getTemplatesByCategory]);
+
+  const handleSelect = () => {
+    if (selectedTemplate) {
+      onSelect(selectedTemplate);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onCancel()}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Choose a Template</DialogTitle>
+          <DialogDescription>
+            Select a template to create a new item with pre-defined structure.
+          </DialogDescription>
+        </DialogHeader>
+
+        {!filterCategory && (
+          <Tabs
+            value={activeCategory}
+            onValueChange={(v) => setActiveCategory(v as TemplateCategory)}
+          >
+            <TabsList className="grid grid-cols-5 w-full">
+              {CATEGORIES.map((cat) => (
+                <TabsTrigger key={cat.value} value={cat.value}>
+                  {cat.label}
+                </TabsTrigger>
+              ))}
+            </TabsList>
+          </Tabs>
+        )}
+
+        <ScrollArea className="h-[300px] pr-4">
+          <div className="space-y-2">
+            {displayedTemplates.length === 0 ? (
+              <p className="text-center text-muted-foreground py-8">
+                No templates in this category
+              </p>
+            ) : (
+              displayedTemplates.map((template) => (
+                <TemplateCard
+                  key={template.id}
+                  template={template}
+                  selected={selectedTemplate?.id === template.id}
+                  onSelect={() => setSelectedTemplate(template)}
+                />
+              ))
+            )}
+          </div>
+        </ScrollArea>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button onClick={handleSelect} disabled={!selectedTemplate}>
+            Use Template
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/ui/components/templates/types.ts
+++ b/src/ui/components/templates/types.ts
@@ -1,0 +1,72 @@
+/**
+ * Types for template system
+ */
+
+/**
+ * Structure of a work item within a template
+ */
+export interface TemplateStructure {
+  kind: 'project' | 'initiative' | 'epic' | 'issue' | 'task';
+  title: string;
+  description?: string;
+  children?: TemplateStructure[];
+  todos?: string[];
+}
+
+/**
+ * A work item template
+ */
+export interface WorkItemTemplate {
+  id: string;
+  name: string;
+  description: string;
+  category: TemplateCategory;
+  structure: TemplateStructure;
+  createdAt: string;
+  isBuiltIn?: boolean;
+}
+
+/**
+ * Template categories
+ */
+export type TemplateCategory =
+  | 'sprint'
+  | 'feature'
+  | 'bugfix'
+  | 'project'
+  | 'custom';
+
+/**
+ * Props for TemplateSelector component
+ */
+export interface TemplateSelectorProps {
+  open: boolean;
+  onSelect: (template: WorkItemTemplate) => void;
+  onCancel: () => void;
+  filterCategory?: TemplateCategory;
+}
+
+/**
+ * Props for SaveTemplateDialog component
+ */
+export interface SaveTemplateDialogProps {
+  open: boolean;
+  item: {
+    id: string;
+    title: string;
+    kind: string;
+    children?: Array<{ id: string; title: string; kind: string }>;
+  };
+  onSave: (template: Omit<WorkItemTemplate, 'id' | 'createdAt'>) => void;
+  onCancel: () => void;
+}
+
+/**
+ * Return type for useTemplates hook
+ */
+export interface UseTemplatesReturn {
+  templates: WorkItemTemplate[];
+  saveTemplate: (template: Omit<WorkItemTemplate, 'id' | 'createdAt'>) => void;
+  deleteTemplate: (id: string) => void;
+  getTemplatesByCategory: (category: TemplateCategory) => WorkItemTemplate[];
+}

--- a/src/ui/components/templates/use-templates.ts
+++ b/src/ui/components/templates/use-templates.ts
@@ -1,0 +1,261 @@
+/**
+ * Hook for managing work item templates
+ */
+import * as React from 'react';
+import type {
+  WorkItemTemplate,
+  TemplateCategory,
+  UseTemplatesReturn,
+} from './types';
+
+const STORAGE_KEY = 'work-item-templates';
+
+/**
+ * Built-in templates available by default
+ */
+const BUILTIN_TEMPLATES: WorkItemTemplate[] = [
+  {
+    id: 'builtin-sprint',
+    name: 'Sprint Planning',
+    description:
+      'An epic with standard sprint issues: planning, development, testing, review',
+    category: 'sprint',
+    isBuiltIn: true,
+    createdAt: '2024-01-01T00:00:00.000Z',
+    structure: {
+      kind: 'epic',
+      title: 'Sprint [N]',
+      description: 'Sprint planning epic',
+      children: [
+        {
+          kind: 'issue',
+          title: 'Sprint Planning',
+          description: 'Plan sprint scope and goals',
+        },
+        {
+          kind: 'issue',
+          title: 'Development',
+          description: 'Implement sprint items',
+        },
+        {
+          kind: 'issue',
+          title: 'Testing',
+          description: 'Test completed features',
+        },
+        {
+          kind: 'issue',
+          title: 'Sprint Review',
+          description: 'Demo and review completed work',
+        },
+        {
+          kind: 'issue',
+          title: 'Retrospective',
+          description: 'Team retrospective',
+        },
+      ],
+    },
+  },
+  {
+    id: 'builtin-feature',
+    name: 'Feature Development',
+    description:
+      'An initiative structure for developing a new feature with design, implementation, and testing phases',
+    category: 'feature',
+    isBuiltIn: true,
+    createdAt: '2024-01-01T00:00:00.000Z',
+    structure: {
+      kind: 'initiative',
+      title: 'Feature: [Name]',
+      description: 'New feature initiative',
+      children: [
+        {
+          kind: 'epic',
+          title: 'Design',
+          description: 'Design the feature',
+          children: [
+            { kind: 'issue', title: 'Requirements Gathering' },
+            { kind: 'issue', title: 'Technical Design' },
+            { kind: 'issue', title: 'UI/UX Design' },
+          ],
+        },
+        {
+          kind: 'epic',
+          title: 'Implementation',
+          description: 'Build the feature',
+          children: [
+            { kind: 'issue', title: 'Backend Development' },
+            { kind: 'issue', title: 'Frontend Development' },
+            { kind: 'issue', title: 'Integration' },
+          ],
+        },
+        {
+          kind: 'epic',
+          title: 'Quality Assurance',
+          description: 'Test and validate',
+          children: [
+            { kind: 'issue', title: 'Unit Tests' },
+            { kind: 'issue', title: 'Integration Tests' },
+            { kind: 'issue', title: 'User Acceptance Testing' },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    id: 'builtin-bugfix',
+    name: 'Bug Fix',
+    description: 'An issue with a standard bug fix checklist',
+    category: 'bugfix',
+    isBuiltIn: true,
+    createdAt: '2024-01-01T00:00:00.000Z',
+    structure: {
+      kind: 'issue',
+      title: 'Bug: [Description]',
+      description: 'Fix the reported bug',
+      todos: [
+        'Reproduce the issue',
+        'Identify root cause',
+        'Write failing test',
+        'Implement fix',
+        'Verify fix resolves issue',
+        'Add regression test',
+        'Update documentation if needed',
+      ],
+    },
+  },
+  {
+    id: 'builtin-project',
+    name: 'New Project',
+    description:
+      'A project structure with standard phases: planning, execution, delivery',
+    category: 'project',
+    isBuiltIn: true,
+    createdAt: '2024-01-01T00:00:00.000Z',
+    structure: {
+      kind: 'project',
+      title: 'Project: [Name]',
+      description: 'New project',
+      children: [
+        {
+          kind: 'initiative',
+          title: 'Planning',
+          description: 'Project planning phase',
+          children: [
+            {
+              kind: 'epic',
+              title: 'Requirements',
+              children: [
+                { kind: 'issue', title: 'Stakeholder Interviews' },
+                { kind: 'issue', title: 'Requirements Document' },
+              ],
+            },
+            {
+              kind: 'epic',
+              title: 'Architecture',
+              children: [
+                { kind: 'issue', title: 'Technical Architecture' },
+                { kind: 'issue', title: 'Infrastructure Planning' },
+              ],
+            },
+          ],
+        },
+        {
+          kind: 'initiative',
+          title: 'Execution',
+          description: 'Project execution phase',
+        },
+        {
+          kind: 'initiative',
+          title: 'Delivery',
+          description: 'Project delivery phase',
+          children: [
+            {
+              kind: 'epic',
+              title: 'Launch',
+              children: [
+                { kind: 'issue', title: 'Deployment' },
+                { kind: 'issue', title: 'Documentation' },
+                { kind: 'issue', title: 'Training' },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  },
+];
+
+function generateId(): string {
+  return `template-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+}
+
+function loadCustomTemplates(): WorkItemTemplate[] {
+  if (typeof window === 'undefined') return [];
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    return stored ? JSON.parse(stored) : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveCustomTemplates(templates: WorkItemTemplate[]): void {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(templates));
+  } catch {
+    // Storage might be full or unavailable
+  }
+}
+
+export function useTemplates(): UseTemplatesReturn {
+  const [customTemplates, setCustomTemplates] = React.useState<
+    WorkItemTemplate[]
+  >(() => loadCustomTemplates());
+
+  const templates = React.useMemo(
+    () => [...BUILTIN_TEMPLATES, ...customTemplates],
+    [customTemplates]
+  );
+
+  const saveTemplate = React.useCallback(
+    (template: Omit<WorkItemTemplate, 'id' | 'createdAt'>) => {
+      const newTemplate: WorkItemTemplate = {
+        ...template,
+        id: generateId(),
+        createdAt: new Date().toISOString(),
+      };
+      const updated = [...customTemplates, newTemplate];
+      setCustomTemplates(updated);
+      saveCustomTemplates(updated);
+    },
+    [customTemplates]
+  );
+
+  const deleteTemplate = React.useCallback(
+    (id: string) => {
+      // Can only delete custom templates
+      const template = customTemplates.find((t) => t.id === id);
+      if (!template) return;
+
+      const updated = customTemplates.filter((t) => t.id !== id);
+      setCustomTemplates(updated);
+      saveCustomTemplates(updated);
+    },
+    [customTemplates]
+  );
+
+  const getTemplatesByCategory = React.useCallback(
+    (category: TemplateCategory) => {
+      return templates.filter((t) => t.category === category);
+    },
+    [templates]
+  );
+
+  return {
+    templates,
+    saveTemplate,
+    deleteTemplate,
+    getTemplatesByCategory,
+  };
+}

--- a/tests/ui/clone-dialog.test.tsx
+++ b/tests/ui/clone-dialog.test.tsx
@@ -1,0 +1,168 @@
+/**
+ * @vitest-environment jsdom
+ */
+import * as React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { CloneDialog } from '@/ui/components/clone-dialog';
+import type { CloneOptions, WorkItemForClone } from '@/ui/components/clone-dialog/types';
+
+describe('CloneDialog', () => {
+  const mockItem: WorkItemForClone = {
+    id: 'item-1',
+    title: 'Test Item',
+    kind: 'epic',
+    hasChildren: true,
+    hasTodos: true,
+  };
+
+  const defaultProps = {
+    open: true,
+    item: mockItem,
+    onClone: vi.fn(),
+    onCancel: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('rendering', () => {
+    it('renders the dialog when open', () => {
+      render(<CloneDialog {...defaultProps} />);
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    it('shows the item title with (Copy) suffix', () => {
+      render(<CloneDialog {...defaultProps} />);
+      expect(screen.getByDisplayValue('Test Item (Copy)')).toBeInTheDocument();
+    });
+
+    it('shows clone options', () => {
+      render(<CloneDialog {...defaultProps} />);
+      expect(screen.getByText(/clone item only/i)).toBeInTheDocument();
+      expect(screen.getByText(/include children/i)).toBeInTheDocument();
+      expect(screen.getByText(/include todos/i)).toBeInTheDocument();
+    });
+
+    it('disables include children when item has no children', () => {
+      const itemNoChildren: WorkItemForClone = { ...mockItem, hasChildren: false };
+      render(<CloneDialog {...defaultProps} item={itemNoChildren} />);
+
+      const checkbox = screen.getByRole('checkbox', { name: /include children/i });
+      expect(checkbox).toBeDisabled();
+    });
+
+    it('disables include todos when item has no todos', () => {
+      const itemNoTodos: WorkItemForClone = { ...mockItem, hasTodos: false };
+      render(<CloneDialog {...defaultProps} item={itemNoTodos} />);
+
+      const checkbox = screen.getByRole('checkbox', { name: /include todos/i });
+      expect(checkbox).toBeDisabled();
+    });
+  });
+
+  describe('title editing', () => {
+    it('allows editing the cloned item title', () => {
+      render(<CloneDialog {...defaultProps} />);
+
+      const input = screen.getByDisplayValue('Test Item (Copy)');
+      fireEvent.change(input, { target: { value: 'My New Item' } });
+
+      expect(screen.getByDisplayValue('My New Item')).toBeInTheDocument();
+    });
+  });
+
+  describe('clone options', () => {
+    it('toggles include children option', () => {
+      render(<CloneDialog {...defaultProps} />);
+
+      const checkbox = screen.getByRole('checkbox', { name: /include children/i });
+      expect(checkbox).not.toBeChecked();
+
+      fireEvent.click(checkbox);
+      expect(checkbox).toBeChecked();
+    });
+
+    it('toggles include todos option', () => {
+      render(<CloneDialog {...defaultProps} />);
+
+      const checkbox = screen.getByRole('checkbox', { name: /include todos/i });
+      expect(checkbox).not.toBeChecked();
+
+      fireEvent.click(checkbox);
+      expect(checkbox).toBeChecked();
+    });
+  });
+
+  describe('actions', () => {
+    it('calls onClone with correct options when Clone button clicked', async () => {
+      const onClone = vi.fn();
+      render(<CloneDialog {...defaultProps} onClone={onClone} />);
+
+      // Change title
+      const input = screen.getByDisplayValue('Test Item (Copy)');
+      fireEvent.change(input, { target: { value: 'Cloned Item' } });
+
+      // Enable options
+      fireEvent.click(screen.getByRole('checkbox', { name: /include children/i }));
+      fireEvent.click(screen.getByRole('checkbox', { name: /include todos/i }));
+
+      // Click Clone
+      fireEvent.click(screen.getByRole('button', { name: /^clone$/i }));
+
+      expect(onClone).toHaveBeenCalledWith({
+        title: 'Cloned Item',
+        includeChildren: true,
+        includeTodos: true,
+      });
+    });
+
+    it('calls onCancel when Cancel button clicked', () => {
+      const onCancel = vi.fn();
+      render(<CloneDialog {...defaultProps} onCancel={onCancel} />);
+
+      fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+
+      expect(onCancel).toHaveBeenCalled();
+    });
+
+    it('disables Clone button when title is empty', () => {
+      render(<CloneDialog {...defaultProps} />);
+
+      const input = screen.getByDisplayValue('Test Item (Copy)');
+      fireEvent.change(input, { target: { value: '' } });
+
+      expect(screen.getByRole('button', { name: /^clone$/i })).toBeDisabled();
+    });
+
+    it('shows loading state during clone', () => {
+      render(<CloneDialog {...defaultProps} isCloning />);
+
+      expect(screen.getByRole('button', { name: /cloning/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /cloning/i })).toBeDisabled();
+    });
+  });
+
+  describe('keyboard shortcuts', () => {
+    it('submits on Enter key', () => {
+      const onClone = vi.fn();
+      render(<CloneDialog {...defaultProps} onClone={onClone} />);
+
+      const input = screen.getByDisplayValue('Test Item (Copy)');
+      fireEvent.keyDown(input, { key: 'Enter' });
+
+      expect(onClone).toHaveBeenCalled();
+    });
+
+    it('cancels on Escape key', () => {
+      const onCancel = vi.fn();
+      render(<CloneDialog {...defaultProps} onCancel={onCancel} />);
+
+      fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' });
+
+      expect(onCancel).toHaveBeenCalled();
+    });
+  });
+});
+

--- a/tests/ui/templates.test.tsx
+++ b/tests/ui/templates.test.tsx
@@ -1,0 +1,352 @@
+/**
+ * @vitest-environment jsdom
+ */
+import * as React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { useTemplates } from '@/ui/components/templates/use-templates';
+import { TemplateSelector } from '@/ui/components/templates/template-selector';
+import { TemplateManager } from '@/ui/components/templates/template-manager';
+import { SaveTemplateDialog } from '@/ui/components/templates/save-template-dialog';
+import type { WorkItemTemplate } from '@/ui/components/templates/types';
+import { renderHook } from '@testing-library/react';
+
+// Mock localStorage
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] || null,
+    setItem: (key: string, value: string) => {
+      store[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+  };
+})();
+
+Object.defineProperty(window, 'localStorage', { value: localStorageMock });
+
+describe('useTemplates hook', () => {
+  beforeEach(() => {
+    localStorageMock.clear();
+  });
+
+  it('returns built-in templates by default', () => {
+    const { result } = renderHook(() => useTemplates());
+
+    expect(result.current.templates.length).toBeGreaterThan(0);
+    expect(result.current.templates.some((t) => t.id === 'builtin-sprint')).toBe(
+      true
+    );
+  });
+
+  it('can save a custom template', () => {
+    const { result } = renderHook(() => useTemplates());
+
+    const template: Omit<WorkItemTemplate, 'id' | 'createdAt'> = {
+      name: 'My Template',
+      description: 'Custom template',
+      category: 'custom',
+      structure: {
+        kind: 'epic',
+        title: 'New Epic',
+        children: [],
+      },
+    };
+
+    act(() => {
+      result.current.saveTemplate(template);
+    });
+
+    const customTemplates = result.current.templates.filter(
+      (t) => t.category === 'custom'
+    );
+    expect(customTemplates.length).toBe(1);
+    expect(customTemplates[0].name).toBe('My Template');
+  });
+
+  it('can delete a custom template', () => {
+    const { result } = renderHook(() => useTemplates());
+
+    const template: Omit<WorkItemTemplate, 'id' | 'createdAt'> = {
+      name: 'Delete Me',
+      description: 'Will be deleted',
+      category: 'custom',
+      structure: {
+        kind: 'issue',
+        title: 'Issue',
+        children: [],
+      },
+    };
+
+    act(() => {
+      result.current.saveTemplate(template);
+    });
+
+    const customTemplate = result.current.templates.find(
+      (t) => t.name === 'Delete Me'
+    );
+    expect(customTemplate).toBeDefined();
+
+    act(() => {
+      result.current.deleteTemplate(customTemplate!.id);
+    });
+
+    expect(
+      result.current.templates.find((t) => t.name === 'Delete Me')
+    ).toBeUndefined();
+  });
+
+  it('persists templates to localStorage', () => {
+    const { result } = renderHook(() => useTemplates());
+
+    act(() => {
+      result.current.saveTemplate({
+        name: 'Persisted',
+        description: 'Should persist',
+        category: 'custom',
+        structure: {
+          kind: 'task',
+          title: 'Task',
+          children: [],
+        },
+      });
+    });
+
+    const stored = localStorageMock.getItem('work-item-templates');
+    expect(stored).not.toBeNull();
+    const parsed = JSON.parse(stored!);
+    expect(parsed.some((t: WorkItemTemplate) => t.name === 'Persisted')).toBe(
+      true
+    );
+  });
+
+  it('filters templates by category', () => {
+    const { result } = renderHook(() => useTemplates());
+
+    const sprintTemplates = result.current.getTemplatesByCategory('sprint');
+    expect(sprintTemplates.length).toBeGreaterThan(0);
+    expect(sprintTemplates.every((t) => t.category === 'sprint')).toBe(true);
+  });
+});
+
+describe('TemplateSelector', () => {
+  const mockOnSelect = vi.fn();
+  const mockOnCancel = vi.fn();
+
+  beforeEach(() => {
+    localStorageMock.clear();
+    vi.clearAllMocks();
+  });
+
+  it('renders template categories', () => {
+    render(
+      <TemplateSelector
+        open={true}
+        onSelect={mockOnSelect}
+        onCancel={mockOnCancel}
+      />
+    );
+
+    // Check for tab triggers specifically
+    expect(screen.getByRole('tab', { name: /sprint/i })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /feature/i })).toBeInTheDocument();
+  });
+
+  it('shows built-in templates', () => {
+    render(
+      <TemplateSelector
+        open={true}
+        onSelect={mockOnSelect}
+        onCancel={mockOnCancel}
+      />
+    );
+
+    expect(screen.getByText('Sprint Planning')).toBeInTheDocument();
+  });
+
+  it('calls onSelect with template when clicking Use Template', () => {
+    render(
+      <TemplateSelector
+        open={true}
+        onSelect={mockOnSelect}
+        onCancel={mockOnCancel}
+      />
+    );
+
+    // Click on a template card
+    fireEvent.click(screen.getByText('Sprint Planning'));
+
+    // Click Use Template button
+    fireEvent.click(screen.getByRole('button', { name: /use template/i }));
+
+    expect(mockOnSelect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Sprint Planning',
+      })
+    );
+  });
+});
+
+describe('TemplateManager', () => {
+  beforeEach(() => {
+    localStorageMock.clear();
+  });
+
+  it('displays all templates', () => {
+    render(<TemplateManager />);
+
+    expect(screen.getByText('Sprint Planning')).toBeInTheDocument();
+    expect(screen.getByText('Feature Development')).toBeInTheDocument();
+  });
+
+  it('filters templates by search', () => {
+    render(<TemplateManager />);
+
+    const searchInput = screen.getByPlaceholderText(/search templates/i);
+    fireEvent.change(searchInput, { target: { value: 'Sprint' } });
+
+    expect(screen.getByText('Sprint Planning')).toBeInTheDocument();
+    expect(screen.queryByText('Feature Development')).not.toBeInTheDocument();
+  });
+
+  it('shows delete button for custom templates', () => {
+    // Pre-populate localStorage with a custom template
+    const customTemplate: WorkItemTemplate = {
+      id: 'custom-1',
+      name: 'My Custom',
+      description: 'A custom template',
+      category: 'custom',
+      structure: {
+        kind: 'epic',
+        title: 'Custom Epic',
+        children: [],
+      },
+      createdAt: new Date().toISOString(),
+    };
+    localStorageMock.setItem(
+      'work-item-templates',
+      JSON.stringify([customTemplate])
+    );
+
+    render(<TemplateManager />);
+
+    // Find the custom template and its delete button
+    const customCard = screen.getByText('My Custom').closest('[data-template]');
+    expect(customCard).toBeInTheDocument();
+
+    const deleteButton = customCard?.querySelector(
+      '[aria-label="Delete template"]'
+    );
+    expect(deleteButton).toBeInTheDocument();
+  });
+});
+
+describe('SaveTemplateDialog', () => {
+  const mockOnSave = vi.fn();
+  const mockOnCancel = vi.fn();
+
+  const mockItem = {
+    id: 'item-1',
+    title: 'My Project',
+    kind: 'epic' as const,
+    children: [
+      { id: 'child-1', title: 'Task 1', kind: 'issue' as const },
+      { id: 'child-2', title: 'Task 2', kind: 'issue' as const },
+    ],
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders dialog with item title as default template name', () => {
+    render(
+      <SaveTemplateDialog
+        open={true}
+        item={mockItem}
+        onSave={mockOnSave}
+        onCancel={mockOnCancel}
+      />
+    );
+
+    expect(screen.getByDisplayValue('My Project')).toBeInTheDocument();
+  });
+
+  it('shows category selection', () => {
+    render(
+      <SaveTemplateDialog
+        open={true}
+        item={mockItem}
+        onSave={mockOnSave}
+        onCancel={mockOnCancel}
+      />
+    );
+
+    expect(screen.getByLabelText(/category/i)).toBeInTheDocument();
+  });
+
+  it('shows include children option', () => {
+    render(
+      <SaveTemplateDialog
+        open={true}
+        item={mockItem}
+        onSave={mockOnSave}
+        onCancel={mockOnCancel}
+      />
+    );
+
+    expect(screen.getByText(/include children/i)).toBeInTheDocument();
+  });
+
+  it('calls onSave with template data when Save clicked', () => {
+    render(
+      <SaveTemplateDialog
+        open={true}
+        item={mockItem}
+        onSave={mockOnSave}
+        onCancel={mockOnCancel}
+      />
+    );
+
+    // Edit template name
+    const nameInput = screen.getByDisplayValue('My Project');
+    fireEvent.change(nameInput, { target: { value: 'My Template' } });
+
+    // Add description
+    const descInput = screen.getByPlaceholderText(/describe this template/i);
+    fireEvent.change(descInput, { target: { value: 'A great template' } });
+
+    // Click save
+    fireEvent.click(screen.getByRole('button', { name: /save template/i }));
+
+    expect(mockOnSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'My Template',
+        description: 'A great template',
+      })
+    );
+  });
+
+  it('disables save when name is empty', () => {
+    render(
+      <SaveTemplateDialog
+        open={true}
+        item={mockItem}
+        onSave={mockOnSave}
+        onCancel={mockOnCancel}
+      />
+    );
+
+    const nameInput = screen.getByDisplayValue('My Project');
+    fireEvent.change(nameInput, { target: { value: '' } });
+
+    expect(
+      screen.getByRole('button', { name: /save template/i })
+    ).toBeDisabled();
+  });
+});


### PR DESCRIPTION
## Summary
- Add CloneDialog component for duplicating work items with clone depth options
- Add template system with built-in and custom templates
- Add TemplateSelector for choosing templates when creating new items
- Add TemplateManager for viewing and managing templates
- Add SaveTemplateDialog for saving items as templates

## Features
### Clone Existing Item
- CloneDialog with options: clone item only, include children, include todos
- Title editing before saving with "(Copy)" suffix default
- Loading state during clone operation
- Keyboard shortcuts (Enter to submit, Escape to cancel)

### Project Templates
- Built-in templates: Sprint Planning, Feature Development, Bug Fix, New Project
- Each template has hierarchical structure with children
- Template selector with category tabs
- Template manager with search and category filtering

### Template Management
- View all templates (built-in and custom)
- Delete custom templates
- localStorage persistence for custom templates
- Category organization

## Test plan
- [x] 14 tests for CloneDialog component
- [x] 16 tests for template system (useTemplates hook, TemplateSelector, TemplateManager, SaveTemplateDialog)
- [x] All 475 UI tests passing

Closes #384

🤖 Generated with [Claude Code](https://claude.com/claude-code)