### PR TITLE
[#407] Implement list view with configurable columns

### DIFF
--- a/src/ui/components/list-view/column-config.tsx
+++ b/src/ui/components/list-view/column-config.tsx
@@ -1,0 +1,99 @@
+/**
+ * Column Config component
+ * Issue #407: Implement list view with configurable columns
+ */
+import * as React from 'react';
+import { Columns3 } from 'lucide-react';
+import { Button } from '@/ui/components/ui/button';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/ui/components/ui/popover';
+import { Checkbox } from '@/ui/components/ui/checkbox';
+import { Label } from '@/ui/components/ui/label';
+import type { ColumnDefinition } from './types';
+
+export interface ColumnConfigProps {
+  columns: ColumnDefinition[];
+  visibleColumns: string[];
+  onColumnsChange: (visibleColumnIds: string[]) => void;
+  defaultColumns?: string[];
+}
+
+export function ColumnConfig({
+  columns,
+  visibleColumns,
+  onColumnsChange,
+  defaultColumns,
+}: ColumnConfigProps) {
+  const [open, setOpen] = React.useState(false);
+
+  const handleToggleColumn = (columnId: string) => {
+    const isCurrentlyVisible = visibleColumns.includes(columnId);
+    if (isCurrentlyVisible) {
+      onColumnsChange(visibleColumns.filter((id) => id !== columnId));
+    } else {
+      onColumnsChange([...visibleColumns, columnId]);
+    }
+  };
+
+  const handleReset = () => {
+    if (defaultColumns) {
+      onColumnsChange(defaultColumns);
+    } else {
+      // Reset to all columns
+      onColumnsChange(columns.map((c) => c.id));
+    }
+  };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button variant="outline" size="sm" aria-label="Columns">
+          <Columns3 className="h-4 w-4 mr-2" />
+          Columns
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-56">
+        <div className="space-y-3">
+          <div className="font-medium text-sm">Show Columns</div>
+          <div className="space-y-2">
+            {columns.map((column) => {
+              const isVisible = visibleColumns.includes(column.id);
+              const isRequired = column.required === true;
+
+              return (
+                <div key={column.id} className="flex items-center gap-2">
+                  <Checkbox
+                    id={`column-${column.id}`}
+                    checked={isVisible}
+                    onCheckedChange={() => handleToggleColumn(column.id)}
+                    disabled={isRequired}
+                    aria-label={column.label}
+                  />
+                  <Label
+                    htmlFor={`column-${column.id}`}
+                    className="text-sm cursor-pointer"
+                  >
+                    {column.label}
+                  </Label>
+                </div>
+              );
+            })}
+          </div>
+          <div className="pt-2 border-t">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="w-full"
+              onClick={handleReset}
+            >
+              Reset to default
+            </Button>
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/ui/components/list-view/index.ts
+++ b/src/ui/components/list-view/index.ts
@@ -1,0 +1,9 @@
+/**
+ * List View components
+ * Issue #407: Implement list view with configurable columns
+ */
+export * from './types';
+export * from './list-view';
+export * from './list-header';
+export * from './list-row';
+export * from './column-config';

--- a/src/ui/components/list-view/list-header.tsx
+++ b/src/ui/components/list-view/list-header.tsx
@@ -1,0 +1,79 @@
+/**
+ * List Header component
+ * Issue #407: Implement list view with configurable columns
+ */
+import * as React from 'react';
+import { ArrowUp, ArrowDown } from 'lucide-react';
+import { Checkbox } from '@/ui/components/ui/checkbox';
+import { cn } from '@/ui/lib/utils';
+import type { ColumnDefinition, SortDirection } from './types';
+
+export interface ListHeaderProps {
+  columns: ColumnDefinition[];
+  onSort?: (columnId: string) => void;
+  sortColumn?: string | null;
+  sortDirection?: SortDirection;
+  selectable?: boolean;
+  allSelected?: boolean;
+  indeterminate?: boolean;
+  onSelectAll?: () => void;
+}
+
+export function ListHeader({
+  columns,
+  onSort,
+  sortColumn,
+  sortDirection,
+  selectable = false,
+  allSelected = false,
+  indeterminate = false,
+  onSelectAll,
+}: ListHeaderProps) {
+  return (
+    <thead className="bg-muted/50">
+      <tr>
+        {selectable && (
+          <th className="w-10 px-2 py-3">
+            <Checkbox
+              checked={indeterminate ? 'indeterminate' : allSelected}
+              onCheckedChange={onSelectAll}
+              aria-label="Select all"
+            />
+          </th>
+        )}
+        {columns.map((column) => {
+          const isSorted = sortColumn === column.id;
+          const canSort = column.sortable !== false;
+
+          return (
+            <th
+              key={column.id}
+              className={cn(
+                'px-4 py-3 text-left text-sm font-medium text-muted-foreground',
+                canSort && 'cursor-pointer hover:text-foreground',
+                column.align === 'center' && 'text-center',
+                column.align === 'right' && 'text-right'
+              )}
+              style={{ width: column.width }}
+              onClick={() => canSort && onSort?.(column.id)}
+              data-sorted={isSorted}
+            >
+              <div className="flex items-center gap-1">
+                <span>{column.label}</span>
+                {isSorted && (
+                  <span className="ml-1">
+                    {sortDirection === 'asc' ? (
+                      <ArrowUp className="h-4 w-4" />
+                    ) : (
+                      <ArrowDown className="h-4 w-4" />
+                    )}
+                  </span>
+                )}
+              </div>
+            </th>
+          );
+        })}
+      </tr>
+    </thead>
+  );
+}

--- a/src/ui/components/list-view/list-row.tsx
+++ b/src/ui/components/list-view/list-row.tsx
@@ -1,0 +1,93 @@
+/**
+ * List Row component
+ * Issue #407: Implement list view with configurable columns
+ */
+import * as React from 'react';
+import { Checkbox } from '@/ui/components/ui/checkbox';
+import { cn } from '@/ui/lib/utils';
+import type { ColumnDefinition, ListItem } from './types';
+
+export interface ListRowProps {
+  item: ListItem;
+  columns: ColumnDefinition[];
+  onClick?: (item: ListItem) => void;
+  selected?: boolean;
+  selectable?: boolean;
+  onSelect?: (itemId: string) => void;
+}
+
+function formatCellValue(value: unknown): string {
+  if (value === null || value === undefined) {
+    return '-';
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (typeof value === 'number') {
+    return String(value);
+  }
+  if (value instanceof Date) {
+    return value.toLocaleDateString();
+  }
+  return String(value);
+}
+
+export function ListRow({
+  item,
+  columns,
+  onClick,
+  selected = false,
+  selectable = false,
+  onSelect,
+}: ListRowProps) {
+  const handleRowClick = (e: React.MouseEvent) => {
+    // Don't trigger row click if clicking on checkbox
+    if ((e.target as HTMLElement).closest('[role="checkbox"]')) {
+      return;
+    }
+    onClick?.(item);
+  };
+
+  const handleCheckboxChange = () => {
+    onSelect?.(item.id);
+  };
+
+  return (
+    <tr
+      data-testid={`list-row-${item.id}`}
+      data-selected={selected}
+      className={cn(
+        'border-b transition-colors hover:bg-muted/50 cursor-pointer',
+        selected && 'bg-accent'
+      )}
+      onClick={handleRowClick}
+    >
+      {selectable && (
+        <td className="w-10 px-2 py-3">
+          <Checkbox
+            checked={selected}
+            onCheckedChange={handleCheckboxChange}
+            aria-label={`Select ${item.title}`}
+          />
+        </td>
+      )}
+      {columns.map((column) => {
+        const value = item[column.id];
+
+        return (
+          <td
+            key={column.id}
+            className={cn(
+              'px-4 py-3 text-sm',
+              column.align === 'center' && 'text-center',
+              column.align === 'right' && 'text-right'
+            )}
+            style={{ width: column.width }}
+          >
+            {formatCellValue(value)}
+          </td>
+        );
+      })}
+    </tr>
+  );
+}

--- a/src/ui/components/list-view/list-view.tsx
+++ b/src/ui/components/list-view/list-view.tsx
@@ -1,0 +1,122 @@
+/**
+ * List View component
+ * Issue #407: Implement list view with configurable columns
+ */
+import * as React from 'react';
+import { Loader2 } from 'lucide-react';
+import { cn } from '@/ui/lib/utils';
+import { ListHeader } from './list-header';
+import { ListRow } from './list-row';
+import type { ColumnDefinition, ListItem, SortDirection } from './types';
+
+export interface ListViewProps {
+  items: ListItem[];
+  columns: ColumnDefinition[];
+  onRowClick?: (item: ListItem) => void;
+  selectable?: boolean;
+  selectedIds?: string[];
+  onSelectionChange?: (selectedIds: string[]) => void;
+  sortColumn?: string | null;
+  sortDirection?: SortDirection;
+  onSort?: (columnId: string, direction: SortDirection) => void;
+  loading?: boolean;
+  className?: string;
+}
+
+export function ListView({
+  items,
+  columns,
+  onRowClick,
+  selectable = false,
+  selectedIds = [],
+  onSelectionChange,
+  sortColumn,
+  sortDirection = 'asc',
+  onSort,
+  loading = false,
+  className,
+}: ListViewProps) {
+  const allSelected = items.length > 0 && selectedIds.length === items.length;
+  const someSelected = selectedIds.length > 0 && selectedIds.length < items.length;
+
+  const handleSort = (columnId: string) => {
+    if (!onSort) return;
+
+    // If clicking the same column, toggle direction
+    if (columnId === sortColumn) {
+      onSort(columnId, sortDirection === 'asc' ? 'desc' : 'asc');
+    } else {
+      // New column, default to ascending
+      onSort(columnId, 'asc');
+    }
+  };
+
+  const handleSelectAll = () => {
+    if (!onSelectionChange) return;
+
+    if (allSelected) {
+      onSelectionChange([]);
+    } else {
+      onSelectionChange(items.map((item) => item.id));
+    }
+  };
+
+  const handleSelectItem = (itemId: string) => {
+    if (!onSelectionChange) return;
+
+    if (selectedIds.includes(itemId)) {
+      onSelectionChange(selectedIds.filter((id) => id !== itemId));
+    } else {
+      onSelectionChange([...selectedIds, itemId]);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div
+        data-testid="list-loading"
+        className="flex items-center justify-center py-12"
+      >
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (items.length === 0) {
+    return (
+      <div className="flex items-center justify-center py-12 text-muted-foreground">
+        No items to display
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn('w-full overflow-auto', className)}>
+      <table className="w-full border-collapse">
+        <ListHeader
+          columns={columns}
+          onSort={handleSort}
+          sortColumn={sortColumn}
+          sortDirection={sortDirection}
+          selectable={selectable}
+          allSelected={allSelected}
+          indeterminate={someSelected}
+          onSelectAll={handleSelectAll}
+        />
+        <tbody>
+          {items.map((item) => (
+            <ListRow
+              key={item.id}
+              item={item}
+              columns={columns}
+              onClick={onRowClick}
+              selected={selectedIds.includes(item.id)}
+              selectable={selectable}
+              onSelect={handleSelectItem}
+            />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/ui/components/list-view/types.ts
+++ b/src/ui/components/list-view/types.ts
@@ -1,0 +1,37 @@
+/**
+ * Types for list view with configurable columns
+ * Issue #407: Implement list view with configurable columns
+ */
+
+export type SortDirection = 'asc' | 'desc';
+
+export interface ColumnDefinition {
+  id: string;
+  label: string;
+  width: number;
+  sortable?: boolean;
+  required?: boolean;
+  align?: 'left' | 'center' | 'right';
+}
+
+export interface Column extends ColumnDefinition {
+  visible: boolean;
+}
+
+export interface ListItem {
+  id: string;
+  title: string;
+  status?: string | null;
+  priority?: string | null;
+  assignee?: string | null;
+  dueDate?: string | null;
+  createdAt?: string | null;
+  updatedAt?: string | null;
+  estimate?: number | null;
+  [key: string]: unknown;
+}
+
+export interface SortState {
+  column: string | null;
+  direction: SortDirection;
+}

--- a/tests/ui/list-view.test.tsx
+++ b/tests/ui/list-view.test.tsx
@@ -1,0 +1,478 @@
+/**
+ * @vitest-environment jsdom
+ * Tests for list view with configurable columns
+ * Issue #407: Implement list view with configurable columns
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import * as React from 'react';
+
+// Components to be implemented
+import {
+  ListView,
+  type ListViewProps,
+} from '@/ui/components/list-view/list-view';
+import {
+  ColumnConfig,
+  type ColumnConfigProps,
+} from '@/ui/components/list-view/column-config';
+import {
+  ListHeader,
+  type ListHeaderProps,
+} from '@/ui/components/list-view/list-header';
+import {
+  ListRow,
+  type ListRowProps,
+} from '@/ui/components/list-view/list-row';
+import type {
+  Column,
+  ColumnDefinition,
+  ListItem,
+} from '@/ui/components/list-view/types';
+
+// Mock data
+const mockColumns: ColumnDefinition[] = [
+  { id: 'title', label: 'Title', width: 250, sortable: true, required: true },
+  { id: 'status', label: 'Status', width: 100, sortable: true },
+  { id: 'priority', label: 'Priority', width: 100, sortable: true },
+  { id: 'assignee', label: 'Assignee', width: 150, sortable: true },
+  { id: 'dueDate', label: 'Due Date', width: 120, sortable: true },
+  { id: 'createdAt', label: 'Created', width: 120, sortable: true },
+];
+
+const mockItems: ListItem[] = [
+  {
+    id: 'item-1',
+    title: 'Implement feature A',
+    status: 'open',
+    priority: 'high',
+    assignee: 'Alice',
+    dueDate: '2026-03-01',
+    createdAt: '2026-01-15',
+  },
+  {
+    id: 'item-2',
+    title: 'Fix bug in module B',
+    status: 'in_progress',
+    priority: 'medium',
+    assignee: 'Bob',
+    dueDate: '2026-02-15',
+    createdAt: '2026-01-20',
+  },
+  {
+    id: 'item-3',
+    title: 'Write documentation',
+    status: 'closed',
+    priority: 'low',
+    assignee: null,
+    dueDate: null,
+    createdAt: '2026-01-10',
+  },
+];
+
+describe('ListView', () => {
+  const defaultProps: ListViewProps = {
+    items: mockItems,
+    columns: mockColumns,
+    onRowClick: vi.fn(),
+    onSelectionChange: vi.fn(),
+    onSort: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render table with items', () => {
+    render(<ListView {...defaultProps} />);
+    expect(screen.getByRole('table')).toBeInTheDocument();
+    expect(screen.getByText('Implement feature A')).toBeInTheDocument();
+    expect(screen.getByText('Fix bug in module B')).toBeInTheDocument();
+    expect(screen.getByText('Write documentation')).toBeInTheDocument();
+  });
+
+  it('should render column headers', () => {
+    render(<ListView {...defaultProps} />);
+    expect(screen.getByText('Title')).toBeInTheDocument();
+    expect(screen.getByText('Status')).toBeInTheDocument();
+    expect(screen.getByText('Priority')).toBeInTheDocument();
+  });
+
+  it('should call onRowClick when row clicked', () => {
+    const onRowClick = vi.fn();
+    render(<ListView {...defaultProps} onRowClick={onRowClick} />);
+
+    fireEvent.click(screen.getByText('Implement feature A'));
+
+    expect(onRowClick).toHaveBeenCalledWith(mockItems[0]);
+  });
+
+  it('should show checkboxes for selection', () => {
+    render(<ListView {...defaultProps} selectable />);
+    const checkboxes = screen.getAllByRole('checkbox');
+    expect(checkboxes.length).toBeGreaterThan(0);
+  });
+
+  it('should call onSelectionChange when items selected', () => {
+    const onSelectionChange = vi.fn();
+    render(
+      <ListView
+        {...defaultProps}
+        selectable
+        onSelectionChange={onSelectionChange}
+      />
+    );
+
+    const checkboxes = screen.getAllByRole('checkbox');
+    fireEvent.click(checkboxes[1]); // First item checkbox (0 is header)
+
+    expect(onSelectionChange).toHaveBeenCalledWith(['item-1']);
+  });
+
+  it('should support select all', () => {
+    const onSelectionChange = vi.fn();
+    render(
+      <ListView
+        {...defaultProps}
+        selectable
+        onSelectionChange={onSelectionChange}
+      />
+    );
+
+    const headerCheckbox = screen.getAllByRole('checkbox')[0];
+    fireEvent.click(headerCheckbox);
+
+    expect(onSelectionChange).toHaveBeenCalledWith(['item-1', 'item-2', 'item-3']);
+  });
+
+  it('should show empty state when no items', () => {
+    render(<ListView {...defaultProps} items={[]} />);
+    expect(screen.getByText(/no items/i)).toBeInTheDocument();
+  });
+
+  it('should show loading state', () => {
+    render(<ListView {...defaultProps} loading />);
+    expect(screen.getByTestId('list-loading')).toBeInTheDocument();
+  });
+
+  it('should call onSort when column header clicked', () => {
+    const onSort = vi.fn();
+    render(<ListView {...defaultProps} onSort={onSort} />);
+
+    fireEvent.click(screen.getByText('Title'));
+
+    expect(onSort).toHaveBeenCalledWith('title', 'asc');
+  });
+
+  it('should toggle sort direction on repeated clicks', () => {
+    const onSort = vi.fn();
+    render(
+      <ListView
+        {...defaultProps}
+        onSort={onSort}
+        sortColumn="title"
+        sortDirection="asc"
+      />
+    );
+
+    fireEvent.click(screen.getByText('Title'));
+
+    expect(onSort).toHaveBeenCalledWith('title', 'desc');
+  });
+
+  it('should show sort indicator on sorted column', () => {
+    render(
+      <ListView
+        {...defaultProps}
+        sortColumn="title"
+        sortDirection="asc"
+      />
+    );
+
+    const titleHeader = screen.getByText('Title').closest('th');
+    expect(titleHeader).toHaveAttribute('data-sorted', 'true');
+  });
+
+  it('should highlight selected rows', () => {
+    render(
+      <ListView
+        {...defaultProps}
+        selectable
+        selectedIds={['item-1']}
+      />
+    );
+
+    const row = screen.getByTestId('list-row-item-1');
+    expect(row).toHaveAttribute('data-selected', 'true');
+  });
+});
+
+describe('ListHeader', () => {
+  const defaultProps: ListHeaderProps = {
+    columns: mockColumns,
+    onSort: vi.fn(),
+    selectable: false,
+    allSelected: false,
+    onSelectAll: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render column headers', () => {
+    render(
+      <table>
+        <ListHeader {...defaultProps} />
+      </table>
+    );
+    expect(screen.getByText('Title')).toBeInTheDocument();
+    expect(screen.getByText('Status')).toBeInTheDocument();
+  });
+
+  it('should show select all checkbox when selectable', () => {
+    render(
+      <table>
+        <ListHeader {...defaultProps} selectable />
+      </table>
+    );
+    expect(screen.getByRole('checkbox')).toBeInTheDocument();
+  });
+
+  it('should call onSelectAll when checkbox clicked', () => {
+    const onSelectAll = vi.fn();
+    render(
+      <table>
+        <ListHeader {...defaultProps} selectable onSelectAll={onSelectAll} />
+      </table>
+    );
+
+    fireEvent.click(screen.getByRole('checkbox'));
+
+    expect(onSelectAll).toHaveBeenCalled();
+  });
+
+  it('should show checked state when all selected', () => {
+    render(
+      <table>
+        <ListHeader {...defaultProps} selectable allSelected />
+      </table>
+    );
+    expect(screen.getByRole('checkbox')).toBeChecked();
+  });
+
+  it('should call onSort with column id', () => {
+    const onSort = vi.fn();
+    render(
+      <table>
+        <ListHeader {...defaultProps} onSort={onSort} />
+      </table>
+    );
+
+    fireEvent.click(screen.getByText('Status'));
+
+    expect(onSort).toHaveBeenCalledWith('status');
+  });
+
+  it('should not call onSort for non-sortable columns', () => {
+    const onSort = vi.fn();
+    const columnsWithNonSortable = [
+      ...mockColumns.slice(0, -1),
+      { id: 'actions', label: 'Actions', width: 80, sortable: false },
+    ];
+    render(
+      <table>
+        <ListHeader {...defaultProps} columns={columnsWithNonSortable} onSort={onSort} />
+      </table>
+    );
+
+    fireEvent.click(screen.getByText('Actions'));
+
+    expect(onSort).not.toHaveBeenCalled();
+  });
+});
+
+describe('ListRow', () => {
+  const mockItem = mockItems[0];
+  const defaultProps: ListRowProps = {
+    item: mockItem,
+    columns: mockColumns,
+    onClick: vi.fn(),
+    selected: false,
+    selectable: false,
+    onSelect: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render item data', () => {
+    render(
+      <table>
+        <tbody>
+          <ListRow {...defaultProps} />
+        </tbody>
+      </table>
+    );
+    expect(screen.getByText('Implement feature A')).toBeInTheDocument();
+    expect(screen.getByText('high')).toBeInTheDocument();
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+  });
+
+  it('should call onClick when clicked', () => {
+    const onClick = vi.fn();
+    render(
+      <table>
+        <tbody>
+          <ListRow {...defaultProps} onClick={onClick} />
+        </tbody>
+      </table>
+    );
+
+    fireEvent.click(screen.getByText('Implement feature A'));
+
+    expect(onClick).toHaveBeenCalledWith(mockItem);
+  });
+
+  it('should show checkbox when selectable', () => {
+    render(
+      <table>
+        <tbody>
+          <ListRow {...defaultProps} selectable />
+        </tbody>
+      </table>
+    );
+    expect(screen.getByRole('checkbox')).toBeInTheDocument();
+  });
+
+  it('should call onSelect when checkbox clicked', () => {
+    const onSelect = vi.fn();
+    render(
+      <table>
+        <tbody>
+          <ListRow {...defaultProps} selectable onSelect={onSelect} />
+        </tbody>
+      </table>
+    );
+
+    fireEvent.click(screen.getByRole('checkbox'));
+
+    expect(onSelect).toHaveBeenCalledWith(mockItem.id);
+  });
+
+  it('should show selected state', () => {
+    render(
+      <table>
+        <tbody>
+          <ListRow {...defaultProps} selectable selected />
+        </tbody>
+      </table>
+    );
+    expect(screen.getByRole('checkbox')).toBeChecked();
+  });
+
+  it('should have data-selected attribute when selected', () => {
+    render(
+      <table>
+        <tbody>
+          <ListRow {...defaultProps} selected />
+        </tbody>
+      </table>
+    );
+
+    const row = screen.getByTestId(`list-row-${mockItem.id}`);
+    expect(row).toHaveAttribute('data-selected', 'true');
+  });
+
+  it('should handle null values gracefully', () => {
+    const itemWithNulls = mockItems[2]; // Has null assignee and dueDate
+    render(
+      <table>
+        <tbody>
+          <ListRow {...defaultProps} item={itemWithNulls} />
+        </tbody>
+      </table>
+    );
+    expect(screen.getByText('Write documentation')).toBeInTheDocument();
+  });
+});
+
+describe('ColumnConfig', () => {
+  const defaultProps: ColumnConfigProps = {
+    columns: mockColumns,
+    visibleColumns: ['title', 'status', 'priority', 'assignee'],
+    onColumnsChange: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render column config button', () => {
+    render(<ColumnConfig {...defaultProps} />);
+    expect(screen.getByRole('button', { name: /columns/i })).toBeInTheDocument();
+  });
+
+  it('should show column list when clicked', () => {
+    render(<ColumnConfig {...defaultProps} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /columns/i }));
+
+    expect(screen.getByText('Title')).toBeInTheDocument();
+    expect(screen.getByText('Status')).toBeInTheDocument();
+    expect(screen.getByText('Due Date')).toBeInTheDocument();
+  });
+
+  it('should show checkboxes for column visibility', () => {
+    render(<ColumnConfig {...defaultProps} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /columns/i }));
+
+    const checkboxes = screen.getAllByRole('checkbox');
+    expect(checkboxes.length).toBe(mockColumns.length);
+  });
+
+  it('should show checked state for visible columns', () => {
+    render(<ColumnConfig {...defaultProps} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /columns/i }));
+
+    // Find the checkbox for 'status' which is visible
+    const statusCheckbox = screen.getByRole('checkbox', { name: /status/i });
+    expect(statusCheckbox).toBeChecked();
+  });
+
+  it('should call onColumnsChange when toggling column', () => {
+    const onColumnsChange = vi.fn();
+    render(<ColumnConfig {...defaultProps} onColumnsChange={onColumnsChange} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /columns/i }));
+    // Toggle 'dueDate' which is not visible
+    const dueDateCheckbox = screen.getByRole('checkbox', { name: /due date/i });
+    fireEvent.click(dueDateCheckbox);
+
+    expect(onColumnsChange).toHaveBeenCalledWith(
+      expect.arrayContaining(['title', 'status', 'priority', 'assignee', 'dueDate'])
+    );
+  });
+
+  it('should not allow hiding required columns', () => {
+    render(<ColumnConfig {...defaultProps} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /columns/i }));
+
+    // Title is required, its checkbox should be disabled
+    const titleCheckbox = screen.getByRole('checkbox', { name: /title/i });
+    expect(titleCheckbox).toBeDisabled();
+  });
+
+  it('should show reset to default button', () => {
+    render(<ColumnConfig {...defaultProps} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /columns/i }));
+
+    expect(screen.getByRole('button', { name: /reset/i })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Add tabular list view for dense display of work items
- Support sortable columns with visual indicators
- Checkbox selection with select all/indeterminate states
- Column configuration popover for show/hide columns
- Loading and empty states handled

## Test plan
- [x] Run `npm test -- --run tests/ui/list-view.test.tsx` - all 32 tests pass
- [x] Verify no regressions in related tests

Closes #407

🤖 Generated with [Claude Code](https://claude.com/claude-code)