### PR TITLE
[#386] Implement custom fields (text, number, date, select, multi-select)

### DIFF
--- a/src/ui/components/custom-fields/custom-field-input.tsx
+++ b/src/ui/components/custom-fields/custom-field-input.tsx
@@ -1,0 +1,165 @@
+/**
+ * Input component for custom field values
+ */
+import * as React from 'react';
+import { Input } from '@/ui/components/ui/input';
+import { Textarea } from '@/ui/components/ui/textarea';
+import { Checkbox } from '@/ui/components/ui/checkbox';
+import { Label } from '@/ui/components/ui/label';
+import { cn } from '@/ui/lib/utils';
+import type { CustomFieldInputProps } from './types';
+
+export function CustomFieldInput({
+  field,
+  value,
+  onChange,
+  disabled = false,
+  error,
+}: CustomFieldInputProps) {
+  const renderInput = () => {
+    switch (field.type) {
+      case 'text':
+        return (
+          <Input
+            type="text"
+            value={(value as string) || ''}
+            onChange={(e) => onChange(e.target.value)}
+            disabled={disabled}
+            placeholder={field.description}
+          />
+        );
+
+      case 'longtext':
+        return (
+          <Textarea
+            value={(value as string) || ''}
+            onChange={(e) => onChange(e.target.value)}
+            disabled={disabled}
+            placeholder={field.description}
+            rows={3}
+          />
+        );
+
+      case 'number':
+        return (
+          <Input
+            type="number"
+            value={value !== undefined && value !== null ? String(value) : ''}
+            onChange={(e) =>
+              onChange(e.target.value ? Number(e.target.value) : null)
+            }
+            disabled={disabled}
+            min={field.validation?.min}
+            max={field.validation?.max}
+          />
+        );
+
+      case 'date':
+        return (
+          <Input
+            type="date"
+            value={(value as string) || ''}
+            onChange={(e) => onChange(e.target.value)}
+            disabled={disabled}
+          />
+        );
+
+      case 'select':
+        return (
+          <select
+            value={(value as string) || ''}
+            onChange={(e) => onChange(e.target.value)}
+            disabled={disabled}
+            className="w-full h-9 rounded-md border border-input bg-background px-3 text-sm"
+            aria-label={field.name}
+          >
+            <option value="">Select...</option>
+            {field.options?.map((option) => (
+              <option key={option} value={option}>
+                {option}
+              </option>
+            ))}
+          </select>
+        );
+
+      case 'multiselect':
+        return (
+          <div className="space-y-2">
+            {field.options?.map((option) => {
+              const selected = Array.isArray(value) && value.includes(option);
+              return (
+                <div key={option} className="flex items-center gap-2">
+                  <Checkbox
+                    id={`${field.id}-${option}`}
+                    checked={selected}
+                    onCheckedChange={(checked) => {
+                      const current = Array.isArray(value) ? value : [];
+                      if (checked) {
+                        onChange([...current, option]);
+                      } else {
+                        onChange(current.filter((v) => v !== option));
+                      }
+                    }}
+                    disabled={disabled}
+                  />
+                  <Label htmlFor={`${field.id}-${option}`}>{option}</Label>
+                </div>
+              );
+            })}
+          </div>
+        );
+
+      case 'checkbox':
+        return (
+          <Checkbox
+            checked={Boolean(value)}
+            onCheckedChange={(checked) => onChange(checked)}
+            disabled={disabled}
+            aria-label={field.name}
+          />
+        );
+
+      case 'url':
+        return (
+          <Input
+            type="url"
+            value={(value as string) || ''}
+            onChange={(e) => onChange(e.target.value)}
+            disabled={disabled}
+            placeholder="https://..."
+          />
+        );
+
+      case 'user':
+        // User picker would need contact integration
+        return (
+          <Input
+            type="text"
+            value={(value as string) || ''}
+            onChange={(e) => onChange(e.target.value)}
+            disabled={disabled}
+            placeholder="User ID"
+          />
+        );
+
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-center gap-1">
+        <Label htmlFor={field.id} className="text-sm font-medium">
+          {field.name}
+        </Label>
+        {field.required && <span className="text-destructive">*</span>}
+      </div>
+      {field.description && field.type !== 'text' && (
+        <p className="text-xs text-muted-foreground">{field.description}</p>
+      )}
+      {renderInput()}
+      {error && <p className="text-xs text-destructive">{error}</p>}
+    </div>
+  );
+}

--- a/src/ui/components/custom-fields/custom-field-list.tsx
+++ b/src/ui/components/custom-fields/custom-field-list.tsx
@@ -1,0 +1,83 @@
+/**
+ * List component for displaying and editing custom field values
+ */
+import * as React from 'react';
+import { cn } from '@/ui/lib/utils';
+import { CustomFieldInput } from './custom-field-input';
+import type { CustomFieldListProps, CustomFieldDefinition } from './types';
+
+export function CustomFieldList({
+  fields,
+  values,
+  onChange,
+  readOnly = false,
+  className,
+}: CustomFieldListProps) {
+  // Create a map for quick value lookup
+  const valueMap = React.useMemo(() => {
+    const map = new Map<string, unknown>();
+    for (const v of values) {
+      map.set(v.fieldId, v.value);
+    }
+    return map;
+  }, [values]);
+
+  // Sort fields by order
+  const sortedFields = React.useMemo(
+    () => [...fields].sort((a, b) => a.order - b.order),
+    [fields]
+  );
+
+  const formatValue = (field: CustomFieldDefinition, value: unknown): string => {
+    if (value === null || value === undefined || value === '') {
+      return '—';
+    }
+
+    switch (field.type) {
+      case 'checkbox':
+        return value ? 'Yes' : 'No';
+      case 'multiselect':
+        return Array.isArray(value) ? value.join(', ') : String(value);
+      case 'date':
+        try {
+          return new Date(value as string).toLocaleDateString();
+        } catch {
+          return String(value);
+        }
+      default:
+        return String(value);
+    }
+  };
+
+  if (fields.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className={cn('space-y-4', className)}>
+      {sortedFields.map((field) => {
+        const value = valueMap.get(field.id);
+
+        if (readOnly) {
+          return (
+            <div key={field.id} className="space-y-1">
+              <dt className="text-sm font-medium text-muted-foreground">
+                {field.name}
+              </dt>
+              <dd className="text-sm">{formatValue(field, value)}</dd>
+            </div>
+          );
+        }
+
+        return (
+          <CustomFieldInput
+            key={field.id}
+            field={field}
+            value={value}
+            onChange={(newValue) => onChange(field.id, newValue)}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/src/ui/components/custom-fields/custom-field-manager.tsx
+++ b/src/ui/components/custom-fields/custom-field-manager.tsx
@@ -1,0 +1,318 @@
+/**
+ * Manager component for creating, editing, and deleting custom field definitions
+ */
+import * as React from 'react';
+import { PlusIcon, TrashIcon, GripVerticalIcon } from 'lucide-react';
+import { Button } from '@/ui/components/ui/button';
+import { Input } from '@/ui/components/ui/input';
+import { Label } from '@/ui/components/ui/label';
+import { Textarea } from '@/ui/components/ui/textarea';
+import { Checkbox } from '@/ui/components/ui/checkbox';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/ui/components/ui/dialog';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/ui/components/ui/alert-dialog';
+import { Badge } from '@/ui/components/ui/badge';
+import { cn } from '@/ui/lib/utils';
+import { fieldTypeHasOptions, fieldTypeHasValidation } from './validation';
+import type {
+  CustomFieldManagerProps,
+  CustomFieldType,
+  CreateCustomFieldData,
+  FIELD_TYPE_LABELS,
+} from './types';
+
+const FIELD_TYPES: { value: CustomFieldType; label: string }[] = [
+  { value: 'text', label: 'Text' },
+  { value: 'longtext', label: 'Long Text' },
+  { value: 'number', label: 'Number' },
+  { value: 'date', label: 'Date' },
+  { value: 'select', label: 'Select' },
+  { value: 'multiselect', label: 'Multi-Select' },
+  { value: 'checkbox', label: 'Checkbox' },
+  { value: 'url', label: 'URL' },
+];
+
+export function CustomFieldManager({
+  projectId,
+  fields,
+  onCreate,
+  onUpdate,
+  onDelete,
+  onReorder,
+  className,
+}: CustomFieldManagerProps) {
+  const [showCreate, setShowCreate] = React.useState(false);
+  const [deleteId, setDeleteId] = React.useState<string | null>(null);
+
+  // Create form state
+  const [name, setName] = React.useState('');
+  const [type, setType] = React.useState<CustomFieldType>('text');
+  const [description, setDescription] = React.useState('');
+  const [required, setRequired] = React.useState(false);
+  const [options, setOptions] = React.useState('');
+  const [minValue, setMinValue] = React.useState('');
+  const [maxValue, setMaxValue] = React.useState('');
+
+  const sortedFields = React.useMemo(
+    () => [...fields].sort((a, b) => a.order - b.order),
+    [fields]
+  );
+
+  const resetForm = () => {
+    setName('');
+    setType('text');
+    setDescription('');
+    setRequired(false);
+    setOptions('');
+    setMinValue('');
+    setMaxValue('');
+  };
+
+  const handleCreate = () => {
+    const data: CreateCustomFieldData = {
+      name: name.trim(),
+      type,
+      description: description.trim() || undefined,
+      required,
+    };
+
+    if (fieldTypeHasOptions(type) && options.trim()) {
+      data.options = options
+        .split('\n')
+        .map((o) => o.trim())
+        .filter(Boolean);
+    }
+
+    if (fieldTypeHasValidation(type)) {
+      const validation: Record<string, number> = {};
+      if (minValue) validation.min = Number(minValue);
+      if (maxValue) validation.max = Number(maxValue);
+      if (Object.keys(validation).length > 0) {
+        data.validation = validation;
+      }
+    }
+
+    onCreate(data);
+    setShowCreate(false);
+    resetForm();
+  };
+
+  const handleDelete = () => {
+    if (deleteId) {
+      onDelete(deleteId);
+      setDeleteId(null);
+    }
+  };
+
+  const fieldToDelete = fields.find((f) => f.id === deleteId);
+
+  return (
+    <div className={cn('space-y-4', className)}>
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="text-lg font-medium">Custom Fields</h3>
+          <p className="text-sm text-muted-foreground">
+            Define custom fields for work items in this project
+          </p>
+        </div>
+        <Button onClick={() => setShowCreate(true)} aria-label="Add field">
+          <PlusIcon className="h-4 w-4 mr-2" />
+          Add Field
+        </Button>
+      </div>
+
+      {/* Field list */}
+      <div className="space-y-2">
+        {sortedFields.length === 0 ? (
+          <p className="text-center text-muted-foreground py-8">
+            No custom fields defined yet
+          </p>
+        ) : (
+          sortedFields.map((field) => (
+            <div
+              key={field.id}
+              className="flex items-center gap-3 p-3 rounded-lg border bg-card"
+            >
+              <GripVerticalIcon className="h-4 w-4 text-muted-foreground cursor-grab" />
+              <div className="flex-1">
+                <div className="flex items-center gap-2">
+                  <span className="font-medium">{field.name}</span>
+                  <Badge variant="secondary">{field.type}</Badge>
+                  {field.required && (
+                    <Badge variant="outline" className="text-destructive">
+                      Required
+                    </Badge>
+                  )}
+                </div>
+                {field.description && (
+                  <p className="text-sm text-muted-foreground mt-0.5">
+                    {field.description}
+                  </p>
+                )}
+              </div>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setDeleteId(field.id)}
+                className="text-destructive hover:text-destructive hover:bg-destructive/10"
+                aria-label={`Delete ${field.name}`}
+              >
+                <TrashIcon className="h-4 w-4" />
+              </Button>
+            </div>
+          ))
+        )}
+      </div>
+
+      {/* Create dialog */}
+      <Dialog open={showCreate} onOpenChange={setShowCreate}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Create Custom Field</DialogTitle>
+            <DialogDescription>
+              Add a new custom field for work items in this project.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4 py-4">
+            <div className="space-y-2">
+              <Label htmlFor="field-name">Field Name</Label>
+              <Input
+                id="field-name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="e.g., Sprint, Story Points"
+                aria-label="Field name"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="field-type">Field Type</Label>
+              <select
+                id="field-type"
+                value={type}
+                onChange={(e) => setType(e.target.value as CustomFieldType)}
+                className="w-full h-9 rounded-md border border-input bg-background px-3 text-sm"
+                aria-label="Field type"
+              >
+                {FIELD_TYPES.map((t) => (
+                  <option key={t.value} value={t.value}>
+                    {t.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="field-description">Description (optional)</Label>
+              <Input
+                id="field-description"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="Help text for this field"
+              />
+            </div>
+
+            <div className="flex items-center gap-2">
+              <Checkbox
+                id="field-required"
+                checked={required}
+                onCheckedChange={(checked) => setRequired(checked === true)}
+              />
+              <Label htmlFor="field-required">Required field</Label>
+            </div>
+
+            {fieldTypeHasOptions(type) && (
+              <div className="space-y-2">
+                <Label htmlFor="field-options">Options (one per line)</Label>
+                <Textarea
+                  id="field-options"
+                  value={options}
+                  onChange={(e) => setOptions(e.target.value)}
+                  placeholder="Option 1&#10;Option 2&#10;Option 3"
+                  rows={4}
+                />
+              </div>
+            )}
+
+            {type === 'number' && (
+              <div className="grid grid-cols-2 gap-4">
+                <div className="space-y-2">
+                  <Label htmlFor="field-min">Min Value</Label>
+                  <Input
+                    id="field-min"
+                    type="number"
+                    value={minValue}
+                    onChange={(e) => setMinValue(e.target.value)}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="field-max">Max Value</Label>
+                  <Input
+                    id="field-max"
+                    type="number"
+                    value={maxValue}
+                    onChange={(e) => setMaxValue(e.target.value)}
+                  />
+                </div>
+              </div>
+            )}
+          </div>
+
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => {
+                setShowCreate(false);
+                resetForm();
+              }}
+            >
+              Cancel
+            </Button>
+            <Button onClick={handleCreate} disabled={!name.trim()}>
+              Create
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete confirmation */}
+      <AlertDialog open={!!deleteId} onOpenChange={() => setDeleteId(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete Custom Field</AlertDialogTitle>
+            <AlertDialogDescription>
+              Are you sure you want to delete the field "{fieldToDelete?.name}"?
+              This will remove all values from existing work items.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDelete}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              Confirm
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/src/ui/components/custom-fields/index.ts
+++ b/src/ui/components/custom-fields/index.ts
@@ -1,0 +1,20 @@
+export { CustomFieldInput } from './custom-field-input';
+export { CustomFieldList } from './custom-field-list';
+export { CustomFieldManager } from './custom-field-manager';
+export {
+  validateFieldValue,
+  fieldTypeHasOptions,
+  fieldTypeHasValidation,
+} from './validation';
+export type {
+  CustomFieldType,
+  CustomFieldDefinition,
+  CustomFieldValue,
+  CreateCustomFieldData,
+  UpdateCustomFieldData,
+  CustomFieldValidation,
+  CustomFieldInputProps,
+  CustomFieldListProps,
+  CustomFieldManagerProps,
+} from './types';
+export { FIELD_TYPE_LABELS } from './types';

--- a/src/ui/components/custom-fields/types.ts
+++ b/src/ui/components/custom-fields/types.ts
@@ -1,0 +1,130 @@
+/**
+ * Types for custom fields system
+ */
+
+/**
+ * Available custom field types
+ */
+export type CustomFieldType =
+  | 'text'
+  | 'longtext'
+  | 'number'
+  | 'date'
+  | 'select'
+  | 'multiselect'
+  | 'checkbox'
+  | 'url'
+  | 'user';
+
+/**
+ * Validation rules for custom fields
+ */
+export interface CustomFieldValidation {
+  min?: number;
+  max?: number;
+  pattern?: string;
+  patternMessage?: string;
+}
+
+/**
+ * Definition of a custom field
+ */
+export interface CustomFieldDefinition {
+  id: string;
+  projectId: string;
+  name: string;
+  type: CustomFieldType;
+  description?: string;
+  required?: boolean;
+  defaultValue?: unknown;
+  options?: string[];
+  validation?: CustomFieldValidation;
+  order: number;
+  archived?: boolean;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+/**
+ * Value of a custom field for a specific work item
+ */
+export interface CustomFieldValue {
+  fieldId: string;
+  value: unknown;
+}
+
+/**
+ * Data for creating a custom field
+ */
+export interface CreateCustomFieldData {
+  name: string;
+  type: CustomFieldType;
+  description?: string;
+  required?: boolean;
+  defaultValue?: unknown;
+  options?: string[];
+  validation?: CustomFieldValidation;
+}
+
+/**
+ * Data for updating a custom field
+ */
+export interface UpdateCustomFieldData {
+  name?: string;
+  description?: string;
+  required?: boolean;
+  defaultValue?: unknown;
+  options?: string[];
+  validation?: CustomFieldValidation;
+  archived?: boolean;
+}
+
+/**
+ * Props for CustomFieldInput component
+ */
+export interface CustomFieldInputProps {
+  field: CustomFieldDefinition;
+  value: unknown;
+  onChange: (value: unknown) => void;
+  disabled?: boolean;
+  error?: string;
+}
+
+/**
+ * Props for CustomFieldList component
+ */
+export interface CustomFieldListProps {
+  fields: CustomFieldDefinition[];
+  values: CustomFieldValue[];
+  onChange: (fieldId: string, value: unknown) => void;
+  readOnly?: boolean;
+  className?: string;
+}
+
+/**
+ * Props for CustomFieldManager component
+ */
+export interface CustomFieldManagerProps {
+  projectId: string;
+  fields: CustomFieldDefinition[];
+  onCreate: (data: CreateCustomFieldData) => void;
+  onUpdate: (id: string, data: UpdateCustomFieldData) => void;
+  onDelete: (id: string) => void;
+  onReorder: (orderedIds: string[]) => void;
+  className?: string;
+}
+
+/**
+ * Type labels for display
+ */
+export const FIELD_TYPE_LABELS: Record<CustomFieldType, string> = {
+  text: 'Text',
+  longtext: 'Long Text',
+  number: 'Number',
+  date: 'Date',
+  select: 'Select',
+  multiselect: 'Multi-Select',
+  checkbox: 'Checkbox',
+  url: 'URL',
+  user: 'User',
+};

--- a/src/ui/components/custom-fields/validation.ts
+++ b/src/ui/components/custom-fields/validation.ts
@@ -1,0 +1,108 @@
+/**
+ * Validation utilities for custom fields
+ */
+import type { CustomFieldDefinition } from './types';
+
+/**
+ * Validate a field value against its definition
+ * Returns error message or null if valid
+ */
+export function validateFieldValue(
+  field: CustomFieldDefinition,
+  value: unknown
+): string | null {
+  // Check required
+  if (field.required) {
+    if (value === null || value === undefined || value === '') {
+      return 'This field is required';
+    }
+    if (Array.isArray(value) && value.length === 0) {
+      return 'This field is required';
+    }
+  }
+
+  // Skip further validation if empty and not required
+  if (value === null || value === undefined || value === '') {
+    return null;
+  }
+
+  // Type-specific validation
+  switch (field.type) {
+    case 'number':
+      return validateNumber(field, value as number);
+    case 'url':
+      return validateUrl(value as string);
+    case 'text':
+    case 'longtext':
+      return validateText(field, value as string);
+    default:
+      return null;
+  }
+}
+
+function validateNumber(
+  field: CustomFieldDefinition,
+  value: number
+): string | null {
+  if (typeof value !== 'number' || isNaN(value)) {
+    return 'Invalid number';
+  }
+
+  const { validation } = field;
+  if (!validation) return null;
+
+  if (validation.min !== undefined && value < validation.min) {
+    return `Value must be at least ${validation.min}`;
+  }
+  if (validation.max !== undefined && value > validation.max) {
+    return `Value must be at most ${validation.max}`;
+  }
+
+  return null;
+}
+
+function validateUrl(value: string): string | null {
+  try {
+    new URL(value);
+    return null;
+  } catch {
+    return 'Invalid URL format';
+  }
+}
+
+function validateText(
+  field: CustomFieldDefinition,
+  value: string
+): string | null {
+  const { validation } = field;
+  if (!validation) return null;
+
+  if (validation.min !== undefined && value.length < validation.min) {
+    return `Must be at least ${validation.min} characters`;
+  }
+  if (validation.max !== undefined && value.length > validation.max) {
+    return `Must be at most ${validation.max} characters`;
+  }
+  if (validation.pattern) {
+    const regex = new RegExp(validation.pattern);
+    if (!regex.test(value)) {
+      return validation.patternMessage || 'Invalid format';
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Check if a field type supports options
+ */
+export function fieldTypeHasOptions(type: string): boolean {
+  return type === 'select' || type === 'multiselect';
+}
+
+/**
+ * Check if a field type supports validation rules
+ */
+export function fieldTypeHasValidation(type: string): boolean {
+  return type === 'number' || type === 'text' || type === 'longtext';
+}

--- a/tests/ui/custom-fields.test.tsx
+++ b/tests/ui/custom-fields.test.tsx
@@ -1,0 +1,353 @@
+/**
+ * @vitest-environment jsdom
+ */
+import * as React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
+import { CustomFieldInput } from '@/ui/components/custom-fields/custom-field-input';
+import { CustomFieldList } from '@/ui/components/custom-fields/custom-field-list';
+import { CustomFieldManager } from '@/ui/components/custom-fields/custom-field-manager';
+import { validateFieldValue } from '@/ui/components/custom-fields/validation';
+import type {
+  CustomFieldDefinition,
+  CustomFieldValue,
+} from '@/ui/components/custom-fields/types';
+
+describe('CustomFieldInput', () => {
+  const baseField: CustomFieldDefinition = {
+    id: 'field-1',
+    name: 'Sprint',
+    type: 'text',
+    projectId: 'proj-1',
+    order: 0,
+  };
+
+  it('renders text input for text type', () => {
+    render(
+      <CustomFieldInput field={baseField} value="" onChange={vi.fn()} />
+    );
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+  });
+
+  it('renders textarea for longtext type', () => {
+    const field: CustomFieldDefinition = { ...baseField, type: 'longtext' };
+    render(<CustomFieldInput field={field} value="" onChange={vi.fn()} />);
+    expect(screen.getByRole('textbox')).toHaveAttribute('rows');
+  });
+
+  it('renders number input for number type', () => {
+    const field: CustomFieldDefinition = { ...baseField, type: 'number' };
+    render(<CustomFieldInput field={field} value={0} onChange={vi.fn()} />);
+    expect(screen.getByRole('spinbutton')).toBeInTheDocument();
+  });
+
+  it('renders date picker for date type', () => {
+    const field: CustomFieldDefinition = { ...baseField, type: 'date' };
+    render(<CustomFieldInput field={field} value="" onChange={vi.fn()} />);
+    // Date input has no accessible role, query by attribute
+    const input = document.querySelector('input[type="date"]');
+    expect(input).toBeInTheDocument();
+  });
+
+  it('renders select for select type', () => {
+    const field: CustomFieldDefinition = {
+      ...baseField,
+      type: 'select',
+      options: ['Option 1', 'Option 2', 'Option 3'],
+    };
+    render(<CustomFieldInput field={field} value="" onChange={vi.fn()} />);
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+  });
+
+  it('renders multi-select checkboxes for multiselect type', () => {
+    const field: CustomFieldDefinition = {
+      ...baseField,
+      type: 'multiselect',
+      options: ['Tag 1', 'Tag 2', 'Tag 3'],
+    };
+    render(<CustomFieldInput field={field} value={[]} onChange={vi.fn()} />);
+    expect(screen.getAllByRole('checkbox')).toHaveLength(3);
+  });
+
+  it('renders checkbox for checkbox type', () => {
+    const field: CustomFieldDefinition = { ...baseField, type: 'checkbox' };
+    render(
+      <CustomFieldInput field={field} value={false} onChange={vi.fn()} />
+    );
+    expect(screen.getByRole('checkbox')).toBeInTheDocument();
+  });
+
+  it('renders URL input for url type', () => {
+    const field: CustomFieldDefinition = { ...baseField, type: 'url' };
+    render(<CustomFieldInput field={field} value="" onChange={vi.fn()} />);
+    expect(screen.getByRole('textbox')).toHaveAttribute('type', 'url');
+  });
+
+  it('calls onChange when value changes', () => {
+    const onChange = vi.fn();
+    render(
+      <CustomFieldInput field={baseField} value="" onChange={onChange} />
+    );
+
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: { value: 'New value' },
+    });
+
+    expect(onChange).toHaveBeenCalledWith('New value');
+  });
+
+  it('shows required indicator when field is required', () => {
+    const field: CustomFieldDefinition = { ...baseField, required: true };
+    render(<CustomFieldInput field={field} value="" onChange={vi.fn()} />);
+    expect(screen.getByText('*')).toBeInTheDocument();
+  });
+
+  it('shows description when provided', () => {
+    // For text fields, description is used as placeholder
+    const field: CustomFieldDefinition = {
+      ...baseField,
+      type: 'number', // Use non-text type so description shows as text
+      description: 'Enter the sprint number',
+    };
+    render(<CustomFieldInput field={field} value={0} onChange={vi.fn()} />);
+    expect(screen.getByText('Enter the sprint number')).toBeInTheDocument();
+  });
+
+  it('respects validation rules for number fields', () => {
+    const field: CustomFieldDefinition = {
+      ...baseField,
+      type: 'number',
+      validation: { min: 0, max: 100 },
+    };
+    render(<CustomFieldInput field={field} value={50} onChange={vi.fn()} />);
+    const input = screen.getByRole('spinbutton');
+    expect(input).toHaveAttribute('min', '0');
+    expect(input).toHaveAttribute('max', '100');
+  });
+});
+
+describe('CustomFieldList', () => {
+  const mockFields: CustomFieldDefinition[] = [
+    { id: 'f1', name: 'Sprint', type: 'text', projectId: 'p1', order: 0 },
+    { id: 'f2', name: 'Points', type: 'number', projectId: 'p1', order: 1 },
+    {
+      id: 'f3',
+      name: 'Environment',
+      type: 'select',
+      projectId: 'p1',
+      order: 2,
+      options: ['Dev', 'Staging', 'Prod'],
+    },
+  ];
+
+  const mockValues: CustomFieldValue[] = [
+    { fieldId: 'f1', value: 'Sprint 5' },
+    { fieldId: 'f2', value: 8 },
+    { fieldId: 'f3', value: 'Dev' },
+  ];
+
+  it('renders all custom fields', () => {
+    render(
+      <CustomFieldList
+        fields={mockFields}
+        values={mockValues}
+        onChange={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('Sprint')).toBeInTheDocument();
+    expect(screen.getByText('Points')).toBeInTheDocument();
+    expect(screen.getByText('Environment')).toBeInTheDocument();
+  });
+
+  it('displays field values', () => {
+    render(
+      <CustomFieldList
+        fields={mockFields}
+        values={mockValues}
+        onChange={vi.fn()}
+      />
+    );
+
+    expect(screen.getByDisplayValue('Sprint 5')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('8')).toBeInTheDocument();
+  });
+
+  it('calls onChange with updated values', () => {
+    const onChange = vi.fn();
+    render(
+      <CustomFieldList
+        fields={mockFields}
+        values={mockValues}
+        onChange={onChange}
+      />
+    );
+
+    const sprintInput = screen.getByDisplayValue('Sprint 5');
+    fireEvent.change(sprintInput, { target: { value: 'Sprint 6' } });
+
+    expect(onChange).toHaveBeenCalledWith('f1', 'Sprint 6');
+  });
+
+  it('renders in read-only mode', () => {
+    render(
+      <CustomFieldList
+        fields={mockFields}
+        values={mockValues}
+        onChange={vi.fn()}
+        readOnly
+      />
+    );
+
+    expect(screen.getByText('Sprint 5')).toBeInTheDocument();
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+  });
+});
+
+describe('CustomFieldManager', () => {
+  const mockFields: CustomFieldDefinition[] = [
+    { id: 'f1', name: 'Sprint', type: 'text', projectId: 'p1', order: 0 },
+    { id: 'f2', name: 'Points', type: 'number', projectId: 'p1', order: 1 },
+  ];
+
+  const defaultProps = {
+    projectId: 'p1',
+    fields: mockFields,
+    onCreate: vi.fn(),
+    onUpdate: vi.fn(),
+    onDelete: vi.fn(),
+    onReorder: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('displays existing fields', () => {
+    render(<CustomFieldManager {...defaultProps} />);
+
+    expect(screen.getByText('Sprint')).toBeInTheDocument();
+    expect(screen.getByText('Points')).toBeInTheDocument();
+  });
+
+  it('shows field type badges', () => {
+    render(<CustomFieldManager {...defaultProps} />);
+
+    expect(screen.getByText('text')).toBeInTheDocument();
+    expect(screen.getByText('number')).toBeInTheDocument();
+  });
+
+  it('opens create field dialog', () => {
+    render(<CustomFieldManager {...defaultProps} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /add field/i }));
+
+    expect(screen.getByText('Create Custom Field')).toBeInTheDocument();
+  });
+
+  it('calls onCreate when creating a field', () => {
+    const onCreate = vi.fn();
+    render(<CustomFieldManager {...defaultProps} onCreate={onCreate} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /add field/i }));
+
+    // Fill in field details
+    fireEvent.change(screen.getByLabelText(/field name/i), {
+      target: { value: 'New Field' },
+    });
+
+    // Select type
+    fireEvent.change(screen.getByLabelText(/field type/i), {
+      target: { value: 'text' },
+    });
+
+    // Submit
+    fireEvent.click(screen.getByRole('button', { name: /^create$/i }));
+
+    expect(onCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'New Field',
+        type: 'text',
+      })
+    );
+  });
+
+  it('shows delete confirmation', () => {
+    render(<CustomFieldManager {...defaultProps} />);
+
+    const deleteButtons = screen.getAllByRole('button', { name: /delete/i });
+    fireEvent.click(deleteButtons[0]);
+
+    expect(screen.getByText(/are you sure/i)).toBeInTheDocument();
+  });
+
+  it('calls onDelete when confirmed', () => {
+    const onDelete = vi.fn();
+    render(<CustomFieldManager {...defaultProps} onDelete={onDelete} />);
+
+    const deleteButtons = screen.getAllByRole('button', { name: /delete/i });
+    fireEvent.click(deleteButtons[0]);
+
+    fireEvent.click(screen.getByRole('button', { name: /confirm/i }));
+
+    expect(onDelete).toHaveBeenCalledWith('f1');
+  });
+
+  it('shows options input for select type', () => {
+    render(<CustomFieldManager {...defaultProps} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /add field/i }));
+
+    // Select select type
+    fireEvent.change(screen.getByLabelText(/field type/i), {
+      target: { value: 'select' },
+    });
+
+    expect(screen.getByText(/options/i)).toBeInTheDocument();
+  });
+});
+
+describe('Field Type Validation', () => {
+  it('validates URL format', () => {
+    const field: CustomFieldDefinition = {
+      id: 'url-field',
+      name: 'Website',
+      type: 'url',
+      projectId: 'p1',
+      order: 0,
+    };
+
+    expect(validateFieldValue(field, 'https://example.com')).toBeNull();
+    expect(validateFieldValue(field, 'not-a-url')).toBe('Invalid URL format');
+  });
+
+  it('validates required fields', () => {
+    const field: CustomFieldDefinition = {
+      id: 'req-field',
+      name: 'Required',
+      type: 'text',
+      projectId: 'p1',
+      order: 0,
+      required: true,
+    };
+
+    expect(validateFieldValue(field, '')).toBe('This field is required');
+    expect(validateFieldValue(field, 'value')).toBeNull();
+  });
+
+  it('validates number range', () => {
+    const field: CustomFieldDefinition = {
+      id: 'num-field',
+      name: 'Score',
+      type: 'number',
+      projectId: 'p1',
+      order: 0,
+      validation: { min: 0, max: 10 },
+    };
+
+    expect(validateFieldValue(field, 5)).toBeNull();
+    expect(validateFieldValue(field, -1)).toBe('Value must be at least 0');
+    expect(validateFieldValue(field, 11)).toBe('Value must be at most 10');
+  });
+});


### PR DESCRIPTION
## Summary
- Add custom fields system for per-project work item metadata
- Implement CustomFieldInput for all field types
- Add CustomFieldList for displaying/editing field values
- Add CustomFieldManager for field administration

## Field Types
- **text**: Single line input
- **longtext**: Multi-line textarea
- **number**: Numeric with min/max validation
- **date**: Date picker
- **select**: Single-choice dropdown
- **multiselect**: Multi-checkbox
- **checkbox**: Boolean toggle
- **url**: URL with format validation

## Features
### Field Definition
- Per-project custom fields
- Required/optional setting
- Description/help text
- Validation rules (min/max, URL format)
- Ordered display

### Field Input
- Type-appropriate input rendering
- Required indicator (*)
- Error display
- Description text

### Field Management
- Create field dialog with type selection
- Delete confirmation
- Field type badges
- Options input for select types

## Test plan
- [x] 26 tests covering CustomFieldInput, CustomFieldList, CustomFieldManager, validation
- [x] All 471 UI tests passing

Closes #386

🤖 Generated with [Claude Code](https://claude.com/claude-code)