### PR TITLE
[#403] Implement activity feed filtering and personalization

### DIFF
--- a/src/ui/components/activity-feed/activity-detail-card.tsx
+++ b/src/ui/components/activity-feed/activity-detail-card.tsx
@@ -1,0 +1,155 @@
+/**
+ * Expandable activity detail card
+ * Issue #403: Implement activity feed filtering and personalization
+ */
+import * as React from 'react';
+import { ChevronDown, ChevronUp } from 'lucide-react';
+import { Button } from '@/ui/components/ui/button';
+import { Badge } from '@/ui/components/ui/badge';
+import { cn } from '@/ui/lib/utils';
+import type { ActivityItem } from './types';
+
+function formatRelativeTime(dateString: string): string {
+  const date = new Date(dateString);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffSecs = Math.floor(diffMs / 1000);
+  const diffMins = Math.floor(diffSecs / 60);
+  const diffHours = Math.floor(diffMins / 60);
+  const diffDays = Math.floor(diffHours / 24);
+
+  if (diffSecs < 60) return 'just now';
+  if (diffMins < 60) return `${diffMins} minute${diffMins === 1 ? '' : 's'} ago`;
+  if (diffHours < 24) return `${diffHours} hour${diffHours === 1 ? '' : 's'} ago`;
+  if (diffDays < 7) return `${diffDays} day${diffDays === 1 ? '' : 's'} ago`;
+  return date.toLocaleDateString();
+}
+
+export interface ActivityDetailCardProps {
+  activity: ActivityItem;
+  expanded?: boolean;
+  onToggle?: () => void;
+  className?: string;
+}
+
+function getInitials(name: string): string {
+  const parts = name.split(' ').filter(Boolean);
+  if (parts.length === 0) return '';
+  if (parts.length === 1) return parts[0].charAt(0).toUpperCase();
+  return (parts[0].charAt(0) + parts[parts.length - 1].charAt(0)).toUpperCase();
+}
+
+function getActionLabel(action: string): string {
+  return action.replace(/_/g, ' ');
+}
+
+function getEntityUrl(entityType: string, entityId: string): string {
+  return `/${entityType}s/${entityId}`;
+}
+
+export function ActivityDetailCard({
+  activity,
+  expanded = false,
+  onToggle,
+  className,
+}: ActivityDetailCardProps) {
+  const hasChanges = activity.changes && activity.changes.length > 0;
+  const showToggle = onToggle && hasChanges;
+
+  return (
+    <div className={cn('rounded-lg border p-3', className)}>
+      {/* Header row */}
+      <div className="flex items-start gap-3">
+        {/* Actor avatar */}
+        {activity.actorAvatar ? (
+          <img
+            src={activity.actorAvatar}
+            alt={activity.actorName}
+            className="h-8 w-8 rounded-full object-cover shrink-0"
+          />
+        ) : (
+          <div className="h-8 w-8 rounded-full bg-muted flex items-center justify-center text-xs font-medium shrink-0">
+            {getInitials(activity.actorName)}
+          </div>
+        )}
+
+        {/* Content */}
+        <div className="flex-1 min-w-0">
+          {/* Summary line */}
+          <div className="flex items-center gap-1.5 flex-wrap text-sm">
+            <span className="font-medium">{activity.actorName}</span>
+            <span className="text-muted-foreground">{getActionLabel(activity.action)}</span>
+            <a
+              href={getEntityUrl(activity.entityType, activity.entityId)}
+              className="font-medium text-primary hover:underline truncate"
+            >
+              {activity.entityTitle}
+            </a>
+          </div>
+
+          {/* Entity type badge and timestamp */}
+          <div className="flex items-center gap-2 mt-1">
+            <Badge variant="outline" className="text-xs">
+              {activity.entityType}
+            </Badge>
+            <span
+              data-testid="activity-timestamp"
+              className="text-xs text-muted-foreground"
+            >
+              {formatRelativeTime(activity.timestamp)}
+            </span>
+          </div>
+        </div>
+
+        {/* Toggle button */}
+        {showToggle && (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7 shrink-0"
+            onClick={onToggle}
+            aria-label={expanded ? 'Collapse details' : 'Show details'}
+          >
+            {expanded ? (
+              <ChevronUp className="h-4 w-4" />
+            ) : (
+              <ChevronDown className="h-4 w-4" />
+            )}
+          </Button>
+        )}
+      </div>
+
+      {/* Expanded changes */}
+      {expanded && hasChanges && (
+        <div className="mt-3 pt-3 border-t space-y-2">
+          <h4 className="text-xs font-medium text-muted-foreground uppercase">
+            Changes
+          </h4>
+          {activity.changes!.map((change, index) => (
+            <div
+              key={index}
+              className="flex items-center gap-2 text-sm bg-muted/50 rounded px-2 py-1"
+            >
+              <span className="font-medium capitalize">{change.field}</span>
+              <span className="text-muted-foreground">:</span>
+              {change.from && (
+                <>
+                  <span className="text-red-600 line-through">{change.from}</span>
+                  <span className="text-muted-foreground">→</span>
+                </>
+              )}
+              <span className="text-green-600">{change.to || '(empty)'}</span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Comment if present */}
+      {activity.comment && (
+        <div className="mt-3 pt-3 border-t">
+          <p className="text-sm text-muted-foreground">{activity.comment}</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/ui/components/activity-feed/activity-feed-filters.tsx
+++ b/src/ui/components/activity-feed/activity-feed-filters.tsx
@@ -1,0 +1,232 @@
+/**
+ * Comprehensive filter controls for activity feed
+ * Issue #403: Implement activity feed filtering and personalization
+ */
+import * as React from 'react';
+import { Filter, X } from 'lucide-react';
+import { Button } from '@/ui/components/ui/button';
+import { Badge } from '@/ui/components/ui/badge';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/ui/components/ui/popover';
+import { Checkbox } from '@/ui/components/ui/checkbox';
+import { cn } from '@/ui/lib/utils';
+import {
+  ACTOR_TYPES,
+  ACTION_TYPES,
+  ENTITY_TYPES,
+  TIME_RANGES,
+  countActiveFilters,
+  type ActivityFilters,
+  type ActorType,
+  type ActionType,
+  type EntityType,
+  type TimeRange,
+} from './types';
+
+export interface ActivityFeedFiltersProps {
+  filters: ActivityFilters;
+  onChange: (filters: ActivityFilters) => void;
+  currentUserId?: string;
+  className?: string;
+}
+
+export function ActivityFeedFilters({
+  filters,
+  onChange,
+  currentUserId,
+  className,
+}: ActivityFeedFiltersProps) {
+  const activeCount = countActiveFilters(filters);
+
+  const handleActorChange = (actorType: ActorType) => {
+    onChange({ ...filters, actorType });
+  };
+
+  const handleActionToggle = (action: ActionType) => {
+    const current = filters.actionType || [];
+    const newActions = current.includes(action)
+      ? current.filter((a) => a !== action)
+      : [...current, action];
+    onChange({ ...filters, actionType: newActions.length > 0 ? newActions : undefined });
+  };
+
+  const handleEntityToggle = (entity: EntityType) => {
+    const current = filters.entityType || [];
+    const newEntities = current.includes(entity)
+      ? current.filter((e) => e !== entity)
+      : [...current, entity];
+    onChange({ ...filters, entityType: newEntities.length > 0 ? newEntities : undefined });
+  };
+
+  const handleTimeChange = (timeRange: TimeRange) => {
+    onChange({ ...filters, timeRange });
+  };
+
+  const handleMyActivityToggle = () => {
+    onChange({ ...filters, myActivityOnly: !filters.myActivityOnly });
+  };
+
+  const handleClear = () => {
+    onChange({});
+  };
+
+  return (
+    <div className={cn('flex flex-wrap items-center gap-2', className)}>
+      {/* Actor Type Filter */}
+      <Popover>
+        <PopoverTrigger asChild>
+          <Button variant="outline" size="sm">
+            Actor
+            {filters.actorType && filters.actorType !== 'all' && (
+              <Badge variant="secondary" className="ml-1.5 px-1">
+                1
+              </Badge>
+            )}
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-40 p-2">
+          <div className="space-y-1">
+            {ACTOR_TYPES.map((type) => (
+              <button
+                key={type.value}
+                className={cn(
+                  'w-full text-left px-2 py-1.5 rounded text-sm',
+                  filters.actorType === type.value
+                    ? 'bg-primary text-primary-foreground'
+                    : 'hover:bg-muted'
+                )}
+                onClick={() => handleActorChange(type.value)}
+              >
+                {type.label}
+              </button>
+            ))}
+          </div>
+        </PopoverContent>
+      </Popover>
+
+      {/* Action Type Filter */}
+      <Popover>
+        <PopoverTrigger asChild>
+          <Button variant="outline" size="sm">
+            Action
+            {filters.actionType && filters.actionType.length > 0 && (
+              <Badge variant="secondary" className="ml-1.5 px-1">
+                {filters.actionType.length}
+              </Badge>
+            )}
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-48 p-2">
+          <div className="space-y-2">
+            {ACTION_TYPES.map((type) => (
+              <label
+                key={type.value}
+                className="flex items-center gap-2 cursor-pointer"
+              >
+                <Checkbox
+                  checked={filters.actionType?.includes(type.value) || false}
+                  onCheckedChange={() => handleActionToggle(type.value)}
+                />
+                <span className="text-sm">{type.label}</span>
+              </label>
+            ))}
+          </div>
+        </PopoverContent>
+      </Popover>
+
+      {/* Entity Type Filter */}
+      <Popover>
+        <PopoverTrigger asChild>
+          <Button variant="outline" size="sm">
+            Entity
+            {filters.entityType && filters.entityType.length > 0 && (
+              <Badge variant="secondary" className="ml-1.5 px-1">
+                {filters.entityType.length}
+              </Badge>
+            )}
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-40 p-2">
+          <div className="space-y-2">
+            {ENTITY_TYPES.map((type) => (
+              <label
+                key={type.value}
+                className="flex items-center gap-2 cursor-pointer"
+              >
+                <Checkbox
+                  checked={filters.entityType?.includes(type.value) || false}
+                  onCheckedChange={() => handleEntityToggle(type.value)}
+                />
+                <span className="text-sm">{type.label}</span>
+              </label>
+            ))}
+          </div>
+        </PopoverContent>
+      </Popover>
+
+      {/* Time Range Filter */}
+      <Popover>
+        <PopoverTrigger asChild>
+          <Button variant="outline" size="sm">
+            Time
+            {filters.timeRange && (
+              <Badge variant="secondary" className="ml-1.5 px-1">
+                1
+              </Badge>
+            )}
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-40 p-2">
+          <div className="space-y-1">
+            {TIME_RANGES.map((range) => (
+              <button
+                key={range.value}
+                className={cn(
+                  'w-full text-left px-2 py-1.5 rounded text-sm',
+                  filters.timeRange === range.value
+                    ? 'bg-primary text-primary-foreground'
+                    : 'hover:bg-muted'
+                )}
+                onClick={() => handleTimeChange(range.value)}
+              >
+                {range.label}
+              </button>
+            ))}
+          </div>
+        </PopoverContent>
+      </Popover>
+
+      {/* My Activity Toggle */}
+      {currentUserId && (
+        <Button
+          variant={filters.myActivityOnly ? 'secondary' : 'outline'}
+          size="sm"
+          onClick={handleMyActivityToggle}
+        >
+          My Activity
+        </Button>
+      )}
+
+      {/* Active Filter Count & Clear */}
+      {activeCount > 0 && (
+        <>
+          <Badge variant="default" className="h-6">
+            {activeCount}
+          </Badge>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleClear}
+            aria-label="Clear filters"
+          >
+            <X className="h-4 w-4 mr-1" />
+            Clear
+          </Button>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/ui/components/activity-feed/activity-feed-personalization.tsx
+++ b/src/ui/components/activity-feed/activity-feed-personalization.tsx
@@ -1,0 +1,152 @@
+/**
+ * Personalization settings for activity feed
+ * Issue #403: Implement activity feed filtering and personalization
+ */
+import * as React from 'react';
+import { Save } from 'lucide-react';
+import { Button } from '@/ui/components/ui/button';
+import { Label } from '@/ui/components/ui/label';
+import { Switch } from '@/ui/components/ui/switch';
+import { Input } from '@/ui/components/ui/input';
+import { cn } from '@/ui/lib/utils';
+import type { ActivityPersonalizationSettings } from './types';
+
+export interface ActivityFeedPersonalizationProps {
+  settings: ActivityPersonalizationSettings;
+  onChange: (settings: ActivityPersonalizationSettings) => void;
+  onSaveDefaults?: (settings: ActivityPersonalizationSettings) => void;
+  className?: string;
+}
+
+export function ActivityFeedPersonalization({
+  settings,
+  onChange,
+  onSaveDefaults,
+  className,
+}: ActivityFeedPersonalizationProps) {
+  const handleToggle = (key: keyof ActivityPersonalizationSettings) => {
+    onChange({
+      ...settings,
+      [key]: !settings[key],
+    });
+  };
+
+  const handleNumberChange = (
+    key: 'collapseThreshold' | 'refreshInterval',
+    value: number
+  ) => {
+    onChange({
+      ...settings,
+      [key]: value,
+    });
+  };
+
+  return (
+    <div className={cn('space-y-6', className)}>
+      {/* Default filters section */}
+      <div>
+        <h4 className="text-sm font-medium mb-3">Default Filters</h4>
+        <p className="text-xs text-muted-foreground">
+          {Object.keys(settings.defaultFilters).length > 0
+            ? `${Object.keys(settings.defaultFilters).length} filter(s) configured`
+            : 'No default filters set'}
+        </p>
+      </div>
+
+      {/* Display settings */}
+      <div className="space-y-4">
+        <h4 className="text-sm font-medium">Display Settings</h4>
+
+        {/* Show my activity first */}
+        <div className="flex items-center justify-between">
+          <Label
+            htmlFor="my-activity-first"
+            className="text-sm cursor-pointer"
+          >
+            Show my activity first
+          </Label>
+          <Switch
+            id="my-activity-first"
+            aria-label="Show my activity first"
+            checked={settings.showMyActivityFirst}
+            onCheckedChange={() => handleToggle('showMyActivityFirst')}
+          />
+        </div>
+
+        {/* Collapse threshold */}
+        <div className="space-y-2">
+          <Label htmlFor="collapse-threshold" className="text-sm">
+            Collapse threshold
+          </Label>
+          <div className="flex items-center gap-2">
+            <Input
+              id="collapse-threshold"
+              type="number"
+              min={2}
+              max={20}
+              value={settings.collapseThreshold}
+              onChange={(e) =>
+                handleNumberChange('collapseThreshold', parseInt(e.target.value, 10))
+              }
+              className="w-20"
+            />
+            <span className="text-xs text-muted-foreground">
+              Group similar activities when there are this many
+            </span>
+          </div>
+        </div>
+      </div>
+
+      {/* Refresh settings */}
+      <div className="space-y-4">
+        <h4 className="text-sm font-medium">Refresh Settings</h4>
+
+        {/* Auto refresh */}
+        <div className="flex items-center justify-between">
+          <Label htmlFor="auto-refresh" className="text-sm cursor-pointer">
+            Auto refresh
+          </Label>
+          <Switch
+            id="auto-refresh"
+            aria-label="Auto refresh"
+            checked={settings.autoRefresh}
+            onCheckedChange={() => handleToggle('autoRefresh')}
+          />
+        </div>
+
+        {/* Refresh interval */}
+        {settings.autoRefresh && (
+          <div className="space-y-2">
+            <Label htmlFor="refresh-interval" className="text-sm">
+              Refresh interval (seconds)
+            </Label>
+            <div className="flex items-center gap-2">
+              <Input
+                id="refresh-interval"
+                type="number"
+                min={10}
+                max={300}
+                value={settings.refreshInterval}
+                onChange={(e) =>
+                  handleNumberChange('refreshInterval', parseInt(e.target.value, 10))
+                }
+                className="w-20"
+              />
+              <span className="text-xs text-muted-foreground">
+                {settings.refreshInterval} seconds
+              </span>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Save button */}
+      {onSaveDefaults && (
+        <Button onClick={() => onSaveDefaults(settings)} className="w-full">
+          <Save className="h-4 w-4 mr-2" />
+          Save as Defaults
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/src/ui/components/activity-feed/activity-quick-filters.tsx
+++ b/src/ui/components/activity-feed/activity-quick-filters.tsx
@@ -1,0 +1,59 @@
+/**
+ * Quick filter presets for activity feed
+ * Issue #403: Implement activity feed filtering and personalization
+ */
+import * as React from 'react';
+import { Button } from '@/ui/components/ui/button';
+import { cn } from '@/ui/lib/utils';
+import type { QuickFilterPreset, ActivityFilters } from './types';
+
+export interface ActivityQuickFiltersProps {
+  presets: QuickFilterPreset[];
+  activePresetId: string | null;
+  onSelectPreset: (presetId: string | null, filters: ActivityFilters) => void;
+  className?: string;
+}
+
+export function ActivityQuickFilters({
+  presets,
+  activePresetId,
+  onSelectPreset,
+  className,
+}: ActivityQuickFiltersProps) {
+  if (presets.length === 0) {
+    return (
+      <div className={cn('text-sm text-muted-foreground', className)}>
+        No presets available
+      </div>
+    );
+  }
+
+  const handleClick = (preset: QuickFilterPreset) => {
+    if (activePresetId === preset.id) {
+      // Deselect
+      onSelectPreset(null, {});
+    } else {
+      onSelectPreset(preset.id, preset.filters);
+    }
+  };
+
+  return (
+    <div className={cn('flex flex-wrap gap-2', className)}>
+      {presets.map((preset) => {
+        const isActive = activePresetId === preset.id;
+
+        return (
+          <Button
+            key={preset.id}
+            variant={isActive ? 'secondary' : 'outline'}
+            size="sm"
+            onClick={() => handleClick(preset)}
+            data-active={isActive}
+          >
+            {preset.name}
+          </Button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/ui/components/activity-feed/collapsed-activity-group.tsx
+++ b/src/ui/components/activity-feed/collapsed-activity-group.tsx
@@ -1,0 +1,62 @@
+/**
+ * Collapsible group of similar activities
+ * Issue #403: Implement activity feed filtering and personalization
+ */
+import * as React from 'react';
+import { ChevronDown, ChevronUp } from 'lucide-react';
+import { Button } from '@/ui/components/ui/button';
+import { Badge } from '@/ui/components/ui/badge';
+import { cn } from '@/ui/lib/utils';
+import { ActivityDetailCard } from './activity-detail-card';
+import type { ActivityItem } from './types';
+
+export interface CollapsedActivityGroupProps {
+  activities: ActivityItem[];
+  groupLabel: string;
+  collapsed: boolean;
+  onToggle: () => void;
+  className?: string;
+}
+
+export function CollapsedActivityGroup({
+  activities,
+  groupLabel,
+  collapsed,
+  onToggle,
+  className,
+}: CollapsedActivityGroupProps) {
+  return (
+    <div className={cn('rounded-lg border', className)}>
+      {/* Group header - always visible */}
+      <button
+        type="button"
+        className="w-full flex items-center justify-between p-3 hover:bg-muted/50 transition-colors"
+        onClick={onToggle}
+        aria-label={collapsed ? 'Expand activities' : 'Collapse activities'}
+      >
+        <div className="flex items-center gap-2">
+          <Badge variant="secondary">{activities.length}</Badge>
+          <span className="text-sm font-medium">{groupLabel}</span>
+        </div>
+        {collapsed ? (
+          <ChevronDown className="h-4 w-4 text-muted-foreground" />
+        ) : (
+          <ChevronUp className="h-4 w-4 text-muted-foreground" />
+        )}
+      </button>
+
+      {/* Expanded activities */}
+      {!collapsed && (
+        <div className="border-t p-3 space-y-3">
+          {activities.map((activity) => (
+            <ActivityDetailCard
+              key={activity.id}
+              activity={activity}
+              expanded={false}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/ui/components/activity-feed/index.ts
+++ b/src/ui/components/activity-feed/index.ts
@@ -1,0 +1,32 @@
+/**
+ * Activity feed filtering and personalization components
+ * Issue #403: Implement activity feed filtering and personalization
+ */
+export { ActivityFeedFilters } from './activity-feed-filters';
+export type { ActivityFeedFiltersProps } from './activity-feed-filters';
+export { ActivityDetailCard } from './activity-detail-card';
+export type { ActivityDetailCardProps } from './activity-detail-card';
+export { CollapsedActivityGroup } from './collapsed-activity-group';
+export type { CollapsedActivityGroupProps } from './collapsed-activity-group';
+export { ActivityQuickFilters } from './activity-quick-filters';
+export type { ActivityQuickFiltersProps } from './activity-quick-filters';
+export { ActivityFeedPersonalization } from './activity-feed-personalization';
+export type { ActivityFeedPersonalizationProps } from './activity-feed-personalization';
+export type {
+  ActivityFilters,
+  ActivityItem,
+  ActivityChange,
+  QuickFilterPreset,
+  ActivityPersonalizationSettings,
+  ActorType,
+  ActionType,
+  EntityType,
+  TimeRange,
+} from './types';
+export {
+  ACTION_TYPES,
+  ACTOR_TYPES,
+  ENTITY_TYPES,
+  TIME_RANGES,
+  countActiveFilters,
+} from './types';

--- a/src/ui/components/activity-feed/types.ts
+++ b/src/ui/components/activity-feed/types.ts
@@ -1,0 +1,123 @@
+/**
+ * Types for activity feed filtering and personalization
+ * Issue #403: Implement activity feed filtering and personalization
+ */
+
+export type ActorType = 'human' | 'agent' | 'all';
+
+export type ActionType =
+  | 'created'
+  | 'updated'
+  | 'status_changed'
+  | 'commented'
+  | 'assigned'
+  | 'completed'
+  | 'deleted'
+  | 'moved';
+
+export type EntityType =
+  | 'project'
+  | 'initiative'
+  | 'epic'
+  | 'issue'
+  | 'task'
+  | 'contact'
+  | 'memory';
+
+export type TimeRange = 'today' | 'this_week' | 'this_month' | 'custom';
+
+export interface ActivityFilters {
+  actorType?: ActorType;
+  actionType?: ActionType[];
+  entityType?: EntityType[];
+  timeRange?: TimeRange;
+  startDate?: string;
+  endDate?: string;
+  myActivityOnly?: boolean;
+  projectId?: string;
+  contactId?: string;
+  excludeActions?: ActionType[];
+}
+
+export interface ActivityChange {
+  field: string;
+  from: string | null;
+  to: string | null;
+}
+
+export interface ActivityItem {
+  id: string;
+  action: ActionType;
+  entityType: EntityType;
+  entityId: string;
+  entityTitle: string;
+  actorId: string;
+  actorName: string;
+  actorAvatar?: string;
+  actorType: ActorType;
+  timestamp: string;
+  changes?: ActivityChange[];
+  comment?: string;
+}
+
+export interface QuickFilterPreset {
+  id: string;
+  name: string;
+  filters: ActivityFilters;
+  icon?: string;
+}
+
+export interface ActivityPersonalizationSettings {
+  defaultFilters: ActivityFilters;
+  showMyActivityFirst: boolean;
+  collapseThreshold: number;
+  autoRefresh: boolean;
+  refreshInterval: number;
+}
+
+export const ACTION_TYPES: { value: ActionType; label: string }[] = [
+  { value: 'created', label: 'Created' },
+  { value: 'updated', label: 'Updated' },
+  { value: 'status_changed', label: 'Status Changed' },
+  { value: 'commented', label: 'Commented' },
+  { value: 'assigned', label: 'Assigned' },
+  { value: 'completed', label: 'Completed' },
+  { value: 'deleted', label: 'Deleted' },
+  { value: 'moved', label: 'Moved' },
+];
+
+export const ACTOR_TYPES: { value: ActorType; label: string }[] = [
+  { value: 'all', label: 'All' },
+  { value: 'human', label: 'Human' },
+  { value: 'agent', label: 'Agent' },
+];
+
+export const ENTITY_TYPES: { value: EntityType; label: string }[] = [
+  { value: 'project', label: 'Project' },
+  { value: 'initiative', label: 'Initiative' },
+  { value: 'epic', label: 'Epic' },
+  { value: 'issue', label: 'Issue' },
+  { value: 'task', label: 'Task' },
+  { value: 'contact', label: 'Contact' },
+  { value: 'memory', label: 'Memory' },
+];
+
+export const TIME_RANGES: { value: TimeRange; label: string }[] = [
+  { value: 'today', label: 'Today' },
+  { value: 'this_week', label: 'This Week' },
+  { value: 'this_month', label: 'This Month' },
+  { value: 'custom', label: 'Custom Range' },
+];
+
+export function countActiveFilters(filters: ActivityFilters): number {
+  let count = 0;
+  if (filters.actorType && filters.actorType !== 'all') count++;
+  if (filters.actionType && filters.actionType.length > 0) count++;
+  if (filters.entityType && filters.entityType.length > 0) count++;
+  if (filters.timeRange) count++;
+  if (filters.myActivityOnly) count++;
+  if (filters.projectId) count++;
+  if (filters.contactId) count++;
+  if (filters.excludeActions && filters.excludeActions.length > 0) count++;
+  return count;
+}

--- a/tests/ui/activity-feed-filtering.test.tsx
+++ b/tests/ui/activity-feed-filtering.test.tsx
@@ -1,0 +1,465 @@
+/**
+ * @vitest-environment jsdom
+ * Tests for activity feed filtering and personalization
+ * Issue #403: Implement activity feed filtering and personalization
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import * as React from 'react';
+
+// Components to be implemented
+import {
+  ActivityFeedFilters,
+  type ActivityFeedFiltersProps,
+} from '@/ui/components/activity-feed/activity-feed-filters';
+import {
+  ActivityDetailCard,
+  type ActivityDetailCardProps,
+} from '@/ui/components/activity-feed/activity-detail-card';
+import {
+  CollapsedActivityGroup,
+  type CollapsedActivityGroupProps,
+} from '@/ui/components/activity-feed/collapsed-activity-group';
+import {
+  ActivityFeedPersonalization,
+  type ActivityFeedPersonalizationProps,
+} from '@/ui/components/activity-feed/activity-feed-personalization';
+import {
+  ActivityQuickFilters,
+  type ActivityQuickFiltersProps,
+} from '@/ui/components/activity-feed/activity-quick-filters';
+import type {
+  ActivityFilters,
+  ActivityItem,
+  QuickFilterPreset,
+  ActivityPersonalizationSettings,
+} from '@/ui/components/activity-feed/types';
+
+describe('ActivityFeedFilters', () => {
+  const defaultProps: ActivityFeedFiltersProps = {
+    filters: {},
+    onChange: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render actor type filter', () => {
+    render(<ActivityFeedFilters {...defaultProps} />);
+    expect(screen.getByText(/actor/i)).toBeInTheDocument();
+  });
+
+  it('should show actor type options', () => {
+    render(<ActivityFeedFilters {...defaultProps} />);
+
+    fireEvent.click(screen.getByText(/actor/i));
+
+    expect(screen.getByText(/all/i)).toBeInTheDocument();
+    expect(screen.getByText(/agent/i)).toBeInTheDocument();
+    expect(screen.getByText(/human/i)).toBeInTheDocument();
+  });
+
+  it('should render action type filter', () => {
+    render(<ActivityFeedFilters {...defaultProps} />);
+    expect(screen.getByText(/action/i)).toBeInTheDocument();
+  });
+
+  it('should show action type options', () => {
+    render(<ActivityFeedFilters {...defaultProps} />);
+
+    fireEvent.click(screen.getByText(/action/i));
+
+    expect(screen.getByText(/created/i)).toBeInTheDocument();
+    expect(screen.getByText(/updated/i)).toBeInTheDocument();
+    expect(screen.getByText(/commented/i)).toBeInTheDocument();
+  });
+
+  it('should render entity type filter', () => {
+    render(<ActivityFeedFilters {...defaultProps} />);
+    expect(screen.getByText(/entity/i)).toBeInTheDocument();
+  });
+
+  it('should show entity type options', () => {
+    render(<ActivityFeedFilters {...defaultProps} />);
+
+    fireEvent.click(screen.getByText(/entity/i));
+
+    expect(screen.getByText(/project/i)).toBeInTheDocument();
+    expect(screen.getByText(/issue/i)).toBeInTheDocument();
+    expect(screen.getByText(/contact/i)).toBeInTheDocument();
+  });
+
+  it('should render time range filter', () => {
+    render(<ActivityFeedFilters {...defaultProps} />);
+    expect(screen.getByText(/time/i)).toBeInTheDocument();
+  });
+
+  it('should show time range options', () => {
+    render(<ActivityFeedFilters {...defaultProps} />);
+
+    fireEvent.click(screen.getByText(/time/i));
+
+    expect(screen.getByText(/today/i)).toBeInTheDocument();
+    expect(screen.getByText(/this week/i)).toBeInTheDocument();
+    expect(screen.getByText(/this month/i)).toBeInTheDocument();
+  });
+
+  it('should call onChange when filter selected', () => {
+    const onChange = vi.fn();
+    render(<ActivityFeedFilters {...defaultProps} onChange={onChange} />);
+
+    fireEvent.click(screen.getByText(/actor/i));
+    fireEvent.click(screen.getByText(/human/i));
+
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({
+      actorType: 'human',
+    }));
+  });
+
+  it('should show my activity toggle', () => {
+    render(<ActivityFeedFilters {...defaultProps} currentUserId="user-1" />);
+    expect(screen.getByText(/my activity/i)).toBeInTheDocument();
+  });
+
+  it('should call onChange when my activity toggled', () => {
+    const onChange = vi.fn();
+    render(<ActivityFeedFilters {...defaultProps} currentUserId="user-1" onChange={onChange} />);
+
+    fireEvent.click(screen.getByText(/my activity/i));
+
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({
+      myActivityOnly: true,
+    }));
+  });
+
+  it('should show clear filters button when filters active', () => {
+    render(<ActivityFeedFilters {...defaultProps} filters={{ actorType: 'human' }} />);
+    expect(screen.getByRole('button', { name: /clear/i })).toBeInTheDocument();
+  });
+
+  it('should call onChange with empty filters on clear', () => {
+    const onChange = vi.fn();
+    render(<ActivityFeedFilters {...defaultProps} filters={{ actorType: 'human' }} onChange={onChange} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /clear/i }));
+
+    expect(onChange).toHaveBeenCalledWith({});
+  });
+
+  it('should show active filter count', () => {
+    render(<ActivityFeedFilters {...defaultProps} filters={{ actorType: 'human', actionType: ['created'] }} />);
+    expect(screen.getByText('2')).toBeInTheDocument();
+  });
+});
+
+describe('ActivityDetailCard', () => {
+  const mockActivity: ActivityItem = {
+    id: 'activity-1',
+    action: 'updated',
+    entityType: 'issue',
+    entityId: 'issue-1',
+    entityTitle: 'Fix login bug',
+    actorId: 'user-1',
+    actorName: 'Alice Smith',
+    actorType: 'human',
+    timestamp: new Date().toISOString(),
+    changes: [
+      { field: 'status', from: 'open', to: 'in_progress' },
+      { field: 'assignee', from: null, to: 'Bob Jones' },
+    ],
+  };
+
+  const defaultProps: ActivityDetailCardProps = {
+    activity: mockActivity,
+    expanded: true,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render activity summary', () => {
+    render(<ActivityDetailCard {...defaultProps} />);
+    expect(screen.getByText(/alice smith/i)).toBeInTheDocument();
+    expect(screen.getByText(/updated/i)).toBeInTheDocument();
+    expect(screen.getByText(/fix login bug/i)).toBeInTheDocument();
+  });
+
+  it('should show changes when expanded', () => {
+    render(<ActivityDetailCard {...defaultProps} expanded />);
+    expect(screen.getByText(/status/i)).toBeInTheDocument();
+    expect(screen.getByText(/open/i)).toBeInTheDocument();
+    expect(screen.getByText(/in_progress/i)).toBeInTheDocument();
+  });
+
+  it('should not show changes when collapsed', () => {
+    render(<ActivityDetailCard {...defaultProps} expanded={false} />);
+    expect(screen.queryByText(/status changed/i)).not.toBeInTheDocument();
+  });
+
+  it('should show expand button when collapsible', () => {
+    render(<ActivityDetailCard {...defaultProps} expanded={false} onToggle={vi.fn()} />);
+    expect(screen.getByRole('button', { name: /expand|show|details/i })).toBeInTheDocument();
+  });
+
+  it('should call onToggle when clicked', () => {
+    const onToggle = vi.fn();
+    render(<ActivityDetailCard {...defaultProps} expanded={false} onToggle={onToggle} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /expand|show|details/i }));
+
+    expect(onToggle).toHaveBeenCalled();
+  });
+
+  it('should show link to entity', () => {
+    render(<ActivityDetailCard {...defaultProps} />);
+    const link = screen.getByRole('link', { name: /fix login bug/i });
+    expect(link).toBeInTheDocument();
+  });
+
+  it('should show timestamp', () => {
+    render(<ActivityDetailCard {...defaultProps} />);
+    expect(screen.getByTestId('activity-timestamp')).toBeInTheDocument();
+  });
+
+  it('should show actor avatar', () => {
+    const activityWithAvatar = {
+      ...mockActivity,
+      actorAvatar: 'https://example.com/alice.png',
+    };
+    render(<ActivityDetailCard {...defaultProps} activity={activityWithAvatar} />);
+    const avatar = screen.getByRole('img');
+    expect(avatar).toHaveAttribute('src', 'https://example.com/alice.png');
+  });
+});
+
+describe('CollapsedActivityGroup', () => {
+  const mockActivities: ActivityItem[] = [
+    {
+      id: 'activity-1',
+      action: 'updated',
+      entityType: 'issue',
+      entityId: 'issue-1',
+      entityTitle: 'Issue 1',
+      actorId: 'user-1',
+      actorName: 'Alice',
+      actorType: 'human',
+      timestamp: new Date().toISOString(),
+    },
+    {
+      id: 'activity-2',
+      action: 'updated',
+      entityType: 'issue',
+      entityId: 'issue-2',
+      entityTitle: 'Issue 2',
+      actorId: 'user-1',
+      actorName: 'Alice',
+      actorType: 'human',
+      timestamp: new Date().toISOString(),
+    },
+    {
+      id: 'activity-3',
+      action: 'updated',
+      entityType: 'issue',
+      entityId: 'issue-3',
+      entityTitle: 'Issue 3',
+      actorId: 'user-1',
+      actorName: 'Alice',
+      actorType: 'human',
+      timestamp: new Date().toISOString(),
+    },
+  ];
+
+  const defaultProps: CollapsedActivityGroupProps = {
+    activities: mockActivities,
+    groupLabel: '3 items updated',
+    collapsed: true,
+    onToggle: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should show group label when collapsed', () => {
+    render(<CollapsedActivityGroup {...defaultProps} />);
+    expect(screen.getByText('3 items updated')).toBeInTheDocument();
+  });
+
+  it('should show expand button when collapsed', () => {
+    render(<CollapsedActivityGroup {...defaultProps} />);
+    expect(screen.getByRole('button', { name: /expand|show/i })).toBeInTheDocument();
+  });
+
+  it('should show all activities when expanded', () => {
+    render(<CollapsedActivityGroup {...defaultProps} collapsed={false} />);
+    expect(screen.getByText(/issue 1/i)).toBeInTheDocument();
+    expect(screen.getByText(/issue 2/i)).toBeInTheDocument();
+    expect(screen.getByText(/issue 3/i)).toBeInTheDocument();
+  });
+
+  it('should call onToggle when expand clicked', () => {
+    const onToggle = vi.fn();
+    render(<CollapsedActivityGroup {...defaultProps} onToggle={onToggle} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /expand|show/i }));
+
+    expect(onToggle).toHaveBeenCalled();
+  });
+
+  it('should show collapse button when expanded', () => {
+    render(<CollapsedActivityGroup {...defaultProps} collapsed={false} />);
+    expect(screen.getByRole('button', { name: /collapse|hide/i })).toBeInTheDocument();
+  });
+
+  it('should show activity count badge', () => {
+    render(<CollapsedActivityGroup {...defaultProps} />);
+    expect(screen.getByText('3')).toBeInTheDocument();
+  });
+});
+
+describe('ActivityQuickFilters', () => {
+  const mockPresets: QuickFilterPreset[] = [
+    {
+      id: 'preset-1',
+      name: 'My Team',
+      filters: { actorType: 'human' },
+    },
+    {
+      id: 'preset-2',
+      name: 'Recent Changes',
+      filters: { timeRange: 'today', actionType: ['updated', 'created'] },
+    },
+  ];
+
+  const defaultProps: ActivityQuickFiltersProps = {
+    presets: mockPresets,
+    activePresetId: null,
+    onSelectPreset: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render preset buttons', () => {
+    render(<ActivityQuickFilters {...defaultProps} />);
+    expect(screen.getByText('My Team')).toBeInTheDocument();
+    expect(screen.getByText('Recent Changes')).toBeInTheDocument();
+  });
+
+  it('should highlight active preset', () => {
+    render(<ActivityQuickFilters {...defaultProps} activePresetId="preset-1" />);
+    const preset1 = screen.getByText('My Team').closest('button');
+    expect(preset1).toHaveAttribute('data-active', 'true');
+  });
+
+  it('should call onSelectPreset when preset clicked', () => {
+    const onSelectPreset = vi.fn();
+    render(<ActivityQuickFilters {...defaultProps} onSelectPreset={onSelectPreset} />);
+
+    fireEvent.click(screen.getByText('My Team'));
+
+    expect(onSelectPreset).toHaveBeenCalledWith('preset-1', mockPresets[0].filters);
+  });
+
+  it('should deselect when active preset clicked again', () => {
+    const onSelectPreset = vi.fn();
+    render(<ActivityQuickFilters {...defaultProps} activePresetId="preset-1" onSelectPreset={onSelectPreset} />);
+
+    fireEvent.click(screen.getByText('My Team'));
+
+    expect(onSelectPreset).toHaveBeenCalledWith(null, {});
+  });
+
+  it('should show empty state when no presets', () => {
+    render(<ActivityQuickFilters presets={[]} activePresetId={null} onSelectPreset={vi.fn()} />);
+    expect(screen.getByText(/no presets/i)).toBeInTheDocument();
+  });
+});
+
+describe('ActivityFeedPersonalization', () => {
+  const mockSettings: ActivityPersonalizationSettings = {
+    defaultFilters: {
+      actorType: 'human',
+    },
+    showMyActivityFirst: true,
+    collapseThreshold: 5,
+    autoRefresh: true,
+    refreshInterval: 30,
+  };
+
+  const defaultProps: ActivityFeedPersonalizationProps = {
+    settings: mockSettings,
+    onChange: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render default filters section', () => {
+    render(<ActivityFeedPersonalization {...defaultProps} />);
+    expect(screen.getByText(/default filters/i)).toBeInTheDocument();
+  });
+
+  it('should show show my activity first toggle', () => {
+    render(<ActivityFeedPersonalization {...defaultProps} />);
+    expect(screen.getByText(/my activity first/i)).toBeInTheDocument();
+  });
+
+  it('should show current toggle state', () => {
+    render(<ActivityFeedPersonalization {...defaultProps} />);
+    const toggle = screen.getByRole('switch', { name: /my activity first/i });
+    expect(toggle).toHaveAttribute('data-state', 'checked');
+  });
+
+  it('should show collapse threshold setting', () => {
+    render(<ActivityFeedPersonalization {...defaultProps} />);
+    expect(screen.getByText(/collapse threshold/i)).toBeInTheDocument();
+  });
+
+  it('should show auto refresh toggle', () => {
+    render(<ActivityFeedPersonalization {...defaultProps} />);
+    expect(screen.getByText(/auto refresh/i)).toBeInTheDocument();
+  });
+
+  it('should show refresh interval when auto refresh enabled', () => {
+    render(<ActivityFeedPersonalization {...defaultProps} />);
+    expect(screen.getByText(/30/)).toBeInTheDocument();
+  });
+
+  it('should call onChange when setting changed', () => {
+    const onChange = vi.fn();
+    render(<ActivityFeedPersonalization {...defaultProps} onChange={onChange} />);
+
+    const toggle = screen.getByRole('switch', { name: /my activity first/i });
+    fireEvent.click(toggle);
+
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({
+      showMyActivityFirst: false,
+    }));
+  });
+
+  it('should hide refresh interval when auto refresh disabled', () => {
+    const settingsNoRefresh = { ...mockSettings, autoRefresh: false };
+    render(<ActivityFeedPersonalization {...defaultProps} settings={settingsNoRefresh} />);
+    expect(screen.queryByText(/refresh interval/i)).not.toBeInTheDocument();
+  });
+
+  it('should show save defaults button', () => {
+    render(<ActivityFeedPersonalization {...defaultProps} onSaveDefaults={vi.fn()} />);
+    expect(screen.getByRole('button', { name: /save/i })).toBeInTheDocument();
+  });
+
+  it('should call onSaveDefaults when save clicked', () => {
+    const onSaveDefaults = vi.fn();
+    render(<ActivityFeedPersonalization {...defaultProps} onSaveDefaults={onSaveDefaults} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+    expect(onSaveDefaults).toHaveBeenCalledWith(mockSettings);
+  });
+});


### PR DESCRIPTION
## Summary
- Add comprehensive activity feed filtering with multiple filter types
- Implement expandable activity detail cards with change diffs
- Support collapsible groups for similar activities
- Add quick filter presets and personalization settings

## Components Added
- `activity-feed-filters.tsx` - Filter by actor, action, entity type, time range
- `activity-detail-card.tsx` - Expandable activity with changes shown
- `collapsed-activity-group.tsx` - Collapsible similar activities
- `activity-quick-filters.tsx` - Preset filter buttons
- `activity-feed-personalization.tsx` - Settings for feed behavior
- `types.ts` - ActivityFilters, ActivityItem, personalization types

## Features
- Multiple filter types with popover dropdowns
- My activity only toggle
- Clear all filters with count badge
- Activity detail expansion with change diffs
- Collapsible similar activity groups
- Quick filter presets with toggle behavior
- Auto-refresh settings with configurable interval
- Collapse threshold configuration

## Test Coverage
- 43 tests covering all components
- Tests for filter selection, clearing
- Tests for activity detail expansion
- Tests for personalization settings

## Test plan
- [x] Run `npm test -- tests/ui/activity-feed-filtering.test.tsx` - all 43 tests pass
- [x] Verify exports from index.ts
- [x] Check component type safety

Closes #403

🤖 Generated with [Claude Code](https://claude.com/claude-code)