### PR TITLE
[#401] Implement watchers/followers on work items

### DIFF
--- a/src/ui/components/watchers/add-watcher-dialog.tsx
+++ b/src/ui/components/watchers/add-watcher-dialog.tsx
@@ -1,0 +1,152 @@
+/**
+ * Dialog for adding watchers to a work item
+ * Issue #401: Implement watchers/followers on work items
+ */
+import * as React from 'react';
+import { Search } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/ui/components/ui/dialog';
+import { Button } from '@/ui/components/ui/button';
+import { Input } from '@/ui/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/ui/components/ui/select';
+import { cn } from '@/ui/lib/utils';
+import {
+  getInitials,
+  NOTIFICATION_LEVELS,
+  type NotificationLevel,
+  type WatcherUser,
+} from './types';
+
+export interface AddWatcherDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  users: WatcherUser[];
+  existingWatcherIds: string[];
+  onAdd: (userId: string, notificationLevel?: NotificationLevel) => void;
+  className?: string;
+}
+
+export function AddWatcherDialog({
+  open,
+  onOpenChange,
+  users,
+  existingWatcherIds,
+  onAdd,
+  className,
+}: AddWatcherDialogProps) {
+  const [search, setSearch] = React.useState('');
+  const [notificationLevel, setNotificationLevel] =
+    React.useState<NotificationLevel>('all');
+
+  // Filter out existing watchers and apply search
+  const availableUsers = React.useMemo(() => {
+    const existing = new Set(existingWatcherIds);
+    return users
+      .filter((user) => !existing.has(user.id))
+      .filter((user) =>
+        user.name.toLowerCase().includes(search.toLowerCase())
+      );
+  }, [users, existingWatcherIds, search]);
+
+  const handleSelect = (userId: string) => {
+    onAdd(userId, notificationLevel);
+    onOpenChange(false);
+    setSearch('');
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className={cn('sm:max-w-md', className)}>
+        <DialogHeader>
+          <DialogTitle>Add watcher</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          {/* Search input */}
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+            <Input
+              placeholder="Search users..."
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="pl-9"
+            />
+          </div>
+
+          {/* Notification level selector */}
+          <div className="space-y-2">
+            <label className="text-sm font-medium">Notification level</label>
+            <Select
+              value={notificationLevel}
+              onValueChange={(value) =>
+                setNotificationLevel(value as NotificationLevel)
+              }
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {NOTIFICATION_LEVELS.map((level) => (
+                  <SelectItem key={level.value} value={level.value}>
+                    {level.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* User list */}
+          <div className="max-h-60 overflow-y-auto space-y-1">
+            {availableUsers.map((user) => (
+              <button
+                key={user.id}
+                type="button"
+                className="w-full flex items-center gap-3 p-2 rounded-md hover:bg-muted text-left"
+                onClick={() => handleSelect(user.id)}
+              >
+                {user.avatar ? (
+                  <img
+                    src={user.avatar}
+                    alt={user.name}
+                    className="h-8 w-8 rounded-full object-cover"
+                  />
+                ) : (
+                  <div className="h-8 w-8 rounded-full bg-muted flex items-center justify-center text-xs font-medium">
+                    {getInitials(user.name)}
+                  </div>
+                )}
+                <span className="text-sm">{user.name}</span>
+              </button>
+            ))}
+
+            {availableUsers.length === 0 && (
+              <div className="py-4 text-center text-sm text-muted-foreground">
+                No users found
+              </div>
+            )}
+          </div>
+
+          {/* Cancel button */}
+          <div className="flex justify-end">
+            <Button
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+            >
+              Cancel
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/ui/components/watchers/index.ts
+++ b/src/ui/components/watchers/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Watchers components
+ * Issue #401: Implement watchers/followers on work items
+ */
+export { WatchButton } from './watch-button';
+export type { WatchButtonProps } from './watch-button';
+export { WatcherList } from './watcher-list';
+export type { WatcherListProps } from './watcher-list';
+export { AddWatcherDialog } from './add-watcher-dialog';
+export type { AddWatcherDialogProps } from './add-watcher-dialog';
+export { WatchedItemsList } from './watched-items-list';
+export type { WatchedItemsListProps } from './watched-items-list';
+export { WatcherSettings } from './watcher-settings';
+export type { WatcherSettingsProps } from './watcher-settings';
+export type {
+  Watcher,
+  WatchedItem,
+  WatcherUser,
+  NotificationLevel,
+  AutoWatchSettings,
+} from './types';
+export { NOTIFICATION_LEVELS, getNotificationLevelLabel, getInitials } from './types';

--- a/src/ui/components/watchers/types.ts
+++ b/src/ui/components/watchers/types.ts
@@ -1,0 +1,55 @@
+/**
+ * Types for watchers/followers on work items
+ * Issue #401: Implement watchers/followers on work items
+ */
+
+export type NotificationLevel = 'all' | 'mentions' | 'status_changes';
+
+export interface Watcher {
+  id: string;
+  userId: string;
+  name: string;
+  avatar?: string;
+  notificationLevel: NotificationLevel;
+  addedAt: string;
+}
+
+export interface WatchedItem {
+  id: string;
+  title: string;
+  type: 'project' | 'epic' | 'initiative' | 'issue' | 'task';
+  status: string;
+  notificationLevel: NotificationLevel;
+  lastActivity: string;
+  unreadCount: number;
+}
+
+export interface AutoWatchSettings {
+  autoWatchCreated: boolean;
+  autoWatchAssigned: boolean;
+  autoWatchCommented: boolean;
+  defaultNotificationLevel: NotificationLevel;
+}
+
+export interface WatcherUser {
+  id: string;
+  name: string;
+  avatar?: string;
+}
+
+export const NOTIFICATION_LEVELS: { value: NotificationLevel; label: string }[] = [
+  { value: 'all', label: 'All activity' },
+  { value: 'mentions', label: 'Mentions only' },
+  { value: 'status_changes', label: 'Status changes only' },
+];
+
+export function getNotificationLevelLabel(level: NotificationLevel): string {
+  return NOTIFICATION_LEVELS.find((l) => l.value === level)?.label ?? level;
+}
+
+export function getInitials(name: string): string {
+  const parts = name.split(' ').filter(Boolean);
+  if (parts.length === 0) return '';
+  if (parts.length === 1) return parts[0].charAt(0).toUpperCase();
+  return (parts[0].charAt(0) + parts[parts.length - 1].charAt(0)).toUpperCase();
+}

--- a/src/ui/components/watchers/watch-button.tsx
+++ b/src/ui/components/watchers/watch-button.tsx
@@ -1,0 +1,55 @@
+/**
+ * Watch/unwatch button for work items
+ * Issue #401: Implement watchers/followers on work items
+ */
+import * as React from 'react';
+import { Eye, Loader2 } from 'lucide-react';
+import { Button } from '@/ui/components/ui/button';
+import { cn } from '@/ui/lib/utils';
+
+export interface WatchButtonProps {
+  isWatching: boolean;
+  onToggle: () => void;
+  watcherCount?: number;
+  loading?: boolean;
+  compact?: boolean;
+  className?: string;
+}
+
+export function WatchButton({
+  isWatching,
+  onToggle,
+  watcherCount,
+  loading = false,
+  compact = false,
+  className,
+}: WatchButtonProps) {
+  return (
+    <Button
+      variant={isWatching ? 'secondary' : 'outline'}
+      size={compact ? 'icon' : 'sm'}
+      onClick={onToggle}
+      disabled={loading}
+      className={cn('gap-1.5', className)}
+    >
+      {loading ? (
+        <Loader2 data-testid="watch-loading" className="h-4 w-4 animate-spin" />
+      ) : (
+        <Eye
+          data-testid="watch-icon"
+          className={cn('h-4 w-4', isWatching && 'fill-current')}
+        />
+      )}
+
+      {!compact && (
+        <span>{isWatching ? 'Watching' : 'Watch'}</span>
+      )}
+
+      {watcherCount !== undefined && watcherCount > 0 && (
+        <span className="ml-1 text-xs bg-muted px-1.5 py-0.5 rounded">
+          {watcherCount}
+        </span>
+      )}
+    </Button>
+  );
+}

--- a/src/ui/components/watchers/watched-items-list.tsx
+++ b/src/ui/components/watchers/watched-items-list.tsx
@@ -1,0 +1,126 @@
+/**
+ * List of items the user is watching
+ * Issue #401: Implement watchers/followers on work items
+ */
+import * as React from 'react';
+import { Eye, EyeOff, Loader2 } from 'lucide-react';
+import { Button } from '@/ui/components/ui/button';
+import { Badge } from '@/ui/components/ui/badge';
+import { cn } from '@/ui/lib/utils';
+import { getNotificationLevelLabel, type WatchedItem } from './types';
+
+export interface WatchedItemsListProps {
+  items: WatchedItem[];
+  onItemClick: (itemId: string) => void;
+  onUnwatch: (itemId: string) => void;
+  filterType?: WatchedItem['type'];
+  loading?: boolean;
+  className?: string;
+}
+
+function getStatusVariant(status: string): 'default' | 'secondary' | 'outline' {
+  switch (status.toLowerCase()) {
+    case 'in_progress':
+    case 'in progress':
+      return 'default';
+    case 'open':
+    case 'todo':
+      return 'secondary';
+    default:
+      return 'outline';
+  }
+}
+
+function formatStatus(status: string): string {
+  return status.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function formatType(type: string): string {
+  return type.charAt(0).toUpperCase() + type.slice(1);
+}
+
+export function WatchedItemsList({
+  items,
+  onItemClick,
+  onUnwatch,
+  filterType,
+  loading = false,
+  className,
+}: WatchedItemsListProps) {
+  const filteredItems = React.useMemo(() => {
+    if (!filterType) return items;
+    return items.filter((item) => item.type === filterType);
+  }, [items, filterType]);
+
+  if (loading) {
+    return (
+      <div
+        data-testid="watched-items-loading"
+        className={cn('flex justify-center py-8', className)}
+      >
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (filteredItems.length === 0) {
+    return (
+      <div className={cn('text-center py-8 text-muted-foreground', className)}>
+        <Eye className="h-8 w-8 mx-auto mb-2 opacity-50" />
+        <p className="text-sm">No watched items</p>
+        <p className="text-xs mt-1">
+          Watch items to get notified about their updates
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn('space-y-2', className)}>
+      {filteredItems.map((item) => (
+        <div
+          key={item.id}
+          className="flex items-start gap-3 p-3 rounded-lg border hover:bg-muted/50 transition-colors"
+        >
+          {/* Main content - clickable */}
+          <button
+            type="button"
+            className="flex-1 text-left min-w-0"
+            onClick={() => onItemClick(item.id)}
+          >
+            <div className="flex items-center gap-2 mb-1">
+              <Badge variant="outline" className="text-xs">
+                {formatType(item.type)}
+              </Badge>
+              <Badge variant={getStatusVariant(item.status)} className="text-xs">
+                {formatStatus(item.status)}
+              </Badge>
+              {item.unreadCount > 0 && (
+                <Badge className="text-xs bg-primary">
+                  {item.unreadCount}
+                </Badge>
+              )}
+            </div>
+
+            <h4 className="font-medium text-sm truncate">{item.title}</h4>
+
+            <div className="text-xs text-muted-foreground mt-1">
+              {getNotificationLevelLabel(item.notificationLevel)}
+            </div>
+          </button>
+
+          {/* Unwatch button */}
+          <Button
+            variant="ghost"
+            size="sm"
+            className="shrink-0"
+            onClick={() => onUnwatch(item.id)}
+            aria-label="Unwatch"
+          >
+            <EyeOff className="h-4 w-4" />
+          </Button>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/ui/components/watchers/watcher-list.tsx
+++ b/src/ui/components/watchers/watcher-list.tsx
@@ -1,0 +1,117 @@
+/**
+ * List of watchers for a work item
+ * Issue #401: Implement watchers/followers on work items
+ */
+import * as React from 'react';
+import { Eye, UserPlus, X } from 'lucide-react';
+import { Button } from '@/ui/components/ui/button';
+import { cn } from '@/ui/lib/utils';
+import { getInitials, getNotificationLevelLabel, type Watcher } from './types';
+
+export interface WatcherListProps {
+  watchers: Watcher[];
+  currentUserId: string;
+  isOwner?: boolean;
+  onRemove?: (watcherId: string) => void;
+  onAddWatcher?: () => void;
+  className?: string;
+}
+
+export function WatcherList({
+  watchers,
+  currentUserId,
+  isOwner = false,
+  onRemove,
+  onAddWatcher,
+  className,
+}: WatcherListProps) {
+  if (watchers.length === 0) {
+    return (
+      <div className={cn('text-sm text-muted-foreground py-4 text-center', className)}>
+        <Eye className="h-8 w-8 mx-auto mb-2 opacity-50" />
+        <p>No watchers yet</p>
+        {isOwner && onAddWatcher && (
+          <Button
+            variant="outline"
+            size="sm"
+            className="mt-2"
+            onClick={onAddWatcher}
+          >
+            <UserPlus className="h-4 w-4 mr-1" />
+            Add watcher
+          </Button>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn('space-y-3', className)}>
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <span className="text-sm text-muted-foreground">
+          {watchers.length} {watchers.length === 1 ? 'watcher' : 'watchers'}
+        </span>
+        {isOwner && onAddWatcher && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onAddWatcher}
+            aria-label="Add watcher"
+          >
+            <UserPlus className="h-4 w-4 mr-1" />
+            Add watcher
+          </Button>
+        )}
+      </div>
+
+      {/* Watcher list */}
+      <div className="space-y-2">
+        {watchers.map((watcher) => {
+          const canRemove = isOwner || watcher.userId === currentUserId;
+
+          return (
+            <div
+              key={watcher.id}
+              className="flex items-center gap-3 p-2 rounded-md hover:bg-muted/50"
+            >
+              {/* Avatar */}
+              {watcher.avatar ? (
+                <img
+                  src={watcher.avatar}
+                  alt={watcher.name}
+                  className="h-8 w-8 rounded-full object-cover"
+                />
+              ) : (
+                <div className="h-8 w-8 rounded-full bg-muted flex items-center justify-center text-xs font-medium">
+                  {getInitials(watcher.name)}
+                </div>
+              )}
+
+              {/* Info */}
+              <div className="flex-1 min-w-0">
+                <div className="font-medium text-sm truncate">{watcher.name}</div>
+                <div className="text-xs text-muted-foreground">
+                  {getNotificationLevelLabel(watcher.notificationLevel)}
+                </div>
+              </div>
+
+              {/* Remove button */}
+              {canRemove && onRemove && (
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7"
+                  onClick={() => onRemove(watcher.id)}
+                  aria-label="Remove watcher"
+                >
+                  <X className="h-4 w-4" />
+                </Button>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/ui/components/watchers/watcher-settings.tsx
+++ b/src/ui/components/watchers/watcher-settings.tsx
@@ -1,0 +1,112 @@
+/**
+ * Watcher settings for auto-watch preferences
+ * Issue #401: Implement watchers/followers on work items
+ */
+import * as React from 'react';
+import { Label } from '@/ui/components/ui/label';
+import { Switch } from '@/ui/components/ui/switch';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/ui/components/ui/select';
+import { cn } from '@/ui/lib/utils';
+import {
+  NOTIFICATION_LEVELS,
+  type AutoWatchSettings,
+  type NotificationLevel,
+} from './types';
+
+export interface WatcherSettingsProps {
+  settings: AutoWatchSettings;
+  onChange: (settings: AutoWatchSettings) => void;
+  className?: string;
+}
+
+export function WatcherSettings({
+  settings,
+  onChange,
+  className,
+}: WatcherSettingsProps) {
+  const handleToggle = (key: keyof AutoWatchSettings) => {
+    onChange({
+      ...settings,
+      [key]: !settings[key],
+    });
+  };
+
+  const handleNotificationLevelChange = (value: NotificationLevel) => {
+    onChange({
+      ...settings,
+      defaultNotificationLevel: value,
+    });
+  };
+
+  return (
+    <div className={cn('space-y-6', className)}>
+      {/* Auto-watch toggles */}
+      <div className="space-y-4">
+        <h4 className="text-sm font-medium">Auto-watch settings</h4>
+
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <Label htmlFor="auto-created" className="text-sm cursor-pointer">
+              Items you create
+            </Label>
+            <Switch
+              id="auto-created"
+              checked={settings.autoWatchCreated}
+              onCheckedChange={() => handleToggle('autoWatchCreated')}
+            />
+          </div>
+
+          <div className="flex items-center justify-between">
+            <Label htmlFor="auto-assigned" className="text-sm cursor-pointer">
+              Items assigned to you
+            </Label>
+            <Switch
+              id="auto-assigned"
+              checked={settings.autoWatchAssigned}
+              onCheckedChange={() => handleToggle('autoWatchAssigned')}
+            />
+          </div>
+
+          <div className="flex items-center justify-between">
+            <Label htmlFor="auto-commented" className="text-sm cursor-pointer">
+              Items you comment on
+            </Label>
+            <Switch
+              id="auto-commented"
+              checked={settings.autoWatchCommented}
+              onCheckedChange={() => handleToggle('autoWatchCommented')}
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Default notification level */}
+      <div className="space-y-2">
+        <Label htmlFor="notification-level" className="text-sm font-medium">
+          Default notification level
+        </Label>
+        <Select
+          value={settings.defaultNotificationLevel}
+          onValueChange={handleNotificationLevelChange}
+        >
+          <SelectTrigger id="notification-level">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {NOTIFICATION_LEVELS.map((level) => (
+              <SelectItem key={level.value} value={level.value}>
+                {level.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  );
+}

--- a/tests/ui/watchers.test.tsx
+++ b/tests/ui/watchers.test.tsx
@@ -1,0 +1,424 @@
+/**
+ * @vitest-environment jsdom
+ * Tests for watchers/followers on work items
+ * Issue #401: Implement watchers/followers on work items
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import * as React from 'react';
+
+// Components to be implemented
+import {
+  WatchButton,
+  type WatchButtonProps,
+} from '@/ui/components/watchers/watch-button';
+import {
+  WatcherList,
+  type WatcherListProps,
+} from '@/ui/components/watchers/watcher-list';
+import {
+  AddWatcherDialog,
+  type AddWatcherDialogProps,
+} from '@/ui/components/watchers/add-watcher-dialog';
+import {
+  WatchedItemsList,
+  type WatchedItemsListProps,
+} from '@/ui/components/watchers/watched-items-list';
+import {
+  WatcherSettings,
+  type WatcherSettingsProps,
+} from '@/ui/components/watchers/watcher-settings';
+import type {
+  Watcher,
+  WatchedItem,
+  NotificationLevel,
+  AutoWatchSettings,
+} from '@/ui/components/watchers/types';
+
+describe('WatchButton', () => {
+  const defaultProps: WatchButtonProps = {
+    isWatching: false,
+    onToggle: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should show Watch text when not watching', () => {
+    render(<WatchButton {...defaultProps} />);
+    expect(screen.getByRole('button', { name: /watch/i })).toBeInTheDocument();
+  });
+
+  it('should show Watching text when watching', () => {
+    render(<WatchButton {...defaultProps} isWatching />);
+    expect(screen.getByRole('button', { name: /watching/i })).toBeInTheDocument();
+  });
+
+  it('should show eye icon', () => {
+    render(<WatchButton {...defaultProps} />);
+    expect(screen.getByTestId('watch-icon')).toBeInTheDocument();
+  });
+
+  it('should call onToggle when clicked', () => {
+    const onToggle = vi.fn();
+    render(<WatchButton {...defaultProps} onToggle={onToggle} />);
+
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(onToggle).toHaveBeenCalled();
+  });
+
+  it('should show loading state', () => {
+    render(<WatchButton {...defaultProps} loading />);
+    expect(screen.getByTestId('watch-loading')).toBeInTheDocument();
+  });
+
+  it('should be disabled when loading', () => {
+    render(<WatchButton {...defaultProps} loading />);
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
+
+  it('should show watcher count when provided', () => {
+    render(<WatchButton {...defaultProps} watcherCount={5} />);
+    expect(screen.getByText('5')).toBeInTheDocument();
+  });
+
+  it('should support compact mode', () => {
+    render(<WatchButton {...defaultProps} compact />);
+    // In compact mode, don't show text, just icon
+    expect(screen.queryByText(/watch/i)).not.toBeInTheDocument();
+  });
+});
+
+describe('WatcherList', () => {
+  const mockWatchers: Watcher[] = [
+    {
+      id: 'watcher-1',
+      userId: 'user-1',
+      name: 'Alice Smith',
+      avatar: 'https://example.com/alice.png',
+      notificationLevel: 'all',
+      addedAt: new Date().toISOString(),
+    },
+    {
+      id: 'watcher-2',
+      userId: 'user-2',
+      name: 'Bob Jones',
+      notificationLevel: 'mentions',
+      addedAt: new Date().toISOString(),
+    },
+  ];
+
+  const defaultProps: WatcherListProps = {
+    watchers: mockWatchers,
+    currentUserId: 'user-3',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render all watchers', () => {
+    render(<WatcherList {...defaultProps} />);
+    expect(screen.getByText('Alice Smith')).toBeInTheDocument();
+    expect(screen.getByText('Bob Jones')).toBeInTheDocument();
+  });
+
+  it('should show watcher count', () => {
+    render(<WatcherList {...defaultProps} />);
+    expect(screen.getByText(/2 watchers/i)).toBeInTheDocument();
+  });
+
+  it('should show avatar when available', () => {
+    render(<WatcherList {...defaultProps} />);
+    const avatar = screen.getByRole('img');
+    expect(avatar).toHaveAttribute('src', 'https://example.com/alice.png');
+  });
+
+  it('should show initials when no avatar', () => {
+    render(<WatcherList {...defaultProps} />);
+    expect(screen.getByText('BJ')).toBeInTheDocument(); // Bob Jones initials
+  });
+
+  it('should show notification level badge', () => {
+    render(<WatcherList {...defaultProps} />);
+    expect(screen.getByText(/all activity/i)).toBeInTheDocument();
+    expect(screen.getByText(/mentions only/i)).toBeInTheDocument();
+  });
+
+  it('should show remove button for own entry', () => {
+    render(<WatcherList {...defaultProps} currentUserId="user-1" onRemove={vi.fn()} />);
+    const removeButtons = screen.getAllByLabelText(/remove watcher/i);
+    expect(removeButtons.length).toBe(1);
+  });
+
+  it('should show remove button for owners', () => {
+    render(<WatcherList {...defaultProps} isOwner onRemove={vi.fn()} />);
+    const removeButtons = screen.getAllByLabelText(/remove watcher/i);
+    expect(removeButtons.length).toBe(2);
+  });
+
+  it('should call onRemove when remove clicked', () => {
+    const onRemove = vi.fn();
+    render(<WatcherList {...defaultProps} isOwner onRemove={onRemove} />);
+
+    const removeButtons = screen.getAllByRole('button', { name: /remove|unwatch/i });
+    fireEvent.click(removeButtons[0]);
+
+    expect(onRemove).toHaveBeenCalledWith('watcher-1');
+  });
+
+  it('should show add watcher button for owners', () => {
+    render(<WatcherList {...defaultProps} isOwner onAddWatcher={vi.fn()} />);
+    expect(screen.getByRole('button', { name: /add watcher/i })).toBeInTheDocument();
+  });
+
+  it('should show empty state when no watchers', () => {
+    render(<WatcherList watchers={[]} currentUserId="user-1" />);
+    expect(screen.getByText(/no watchers/i)).toBeInTheDocument();
+  });
+});
+
+describe('AddWatcherDialog', () => {
+  const mockUsers = [
+    { id: 'user-1', name: 'Alice Smith', avatar: 'https://example.com/alice.png' },
+    { id: 'user-2', name: 'Bob Jones' },
+    { id: 'user-3', name: 'Charlie Brown' },
+  ];
+
+  const defaultProps: AddWatcherDialogProps = {
+    open: true,
+    onOpenChange: vi.fn(),
+    users: mockUsers,
+    existingWatcherIds: ['user-3'],
+    onAdd: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render dialog when open', () => {
+    render(<AddWatcherDialog {...defaultProps} />);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('should show available users', () => {
+    render(<AddWatcherDialog {...defaultProps} />);
+    expect(screen.getByText('Alice Smith')).toBeInTheDocument();
+    expect(screen.getByText('Bob Jones')).toBeInTheDocument();
+  });
+
+  it('should exclude existing watchers', () => {
+    render(<AddWatcherDialog {...defaultProps} />);
+    // Charlie Brown is already a watcher
+    expect(screen.queryByText('Charlie Brown')).not.toBeInTheDocument();
+  });
+
+  it('should support search', () => {
+    render(<AddWatcherDialog {...defaultProps} />);
+
+    const searchInput = screen.getByPlaceholderText(/search/i);
+    fireEvent.change(searchInput, { target: { value: 'alice' } });
+
+    expect(screen.getByText('Alice Smith')).toBeInTheDocument();
+    expect(screen.queryByText('Bob Jones')).not.toBeInTheDocument();
+  });
+
+  it('should call onAdd when user selected', () => {
+    const onAdd = vi.fn();
+    render(<AddWatcherDialog {...defaultProps} onAdd={onAdd} />);
+
+    fireEvent.click(screen.getByText('Alice Smith'));
+
+    expect(onAdd).toHaveBeenCalledWith('user-1', 'all');
+  });
+
+  it('should allow selecting notification level', () => {
+    render(<AddWatcherDialog {...defaultProps} />);
+    expect(screen.getByText(/notification level/i)).toBeInTheDocument();
+  });
+
+  it('should close when cancel clicked', () => {
+    const onOpenChange = vi.fn();
+    render(<AddWatcherDialog {...defaultProps} onOpenChange={onOpenChange} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});
+
+describe('WatchedItemsList', () => {
+  const mockItems: WatchedItem[] = [
+    {
+      id: 'wi-1',
+      title: 'Fix login bug',
+      type: 'issue',
+      status: 'in_progress',
+      notificationLevel: 'all',
+      lastActivity: new Date().toISOString(),
+      unreadCount: 2,
+    },
+    {
+      id: 'wi-2',
+      title: 'Add user dashboard',
+      type: 'task',
+      status: 'open',
+      notificationLevel: 'mentions',
+      lastActivity: new Date(Date.now() - 86400000).toISOString(),
+      unreadCount: 0,
+    },
+  ];
+
+  const defaultProps: WatchedItemsListProps = {
+    items: mockItems,
+    onItemClick: vi.fn(),
+    onUnwatch: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render all watched items', () => {
+    render(<WatchedItemsList {...defaultProps} />);
+    expect(screen.getByText('Fix login bug')).toBeInTheDocument();
+    expect(screen.getByText('Add user dashboard')).toBeInTheDocument();
+  });
+
+  it('should show item type', () => {
+    render(<WatchedItemsList {...defaultProps} />);
+    expect(screen.getByText(/issue/i)).toBeInTheDocument();
+    expect(screen.getByText(/task/i)).toBeInTheDocument();
+  });
+
+  it('should show item status', () => {
+    render(<WatchedItemsList {...defaultProps} />);
+    expect(screen.getByText(/in progress/i)).toBeInTheDocument();
+    expect(screen.getByText(/open/i)).toBeInTheDocument();
+  });
+
+  it('should show unread count badge', () => {
+    render(<WatchedItemsList {...defaultProps} />);
+    expect(screen.getByText('2')).toBeInTheDocument();
+  });
+
+  it('should show notification level', () => {
+    render(<WatchedItemsList {...defaultProps} />);
+    expect(screen.getByText(/all activity/i)).toBeInTheDocument();
+    expect(screen.getByText(/mentions only/i)).toBeInTheDocument();
+  });
+
+  it('should call onItemClick when item clicked', () => {
+    const onItemClick = vi.fn();
+    render(<WatchedItemsList {...defaultProps} onItemClick={onItemClick} />);
+
+    fireEvent.click(screen.getByText('Fix login bug'));
+
+    expect(onItemClick).toHaveBeenCalledWith('wi-1');
+  });
+
+  it('should call onUnwatch when unwatch clicked', () => {
+    const onUnwatch = vi.fn();
+    render(<WatchedItemsList {...defaultProps} onUnwatch={onUnwatch} />);
+
+    const unwatchButtons = screen.getAllByRole('button', { name: /unwatch/i });
+    fireEvent.click(unwatchButtons[0]);
+
+    expect(onUnwatch).toHaveBeenCalledWith('wi-1');
+  });
+
+  it('should show empty state when no items', () => {
+    render(<WatchedItemsList items={[]} onItemClick={vi.fn()} onUnwatch={vi.fn()} />);
+    expect(screen.getByText(/no watched items/i)).toBeInTheDocument();
+  });
+
+  it('should support filtering by type', () => {
+    render(<WatchedItemsList {...defaultProps} filterType="issue" />);
+    expect(screen.getByText('Fix login bug')).toBeInTheDocument();
+    expect(screen.queryByText('Add user dashboard')).not.toBeInTheDocument();
+  });
+
+  it('should show loading state', () => {
+    render(<WatchedItemsList {...defaultProps} loading />);
+    expect(screen.getByTestId('watched-items-loading')).toBeInTheDocument();
+  });
+});
+
+describe('WatcherSettings', () => {
+  const mockSettings: AutoWatchSettings = {
+    autoWatchCreated: true,
+    autoWatchAssigned: true,
+    autoWatchCommented: false,
+    defaultNotificationLevel: 'all',
+  };
+
+  const defaultProps: WatcherSettingsProps = {
+    settings: mockSettings,
+    onChange: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render auto-watch options', () => {
+    render(<WatcherSettings {...defaultProps} />);
+    expect(screen.getByText(/items you create/i)).toBeInTheDocument();
+    expect(screen.getByText(/items assigned to you/i)).toBeInTheDocument();
+    expect(screen.getByText(/items you comment on/i)).toBeInTheDocument();
+  });
+
+  it('should show current toggle states', () => {
+    render(<WatcherSettings {...defaultProps} />);
+    const switches = screen.getAllByRole('switch');
+    expect(switches[0]).toHaveAttribute('data-state', 'checked'); // autoWatchCreated
+    expect(switches[1]).toHaveAttribute('data-state', 'checked'); // autoWatchAssigned
+    expect(switches[2]).toHaveAttribute('data-state', 'unchecked'); // autoWatchCommented
+  });
+
+  it('should call onChange when toggle changed', () => {
+    const onChange = vi.fn();
+    render(<WatcherSettings {...defaultProps} onChange={onChange} />);
+
+    const switches = screen.getAllByRole('switch');
+    fireEvent.click(switches[2]); // Toggle autoWatchCommented
+
+    expect(onChange).toHaveBeenCalledWith({
+      ...mockSettings,
+      autoWatchCommented: true,
+    });
+  });
+
+  it('should show default notification level selector', () => {
+    render(<WatcherSettings {...defaultProps} />);
+    expect(screen.getByText(/default notification level/i)).toBeInTheDocument();
+  });
+
+  it('should show all notification level options', () => {
+    render(<WatcherSettings {...defaultProps} />);
+    // The selected option should be visible
+    expect(screen.getByText(/all activity/i)).toBeInTheDocument();
+  });
+
+  it('should call onChange when notification level changed', () => {
+    const onChange = vi.fn();
+    render(<WatcherSettings {...defaultProps} onChange={onChange} />);
+
+    // Find and click the notification level dropdown
+    const dropdown = screen.getByRole('combobox');
+    fireEvent.click(dropdown);
+
+    // Select a different option
+    const mentionsOption = screen.getByRole('option', { name: /mentions only/i });
+    fireEvent.click(mentionsOption);
+
+    expect(onChange).toHaveBeenCalledWith({
+      ...mockSettings,
+      defaultNotificationLevel: 'mentions',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add watcher components for following work items and getting notifications
- Implement watch/unwatch button with visual indicator
- Support configurable notification levels (all, mentions, status changes)
- Add auto-watch preferences for items you create/assigned/comment on

## Components Added
- `watch-button.tsx` - Toggle watch status with watcher count display
- `watcher-list.tsx` - Display and manage item watchers with remove capability
- `add-watcher-dialog.tsx` - Search and add users as watchers
- `watched-items-list.tsx` - View all watched items with type filtering
- `watcher-settings.tsx` - Auto-watch preferences configuration
- `types.ts` - Watcher, WatchedItem, NotificationLevel types

## Features
- Three notification levels: all activity, mentions only, status changes only
- Auto-watch settings for items you create, are assigned to, or comment on
- Compact mode for icon-only watch button in tight spaces
- Owner and self can remove watchers

## Test Coverage
- 41 tests covering all components
- Tests for watch toggle, watcher management
- Tests for settings, notification levels, filtering

## Test plan
- [x] Run `npm test -- tests/ui/watchers.test.tsx` - all 41 tests pass
- [x] Verify exports from index.ts
- [x] Check component type safety

Closes #401

🤖 Generated with [Claude Code](https://claude.com/claude-code)