### PR TITLE
[#400] Implement @mention support with notifications

### DIFF
--- a/src/ui/components/mentions/index.ts
+++ b/src/ui/components/mentions/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Mentions components
+ * Issue #400: Implement @mention support with notifications
+ */
+export { MentionAutocomplete } from './mention-autocomplete';
+export type { MentionAutocompleteProps } from './mention-autocomplete';
+export { MentionBadge } from './mention-badge';
+export type { MentionBadgeProps } from './mention-badge';
+export { MentionInput } from './mention-input';
+export type { MentionInputProps } from './mention-input';
+export { MentionList } from './mention-list';
+export type { MentionListProps } from './mention-list';
+export {
+  parseMentions,
+  extractMentionIds,
+  serializeMentions,
+  createMentionToken,
+  getInitials,
+  findMentionTrigger,
+  filterUsers,
+} from './mention-utils';
+export type { Mention, MentionUser } from './mention-utils';

--- a/src/ui/components/mentions/mention-autocomplete.tsx
+++ b/src/ui/components/mentions/mention-autocomplete.tsx
@@ -1,0 +1,109 @@
+/**
+ * Mention autocomplete dropdown
+ * Issue #400: Implement @mention support with notifications
+ */
+import * as React from 'react';
+import { Loader2 } from 'lucide-react';
+import { cn } from '@/ui/lib/utils';
+import { filterUsers, getInitials, type MentionUser } from './mention-utils';
+
+export interface MentionAutocompleteProps {
+  users: MentionUser[];
+  onSelect: (user: MentionUser) => void;
+  onNavigate?: (index: number) => void;
+  query: string;
+  visible: boolean;
+  highlightedIndex?: number;
+  loading?: boolean;
+  className?: string;
+}
+
+export function MentionAutocomplete({
+  users,
+  onSelect,
+  onNavigate,
+  query,
+  visible,
+  highlightedIndex = 0,
+  loading = false,
+  className,
+}: MentionAutocompleteProps) {
+  if (!visible) {
+    return null;
+  }
+
+  const filteredUsers = filterUsers(users, query);
+
+  if (loading) {
+    return (
+      <div
+        data-testid="mention-loading"
+        className={cn(
+          'absolute z-50 bg-popover border rounded-md shadow-md p-2',
+          className
+        )}
+      >
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          <span>Loading users...</span>
+        </div>
+      </div>
+    );
+  }
+
+  if (filteredUsers.length === 0) {
+    return (
+      <div
+        className={cn(
+          'absolute z-50 bg-popover border rounded-md shadow-md p-2',
+          className
+        )}
+      >
+        <div className="text-sm text-muted-foreground px-2 py-1">
+          No users found
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={cn(
+        'absolute z-50 bg-popover border rounded-md shadow-md py-1 max-h-60 overflow-y-auto',
+        className
+      )}
+    >
+      {filteredUsers.map((user, index) => {
+        const isHighlighted = index === highlightedIndex;
+
+        return (
+          <button
+            key={user.id}
+            type="button"
+            data-testid={`mention-option-${index}`}
+            data-highlighted={isHighlighted}
+            className={cn(
+              'w-full flex items-center gap-2 px-3 py-2 text-sm text-left transition-colors',
+              isHighlighted ? 'bg-accent text-accent-foreground' : 'hover:bg-muted'
+            )}
+            onClick={() => onSelect(user)}
+            onMouseEnter={() => onNavigate?.(index)}
+          >
+            {user.avatar ? (
+              <img
+                src={user.avatar}
+                alt={user.name}
+                className="h-6 w-6 rounded-full object-cover"
+              />
+            ) : (
+              <div className="h-6 w-6 rounded-full bg-muted flex items-center justify-center text-xs font-medium">
+                {getInitials(user.name)}
+              </div>
+            )}
+            <span>{user.name}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/ui/components/mentions/mention-badge.tsx
+++ b/src/ui/components/mentions/mention-badge.tsx
@@ -1,0 +1,51 @@
+/**
+ * Mention badge/chip display
+ * Issue #400: Implement @mention support with notifications
+ */
+import * as React from 'react';
+import { cn } from '@/ui/lib/utils';
+import type { Mention } from './mention-utils';
+
+export interface MentionBadgeProps {
+  mention: Mention;
+  onClick?: (mention: Mention) => void;
+  href?: string;
+  className?: string;
+}
+
+export function MentionBadge({
+  mention,
+  onClick,
+  href,
+  className,
+}: MentionBadgeProps) {
+  const baseClasses = cn(
+    'inline-flex items-center px-1.5 py-0.5 rounded text-sm font-medium',
+    'bg-primary/10 text-primary hover:bg-primary/20 transition-colors',
+    className
+  );
+
+  const content = `@${mention.name}`;
+
+  if (href) {
+    return (
+      <a href={href} className={baseClasses}>
+        {content}
+      </a>
+    );
+  }
+
+  if (onClick) {
+    return (
+      <button
+        type="button"
+        onClick={() => onClick(mention)}
+        className={baseClasses}
+      >
+        {content}
+      </button>
+    );
+  }
+
+  return <span className={baseClasses}>{content}</span>;
+}

--- a/src/ui/components/mentions/mention-input.tsx
+++ b/src/ui/components/mentions/mention-input.tsx
@@ -1,0 +1,145 @@
+/**
+ * Input with mention autocomplete support
+ * Issue #400: Implement @mention support with notifications
+ */
+import * as React from 'react';
+import { cn } from '@/ui/lib/utils';
+import { Textarea } from '@/ui/components/ui/textarea';
+import { MentionAutocomplete } from './mention-autocomplete';
+import {
+  createMentionToken,
+  findMentionTrigger,
+  filterUsers,
+  type MentionUser,
+} from './mention-utils';
+
+export interface MentionInputProps {
+  users: MentionUser[];
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  className?: string;
+  disabled?: boolean;
+  rows?: number;
+}
+
+export function MentionInput({
+  users,
+  value,
+  onChange,
+  placeholder,
+  className,
+  disabled = false,
+  rows = 3,
+}: MentionInputProps) {
+  const [showAutocomplete, setShowAutocomplete] = React.useState(false);
+  const [query, setQuery] = React.useState('');
+  const [triggerStart, setTriggerStart] = React.useState<number | null>(null);
+  const [highlightedIndex, setHighlightedIndex] = React.useState(0);
+  const textareaRef = React.useRef<HTMLTextAreaElement>(null);
+
+  const filteredUsers = filterUsers(users, query);
+
+  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const newValue = e.target.value;
+    const cursorPos = e.target.selectionStart;
+
+    onChange(newValue);
+
+    // Check for mention trigger
+    const trigger = findMentionTrigger(newValue, cursorPos);
+
+    if (trigger) {
+      setShowAutocomplete(true);
+      setQuery(trigger.query);
+      setTriggerStart(trigger.start);
+      setHighlightedIndex(0);
+    } else {
+      setShowAutocomplete(false);
+      setQuery('');
+      setTriggerStart(null);
+    }
+  };
+
+  const handleSelectUser = (user: MentionUser) => {
+    if (triggerStart === null) return;
+
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+
+    const cursorPos = textarea.selectionStart;
+    const before = value.slice(0, triggerStart);
+    const after = value.slice(cursorPos);
+    const mentionToken = createMentionToken(user);
+
+    const newValue = before + mentionToken + ' ' + after;
+    onChange(newValue);
+
+    setShowAutocomplete(false);
+    setQuery('');
+    setTriggerStart(null);
+
+    // Focus textarea and set cursor after mention
+    setTimeout(() => {
+      textarea.focus();
+      const newPos = triggerStart + mentionToken.length + 1;
+      textarea.setSelectionRange(newPos, newPos);
+    }, 0);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (!showAutocomplete) return;
+
+    switch (e.key) {
+      case 'Escape':
+        e.preventDefault();
+        setShowAutocomplete(false);
+        break;
+
+      case 'ArrowDown':
+        e.preventDefault();
+        setHighlightedIndex((prev) =>
+          prev < filteredUsers.length - 1 ? prev + 1 : prev
+        );
+        break;
+
+      case 'ArrowUp':
+        e.preventDefault();
+        setHighlightedIndex((prev) => (prev > 0 ? prev - 1 : prev));
+        break;
+
+      case 'Enter':
+      case 'Tab':
+        if (filteredUsers.length > 0) {
+          e.preventDefault();
+          handleSelectUser(filteredUsers[highlightedIndex]);
+        }
+        break;
+    }
+  };
+
+  return (
+    <div className={cn('relative', className)}>
+      <Textarea
+        ref={textareaRef}
+        value={value}
+        onChange={handleChange}
+        onKeyDown={handleKeyDown}
+        placeholder={placeholder}
+        disabled={disabled}
+        rows={rows}
+        className="resize-none"
+      />
+
+      <MentionAutocomplete
+        users={users}
+        onSelect={handleSelectUser}
+        onNavigate={setHighlightedIndex}
+        query={query}
+        visible={showAutocomplete}
+        highlightedIndex={highlightedIndex}
+        className="top-full left-0 mt-1 min-w-[200px]"
+      />
+    </div>
+  );
+}

--- a/src/ui/components/mentions/mention-list.tsx
+++ b/src/ui/components/mentions/mention-list.tsx
@@ -1,0 +1,89 @@
+/**
+ * List display for mentions
+ * Issue #400: Implement @mention support with notifications
+ */
+import * as React from 'react';
+import { Users, Building } from 'lucide-react';
+import { cn } from '@/ui/lib/utils';
+import { MentionBadge } from './mention-badge';
+import type { Mention } from './mention-utils';
+
+export interface MentionListProps {
+  mentions: Mention[];
+  onMentionClick?: (mention: Mention) => void;
+  groupByType?: boolean;
+  className?: string;
+}
+
+export function MentionList({
+  mentions,
+  onMentionClick,
+  groupByType = false,
+  className,
+}: MentionListProps) {
+  if (mentions.length === 0) {
+    return (
+      <div className={cn('text-sm text-muted-foreground', className)}>
+        No mentions
+      </div>
+    );
+  }
+
+  if (!groupByType) {
+    return (
+      <div className={cn('flex flex-wrap gap-1', className)}>
+        {mentions.map((mention) => (
+          <MentionBadge
+            key={`${mention.type}-${mention.id}`}
+            mention={mention}
+            onClick={onMentionClick}
+          />
+        ))}
+      </div>
+    );
+  }
+
+  // Group by type
+  const userMentions = mentions.filter((m) => m.type === 'user');
+  const teamMentions = mentions.filter((m) => m.type === 'team');
+
+  return (
+    <div className={cn('space-y-3', className)}>
+      {userMentions.length > 0 && (
+        <div>
+          <div className="flex items-center gap-1.5 text-xs text-muted-foreground mb-1.5">
+            <Users className="h-3.5 w-3.5" />
+            <span>Users</span>
+          </div>
+          <div className="flex flex-wrap gap-1">
+            {userMentions.map((mention) => (
+              <MentionBadge
+                key={mention.id}
+                mention={mention}
+                onClick={onMentionClick}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {teamMentions.length > 0 && (
+        <div>
+          <div className="flex items-center gap-1.5 text-xs text-muted-foreground mb-1.5">
+            <Building className="h-3.5 w-3.5" />
+            <span>Teams</span>
+          </div>
+          <div className="flex flex-wrap gap-1">
+            {teamMentions.map((mention) => (
+              <MentionBadge
+                key={mention.id}
+                mention={mention}
+                onClick={onMentionClick}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/ui/components/mentions/mention-utils.ts
+++ b/src/ui/components/mentions/mention-utils.ts
@@ -1,0 +1,126 @@
+/**
+ * Mention parsing and utility functions
+ * Issue #400: Implement @mention support with notifications
+ */
+
+export interface MentionUser {
+  id: string;
+  name: string;
+  avatar?: string;
+}
+
+export interface Mention {
+  id: string;
+  name: string;
+  type: 'user' | 'team';
+}
+
+// Regex to match mention tokens: @[Name](type:id)
+const MENTION_REGEX = /@\[([^\]]+)\]\((\w+):([^)]+)\)/g;
+
+/**
+ * Parse mention tokens from text and return Mention objects
+ */
+export function parseMentions(text: string): Mention[] {
+  const mentions: Mention[] = [];
+  let match;
+
+  // Reset regex
+  const regex = new RegExp(MENTION_REGEX.source, 'g');
+
+  while ((match = regex.exec(text)) !== null) {
+    mentions.push({
+      name: match[1],
+      type: match[2] as 'user' | 'team',
+      id: match[3],
+    });
+  }
+
+  return mentions;
+}
+
+/**
+ * Extract unique mention IDs from text
+ */
+export function extractMentionIds(text: string): string[] {
+  const mentions = parseMentions(text);
+  const uniqueIds = new Set(mentions.map((m) => m.id));
+  return Array.from(uniqueIds);
+}
+
+/**
+ * Serialize a mention into the token format
+ */
+export function serializeMentions(
+  before: string,
+  mention: Mention,
+  after: string
+): string {
+  return `${before}@[${mention.name}](${mention.type}:${mention.id})${after}`;
+}
+
+/**
+ * Create a mention token string from a user
+ */
+export function createMentionToken(user: MentionUser, type: 'user' | 'team' = 'user'): string {
+  return `@[${user.name}](${type}:${user.id})`;
+}
+
+/**
+ * Get initials from a name
+ */
+export function getInitials(name: string): string {
+  const parts = name.split(' ').filter(Boolean);
+  if (parts.length === 0) return '';
+  if (parts.length === 1) return parts[0].charAt(0).toUpperCase();
+  return (parts[0].charAt(0) + parts[parts.length - 1].charAt(0)).toUpperCase();
+}
+
+/**
+ * Find the @ trigger position in text
+ * Returns the index of @ and the query after it, or null if no trigger
+ */
+export function findMentionTrigger(
+  text: string,
+  cursorPosition: number
+): { start: number; query: string } | null {
+  // Look backwards from cursor for @
+  let searchPos = cursorPosition - 1;
+
+  while (searchPos >= 0) {
+    const char = text[searchPos];
+
+    // Found @
+    if (char === '@') {
+      // Check if it's the start of text or preceded by whitespace
+      if (searchPos === 0 || /\s/.test(text[searchPos - 1])) {
+        const query = text.slice(searchPos + 1, cursorPosition);
+        // Make sure query doesn't contain spaces (would indicate completed mention)
+        if (!/\s/.test(query)) {
+          return { start: searchPos, query };
+        }
+      }
+      break;
+    }
+
+    // Stop if we hit whitespace
+    if (/\s/.test(char)) {
+      break;
+    }
+
+    searchPos--;
+  }
+
+  return null;
+}
+
+/**
+ * Filter users by search query
+ */
+export function filterUsers(users: MentionUser[], query: string): MentionUser[] {
+  if (!query) return users;
+  const lowerQuery = query.toLowerCase();
+  return users.filter((user) =>
+    user.name.toLowerCase().includes(lowerQuery)
+  );
+}

--- a/tests/ui/mentions.test.tsx
+++ b/tests/ui/mentions.test.tsx
@@ -1,0 +1,427 @@
+/**
+ * @vitest-environment jsdom
+ * Tests for @mention support with notifications
+ * Issue #400: Implement @mention support with notifications
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import * as React from 'react';
+
+// Components to be implemented
+import {
+  MentionAutocomplete,
+  type MentionAutocompleteProps,
+} from '@/ui/components/mentions/mention-autocomplete';
+import {
+  MentionBadge,
+  type MentionBadgeProps,
+} from '@/ui/components/mentions/mention-badge';
+import {
+  MentionInput,
+  type MentionInputProps,
+} from '@/ui/components/mentions/mention-input';
+import {
+  MentionList,
+  type MentionListProps,
+} from '@/ui/components/mentions/mention-list';
+import {
+  parseMentions,
+  extractMentionIds,
+  serializeMentions,
+  createMentionToken,
+  type Mention,
+  type MentionUser,
+} from '@/ui/components/mentions/mention-utils';
+
+describe('MentionAutocomplete', () => {
+  const mockUsers: MentionUser[] = [
+    { id: 'user-1', name: 'Alice Smith', avatar: 'https://example.com/alice.png' },
+    { id: 'user-2', name: 'Bob Jones', avatar: 'https://example.com/bob.png' },
+    { id: 'user-3', name: 'Charlie Brown' },
+  ];
+
+  const defaultProps: MentionAutocompleteProps = {
+    users: mockUsers,
+    onSelect: vi.fn(),
+    query: '',
+    visible: true,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render user list when visible', () => {
+    render(<MentionAutocomplete {...defaultProps} />);
+    expect(screen.getByText('Alice Smith')).toBeInTheDocument();
+    expect(screen.getByText('Bob Jones')).toBeInTheDocument();
+  });
+
+  it('should not render when not visible', () => {
+    render(<MentionAutocomplete {...defaultProps} visible={false} />);
+    expect(screen.queryByText('Alice Smith')).not.toBeInTheDocument();
+  });
+
+  it('should filter users by query', () => {
+    render(<MentionAutocomplete {...defaultProps} query="alice" />);
+    expect(screen.getByText('Alice Smith')).toBeInTheDocument();
+    expect(screen.queryByText('Bob Jones')).not.toBeInTheDocument();
+  });
+
+  it('should show avatars when available', () => {
+    render(<MentionAutocomplete {...defaultProps} />);
+    const avatars = screen.getAllByRole('img');
+    expect(avatars.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('should show initials when no avatar', () => {
+    render(<MentionAutocomplete {...defaultProps} />);
+    expect(screen.getByText('CB')).toBeInTheDocument(); // Charlie Brown initials
+  });
+
+  it('should highlight first item by default', () => {
+    render(<MentionAutocomplete {...defaultProps} />);
+    const firstItem = screen.getByTestId('mention-option-0');
+    expect(firstItem).toHaveAttribute('data-highlighted', 'true');
+  });
+
+  it('should call onSelect when item clicked', () => {
+    const onSelect = vi.fn();
+    render(<MentionAutocomplete {...defaultProps} onSelect={onSelect} />);
+
+    fireEvent.click(screen.getByText('Bob Jones'));
+
+    expect(onSelect).toHaveBeenCalledWith(mockUsers[1]);
+  });
+
+  it('should show no results message when no matches', () => {
+    render(<MentionAutocomplete {...defaultProps} query="xyz" />);
+    expect(screen.getByText(/no users found/i)).toBeInTheDocument();
+  });
+
+  it('should support keyboard navigation', () => {
+    const onSelect = vi.fn();
+    const onNavigate = vi.fn();
+    render(
+      <MentionAutocomplete
+        {...defaultProps}
+        onSelect={onSelect}
+        onNavigate={onNavigate}
+        highlightedIndex={1}
+      />
+    );
+
+    const secondItem = screen.getByTestId('mention-option-1');
+    expect(secondItem).toHaveAttribute('data-highlighted', 'true');
+  });
+
+  it('should show loading state', () => {
+    render(<MentionAutocomplete {...defaultProps} loading />);
+    expect(screen.getByTestId('mention-loading')).toBeInTheDocument();
+  });
+});
+
+describe('MentionBadge', () => {
+  const mockMention: Mention = {
+    id: 'user-1',
+    name: 'Alice Smith',
+    type: 'user',
+  };
+
+  const defaultProps: MentionBadgeProps = {
+    mention: mockMention,
+  };
+
+  it('should render mention name with @ prefix', () => {
+    render(<MentionBadge {...defaultProps} />);
+    expect(screen.getByText('@Alice Smith')).toBeInTheDocument();
+  });
+
+  it('should apply mention styling', () => {
+    render(<MentionBadge {...defaultProps} />);
+    const badge = screen.getByText('@Alice Smith');
+    expect(badge).toHaveClass('bg-primary/10');
+  });
+
+  it('should be clickable when onClick provided', () => {
+    const onClick = vi.fn();
+    render(<MentionBadge {...defaultProps} onClick={onClick} />);
+
+    fireEvent.click(screen.getByText('@Alice Smith'));
+
+    expect(onClick).toHaveBeenCalledWith(mockMention);
+  });
+
+  it('should show as link when href provided', () => {
+    render(<MentionBadge {...defaultProps} href="/contacts/user-1" />);
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', '/contacts/user-1');
+  });
+
+  it('should support different mention types', () => {
+    const teamMention: Mention = { id: 'team-1', name: 'Engineering', type: 'team' };
+    render(<MentionBadge mention={teamMention} />);
+    expect(screen.getByText('@Engineering')).toBeInTheDocument();
+  });
+});
+
+describe('MentionInput', () => {
+  const mockUsers: MentionUser[] = [
+    { id: 'user-1', name: 'Alice Smith' },
+    { id: 'user-2', name: 'Bob Jones' },
+  ];
+
+  const defaultProps: MentionInputProps = {
+    users: mockUsers,
+    value: '',
+    onChange: vi.fn(),
+    placeholder: 'Type @ to mention someone...',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render textarea with placeholder', () => {
+    render(<MentionInput {...defaultProps} />);
+    expect(screen.getByPlaceholderText('Type @ to mention someone...')).toBeInTheDocument();
+  });
+
+  it('should show autocomplete when @ typed', async () => {
+    render(<MentionInput {...defaultProps} />);
+
+    const textarea = screen.getByPlaceholderText('Type @ to mention someone...');
+    fireEvent.change(textarea, { target: { value: '@' } });
+
+    await waitFor(() => {
+      expect(screen.getByText('Alice Smith')).toBeInTheDocument();
+    });
+  });
+
+  it('should filter autocomplete based on text after @', async () => {
+    render(<MentionInput {...defaultProps} />);
+
+    const textarea = screen.getByPlaceholderText('Type @ to mention someone...');
+    fireEvent.change(textarea, { target: { value: '@ali' } });
+
+    await waitFor(() => {
+      expect(screen.getByText('Alice Smith')).toBeInTheDocument();
+      expect(screen.queryByText('Bob Jones')).not.toBeInTheDocument();
+    });
+  });
+
+  it('should insert mention when user selected', async () => {
+    const onChange = vi.fn();
+    render(<MentionInput {...defaultProps} onChange={onChange} />);
+
+    const textarea = screen.getByPlaceholderText('Type @ to mention someone...');
+    fireEvent.change(textarea, { target: { value: '@ali' } });
+
+    await waitFor(() => {
+      expect(screen.getByText('Alice Smith')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('Alice Smith'));
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalled();
+    });
+  });
+
+  it('should close autocomplete when escape pressed', async () => {
+    render(<MentionInput {...defaultProps} />);
+
+    const textarea = screen.getByPlaceholderText('Type @ to mention someone...');
+    fireEvent.change(textarea, { target: { value: '@' } });
+
+    await waitFor(() => {
+      expect(screen.getByText('Alice Smith')).toBeInTheDocument();
+    });
+
+    fireEvent.keyDown(textarea, { key: 'Escape' });
+
+    await waitFor(() => {
+      expect(screen.queryByText('Alice Smith')).not.toBeInTheDocument();
+    });
+  });
+
+  it('should navigate autocomplete with arrow keys', async () => {
+    render(<MentionInput {...defaultProps} />);
+
+    const textarea = screen.getByPlaceholderText('Type @ to mention someone...');
+    fireEvent.change(textarea, { target: { value: '@' } });
+
+    await waitFor(() => {
+      expect(screen.getByText('Alice Smith')).toBeInTheDocument();
+    });
+
+    fireEvent.keyDown(textarea, { key: 'ArrowDown' });
+
+    const secondItem = screen.getByTestId('mention-option-1');
+    expect(secondItem).toHaveAttribute('data-highlighted', 'true');
+  });
+
+  it('should select with Enter key', async () => {
+    const onChange = vi.fn();
+    render(<MentionInput {...defaultProps} onChange={onChange} />);
+
+    const textarea = screen.getByPlaceholderText('Type @ to mention someone...');
+    fireEvent.change(textarea, { target: { value: '@' } });
+
+    await waitFor(() => {
+      expect(screen.getByText('Alice Smith')).toBeInTheDocument();
+    });
+
+    fireEvent.keyDown(textarea, { key: 'Enter' });
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalled();
+    });
+  });
+
+  it('should render existing mentions in value', () => {
+    const valueWithMention = 'Hello @[Alice Smith](user:user-1), how are you?';
+    render(<MentionInput {...defaultProps} value={valueWithMention} />);
+
+    // The input should show the value
+    const textarea = screen.getByPlaceholderText('Type @ to mention someone...');
+    expect(textarea).toHaveValue(valueWithMention);
+  });
+
+  it('should support multiple mentions', async () => {
+    const onChange = vi.fn();
+    const value = 'Hey @[Alice Smith](user:user-1), ';
+    render(<MentionInput {...defaultProps} value={value} onChange={onChange} />);
+
+    const textarea = screen.getByPlaceholderText('Type @ to mention someone...');
+    fireEvent.change(textarea, { target: { value: value + '@bob' } });
+
+    await waitFor(() => {
+      expect(screen.getByText('Bob Jones')).toBeInTheDocument();
+    });
+  });
+});
+
+describe('MentionList', () => {
+  const mockMentions: Mention[] = [
+    { id: 'user-1', name: 'Alice Smith', type: 'user' },
+    { id: 'user-2', name: 'Bob Jones', type: 'user' },
+    { id: 'team-1', name: 'Engineering', type: 'team' },
+  ];
+
+  const defaultProps: MentionListProps = {
+    mentions: mockMentions,
+  };
+
+  it('should render all mentions', () => {
+    render(<MentionList {...defaultProps} />);
+    expect(screen.getByText('@Alice Smith')).toBeInTheDocument();
+    expect(screen.getByText('@Bob Jones')).toBeInTheDocument();
+    expect(screen.getByText('@Engineering')).toBeInTheDocument();
+  });
+
+  it('should show empty message when no mentions', () => {
+    render(<MentionList mentions={[]} />);
+    expect(screen.getByText(/no mentions/i)).toBeInTheDocument();
+  });
+
+  it('should group mentions by type', () => {
+    render(<MentionList {...defaultProps} groupByType />);
+    expect(screen.getByText(/users/i)).toBeInTheDocument();
+    expect(screen.getByText(/teams/i)).toBeInTheDocument();
+  });
+
+  it('should call onMentionClick when mention clicked', () => {
+    const onMentionClick = vi.fn();
+    render(<MentionList {...defaultProps} onMentionClick={onMentionClick} />);
+
+    fireEvent.click(screen.getByText('@Alice Smith'));
+
+    expect(onMentionClick).toHaveBeenCalledWith(mockMentions[0]);
+  });
+});
+
+describe('Mention Utilities', () => {
+  describe('parseMentions', () => {
+    it('should parse mention tokens from text', () => {
+      const text = 'Hello @[Alice Smith](user:user-1), how are you?';
+      const result = parseMentions(text);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        id: 'user-1',
+        name: 'Alice Smith',
+        type: 'user',
+      });
+    });
+
+    it('should parse multiple mentions', () => {
+      const text = 'Hey @[Alice](user:user-1) and @[Bob](user:user-2)!';
+      const result = parseMentions(text);
+
+      expect(result).toHaveLength(2);
+      expect(result[0].id).toBe('user-1');
+      expect(result[1].id).toBe('user-2');
+    });
+
+    it('should return empty array for no mentions', () => {
+      const text = 'Hello world, no mentions here!';
+      const result = parseMentions(text);
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('should handle team mentions', () => {
+      const text = 'Attention @[Engineering](team:team-1)!';
+      const result = parseMentions(text);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].type).toBe('team');
+    });
+  });
+
+  describe('extractMentionIds', () => {
+    it('should extract just the IDs from text', () => {
+      const text = 'Hey @[Alice](user:user-1) and @[Bob](user:user-2)!';
+      const ids = extractMentionIds(text);
+
+      expect(ids).toEqual(['user-1', 'user-2']);
+    });
+
+    it('should return unique IDs', () => {
+      const text = '@[Alice](user:user-1) says hi to @[Alice](user:user-1)';
+      const ids = extractMentionIds(text);
+
+      expect(ids).toEqual(['user-1']);
+    });
+  });
+
+  describe('serializeMentions', () => {
+    it('should convert mentions array to token string', () => {
+      const mentions: Mention[] = [
+        { id: 'user-1', name: 'Alice', type: 'user' },
+      ];
+
+      const result = serializeMentions('Hello ', mentions[0], '!');
+
+      expect(result).toBe('Hello @[Alice](user:user-1)!');
+    });
+  });
+
+  describe('createMentionToken', () => {
+    it('should create mention token from user', () => {
+      const user: MentionUser = { id: 'user-1', name: 'Alice Smith' };
+      const token = createMentionToken(user);
+
+      expect(token).toBe('@[Alice Smith](user:user-1)');
+    });
+
+    it('should handle names with special characters', () => {
+      const user: MentionUser = { id: 'user-1', name: "Alice O'Brien" };
+      const token = createMentionToken(user);
+
+      expect(token).toBe("@[Alice O'Brien](user:user-1)");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add mention components for @-style user mentions in comments and descriptions
- Implement autocomplete dropdown triggered by @ character
- Support keyboard navigation and user filtering
- Parse and serialize mention tokens for storage and notification extraction

## Components Added
- `mention-autocomplete.tsx` - Dropdown with user search and keyboard navigation
- `mention-badge.tsx` - Styled @mention chip display
- `mention-input.tsx` - Textarea with @ trigger autocomplete integration
- `mention-list.tsx` - Display list of mentions with optional type grouping
- `mention-utils.ts` - Parse/serialize mention tokens, filtering utilities

## Mention Format
Uses `@[Name](type:id)` format that:
- Survives editing in plain text
- Can be extracted for notifications
- Supports both user and team mentions

## Test Coverage
- 37 tests covering all components
- Tests for autocomplete behavior, keyboard navigation
- Tests for mention parsing and serialization

## Test plan
- [x] Run `npm test -- tests/ui/mentions.test.tsx` - all 37 tests pass
- [x] Verify exports from index.ts
- [x] Check component type safety

Closes #400

🤖 Generated with [Claude Code](https://claude.com/claude-code)