### PR TITLE
[#395] Implement contact relationship types

### DIFF
--- a/src/ui/components/relationships/add-relationship-dialog.tsx
+++ b/src/ui/components/relationships/add-relationship-dialog.tsx
@@ -1,0 +1,232 @@
+/**
+ * Dialog for adding a relationship
+ * Issue #395: Implement contact relationship types
+ */
+import * as React from 'react';
+import { Button } from '@/ui/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/ui/components/ui/dialog';
+import { Label } from '@/ui/components/ui/label';
+import { Textarea } from '@/ui/components/ui/textarea';
+import { ScrollArea } from '@/ui/components/ui/scroll-area';
+import { cn } from '@/ui/lib/utils';
+import type {
+  Contact,
+  RelationshipType,
+  RelationshipStrength,
+  RelationshipDirection,
+  NewRelationshipData,
+} from './types';
+import {
+  RELATIONSHIP_TYPES,
+  CATEGORY_LABELS,
+  getRelationshipLabel,
+  CATEGORY_COLORS,
+  STRENGTH_LABELS,
+  DIRECTION_LABELS,
+} from './relationship-utils';
+
+export interface AddRelationshipDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  currentContactId: string;
+  availableContacts: Contact[];
+  onAddRelationship: (data: NewRelationshipData) => void;
+}
+
+export function AddRelationshipDialog({
+  open,
+  onOpenChange,
+  currentContactId,
+  availableContacts,
+  onAddRelationship,
+}: AddRelationshipDialogProps) {
+  const [selectedContactId, setSelectedContactId] = React.useState<string | null>(null);
+  const [selectedType, setSelectedType] = React.useState<RelationshipType>('colleague');
+  const [strength, setStrength] = React.useState<RelationshipStrength>('medium');
+  const [direction, setDirection] = React.useState<RelationshipDirection>('bidirectional');
+  const [notes, setNotes] = React.useState('');
+
+  // Filter out current contact
+  const filteredContacts = React.useMemo(
+    () => availableContacts.filter((c) => c.id !== currentContactId),
+    [availableContacts, currentContactId]
+  );
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!selectedContactId) return;
+
+    onAddRelationship({
+      contactId: currentContactId,
+      relatedContactId: selectedContactId,
+      type: selectedType,
+      strength,
+      direction,
+      notes: notes || undefined,
+    });
+
+    // Reset form
+    setSelectedContactId(null);
+    setSelectedType('colleague');
+    setStrength('medium');
+    setDirection('bidirectional');
+    setNotes('');
+    onOpenChange(false);
+  };
+
+  const handleCancel = () => {
+    onOpenChange(false);
+  };
+
+  if (!open) return null;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[500px]">
+        <form onSubmit={handleSubmit}>
+          <DialogHeader>
+            <DialogTitle>Add Relationship</DialogTitle>
+            <DialogDescription>
+              Create a relationship between contacts.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="grid gap-4 py-4">
+            {/* Contact selector */}
+            <div className="space-y-2">
+              <Label>Select Contact</Label>
+              <ScrollArea className="h-32 border rounded-md">
+                <div className="p-1" role="listbox">
+                  {filteredContacts.map((contact) => (
+                    <button
+                      key={contact.id}
+                      type="button"
+                      role="option"
+                      aria-selected={selectedContactId === contact.id}
+                      className={cn(
+                        'w-full flex items-center gap-2 px-2 py-1.5 rounded text-sm text-left',
+                        'hover:bg-muted transition-colors',
+                        selectedContactId === contact.id && 'bg-muted'
+                      )}
+                      onClick={() => setSelectedContactId(contact.id)}
+                    >
+                      <span className="font-medium">{contact.name}</span>
+                      {contact.email && (
+                        <span className="text-muted-foreground text-xs">{contact.email}</span>
+                      )}
+                    </button>
+                  ))}
+                </div>
+              </ScrollArea>
+            </div>
+
+            {/* Relationship type selector */}
+            <div className="space-y-2">
+              <Label>Relationship Type</Label>
+              <div className="space-y-3">
+                {(Object.entries(RELATIONSHIP_TYPES) as [string, RelationshipType[]][]).map(
+                  ([category, types]) => (
+                    <div key={category}>
+                      <div className="text-xs font-medium text-muted-foreground mb-1">
+                        {CATEGORY_LABELS[category as keyof typeof CATEGORY_LABELS]}
+                      </div>
+                      <div className="flex flex-wrap gap-1">
+                        {types.map((type) => (
+                          <button
+                            key={type}
+                            type="button"
+                            className={cn(
+                              'px-2 py-1 text-xs rounded-full transition-colors',
+                              selectedType === type
+                                ? CATEGORY_COLORS[category as keyof typeof CATEGORY_COLORS]
+                                : 'bg-muted hover:bg-muted/80'
+                            )}
+                            onClick={() => setSelectedType(type)}
+                          >
+                            {getRelationshipLabel(type)}
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+                  )
+                )}
+              </div>
+            </div>
+
+            {/* Strength selector */}
+            <div className="space-y-2">
+              <Label>Strength</Label>
+              <div className="flex gap-2">
+                {(['strong', 'medium', 'weak'] as RelationshipStrength[]).map((s) => (
+                  <button
+                    key={s}
+                    type="button"
+                    className={cn(
+                      'flex-1 px-3 py-1.5 text-sm rounded-md border transition-colors',
+                      strength === s
+                        ? 'border-primary bg-primary/10'
+                        : 'border-muted hover:bg-muted'
+                    )}
+                    onClick={() => setStrength(s)}
+                  >
+                    {STRENGTH_LABELS[s]}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Direction selector */}
+            <div className="space-y-2">
+              <Label>Direction</Label>
+              <div className="flex gap-2">
+                {(['bidirectional', 'outgoing', 'incoming'] as RelationshipDirection[]).map((d) => (
+                  <button
+                    key={d}
+                    type="button"
+                    className={cn(
+                      'flex-1 px-3 py-1.5 text-sm rounded-md border transition-colors',
+                      direction === d
+                        ? 'border-primary bg-primary/10'
+                        : 'border-muted hover:bg-muted'
+                    )}
+                    onClick={() => setDirection(d)}
+                  >
+                    {DIRECTION_LABELS[d]}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Notes */}
+            <div className="space-y-2">
+              <Label htmlFor="notes">Notes</Label>
+              <Textarea
+                id="notes"
+                placeholder="Add notes about this relationship..."
+                value={notes}
+                onChange={(e) => setNotes(e.target.value)}
+                rows={2}
+              />
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={handleCancel}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={!selectedContactId}>
+              Add Relationship
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/ui/components/relationships/contact-relationship-section.tsx
+++ b/src/ui/components/relationships/contact-relationship-section.tsx
@@ -1,0 +1,145 @@
+/**
+ * Section for displaying contact relationships
+ * Issue #395: Implement contact relationship types
+ */
+import * as React from 'react';
+import { Plus, Users } from 'lucide-react';
+import { Button } from '@/ui/components/ui/button';
+import { cn } from '@/ui/lib/utils';
+import { RelationshipCard } from './relationship-card';
+import { AddRelationshipDialog } from './add-relationship-dialog';
+import type {
+  ContactRelationship,
+  Contact,
+  NewRelationshipData,
+  RelationshipCategory,
+} from './types';
+import {
+  getRelationshipCategory,
+  CATEGORY_LABELS,
+} from './relationship-utils';
+
+export interface ContactRelationshipSectionProps {
+  contactId: string;
+  relationships: ContactRelationship[];
+  relatedContacts: Contact[];
+  availableContacts: Contact[];
+  onAddRelationship: (data: NewRelationshipData) => void;
+  onEditRelationship: (relationshipId: string) => void;
+  onRemoveRelationship: (relationshipId: string) => void;
+  className?: string;
+}
+
+export function ContactRelationshipSection({
+  contactId,
+  relationships,
+  relatedContacts,
+  availableContacts,
+  onAddRelationship,
+  onEditRelationship,
+  onRemoveRelationship,
+  className,
+}: ContactRelationshipSectionProps) {
+  const [dialogOpen, setDialogOpen] = React.useState(false);
+
+  // Group relationships by category
+  const groupedRelationships = React.useMemo(() => {
+    const groups: Record<RelationshipCategory, ContactRelationship[]> = {
+      professional: [],
+      business: [],
+      personal: [],
+    };
+
+    for (const rel of relationships) {
+      const category = getRelationshipCategory(rel.type);
+      groups[category].push(rel);
+    }
+
+    return groups;
+  }, [relationships]);
+
+  // Map of related contact ID to contact
+  const contactMap = React.useMemo(() => {
+    const map = new Map<string, Contact>();
+    for (const contact of relatedContacts) {
+      map.set(contact.id, contact);
+    }
+    return map;
+  }, [relatedContacts]);
+
+  const hasRelationships = relationships.length > 0;
+
+  return (
+    <div className={cn('space-y-4', className)}>
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Users className="h-4 w-4 text-muted-foreground" />
+          <h3 className="text-sm font-medium">Relationships</h3>
+          <span className="text-xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded">
+            {relationships.length}
+          </span>
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-7"
+          onClick={() => setDialogOpen(true)}
+        >
+          <Plus className="h-3.5 w-3.5 mr-1" />
+          Add Relationship
+        </Button>
+      </div>
+
+      {/* Content */}
+      {hasRelationships ? (
+        <div className="space-y-4">
+          {(Object.entries(groupedRelationships) as [RelationshipCategory, ContactRelationship[]][]).map(
+            ([category, rels]) => {
+              if (rels.length === 0) return null;
+
+              return (
+                <div key={category}>
+                  <div className="text-xs font-medium text-muted-foreground mb-2">
+                    {CATEGORY_LABELS[category]}
+                  </div>
+                  <div className="space-y-2">
+                    {rels.map((rel) => {
+                      const contact = contactMap.get(rel.relatedContactId);
+                      if (!contact) return null;
+
+                      return (
+                        <RelationshipCard
+                          key={rel.id}
+                          relationship={rel}
+                          contact={contact}
+                          onEdit={onEditRelationship}
+                          onRemove={onRemoveRelationship}
+                        />
+                      );
+                    })}
+                  </div>
+                </div>
+              );
+            }
+          )}
+        </div>
+      ) : (
+        <div className="py-8 text-center text-muted-foreground">
+          <Users className="h-8 w-8 mx-auto mb-2 opacity-50" />
+          <p className="text-sm">No relationships yet</p>
+          <p className="text-xs mt-1">Add relationships to track connections</p>
+        </div>
+      )}
+
+      {/* Add dialog */}
+      <AddRelationshipDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        currentContactId={contactId}
+        availableContacts={availableContacts}
+        onAddRelationship={onAddRelationship}
+      />
+    </div>
+  );
+}

--- a/src/ui/components/relationships/index.ts
+++ b/src/ui/components/relationships/index.ts
@@ -1,0 +1,33 @@
+/**
+ * Contact relationship components
+ * Issue #395: Implement contact relationship types
+ */
+export { RelationshipBadge } from './relationship-badge';
+export type { RelationshipBadgeProps } from './relationship-badge';
+export { RelationshipCard } from './relationship-card';
+export type { RelationshipCardProps } from './relationship-card';
+export { AddRelationshipDialog } from './add-relationship-dialog';
+export type { AddRelationshipDialogProps } from './add-relationship-dialog';
+export { RelationshipFilter } from './relationship-filter';
+export type { RelationshipFilterProps } from './relationship-filter';
+export { ContactRelationshipSection } from './contact-relationship-section';
+export type { ContactRelationshipSectionProps } from './contact-relationship-section';
+export type {
+  RelationshipType,
+  RelationshipCategory,
+  RelationshipStrength,
+  RelationshipDirection,
+  ContactRelationship,
+  Contact,
+  NewRelationshipData,
+} from './types';
+export {
+  RELATIONSHIP_TYPES,
+  ALL_RELATIONSHIP_TYPES,
+  CATEGORY_LABELS,
+  getRelationshipLabel,
+  getRelationshipCategory,
+  CATEGORY_COLORS,
+  STRENGTH_LABELS,
+  DIRECTION_LABELS,
+} from './relationship-utils';

--- a/src/ui/components/relationships/relationship-badge.tsx
+++ b/src/ui/components/relationships/relationship-badge.tsx
@@ -1,0 +1,62 @@
+/**
+ * Badge for displaying relationship type
+ * Issue #395: Implement contact relationship types
+ */
+import * as React from 'react';
+import { cn } from '@/ui/lib/utils';
+import type { RelationshipType, RelationshipStrength } from './types';
+import {
+  getRelationshipLabel,
+  getRelationshipCategory,
+  CATEGORY_COLORS,
+} from './relationship-utils';
+
+export interface RelationshipBadgeProps {
+  type: RelationshipType;
+  strength?: RelationshipStrength;
+  showStrength?: boolean;
+  size?: 'sm' | 'md';
+  className?: string;
+}
+
+export function RelationshipBadge({
+  type,
+  strength,
+  showStrength = false,
+  size = 'md',
+  className,
+}: RelationshipBadgeProps) {
+  const category = getRelationshipCategory(type);
+  const label = getRelationshipLabel(type);
+
+  const sizeClasses = {
+    sm: 'text-xs px-1.5 py-0.5',
+    md: 'text-sm px-2 py-1',
+  };
+
+  return (
+    <span
+      data-testid="relationship-badge"
+      data-category={category}
+      className={cn(
+        'inline-flex items-center gap-1 rounded-full font-medium',
+        CATEGORY_COLORS[category],
+        sizeClasses[size],
+        className
+      )}
+    >
+      <span>{label}</span>
+      {showStrength && strength && (
+        <span
+          data-testid="strength-indicator"
+          className={cn(
+            'w-1.5 h-1.5 rounded-full',
+            strength === 'strong' && 'bg-current opacity-100',
+            strength === 'medium' && 'bg-current opacity-60',
+            strength === 'weak' && 'bg-current opacity-30'
+          )}
+        />
+      )}
+    </span>
+  );
+}

--- a/src/ui/components/relationships/relationship-card.tsx
+++ b/src/ui/components/relationships/relationship-card.tsx
@@ -1,0 +1,123 @@
+/**
+ * Card for displaying a relationship
+ * Issue #395: Implement contact relationship types
+ */
+import * as React from 'react';
+import { ArrowRight, ArrowLeftRight, Pencil, Trash2 } from 'lucide-react';
+import { Button } from '@/ui/components/ui/button';
+import { cn } from '@/ui/lib/utils';
+import { RelationshipBadge } from './relationship-badge';
+import type { ContactRelationship, Contact } from './types';
+
+export interface RelationshipCardProps {
+  relationship: ContactRelationship;
+  contact: Contact;
+  onEdit?: (relationshipId: string) => void;
+  onRemove?: (relationshipId: string) => void;
+  className?: string;
+}
+
+function formatDate(dateString: string): string {
+  const date = new Date(dateString);
+  return date.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+export function RelationshipCard({
+  relationship,
+  contact,
+  onEdit,
+  onRemove,
+  className,
+}: RelationshipCardProps) {
+  const initials = contact.name
+    .split(' ')
+    .map((n) => n[0])
+    .join('')
+    .toUpperCase()
+    .slice(0, 2);
+
+  return (
+    <div
+      className={cn(
+        'flex items-start gap-3 p-3 rounded-lg border bg-card hover:bg-muted/50 transition-colors',
+        className
+      )}
+    >
+      {/* Avatar */}
+      <div className="shrink-0">
+        {contact.avatar ? (
+          <img
+            src={contact.avatar}
+            alt={contact.name}
+            className="w-10 h-10 rounded-full object-cover"
+          />
+        ) : (
+          <div className="w-10 h-10 rounded-full bg-muted flex items-center justify-center text-sm font-medium">
+            {initials}
+          </div>
+        )}
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className="font-medium truncate">{contact.name}</span>
+          <RelationshipBadge type={relationship.type} size="sm" />
+          {relationship.direction !== 'bidirectional' && (
+            <span
+              data-testid="direction-indicator"
+              className="text-muted-foreground"
+              title={relationship.direction === 'outgoing' ? 'You → Them' : 'Them → You'}
+            >
+              {relationship.direction === 'outgoing' ? (
+                <ArrowRight className="h-3.5 w-3.5" />
+              ) : (
+                <ArrowLeftRight className="h-3.5 w-3.5" />
+              )}
+            </span>
+          )}
+        </div>
+
+        {relationship.notes && (
+          <p className="text-sm text-muted-foreground mt-1 line-clamp-2">{relationship.notes}</p>
+        )}
+
+        {relationship.lastInteraction && (
+          <p className="text-xs text-muted-foreground mt-1">
+            Last interaction: {formatDate(relationship.lastInteraction)}
+          </p>
+        )}
+      </div>
+
+      {/* Actions */}
+      <div className="flex items-center gap-1 shrink-0">
+        {onEdit && (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8"
+            onClick={() => onEdit(relationship.id)}
+            aria-label="Edit relationship"
+          >
+            <Pencil className="h-4 w-4" />
+          </Button>
+        )}
+        {onRemove && (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8 text-destructive hover:text-destructive"
+            onClick={() => onRemove(relationship.id)}
+            aria-label="Remove relationship"
+          >
+            <Trash2 className="h-4 w-4" />
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/ui/components/relationships/relationship-filter.tsx
+++ b/src/ui/components/relationships/relationship-filter.tsx
@@ -1,0 +1,137 @@
+/**
+ * Filter panel for relationships
+ * Issue #395: Implement contact relationship types
+ */
+import * as React from 'react';
+import { X } from 'lucide-react';
+import { Button } from '@/ui/components/ui/button';
+import { cn } from '@/ui/lib/utils';
+import type { RelationshipType, RelationshipStrength, RelationshipCategory } from './types';
+import {
+  RELATIONSHIP_TYPES,
+  CATEGORY_LABELS,
+  getRelationshipLabel,
+  CATEGORY_COLORS,
+  STRENGTH_LABELS,
+} from './relationship-utils';
+
+export interface RelationshipFilterProps {
+  selectedTypes: RelationshipType[];
+  selectedStrengths: RelationshipStrength[];
+  onTypeChange: (types: RelationshipType[]) => void;
+  onStrengthChange: (strengths: RelationshipStrength[]) => void;
+  className?: string;
+}
+
+export function RelationshipFilter({
+  selectedTypes,
+  selectedStrengths,
+  onTypeChange,
+  onStrengthChange,
+  className,
+}: RelationshipFilterProps) {
+  const hasFilters = selectedTypes.length > 0 || selectedStrengths.length > 0;
+
+  const toggleType = (type: RelationshipType) => {
+    if (selectedTypes.includes(type)) {
+      onTypeChange(selectedTypes.filter((t) => t !== type));
+    } else {
+      onTypeChange([...selectedTypes, type]);
+    }
+  };
+
+  const toggleStrength = (strength: RelationshipStrength) => {
+    if (selectedStrengths.includes(strength)) {
+      onStrengthChange(selectedStrengths.filter((s) => s !== strength));
+    } else {
+      onStrengthChange([...selectedStrengths, strength]);
+    }
+  };
+
+  const clearFilters = () => {
+    onTypeChange([]);
+    onStrengthChange([]);
+  };
+
+  return (
+    <div className={cn('space-y-4', className)}>
+      {/* Header with clear button */}
+      {hasFilters && (
+        <div className="flex items-center justify-between">
+          <span className="text-sm font-medium">Filters</span>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 text-xs"
+            onClick={clearFilters}
+          >
+            <X className="h-3 w-3 mr-1" />
+            Clear
+          </Button>
+        </div>
+      )}
+
+      {/* Relationship type filter */}
+      <div className="space-y-3">
+        <div className="text-sm font-medium text-muted-foreground">Relationship Type</div>
+
+        {(Object.entries(RELATIONSHIP_TYPES) as [RelationshipCategory, RelationshipType[]][]).map(
+          ([category, types]) => (
+            <div key={category}>
+              <div className="text-xs font-medium mb-1">
+                {CATEGORY_LABELS[category]}
+              </div>
+              <div className="flex flex-wrap gap-1">
+                {types.map((type) => {
+                  const isSelected = selectedTypes.includes(type);
+                  return (
+                    <button
+                      key={type}
+                      type="button"
+                      data-selected={isSelected}
+                      className={cn(
+                        'px-2 py-0.5 text-xs rounded-full transition-colors',
+                        isSelected
+                          ? CATEGORY_COLORS[category]
+                          : 'bg-muted hover:bg-muted/80 text-muted-foreground'
+                      )}
+                      onClick={() => toggleType(type)}
+                    >
+                      {getRelationshipLabel(type)}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          )
+        )}
+      </div>
+
+      {/* Strength filter */}
+      <div className="space-y-2">
+        <div className="text-sm font-medium text-muted-foreground">Strength</div>
+        <div className="flex flex-wrap gap-1">
+          {(['strong', 'medium', 'weak'] as RelationshipStrength[]).map((strength) => {
+            const isSelected = selectedStrengths.includes(strength);
+            return (
+              <button
+                key={strength}
+                type="button"
+                data-selected={isSelected}
+                className={cn(
+                  'px-2 py-0.5 text-xs rounded-full transition-colors',
+                  isSelected
+                    ? 'bg-primary text-primary-foreground'
+                    : 'bg-muted hover:bg-muted/80 text-muted-foreground'
+                )}
+                onClick={() => toggleStrength(strength)}
+              >
+                {STRENGTH_LABELS[strength]}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/components/relationships/relationship-utils.ts
+++ b/src/ui/components/relationships/relationship-utils.ts
@@ -1,0 +1,85 @@
+/**
+ * Utility functions for contact relationships
+ * Issue #395: Implement contact relationship types
+ */
+import type {
+  RelationshipType,
+  RelationshipCategory,
+  ProfessionalRelationType,
+  BusinessRelationType,
+  PersonalRelationType,
+} from './types';
+
+/** Relationship types grouped by category */
+export const RELATIONSHIP_TYPES: Record<RelationshipCategory, RelationshipType[]> = {
+  professional: ['colleague', 'manager', 'direct_report', 'mentor'],
+  business: ['client', 'vendor', 'partner', 'investor', 'advisor'],
+  personal: ['friend', 'family', 'acquaintance'],
+};
+
+/** All relationship types flat */
+export const ALL_RELATIONSHIP_TYPES: RelationshipType[] = [
+  ...RELATIONSHIP_TYPES.professional,
+  ...RELATIONSHIP_TYPES.business,
+  ...RELATIONSHIP_TYPES.personal,
+];
+
+/** Human-readable labels for relationship types */
+const RELATIONSHIP_LABELS: Record<RelationshipType, string> = {
+  colleague: 'Colleague',
+  manager: 'Manager',
+  direct_report: 'Direct Report',
+  mentor: 'Mentor',
+  client: 'Client',
+  vendor: 'Vendor',
+  partner: 'Partner',
+  investor: 'Investor',
+  advisor: 'Advisor',
+  friend: 'Friend',
+  family: 'Family',
+  acquaintance: 'Acquaintance',
+};
+
+/** Human-readable labels for categories */
+export const CATEGORY_LABELS: Record<RelationshipCategory, string> = {
+  professional: 'Professional',
+  business: 'Business',
+  personal: 'Personal',
+};
+
+/** Get human-readable label for relationship type */
+export function getRelationshipLabel(type: RelationshipType): string {
+  return RELATIONSHIP_LABELS[type] || type;
+}
+
+/** Get category for relationship type */
+export function getRelationshipCategory(type: RelationshipType): RelationshipCategory {
+  if ((RELATIONSHIP_TYPES.professional as readonly string[]).includes(type)) {
+    return 'professional';
+  }
+  if ((RELATIONSHIP_TYPES.business as readonly string[]).includes(type)) {
+    return 'business';
+  }
+  return 'personal';
+}
+
+/** Color classes for categories */
+export const CATEGORY_COLORS: Record<RelationshipCategory, string> = {
+  professional: 'bg-blue-100 text-blue-800',
+  business: 'bg-green-100 text-green-800',
+  personal: 'bg-purple-100 text-purple-800',
+};
+
+/** Strength labels */
+export const STRENGTH_LABELS: Record<string, string> = {
+  strong: 'Strong',
+  medium: 'Medium',
+  weak: 'Weak',
+};
+
+/** Direction labels */
+export const DIRECTION_LABELS: Record<string, string> = {
+  bidirectional: 'Mutual',
+  outgoing: 'Outgoing',
+  incoming: 'Incoming',
+};

--- a/src/ui/components/relationships/types.ts
+++ b/src/ui/components/relationships/types.ts
@@ -1,0 +1,60 @@
+/**
+ * Types for contact relationships
+ * Issue #395: Implement contact relationship types
+ */
+
+/** Professional relationship types */
+export type ProfessionalRelationType = 'colleague' | 'manager' | 'direct_report' | 'mentor';
+
+/** Business relationship types */
+export type BusinessRelationType = 'client' | 'vendor' | 'partner' | 'investor' | 'advisor';
+
+/** Personal relationship types */
+export type PersonalRelationType = 'friend' | 'family' | 'acquaintance';
+
+/** All relationship types */
+export type RelationshipType = ProfessionalRelationType | BusinessRelationType | PersonalRelationType;
+
+/** Relationship category */
+export type RelationshipCategory = 'professional' | 'business' | 'personal';
+
+/** Relationship strength */
+export type RelationshipStrength = 'strong' | 'medium' | 'weak';
+
+/** Relationship direction */
+export type RelationshipDirection = 'bidirectional' | 'outgoing' | 'incoming';
+
+/** A relationship between contacts */
+export interface ContactRelationship {
+  id: string;
+  contactId: string;
+  relatedContactId: string;
+  type: RelationshipType;
+  strength?: RelationshipStrength;
+  direction: RelationshipDirection;
+  notes?: string;
+  lastInteraction?: string;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+/** A contact for relationship display */
+export interface Contact {
+  id: string;
+  name: string;
+  email?: string;
+  phone?: string;
+  avatar?: string;
+  organizationId?: string;
+  organizationName?: string;
+}
+
+/** New relationship data for creation */
+export interface NewRelationshipData {
+  contactId: string;
+  relatedContactId: string;
+  type: RelationshipType;
+  strength?: RelationshipStrength;
+  direction: RelationshipDirection;
+  notes?: string;
+}

--- a/tests/ui/contact-relationships.test.tsx
+++ b/tests/ui/contact-relationships.test.tsx
@@ -1,0 +1,480 @@
+/**
+ * @vitest-environment jsdom
+ * Tests for contact relationship components
+ * Issue #395: Implement contact relationship types
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import * as React from 'react';
+
+// Components to be implemented
+import {
+  RelationshipBadge,
+  type RelationshipBadgeProps,
+} from '@/ui/components/relationships/relationship-badge';
+import {
+  RelationshipCard,
+  type RelationshipCardProps,
+} from '@/ui/components/relationships/relationship-card';
+import {
+  AddRelationshipDialog,
+  type AddRelationshipDialogProps,
+} from '@/ui/components/relationships/add-relationship-dialog';
+import {
+  RelationshipFilter,
+  type RelationshipFilterProps,
+} from '@/ui/components/relationships/relationship-filter';
+import {
+  ContactRelationshipSection,
+  type ContactRelationshipSectionProps,
+} from '@/ui/components/relationships/contact-relationship-section';
+import type {
+  RelationshipType,
+  RelationshipStrength,
+  ContactRelationship,
+  Contact,
+} from '@/ui/components/relationships/types';
+import {
+  RELATIONSHIP_TYPES,
+  getRelationshipLabel,
+  getRelationshipCategory,
+} from '@/ui/components/relationships/relationship-utils';
+
+describe('RelationshipBadge', () => {
+  const defaultProps: RelationshipBadgeProps = {
+    type: 'colleague',
+  };
+
+  it('should render relationship type label', () => {
+    render(<RelationshipBadge {...defaultProps} />);
+    expect(screen.getByText('Colleague')).toBeInTheDocument();
+  });
+
+  it('should apply category-based styling for professional', () => {
+    render(<RelationshipBadge type="colleague" />);
+    const badge = screen.getByTestId('relationship-badge');
+    expect(badge).toHaveAttribute('data-category', 'professional');
+  });
+
+  it('should apply category-based styling for business', () => {
+    render(<RelationshipBadge type="client" />);
+    const badge = screen.getByTestId('relationship-badge');
+    expect(badge).toHaveAttribute('data-category', 'business');
+  });
+
+  it('should apply category-based styling for personal', () => {
+    render(<RelationshipBadge type="friend" />);
+    const badge = screen.getByTestId('relationship-badge');
+    expect(badge).toHaveAttribute('data-category', 'personal');
+  });
+
+  it('should show strength indicator when provided', () => {
+    render(<RelationshipBadge {...defaultProps} strength="strong" showStrength />);
+    expect(screen.getByTestId('strength-indicator')).toBeInTheDocument();
+  });
+
+  it('should not show strength indicator by default', () => {
+    render(<RelationshipBadge {...defaultProps} />);
+    expect(screen.queryByTestId('strength-indicator')).not.toBeInTheDocument();
+  });
+});
+
+describe('RelationshipCard', () => {
+  const mockContact: Contact = {
+    id: 'contact-1',
+    name: 'Alice Smith',
+    email: 'alice@example.com',
+    avatar: 'https://example.com/alice.png',
+  };
+
+  const mockRelationship: ContactRelationship = {
+    id: 'rel-1',
+    contactId: 'contact-1',
+    relatedContactId: 'contact-2',
+    type: 'colleague',
+    strength: 'strong',
+    direction: 'bidirectional',
+    notes: 'Work together on Project X',
+    lastInteraction: '2024-01-15',
+  };
+
+  const defaultProps: RelationshipCardProps = {
+    relationship: mockRelationship,
+    contact: mockContact,
+    onEdit: vi.fn(),
+    onRemove: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render contact name', () => {
+    render(<RelationshipCard {...defaultProps} />);
+    expect(screen.getByText('Alice Smith')).toBeInTheDocument();
+  });
+
+  it('should render relationship type badge', () => {
+    render(<RelationshipCard {...defaultProps} />);
+    expect(screen.getByText('Colleague')).toBeInTheDocument();
+  });
+
+  it('should show relationship notes', () => {
+    render(<RelationshipCard {...defaultProps} />);
+    expect(screen.getByText(/Work together on Project X/)).toBeInTheDocument();
+  });
+
+  it('should show last interaction date', () => {
+    render(<RelationshipCard {...defaultProps} />);
+    expect(screen.getByText(/Jan 15, 2024/)).toBeInTheDocument();
+  });
+
+  it('should call onEdit when edit button clicked', () => {
+    const onEdit = vi.fn();
+    render(<RelationshipCard {...defaultProps} onEdit={onEdit} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /edit/i }));
+
+    expect(onEdit).toHaveBeenCalledWith('rel-1');
+  });
+
+  it('should call onRemove when remove button clicked', () => {
+    const onRemove = vi.fn();
+    render(<RelationshipCard {...defaultProps} onRemove={onRemove} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /remove/i }));
+
+    expect(onRemove).toHaveBeenCalledWith('rel-1');
+  });
+
+  it('should show direction indicator for directional relationships', () => {
+    const directionalRelationship = { ...mockRelationship, direction: 'outgoing' as const };
+    render(<RelationshipCard {...defaultProps} relationship={directionalRelationship} />);
+    expect(screen.getByTestId('direction-indicator')).toBeInTheDocument();
+  });
+
+  it('should show contact avatar', () => {
+    render(<RelationshipCard {...defaultProps} />);
+    const avatar = screen.getByRole('img');
+    expect(avatar).toHaveAttribute('src', 'https://example.com/alice.png');
+  });
+});
+
+describe('AddRelationshipDialog', () => {
+  const mockContacts: Contact[] = [
+    { id: 'contact-1', name: 'Alice Smith', email: 'alice@example.com' },
+    { id: 'contact-2', name: 'Bob Jones', email: 'bob@example.com' },
+    { id: 'contact-3', name: 'Carol White', email: 'carol@example.com' },
+  ];
+
+  const defaultProps: AddRelationshipDialogProps = {
+    open: true,
+    onOpenChange: vi.fn(),
+    currentContactId: 'contact-1',
+    availableContacts: mockContacts,
+    onAddRelationship: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render dialog when open', () => {
+    render(<AddRelationshipDialog {...defaultProps} />);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('should not render when closed', () => {
+    render(<AddRelationshipDialog {...defaultProps} open={false} />);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('should show relationship type selector', () => {
+    render(<AddRelationshipDialog {...defaultProps} />);
+    expect(screen.getByText(/relationship type/i)).toBeInTheDocument();
+  });
+
+  it('should show contact selector', () => {
+    render(<AddRelationshipDialog {...defaultProps} />);
+    expect(screen.getByText(/select contact/i)).toBeInTheDocument();
+  });
+
+  it('should not show current contact in list', () => {
+    render(<AddRelationshipDialog {...defaultProps} />);
+    // Alice is currentContactId, should not appear in dropdown
+    const options = screen.getAllByRole('option');
+    const hasAlice = options.some((opt) => opt.textContent?.includes('Alice'));
+    expect(hasAlice).toBe(false);
+  });
+
+  it('should show strength selector', () => {
+    render(<AddRelationshipDialog {...defaultProps} />);
+    expect(screen.getByText(/strength/i)).toBeInTheDocument();
+  });
+
+  it('should show direction selector', () => {
+    render(<AddRelationshipDialog {...defaultProps} />);
+    expect(screen.getByText(/direction/i)).toBeInTheDocument();
+  });
+
+  it('should show notes field', () => {
+    render(<AddRelationshipDialog {...defaultProps} />);
+    expect(screen.getByLabelText(/notes/i)).toBeInTheDocument();
+  });
+
+  it('should call onAddRelationship when form submitted', async () => {
+    const onAddRelationship = vi.fn();
+    render(<AddRelationshipDialog {...defaultProps} onAddRelationship={onAddRelationship} />);
+
+    // Select contact
+    fireEvent.click(screen.getByText('Bob Jones'));
+
+    // Select relationship type
+    fireEvent.click(screen.getByText('Colleague'));
+
+    // Submit
+    fireEvent.click(screen.getByRole('button', { name: /add relationship/i }));
+
+    await waitFor(() => {
+      expect(onAddRelationship).toHaveBeenCalledWith(
+        expect.objectContaining({
+          contactId: 'contact-1',
+          relatedContactId: 'contact-2',
+          type: 'colleague',
+        })
+      );
+    });
+  });
+
+  it('should disable submit until contact selected', () => {
+    render(<AddRelationshipDialog {...defaultProps} />);
+    const submitButton = screen.getByRole('button', { name: /add relationship/i });
+    expect(submitButton).toBeDisabled();
+  });
+
+  it('should close dialog on cancel', () => {
+    const onOpenChange = vi.fn();
+    render(<AddRelationshipDialog {...defaultProps} onOpenChange={onOpenChange} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});
+
+describe('RelationshipFilter', () => {
+  const defaultProps: RelationshipFilterProps = {
+    selectedTypes: [],
+    selectedStrengths: [],
+    onTypeChange: vi.fn(),
+    onStrengthChange: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render type filter section', () => {
+    render(<RelationshipFilter {...defaultProps} />);
+    expect(screen.getByText(/relationship type/i)).toBeInTheDocument();
+  });
+
+  it('should render strength filter section', () => {
+    render(<RelationshipFilter {...defaultProps} />);
+    expect(screen.getByText(/strength/i)).toBeInTheDocument();
+  });
+
+  it('should show all relationship types grouped by category', () => {
+    render(<RelationshipFilter {...defaultProps} />);
+    expect(screen.getByText('Professional')).toBeInTheDocument();
+    expect(screen.getByText('Business')).toBeInTheDocument();
+    expect(screen.getByText('Personal')).toBeInTheDocument();
+  });
+
+  it('should call onTypeChange when type toggled', () => {
+    const onTypeChange = vi.fn();
+    render(<RelationshipFilter {...defaultProps} onTypeChange={onTypeChange} />);
+
+    fireEvent.click(screen.getByText('Colleague'));
+
+    expect(onTypeChange).toHaveBeenCalledWith(['colleague']);
+  });
+
+  it('should highlight selected types', () => {
+    render(<RelationshipFilter {...defaultProps} selectedTypes={['colleague']} />);
+    const colleagueBtn = screen.getByText('Colleague').closest('button');
+    expect(colleagueBtn).toHaveAttribute('data-selected', 'true');
+  });
+
+  it('should call onStrengthChange when strength toggled', () => {
+    const onStrengthChange = vi.fn();
+    render(<RelationshipFilter {...defaultProps} onStrengthChange={onStrengthChange} />);
+
+    fireEvent.click(screen.getByText('Strong'));
+
+    expect(onStrengthChange).toHaveBeenCalledWith(['strong']);
+  });
+
+  it('should show clear filters button when filters active', () => {
+    render(<RelationshipFilter {...defaultProps} selectedTypes={['colleague']} />);
+    expect(screen.getByRole('button', { name: /clear/i })).toBeInTheDocument();
+  });
+
+  it('should call clear handlers when clear clicked', () => {
+    const onTypeChange = vi.fn();
+    const onStrengthChange = vi.fn();
+    render(
+      <RelationshipFilter
+        {...defaultProps}
+        selectedTypes={['colleague']}
+        onTypeChange={onTypeChange}
+        onStrengthChange={onStrengthChange}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /clear/i }));
+
+    expect(onTypeChange).toHaveBeenCalledWith([]);
+    expect(onStrengthChange).toHaveBeenCalledWith([]);
+  });
+});
+
+describe('ContactRelationshipSection', () => {
+  const mockContact: Contact = {
+    id: 'contact-1',
+    name: 'Alice Smith',
+    email: 'alice@example.com',
+  };
+
+  const mockRelatedContacts: Contact[] = [
+    { id: 'contact-2', name: 'Bob Jones', email: 'bob@example.com' },
+    { id: 'contact-3', name: 'Carol White', email: 'carol@example.com' },
+  ];
+
+  const mockRelationships: ContactRelationship[] = [
+    {
+      id: 'rel-1',
+      contactId: 'contact-1',
+      relatedContactId: 'contact-2',
+      type: 'colleague',
+      strength: 'strong',
+      direction: 'bidirectional',
+    },
+    {
+      id: 'rel-2',
+      contactId: 'contact-1',
+      relatedContactId: 'contact-3',
+      type: 'client',
+      strength: 'medium',
+      direction: 'outgoing',
+    },
+  ];
+
+  const defaultProps: ContactRelationshipSectionProps = {
+    contactId: 'contact-1',
+    relationships: mockRelationships,
+    relatedContacts: mockRelatedContacts,
+    availableContacts: [...mockRelatedContacts],
+    onAddRelationship: vi.fn(),
+    onEditRelationship: vi.fn(),
+    onRemoveRelationship: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render section title', () => {
+    render(<ContactRelationshipSection {...defaultProps} />);
+    expect(screen.getByText(/relationships/i)).toBeInTheDocument();
+  });
+
+  it('should render all relationships', () => {
+    render(<ContactRelationshipSection {...defaultProps} />);
+    expect(screen.getByText('Bob Jones')).toBeInTheDocument();
+    expect(screen.getByText('Carol White')).toBeInTheDocument();
+  });
+
+  it('should show add relationship button', () => {
+    render(<ContactRelationshipSection {...defaultProps} />);
+    expect(screen.getByRole('button', { name: /add relationship/i })).toBeInTheDocument();
+  });
+
+  it('should open add dialog when button clicked', () => {
+    render(<ContactRelationshipSection {...defaultProps} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /add relationship/i }));
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('should show empty state when no relationships', () => {
+    render(<ContactRelationshipSection {...defaultProps} relationships={[]} />);
+    expect(screen.getByText(/no relationships/i)).toBeInTheDocument();
+  });
+
+  it('should call onRemoveRelationship when relationship removed', () => {
+    const onRemoveRelationship = vi.fn();
+    render(
+      <ContactRelationshipSection {...defaultProps} onRemoveRelationship={onRemoveRelationship} />
+    );
+
+    const removeButtons = screen.getAllByRole('button', { name: /remove/i });
+    fireEvent.click(removeButtons[0]);
+
+    expect(onRemoveRelationship).toHaveBeenCalledWith('rel-1');
+  });
+
+  it('should show relationship count', () => {
+    render(<ContactRelationshipSection {...defaultProps} />);
+    expect(screen.getByText('2')).toBeInTheDocument();
+  });
+
+  it('should group relationships by category', () => {
+    render(<ContactRelationshipSection {...defaultProps} />);
+    expect(screen.getByText('Professional')).toBeInTheDocument();
+    expect(screen.getByText('Business')).toBeInTheDocument();
+  });
+});
+
+describe('relationship-utils', () => {
+  describe('RELATIONSHIP_TYPES', () => {
+    it('should include professional types', () => {
+      expect(RELATIONSHIP_TYPES.professional).toContain('colleague');
+      expect(RELATIONSHIP_TYPES.professional).toContain('manager');
+      expect(RELATIONSHIP_TYPES.professional).toContain('direct_report');
+      expect(RELATIONSHIP_TYPES.professional).toContain('mentor');
+    });
+
+    it('should include business types', () => {
+      expect(RELATIONSHIP_TYPES.business).toContain('client');
+      expect(RELATIONSHIP_TYPES.business).toContain('vendor');
+      expect(RELATIONSHIP_TYPES.business).toContain('partner');
+      expect(RELATIONSHIP_TYPES.business).toContain('investor');
+      expect(RELATIONSHIP_TYPES.business).toContain('advisor');
+    });
+
+    it('should include personal types', () => {
+      expect(RELATIONSHIP_TYPES.personal).toContain('friend');
+      expect(RELATIONSHIP_TYPES.personal).toContain('family');
+      expect(RELATIONSHIP_TYPES.personal).toContain('acquaintance');
+    });
+  });
+
+  describe('getRelationshipLabel', () => {
+    it('should return human-readable label for type', () => {
+      expect(getRelationshipLabel('colleague')).toBe('Colleague');
+      expect(getRelationshipLabel('direct_report')).toBe('Direct Report');
+      expect(getRelationshipLabel('client')).toBe('Client');
+    });
+  });
+
+  describe('getRelationshipCategory', () => {
+    it('should return category for relationship type', () => {
+      expect(getRelationshipCategory('colleague')).toBe('professional');
+      expect(getRelationshipCategory('client')).toBe('business');
+      expect(getRelationshipCategory('friend')).toBe('personal');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add relationship components for tracking connections between contacts
- Support professional, business, and personal relationship types
- Include relationship strength (strong/medium/weak) and direction (bidirectional/outgoing/incoming)
- Add filtering by relationship type and strength

## Components
- `RelationshipBadge` - displays relationship type with category-based styling
- `RelationshipCard` - shows relationship with contact info, notes, and actions
- `AddRelationshipDialog` - form for creating new relationships
- `RelationshipFilter` - filter panel for relationship type and strength
- `ContactRelationshipSection` - section for managing all relationships of a contact

## Test plan
- [x] RelationshipBadge renders with correct labels and styling
- [x] RelationshipCard displays contact info, notes, and last interaction
- [x] AddRelationshipDialog validates input and submits correctly
- [x] RelationshipFilter toggles selections properly
- [x] ContactRelationshipSection groups by category and shows empty state
- [x] 46 tests passing

Closes #395

🤖 Generated with [Claude Code](https://claude.com/claude-code)