### PR TITLE
[#408] Implement calendar view for due dates

### DIFF
--- a/src/ui/components/calendar-view/calendar-header.tsx
+++ b/src/ui/components/calendar-view/calendar-header.tsx
@@ -1,0 +1,81 @@
+/**
+ * Calendar Header component
+ * Issue #408: Implement calendar view for due dates
+ */
+import * as React from 'react';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { Button } from '@/ui/components/ui/button';
+import type { CalendarViewMode } from './types';
+
+export interface CalendarHeaderProps {
+  currentDate: Date;
+  viewMode: CalendarViewMode;
+  onPrevious: () => void;
+  onNext: () => void;
+  onToday: () => void;
+  onViewModeChange: (mode: CalendarViewMode) => void;
+}
+
+function formatMonthYear(date: Date): string {
+  return date.toLocaleDateString('en-US', {
+    month: 'long',
+    year: 'numeric',
+  });
+}
+
+export function CalendarHeader({
+  currentDate,
+  viewMode,
+  onPrevious,
+  onNext,
+  onToday,
+  onViewModeChange,
+}: CalendarHeaderProps) {
+  return (
+    <div className="flex items-center justify-between mb-4">
+      <div className="flex items-center gap-2">
+        <Button
+          variant="outline"
+          size="icon"
+          onClick={onPrevious}
+          aria-label="Previous"
+        >
+          <ChevronLeft className="h-4 w-4" />
+        </Button>
+        <Button
+          variant="outline"
+          size="icon"
+          onClick={onNext}
+          aria-label="Next"
+        >
+          <ChevronRight className="h-4 w-4" />
+        </Button>
+        <Button variant="outline" size="sm" onClick={onToday}>
+          Today
+        </Button>
+        <h2 className="text-lg font-semibold ml-2">{formatMonthYear(currentDate)}</h2>
+      </div>
+
+      <div className="flex items-center gap-1">
+        <Button
+          variant={viewMode === 'month' ? 'default' : 'outline'}
+          size="sm"
+          onClick={() => onViewModeChange('month')}
+          data-active={viewMode === 'month'}
+          aria-label="Month view"
+        >
+          Month
+        </Button>
+        <Button
+          variant={viewMode === 'week' ? 'default' : 'outline'}
+          size="sm"
+          onClick={() => onViewModeChange('week')}
+          data-active={viewMode === 'week'}
+          aria-label="Week view"
+        >
+          Week
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/components/calendar-view/calendar-item.tsx
+++ b/src/ui/components/calendar-view/calendar-item.tsx
@@ -1,0 +1,57 @@
+/**
+ * Calendar Item component
+ * Issue #408: Implement calendar view for due dates
+ */
+import * as React from 'react';
+import { cn } from '@/ui/lib/utils';
+import type { CalendarEvent } from './types';
+
+export interface CalendarItemProps {
+  event: CalendarEvent;
+  onClick?: (event: CalendarEvent) => void;
+  compact?: boolean;
+}
+
+const priorityColors: Record<string, string> = {
+  high: 'bg-red-100 border-red-300 text-red-800 dark:bg-red-950 dark:border-red-800 dark:text-red-200',
+  medium: 'bg-yellow-100 border-yellow-300 text-yellow-800 dark:bg-yellow-950 dark:border-yellow-800 dark:text-yellow-200',
+  low: 'bg-green-100 border-green-300 text-green-800 dark:bg-green-950 dark:border-green-800 dark:text-green-200',
+};
+
+const statusStyles: Record<string, string> = {
+  open: '',
+  in_progress: 'border-l-4 border-l-blue-500',
+  closed: 'opacity-60 line-through',
+};
+
+export function CalendarItem({
+  event,
+  onClick,
+  compact = false,
+}: CalendarItemProps) {
+  const handleClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onClick?.(event);
+  };
+
+  const priorityClass = priorityColors[event.priority || 'medium'];
+  const statusClass = statusStyles[event.status || 'open'];
+
+  return (
+    <div
+      data-testid={`calendar-item-${event.id}`}
+      data-priority={event.priority}
+      data-status={event.status}
+      className={cn(
+        'truncate cursor-pointer rounded border px-1.5 py-0.5 text-xs transition-colors hover:opacity-80',
+        priorityClass,
+        statusClass,
+        compact && 'text-[10px] px-1'
+      )}
+      onClick={handleClick}
+      title={event.title}
+    >
+      {event.title}
+    </div>
+  );
+}

--- a/src/ui/components/calendar-view/calendar-view.tsx
+++ b/src/ui/components/calendar-view/calendar-view.tsx
@@ -1,0 +1,105 @@
+/**
+ * Calendar View component
+ * Issue #408: Implement calendar view for due dates
+ */
+import * as React from 'react';
+import { CalendarHeader } from './calendar-header';
+import { MonthView } from './month-view';
+import { WeekView } from './week-view';
+import type { CalendarEvent, CalendarViewMode } from './types';
+
+export interface CalendarViewProps {
+  events: CalendarEvent[];
+  currentDate?: Date;
+  viewMode?: CalendarViewMode;
+  onEventClick?: (event: CalendarEvent) => void;
+  onDateClick?: (date: Date) => void;
+  onDateChange?: (date: Date) => void;
+  onViewModeChange?: (mode: CalendarViewMode) => void;
+}
+
+export function CalendarView({
+  events,
+  currentDate: controlledDate,
+  viewMode: controlledViewMode,
+  onEventClick,
+  onDateClick,
+  onDateChange,
+  onViewModeChange,
+}: CalendarViewProps) {
+  const [internalDate, setInternalDate] = React.useState(new Date());
+  const [internalViewMode, setInternalViewMode] =
+    React.useState<CalendarViewMode>('month');
+
+  const currentDate = controlledDate ?? internalDate;
+  const viewMode = controlledViewMode ?? internalViewMode;
+
+  const handleDateChange = (date: Date) => {
+    if (onDateChange) {
+      onDateChange(date);
+    } else {
+      setInternalDate(date);
+    }
+  };
+
+  const handleViewModeChange = (mode: CalendarViewMode) => {
+    if (onViewModeChange) {
+      onViewModeChange(mode);
+    } else {
+      setInternalViewMode(mode);
+    }
+  };
+
+  const handlePrevious = () => {
+    const newDate = new Date(currentDate);
+    if (viewMode === 'month') {
+      newDate.setMonth(newDate.getMonth() - 1);
+    } else {
+      newDate.setDate(newDate.getDate() - 7);
+    }
+    handleDateChange(newDate);
+  };
+
+  const handleNext = () => {
+    const newDate = new Date(currentDate);
+    if (viewMode === 'month') {
+      newDate.setMonth(newDate.getMonth() + 1);
+    } else {
+      newDate.setDate(newDate.getDate() + 7);
+    }
+    handleDateChange(newDate);
+  };
+
+  const handleToday = () => {
+    handleDateChange(new Date());
+  };
+
+  return (
+    <div data-testid="calendar-view" className="w-full">
+      <CalendarHeader
+        currentDate={currentDate}
+        viewMode={viewMode}
+        onPrevious={handlePrevious}
+        onNext={handleNext}
+        onToday={handleToday}
+        onViewModeChange={handleViewModeChange}
+      />
+
+      {viewMode === 'month' ? (
+        <MonthView
+          currentDate={currentDate}
+          events={events}
+          onEventClick={onEventClick}
+          onDateClick={onDateClick}
+        />
+      ) : (
+        <WeekView
+          currentDate={currentDate}
+          events={events}
+          onEventClick={onEventClick}
+          onDateClick={onDateClick}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/ui/components/calendar-view/index.ts
+++ b/src/ui/components/calendar-view/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Calendar View components
+ * Issue #408: Implement calendar view for due dates
+ */
+export * from './types';
+export * from './calendar-view';
+export * from './calendar-header';
+export * from './month-view';
+export * from './week-view';
+export * from './calendar-item';

--- a/src/ui/components/calendar-view/month-view.tsx
+++ b/src/ui/components/calendar-view/month-view.tsx
@@ -1,0 +1,130 @@
+/**
+ * Month View component
+ * Issue #408: Implement calendar view for due dates
+ */
+import * as React from 'react';
+import { cn } from '@/ui/lib/utils';
+import { CalendarItem } from './calendar-item';
+import type { CalendarEvent, DayEvents } from './types';
+
+export interface MonthViewProps {
+  currentDate: Date;
+  events: CalendarEvent[];
+  onEventClick?: (event: CalendarEvent) => void;
+  onDateClick?: (date: Date) => void;
+}
+
+const DAY_NAMES = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+function getMonthDays(date: Date): DayEvents[] {
+  const year = date.getFullYear();
+  const month = date.getMonth();
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  // Get first day of month and calculate start of grid (previous Sunday)
+  const firstDay = new Date(year, month, 1);
+  const startOfGrid = new Date(firstDay);
+  startOfGrid.setDate(firstDay.getDate() - firstDay.getDay());
+
+  // Get last day of month and calculate end of grid (next Saturday)
+  const lastDay = new Date(year, month + 1, 0);
+  const endOfGrid = new Date(lastDay);
+  endOfGrid.setDate(lastDay.getDate() + (6 - lastDay.getDay()));
+
+  const days: DayEvents[] = [];
+  const current = new Date(startOfGrid);
+
+  while (current <= endOfGrid) {
+    days.push({
+      date: new Date(current),
+      events: [],
+      isToday:
+        current.getDate() === today.getDate() &&
+        current.getMonth() === today.getMonth() &&
+        current.getFullYear() === today.getFullYear(),
+      isCurrentMonth: current.getMonth() === month,
+    });
+    current.setDate(current.getDate() + 1);
+  }
+
+  return days;
+}
+
+function getEventsForDate(events: CalendarEvent[], date: Date): CalendarEvent[] {
+  const dateStr = date.toISOString().split('T')[0];
+  return events.filter((event) => event.date === dateStr);
+}
+
+export function MonthView({
+  currentDate,
+  events,
+  onEventClick,
+  onDateClick,
+}: MonthViewProps) {
+  const days = getMonthDays(currentDate);
+
+  // Add events to days
+  const daysWithEvents = days.map((day) => ({
+    ...day,
+    events: getEventsForDate(events, day.date),
+  }));
+
+  return (
+    <div data-testid="month-view" className="w-full">
+      {/* Day headers */}
+      <div className="grid grid-cols-7 border-b">
+        {DAY_NAMES.map((name) => (
+          <div
+            key={name}
+            className="px-2 py-2 text-sm font-medium text-muted-foreground text-center"
+          >
+            {name}
+          </div>
+        ))}
+      </div>
+
+      {/* Calendar grid */}
+      <div className="grid grid-cols-7">
+        {daysWithEvents.map((day, index) => (
+          <div
+            key={index}
+            data-testid={`day-${day.date.getDate()}`}
+            data-today={day.isToday}
+            className={cn(
+              'min-h-24 border-b border-r p-1 cursor-pointer hover:bg-muted/50',
+              !day.isCurrentMonth && 'bg-muted/30 text-muted-foreground',
+              day.isToday && 'bg-accent/20'
+            )}
+            onClick={() => onDateClick?.(day.date)}
+          >
+            <div
+              className={cn(
+                'text-sm font-medium mb-1',
+                day.isToday &&
+                  'bg-primary text-primary-foreground rounded-full w-6 h-6 flex items-center justify-center'
+              )}
+            >
+              {day.date.getDate()}
+            </div>
+            <div className="space-y-1">
+              {day.events.slice(0, 3).map((event) => (
+                <CalendarItem
+                  key={event.id}
+                  event={event}
+                  onClick={onEventClick}
+                  compact
+                />
+              ))}
+              {day.events.length > 3 && (
+                <div className="text-xs text-muted-foreground px-1">
+                  +{day.events.length - 3} more
+                </div>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/ui/components/calendar-view/types.ts
+++ b/src/ui/components/calendar-view/types.ts
@@ -1,0 +1,27 @@
+/**
+ * Types for calendar view
+ * Issue #408: Implement calendar view for due dates
+ */
+
+export type CalendarViewMode = 'month' | 'week';
+
+export type Priority = 'high' | 'medium' | 'low';
+export type Status = 'open' | 'in_progress' | 'closed';
+
+export interface CalendarEvent {
+  id: string;
+  title: string;
+  date: string; // ISO date string (YYYY-MM-DD)
+  endDate?: string; // For multi-day events
+  priority?: Priority;
+  status?: Status;
+  assignee?: string;
+  color?: string;
+}
+
+export interface DayEvents {
+  date: Date;
+  events: CalendarEvent[];
+  isToday: boolean;
+  isCurrentMonth: boolean;
+}

--- a/src/ui/components/calendar-view/week-view.tsx
+++ b/src/ui/components/calendar-view/week-view.tsx
@@ -1,0 +1,110 @@
+/**
+ * Week View component
+ * Issue #408: Implement calendar view for due dates
+ */
+import * as React from 'react';
+import { cn } from '@/ui/lib/utils';
+import { CalendarItem } from './calendar-item';
+import type { CalendarEvent, DayEvents } from './types';
+
+export interface WeekViewProps {
+  currentDate: Date;
+  events: CalendarEvent[];
+  onEventClick?: (event: CalendarEvent) => void;
+  onDateClick?: (date: Date) => void;
+}
+
+const DAY_NAMES = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+function getWeekDays(date: Date): DayEvents[] {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  // Get start of week (Sunday)
+  const startOfWeek = new Date(date);
+  startOfWeek.setDate(date.getDate() - date.getDay());
+
+  const days: DayEvents[] = [];
+
+  for (let i = 0; i < 7; i++) {
+    const day = new Date(startOfWeek);
+    day.setDate(startOfWeek.getDate() + i);
+    days.push({
+      date: day,
+      events: [],
+      isToday:
+        day.getDate() === today.getDate() &&
+        day.getMonth() === today.getMonth() &&
+        day.getFullYear() === today.getFullYear(),
+      isCurrentMonth: day.getMonth() === date.getMonth(),
+    });
+  }
+
+  return days;
+}
+
+function getEventsForDate(events: CalendarEvent[], date: Date): CalendarEvent[] {
+  const dateStr = date.toISOString().split('T')[0];
+  return events.filter((event) => event.date === dateStr);
+}
+
+export function WeekView({
+  currentDate,
+  events,
+  onEventClick,
+  onDateClick,
+}: WeekViewProps) {
+  const days = getWeekDays(currentDate);
+
+  // Add events to days
+  const daysWithEvents = days.map((day) => ({
+    ...day,
+    events: getEventsForDate(events, day.date),
+  }));
+
+  return (
+    <div data-testid="week-view" className="w-full">
+      {/* Day headers */}
+      <div className="grid grid-cols-7 border-b">
+        {daysWithEvents.map((day, index) => (
+          <div
+            key={index}
+            className={cn(
+              'px-2 py-2 text-center border-r',
+              day.isToday && 'bg-accent/20'
+            )}
+          >
+            <div className="text-sm text-muted-foreground">
+              {DAY_NAMES[index]} {day.date.getDate()}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Day columns */}
+      <div className="grid grid-cols-7 min-h-[400px]">
+        {daysWithEvents.map((day, index) => (
+          <div
+            key={index}
+            data-testid={`week-day-${index}`}
+            className={cn(
+              'border-r p-2 cursor-pointer hover:bg-muted/50',
+              day.isToday && 'bg-accent/10'
+            )}
+            onClick={() => onDateClick?.(day.date)}
+          >
+            <div className="space-y-2">
+              {day.events.map((event) => (
+                <CalendarItem
+                  key={event.id}
+                  event={event}
+                  onClick={onEventClick}
+                />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/tests/ui/calendar-view.test.tsx
+++ b/tests/ui/calendar-view.test.tsx
@@ -1,0 +1,375 @@
+/**
+ * @vitest-environment jsdom
+ * Tests for calendar view for due dates
+ * Issue #408: Implement calendar view for due dates
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import * as React from 'react';
+
+// Components to be implemented
+import {
+  CalendarView,
+  type CalendarViewProps,
+} from '@/ui/components/calendar-view/calendar-view';
+import {
+  CalendarHeader,
+  type CalendarHeaderProps,
+} from '@/ui/components/calendar-view/calendar-header';
+import {
+  MonthView,
+  type MonthViewProps,
+} from '@/ui/components/calendar-view/month-view';
+import {
+  WeekView,
+  type WeekViewProps,
+} from '@/ui/components/calendar-view/week-view';
+import {
+  CalendarItem,
+  type CalendarItemProps,
+} from '@/ui/components/calendar-view/calendar-item';
+import type {
+  CalendarEvent,
+  CalendarViewMode,
+} from '@/ui/components/calendar-view/types';
+
+// Mock data
+const mockEvents: CalendarEvent[] = [
+  {
+    id: 'event-1',
+    title: 'Implement feature A',
+    date: '2026-02-10',
+    priority: 'high',
+    status: 'open',
+  },
+  {
+    id: 'event-2',
+    title: 'Fix bug in module B',
+    date: '2026-02-15',
+    priority: 'medium',
+    status: 'in_progress',
+  },
+  {
+    id: 'event-3',
+    title: 'Write documentation',
+    date: '2026-02-15', // Same day as event-2
+    priority: 'low',
+    status: 'closed',
+  },
+  {
+    id: 'event-4',
+    title: 'Multi-day task',
+    date: '2026-02-20',
+    endDate: '2026-02-22',
+    priority: 'high',
+    status: 'open',
+  },
+];
+
+describe('CalendarView', () => {
+  const defaultProps: CalendarViewProps = {
+    events: mockEvents,
+    currentDate: new Date('2026-02-01'),
+    onEventClick: vi.fn(),
+    onDateChange: vi.fn(),
+    onViewModeChange: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render calendar view', () => {
+    render(<CalendarView {...defaultProps} />);
+    expect(screen.getByTestId('calendar-view')).toBeInTheDocument();
+  });
+
+  it('should show current month by default', () => {
+    render(<CalendarView {...defaultProps} />);
+    expect(screen.getByText(/february 2026/i)).toBeInTheDocument();
+  });
+
+  it('should show month view by default', () => {
+    render(<CalendarView {...defaultProps} />);
+    expect(screen.getByTestId('month-view')).toBeInTheDocument();
+  });
+
+  it('should switch to week view', () => {
+    render(<CalendarView {...defaultProps} viewMode="week" />);
+    expect(screen.getByTestId('week-view')).toBeInTheDocument();
+  });
+
+  it('should call onEventClick when event clicked', () => {
+    const onEventClick = vi.fn();
+    render(<CalendarView {...defaultProps} onEventClick={onEventClick} />);
+
+    fireEvent.click(screen.getByText('Implement feature A'));
+
+    expect(onEventClick).toHaveBeenCalledWith(mockEvents[0]);
+  });
+
+  it('should navigate to previous month', () => {
+    const onDateChange = vi.fn();
+    render(<CalendarView {...defaultProps} onDateChange={onDateChange} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /previous/i }));
+
+    expect(onDateChange).toHaveBeenCalled();
+  });
+
+  it('should navigate to next month', () => {
+    const onDateChange = vi.fn();
+    render(<CalendarView {...defaultProps} onDateChange={onDateChange} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /next/i }));
+
+    expect(onDateChange).toHaveBeenCalled();
+  });
+
+  it('should show today button', () => {
+    render(<CalendarView {...defaultProps} />);
+    expect(screen.getByRole('button', { name: /today/i })).toBeInTheDocument();
+  });
+
+  it('should show view mode switcher', () => {
+    render(<CalendarView {...defaultProps} />);
+    expect(screen.getByRole('button', { name: /month/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /week/i })).toBeInTheDocument();
+  });
+});
+
+describe('CalendarHeader', () => {
+  const defaultProps: CalendarHeaderProps = {
+    currentDate: new Date('2026-02-15'),
+    viewMode: 'month' as CalendarViewMode,
+    onPrevious: vi.fn(),
+    onNext: vi.fn(),
+    onToday: vi.fn(),
+    onViewModeChange: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should show current month and year', () => {
+    render(<CalendarHeader {...defaultProps} />);
+    expect(screen.getByText(/february 2026/i)).toBeInTheDocument();
+  });
+
+  it('should show navigation buttons', () => {
+    render(<CalendarHeader {...defaultProps} />);
+    expect(screen.getByRole('button', { name: /previous/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /next/i })).toBeInTheDocument();
+  });
+
+  it('should call onPrevious when previous clicked', () => {
+    const onPrevious = vi.fn();
+    render(<CalendarHeader {...defaultProps} onPrevious={onPrevious} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /previous/i }));
+
+    expect(onPrevious).toHaveBeenCalled();
+  });
+
+  it('should call onNext when next clicked', () => {
+    const onNext = vi.fn();
+    render(<CalendarHeader {...defaultProps} onNext={onNext} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /next/i }));
+
+    expect(onNext).toHaveBeenCalled();
+  });
+
+  it('should call onToday when today clicked', () => {
+    const onToday = vi.fn();
+    render(<CalendarHeader {...defaultProps} onToday={onToday} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /today/i }));
+
+    expect(onToday).toHaveBeenCalled();
+  });
+
+  it('should highlight active view mode', () => {
+    render(<CalendarHeader {...defaultProps} viewMode="month" />);
+    const monthButton = screen.getByRole('button', { name: /month/i });
+    expect(monthButton).toHaveAttribute('data-active', 'true');
+  });
+
+  it('should call onViewModeChange when view mode clicked', () => {
+    const onViewModeChange = vi.fn();
+    render(<CalendarHeader {...defaultProps} onViewModeChange={onViewModeChange} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /week/i }));
+
+    expect(onViewModeChange).toHaveBeenCalledWith('week');
+  });
+});
+
+describe('MonthView', () => {
+  const defaultProps: MonthViewProps = {
+    currentDate: new Date('2026-02-15'),
+    events: mockEvents,
+    onEventClick: vi.fn(),
+    onDateClick: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render month grid', () => {
+    render(<MonthView {...defaultProps} />);
+    expect(screen.getByTestId('month-view')).toBeInTheDocument();
+  });
+
+  it('should show day headers', () => {
+    render(<MonthView {...defaultProps} />);
+    expect(screen.getByText('Sun')).toBeInTheDocument();
+    expect(screen.getByText('Mon')).toBeInTheDocument();
+    expect(screen.getByText('Tue')).toBeInTheDocument();
+    expect(screen.getByText('Wed')).toBeInTheDocument();
+    expect(screen.getByText('Thu')).toBeInTheDocument();
+    expect(screen.getByText('Fri')).toBeInTheDocument();
+    expect(screen.getByText('Sat')).toBeInTheDocument();
+  });
+
+  it('should show day numbers', () => {
+    render(<MonthView {...defaultProps} />);
+    // February 2026 has 28 days
+    expect(screen.getByText('1')).toBeInTheDocument();
+    expect(screen.getByText('15')).toBeInTheDocument();
+    expect(screen.getByText('28')).toBeInTheDocument();
+  });
+
+  it('should highlight today', () => {
+    const today = new Date();
+    render(<MonthView {...defaultProps} currentDate={today} />);
+    const todayCell = screen.getByTestId(`day-${today.getDate()}`);
+    expect(todayCell).toHaveAttribute('data-today', 'true');
+  });
+
+  it('should show events on their dates', () => {
+    render(<MonthView {...defaultProps} />);
+    expect(screen.getByText('Implement feature A')).toBeInTheDocument();
+  });
+
+  it('should call onEventClick when event clicked', () => {
+    const onEventClick = vi.fn();
+    render(<MonthView {...defaultProps} onEventClick={onEventClick} />);
+
+    fireEvent.click(screen.getByText('Implement feature A'));
+
+    expect(onEventClick).toHaveBeenCalledWith(mockEvents[0]);
+  });
+
+  it('should call onDateClick when date clicked', () => {
+    const onDateClick = vi.fn();
+    render(<MonthView {...defaultProps} onDateClick={onDateClick} />);
+
+    fireEvent.click(screen.getByTestId('day-10'));
+
+    expect(onDateClick).toHaveBeenCalled();
+  });
+
+  it('should show multiple events on same day', () => {
+    render(<MonthView {...defaultProps} />);
+    // Events 2 and 3 are both on Feb 15
+    expect(screen.getByText('Fix bug in module B')).toBeInTheDocument();
+    expect(screen.getByText('Write documentation')).toBeInTheDocument();
+  });
+});
+
+describe('WeekView', () => {
+  const defaultProps: WeekViewProps = {
+    currentDate: new Date('2026-02-15'),
+    events: mockEvents,
+    onEventClick: vi.fn(),
+    onDateClick: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render week view', () => {
+    render(<WeekView {...defaultProps} />);
+    expect(screen.getByTestId('week-view')).toBeInTheDocument();
+  });
+
+  it('should show 7 days', () => {
+    render(<WeekView {...defaultProps} />);
+    const dayCells = screen.getAllByTestId(/^week-day-/);
+    expect(dayCells.length).toBe(7);
+  });
+
+  it('should show day headers with dates', () => {
+    render(<WeekView {...defaultProps} />);
+    // Week of Feb 15, 2026 starts on Feb 15 (Sunday)
+    expect(screen.getByText(/sun.*15/i)).toBeInTheDocument();
+    expect(screen.getByText(/sat.*21/i)).toBeInTheDocument();
+  });
+
+  it('should show events', () => {
+    render(<WeekView {...defaultProps} />);
+    expect(screen.getByText('Fix bug in module B')).toBeInTheDocument();
+  });
+
+  it('should call onEventClick when event clicked', () => {
+    const onEventClick = vi.fn();
+    render(<WeekView {...defaultProps} onEventClick={onEventClick} />);
+
+    fireEvent.click(screen.getByText('Fix bug in module B'));
+
+    expect(onEventClick).toHaveBeenCalledWith(mockEvents[1]);
+  });
+});
+
+describe('CalendarItem', () => {
+  const mockEvent = mockEvents[0];
+  const defaultProps: CalendarItemProps = {
+    event: mockEvent,
+    onClick: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render event title', () => {
+    render(<CalendarItem {...defaultProps} />);
+    expect(screen.getByText('Implement feature A')).toBeInTheDocument();
+  });
+
+  it('should show priority indicator', () => {
+    render(<CalendarItem {...defaultProps} />);
+    const item = screen.getByTestId(`calendar-item-${mockEvent.id}`);
+    expect(item).toHaveAttribute('data-priority', 'high');
+  });
+
+  it('should call onClick when clicked', () => {
+    const onClick = vi.fn();
+    render(<CalendarItem {...defaultProps} onClick={onClick} />);
+
+    fireEvent.click(screen.getByText('Implement feature A'));
+
+    expect(onClick).toHaveBeenCalledWith(mockEvent);
+  });
+
+  it('should truncate long titles', () => {
+    const longTitleEvent = {
+      ...mockEvent,
+      title: 'This is a very long title that should be truncated in the display',
+    };
+    render(<CalendarItem {...defaultProps} event={longTitleEvent} />);
+    const item = screen.getByTestId(`calendar-item-${mockEvent.id}`);
+    expect(item).toHaveClass('truncate');
+  });
+
+  it('should show status styling', () => {
+    render(<CalendarItem {...defaultProps} />);
+    const item = screen.getByTestId(`calendar-item-${mockEvent.id}`);
+    expect(item).toHaveAttribute('data-status', 'open');
+  });
+});


### PR DESCRIPTION
## Summary
- Add calendar visualization for work items by due date
- Month view with grid display and day cells
- Week view with 7-day column layout
- Navigation between months/weeks with Today button
- Events colored by priority with status indicators

## Test plan
- [x] Run `npm test -- --run tests/ui/calendar-view.test.tsx` - all 34 tests pass
- [x] Verify no regressions in related tests

Closes #408

🤖 Generated with [Claude Code](https://claude.com/claude-code)