### PR TITLE
[#409] Implement board view customization

### DIFF
--- a/src/ui/components/board-config/board-config.tsx
+++ b/src/ui/components/board-config/board-config.tsx
@@ -1,0 +1,108 @@
+/**
+ * Board Config component
+ * Issue #409: Implement board view customization
+ */
+import * as React from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/ui/components/ui/dialog';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/ui/components/ui/tabs';
+import { Button } from '@/ui/components/ui/button';
+import { ColumnManager } from './column-manager';
+import { SwimlanesConfig } from './swimlanes-config';
+import { WipLimitsConfig } from './wip-limits-config';
+import { CardDisplayConfig } from './card-display-config';
+import type {
+  BoardColumn,
+  SwimlaneSetting,
+  WipLimit,
+  CardDisplayMode,
+  CardField,
+} from './types';
+
+export interface BoardConfigProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  columns: BoardColumn[];
+  onColumnsChange: (columns: BoardColumn[]) => void;
+  swimlanes: SwimlaneSetting | null;
+  onSwimlanesChange: (swimlanes: SwimlaneSetting | null) => void;
+  wipLimits: Record<string, WipLimit>;
+  onWipLimitsChange: (limits: Record<string, WipLimit>) => void;
+  cardDisplayMode: CardDisplayMode;
+  onCardDisplayModeChange: (mode: CardDisplayMode) => void;
+  visibleFields?: CardField[];
+  onVisibleFieldsChange?: (fields: CardField[]) => void;
+}
+
+export function BoardConfig({
+  open,
+  onOpenChange,
+  columns,
+  onColumnsChange,
+  swimlanes,
+  onSwimlanesChange,
+  wipLimits,
+  onWipLimitsChange,
+  cardDisplayMode,
+  onCardDisplayModeChange,
+  visibleFields = ['title', 'status', 'priority'],
+  onVisibleFieldsChange,
+}: BoardConfigProps) {
+  const handleClose = () => {
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Board Settings</DialogTitle>
+        </DialogHeader>
+
+        <Tabs defaultValue="columns" className="w-full">
+          <TabsList className="grid w-full grid-cols-4">
+            <TabsTrigger value="columns">Columns</TabsTrigger>
+            <TabsTrigger value="swimlanes">Swimlanes</TabsTrigger>
+            <TabsTrigger value="limits">Limits</TabsTrigger>
+            <TabsTrigger value="display">Display</TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="columns" className="mt-4">
+            <ColumnManager columns={columns} onChange={onColumnsChange} />
+          </TabsContent>
+
+          <TabsContent value="swimlanes" className="mt-4">
+            <SwimlanesConfig value={swimlanes} onChange={onSwimlanesChange} />
+          </TabsContent>
+
+          <TabsContent value="limits" className="mt-4">
+            <WipLimitsConfig
+              columns={columns}
+              limits={wipLimits}
+              onChange={onWipLimitsChange}
+            />
+          </TabsContent>
+
+          <TabsContent value="display" className="mt-4">
+            <CardDisplayConfig
+              mode={cardDisplayMode}
+              onChange={onCardDisplayModeChange}
+              visibleFields={visibleFields}
+              onVisibleFieldsChange={onVisibleFieldsChange ?? (() => {})}
+            />
+          </TabsContent>
+        </Tabs>
+
+        <div className="flex justify-end mt-4">
+          <Button variant="outline" onClick={handleClose}>
+            Close
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/ui/components/board-config/card-display-config.tsx
+++ b/src/ui/components/board-config/card-display-config.tsx
@@ -1,0 +1,97 @@
+/**
+ * Card Display Config component
+ * Issue #409: Implement board view customization
+ */
+import * as React from 'react';
+import { Checkbox } from '@/ui/components/ui/checkbox';
+import { Label } from '@/ui/components/ui/label';
+import { cn } from '@/ui/lib/utils';
+import type { CardDisplayMode, CardField } from './types';
+
+export interface CardDisplayConfigProps {
+  mode: CardDisplayMode;
+  onChange: (mode: CardDisplayMode) => void;
+  visibleFields: CardField[];
+  onVisibleFieldsChange: (fields: CardField[]) => void;
+}
+
+const displayModes: { value: CardDisplayMode; label: string }[] = [
+  { value: 'compact', label: 'Compact' },
+  { value: 'detailed', label: 'Detailed' },
+];
+
+const availableFields: { value: CardField; label: string }[] = [
+  { value: 'title', label: 'Title' },
+  { value: 'status', label: 'Status' },
+  { value: 'priority', label: 'Priority' },
+  { value: 'assignee', label: 'Assignee' },
+  { value: 'dueDate', label: 'Due Date' },
+  { value: 'labels', label: 'Labels' },
+  { value: 'estimate', label: 'Estimate' },
+  { value: 'progress', label: 'Progress' },
+];
+
+export function CardDisplayConfig({
+  mode,
+  onChange,
+  visibleFields,
+  onVisibleFieldsChange,
+}: CardDisplayConfigProps) {
+  const handleFieldToggle = (field: CardField) => {
+    if (visibleFields.includes(field)) {
+      onVisibleFieldsChange(visibleFields.filter((f) => f !== field));
+    } else {
+      onVisibleFieldsChange([...visibleFields, field]);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h3 className="text-sm font-medium mb-3">Card Display Mode</h3>
+        <div className="space-y-2">
+          {displayModes.map((option) => {
+            const inputId = `mode-${option.value}`;
+            return (
+              <div key={option.value} className="flex items-center space-x-2">
+                <input
+                  type="radio"
+                  id={inputId}
+                  name="displayMode"
+                  value={option.value}
+                  checked={mode === option.value}
+                  onChange={() => onChange(option.value)}
+                  className={cn(
+                    'h-4 w-4 border-gray-300 text-primary focus:ring-primary'
+                  )}
+                  aria-label={option.label}
+                />
+                <Label htmlFor={inputId}>{option.label}</Label>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      <div>
+        <h3 className="text-sm font-medium mb-3">Visible Fields</h3>
+        <p className="text-sm text-muted-foreground mb-3">
+          Select which fields to display on cards.
+        </p>
+        <div className="grid grid-cols-2 gap-2">
+          {availableFields.map((field) => (
+            <div key={field.value} className="flex items-center space-x-2">
+              <Checkbox
+                id={`field-${field.value}`}
+                checked={visibleFields.includes(field.value)}
+                onCheckedChange={() => handleFieldToggle(field.value)}
+                aria-label={field.label}
+              />
+              <Label htmlFor={`field-${field.value}`}>{field.label}</Label>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/components/board-config/column-manager.tsx
+++ b/src/ui/components/board-config/column-manager.tsx
@@ -1,0 +1,78 @@
+/**
+ * Column Manager component
+ * Issue #409: Implement board view customization
+ */
+import * as React from 'react';
+import { GripVertical, Trash2, Plus } from 'lucide-react';
+import { Button } from '@/ui/components/ui/button';
+import { Input } from '@/ui/components/ui/input';
+import type { BoardColumn } from './types';
+
+export interface ColumnManagerProps {
+  columns: BoardColumn[];
+  onChange: (columns: BoardColumn[]) => void;
+}
+
+function generateId(): string {
+  return `col-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+}
+
+export function ColumnManager({ columns, onChange }: ColumnManagerProps) {
+  const handleAddColumn = () => {
+    const newColumn: BoardColumn = {
+      id: generateId(),
+      name: 'New Column',
+      order: columns.length,
+    };
+    onChange([...columns, newColumn]);
+  };
+
+  const handleRenameColumn = (id: string, name: string) => {
+    onChange(columns.map((col) => (col.id === id ? { ...col, name } : col)));
+  };
+
+  const handleDeleteColumn = (id: string) => {
+    const filtered = columns.filter((col) => col.id !== id);
+    // Reorder remaining columns
+    onChange(filtered.map((col, index) => ({ ...col, order: index })));
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        {columns.map((column) => (
+          <div
+            key={column.id}
+            data-testid={`column-item-${column.id}`}
+            className="flex items-center gap-2 p-2 border rounded-lg bg-background"
+          >
+            <GripVertical className="h-4 w-4 text-muted-foreground cursor-move" />
+            <Input
+              value={column.name}
+              onChange={(e) => handleRenameColumn(column.id, e.target.value)}
+              className="flex-1"
+            />
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => handleDeleteColumn(column.id)}
+              aria-label="Delete column"
+            >
+              <Trash2 className="h-4 w-4 text-muted-foreground" />
+            </Button>
+          </div>
+        ))}
+      </div>
+
+      <Button
+        variant="outline"
+        className="w-full"
+        onClick={handleAddColumn}
+        aria-label="Add column"
+      >
+        <Plus className="h-4 w-4 mr-2" />
+        Add Column
+      </Button>
+    </div>
+  );
+}

--- a/src/ui/components/board-config/index.ts
+++ b/src/ui/components/board-config/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Board Config components
+ * Issue #409: Implement board view customization
+ */
+export * from './types';
+export * from './board-config';
+export * from './column-manager';
+export * from './swimlanes-config';
+export * from './wip-limits-config';
+export * from './card-display-config';

--- a/src/ui/components/board-config/swimlanes-config.tsx
+++ b/src/ui/components/board-config/swimlanes-config.tsx
@@ -1,0 +1,69 @@
+/**
+ * Swimlanes Config component
+ * Issue #409: Implement board view customization
+ */
+import * as React from 'react';
+import { Label } from '@/ui/components/ui/label';
+import { cn } from '@/ui/lib/utils';
+import type { SwimlaneSetting, SwimlaneGroupBy } from './types';
+
+export interface SwimlanesConfigProps {
+  value: SwimlaneSetting | null;
+  onChange: (value: SwimlaneSetting | null) => void;
+}
+
+const swimlaneOptions: { value: SwimlaneGroupBy | 'none'; label: string }[] = [
+  { value: 'none', label: 'No Swimlanes' },
+  { value: 'priority', label: 'Priority' },
+  { value: 'assignee', label: 'Assignee' },
+  { value: 'label', label: 'Label' },
+  { value: 'parent', label: 'Parent Item' },
+];
+
+export function SwimlanesConfig({ value, onChange }: SwimlanesConfigProps) {
+  const currentValue = value?.groupBy ?? 'none';
+
+  const handleChange = (newValue: string) => {
+    if (newValue === 'none') {
+      onChange(null);
+    } else {
+      onChange({ groupBy: newValue as SwimlaneGroupBy });
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h3 className="text-sm font-medium mb-3">Swimlanes</h3>
+        <p className="text-sm text-muted-foreground mb-4">
+          Group cards into horizontal lanes across all columns.
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        {swimlaneOptions.map((option) => {
+          const isSelected = currentValue === option.value;
+          const inputId = `swimlane-${option.value}`;
+
+          return (
+            <div key={option.value} className="flex items-center space-x-2">
+              <input
+                type="radio"
+                id={inputId}
+                name="swimlane"
+                value={option.value}
+                checked={isSelected}
+                onChange={() => handleChange(option.value)}
+                className={cn(
+                  'h-4 w-4 border-gray-300 text-primary focus:ring-primary'
+                )}
+                aria-label={option.label}
+              />
+              <Label htmlFor={inputId}>{option.label}</Label>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/ui/components/board-config/types.ts
+++ b/src/ui/components/board-config/types.ts
@@ -1,0 +1,41 @@
+/**
+ * Types for board configuration
+ * Issue #409: Implement board view customization
+ */
+
+export type WorkItemStatus = 'open' | 'in_progress' | 'blocked' | 'closed';
+
+export interface BoardColumn {
+  id: string;
+  name: string;
+  status?: WorkItemStatus;
+  order: number;
+}
+
+export type SwimlaneGroupBy = 'priority' | 'assignee' | 'label' | 'parent';
+
+export interface SwimlaneSetting {
+  groupBy: SwimlaneGroupBy;
+}
+
+export type WipLimit = number;
+
+export type CardDisplayMode = 'compact' | 'detailed';
+
+export type CardField =
+  | 'title'
+  | 'status'
+  | 'priority'
+  | 'assignee'
+  | 'dueDate'
+  | 'labels'
+  | 'estimate'
+  | 'progress';
+
+export interface BoardSettings {
+  columns: BoardColumn[];
+  swimlanes: SwimlaneSetting | null;
+  wipLimits: Record<string, WipLimit>;
+  cardDisplayMode: CardDisplayMode;
+  visibleFields: CardField[];
+}

--- a/src/ui/components/board-config/wip-limits-config.tsx
+++ b/src/ui/components/board-config/wip-limits-config.tsx
@@ -1,0 +1,64 @@
+/**
+ * WIP Limits Config component
+ * Issue #409: Implement board view customization
+ */
+import * as React from 'react';
+import { Input } from '@/ui/components/ui/input';
+import { Label } from '@/ui/components/ui/label';
+import type { BoardColumn, WipLimit } from './types';
+
+export interface WipLimitsConfigProps {
+  columns: BoardColumn[];
+  limits: Record<string, WipLimit>;
+  onChange: (limits: Record<string, WipLimit>) => void;
+}
+
+export function WipLimitsConfig({
+  columns,
+  limits,
+  onChange,
+}: WipLimitsConfigProps) {
+  const handleLimitChange = (columnId: string, value: string) => {
+    const numValue = parseInt(value, 10);
+    const newLimits = { ...limits };
+
+    if (value === '' || isNaN(numValue)) {
+      delete newLimits[columnId];
+    } else {
+      newLimits[columnId] = numValue;
+    }
+
+    onChange(newLimits);
+  };
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h3 className="text-sm font-medium mb-3">Work In Progress Limits</h3>
+        <p className="text-sm text-muted-foreground mb-4">
+          Set maximum items per column. Exceeding the limit will show a warning.
+        </p>
+      </div>
+
+      <div className="space-y-3">
+        {columns.map((column) => (
+          <div key={column.id} className="flex items-center gap-3">
+            <Label htmlFor={`wip-${column.id}`} className="w-32 shrink-0">
+              {column.name}
+            </Label>
+            <Input
+              id={`wip-${column.id}`}
+              type="number"
+              min={0}
+              placeholder="No limit"
+              value={limits[column.id] ?? ''}
+              onChange={(e) => handleLimitChange(column.id, e.target.value)}
+              className="w-24"
+            />
+            <span className="text-sm text-muted-foreground">items max</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/tests/ui/board-config.test.tsx
+++ b/tests/ui/board-config.test.tsx
@@ -1,0 +1,340 @@
+/**
+ * @vitest-environment jsdom
+ * Tests for board view customization
+ * Issue #409: Implement board view customization
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import * as React from 'react';
+
+// Components to be implemented
+import {
+  BoardConfig,
+  type BoardConfigProps,
+} from '@/ui/components/board-config/board-config';
+import {
+  ColumnManager,
+  type ColumnManagerProps,
+} from '@/ui/components/board-config/column-manager';
+import {
+  SwimlanesConfig,
+  type SwimlanesConfigProps,
+} from '@/ui/components/board-config/swimlanes-config';
+import {
+  WipLimitsConfig,
+  type WipLimitsConfigProps,
+} from '@/ui/components/board-config/wip-limits-config';
+import {
+  CardDisplayConfig,
+  type CardDisplayConfigProps,
+} from '@/ui/components/board-config/card-display-config';
+import type {
+  BoardColumn,
+  SwimlaneSetting,
+  WipLimit,
+  CardDisplayMode,
+} from '@/ui/components/board-config/types';
+
+// Mock data
+const mockColumns: BoardColumn[] = [
+  { id: 'col-1', name: 'To Do', status: 'open', order: 0 },
+  { id: 'col-2', name: 'In Progress', status: 'in_progress', order: 1 },
+  { id: 'col-3', name: 'Done', status: 'closed', order: 2 },
+];
+
+describe('BoardConfig', () => {
+  const defaultProps: BoardConfigProps = {
+    open: true,
+    onOpenChange: vi.fn(),
+    columns: mockColumns,
+    onColumnsChange: vi.fn(),
+    swimlanes: null,
+    onSwimlanesChange: vi.fn(),
+    wipLimits: {},
+    onWipLimitsChange: vi.fn(),
+    cardDisplayMode: 'compact',
+    onCardDisplayModeChange: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render board config dialog', () => {
+    render(<BoardConfig {...defaultProps} />);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('should show tabs for different config sections', () => {
+    render(<BoardConfig {...defaultProps} />);
+    expect(screen.getByRole('tab', { name: /columns/i })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /swimlanes/i })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /limits/i })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /display/i })).toBeInTheDocument();
+  });
+
+  it('should show columns tab by default', () => {
+    render(<BoardConfig {...defaultProps} />);
+    expect(screen.getByRole('tab', { name: /columns/i })).toHaveAttribute(
+      'data-state',
+      'active'
+    );
+  });
+
+  it('should switch between tabs', () => {
+    render(<BoardConfig {...defaultProps} />);
+
+    // Verify all tabs are rendered and can be interacted with
+    const swimlanesTab = screen.getByRole('tab', { name: /swimlanes/i });
+    expect(swimlanesTab).toBeInTheDocument();
+    expect(swimlanesTab).toHaveAttribute('aria-controls');
+  });
+
+  it('should close on cancel', () => {
+    const onOpenChange = vi.fn();
+    render(<BoardConfig {...defaultProps} onOpenChange={onOpenChange} />);
+
+    // Find the Close button in the dialog footer
+    const closeButtons = screen.getAllByRole('button', { name: /close/i });
+    fireEvent.click(closeButtons[closeButtons.length - 1]); // Get the last Close button
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});
+
+describe('ColumnManager', () => {
+  const defaultProps: ColumnManagerProps = {
+    columns: mockColumns,
+    onChange: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render all columns', () => {
+    render(<ColumnManager {...defaultProps} />);
+    // Columns are displayed in input fields
+    expect(screen.getByDisplayValue('To Do')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('In Progress')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Done')).toBeInTheDocument();
+  });
+
+  it('should show add column button', () => {
+    render(<ColumnManager {...defaultProps} />);
+    expect(screen.getByRole('button', { name: /add column/i })).toBeInTheDocument();
+  });
+
+  it('should call onChange when adding column', () => {
+    const onChange = vi.fn();
+    render(<ColumnManager {...defaultProps} onChange={onChange} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /add column/i }));
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        ...mockColumns,
+        expect.objectContaining({ name: expect.any(String) }),
+      ])
+    );
+  });
+
+  it('should allow renaming column', () => {
+    const onChange = vi.fn();
+    render(<ColumnManager {...defaultProps} onChange={onChange} />);
+
+    const input = screen.getAllByRole('textbox')[0];
+    fireEvent.change(input, { target: { value: 'Backlog' } });
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'col-1', name: 'Backlog' }),
+      ])
+    );
+  });
+
+  it('should show delete button for each column', () => {
+    render(<ColumnManager {...defaultProps} />);
+    const deleteButtons = screen.getAllByRole('button', { name: /delete|remove/i });
+    expect(deleteButtons.length).toBe(mockColumns.length);
+  });
+
+  it('should call onChange when deleting column', () => {
+    const onChange = vi.fn();
+    render(<ColumnManager {...defaultProps} onChange={onChange} />);
+
+    const deleteButtons = screen.getAllByRole('button', { name: /delete|remove/i });
+    fireEvent.click(deleteButtons[0]);
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.not.arrayContaining([expect.objectContaining({ id: 'col-1' })])
+    );
+  });
+
+  it('should show column order', () => {
+    render(<ColumnManager {...defaultProps} />);
+    // Columns should be visually numbered or have drag handles
+    expect(screen.getByTestId('column-item-col-1')).toBeInTheDocument();
+  });
+});
+
+describe('SwimlanesConfig', () => {
+  const defaultProps: SwimlanesConfigProps = {
+    value: null,
+    onChange: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render swimlanes options', () => {
+    render(<SwimlanesConfig {...defaultProps} />);
+    // Check for the heading text specifically
+    expect(screen.getByRole('heading', { name: /swimlanes/i })).toBeInTheDocument();
+  });
+
+  it('should show no swimlanes option', () => {
+    render(<SwimlanesConfig {...defaultProps} />);
+    expect(screen.getByLabelText(/none|no swimlanes/i)).toBeInTheDocument();
+  });
+
+  it('should show swimlane group by options', () => {
+    render(<SwimlanesConfig {...defaultProps} />);
+    expect(screen.getByLabelText(/priority/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/assignee/i)).toBeInTheDocument();
+  });
+
+  it('should call onChange when selecting swimlane option', () => {
+    const onChange = vi.fn();
+    render(<SwimlanesConfig {...defaultProps} onChange={onChange} />);
+
+    fireEvent.click(screen.getByLabelText(/priority/i));
+
+    expect(onChange).toHaveBeenCalledWith({ groupBy: 'priority' });
+  });
+
+  it('should highlight selected option', () => {
+    render(<SwimlanesConfig {...defaultProps} value={{ groupBy: 'priority' }} />);
+    expect(screen.getByLabelText(/priority/i)).toBeChecked();
+  });
+});
+
+describe('WipLimitsConfig', () => {
+  const defaultProps: WipLimitsConfigProps = {
+    columns: mockColumns,
+    limits: {},
+    onChange: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render WIP limits for each column', () => {
+    render(<WipLimitsConfig {...defaultProps} />);
+    expect(screen.getByText('To Do')).toBeInTheDocument();
+    expect(screen.getByText('In Progress')).toBeInTheDocument();
+    expect(screen.getByText('Done')).toBeInTheDocument();
+  });
+
+  it('should show input for limit value', () => {
+    render(<WipLimitsConfig {...defaultProps} />);
+    const inputs = screen.getAllByRole('spinbutton');
+    expect(inputs.length).toBe(mockColumns.length);
+  });
+
+  it('should call onChange when setting limit', () => {
+    const onChange = vi.fn();
+    render(<WipLimitsConfig {...defaultProps} onChange={onChange} />);
+
+    const inputs = screen.getAllByRole('spinbutton');
+    fireEvent.change(inputs[1], { target: { value: '5' } });
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ 'col-2': 5 })
+    );
+  });
+
+  it('should show current limits', () => {
+    const limits: Record<string, number> = { 'col-2': 3 };
+    render(<WipLimitsConfig {...defaultProps} limits={limits} />);
+
+    const inputs = screen.getAllByRole('spinbutton');
+    expect(inputs[1]).toHaveValue(3);
+  });
+
+  it('should allow clearing limit', () => {
+    const onChange = vi.fn();
+    const limits: Record<string, number> = { 'col-2': 3 };
+    render(<WipLimitsConfig {...defaultProps} limits={limits} onChange={onChange} />);
+
+    const inputs = screen.getAllByRole('spinbutton');
+    fireEvent.change(inputs[1], { target: { value: '' } });
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.not.objectContaining({ 'col-2': expect.anything() })
+    );
+  });
+});
+
+describe('CardDisplayConfig', () => {
+  const defaultProps: CardDisplayConfigProps = {
+    mode: 'compact',
+    onChange: vi.fn(),
+    visibleFields: ['title', 'status', 'priority'],
+    onVisibleFieldsChange: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render display mode options', () => {
+    render(<CardDisplayConfig {...defaultProps} />);
+    expect(screen.getByLabelText(/compact/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/detailed/i)).toBeInTheDocument();
+  });
+
+  it('should highlight selected mode', () => {
+    render(<CardDisplayConfig {...defaultProps} mode="compact" />);
+    expect(screen.getByLabelText(/compact/i)).toBeChecked();
+  });
+
+  it('should call onChange when mode selected', () => {
+    const onChange = vi.fn();
+    render(<CardDisplayConfig {...defaultProps} onChange={onChange} />);
+
+    fireEvent.click(screen.getByLabelText(/detailed/i));
+
+    expect(onChange).toHaveBeenCalledWith('detailed');
+  });
+
+  it('should show field visibility options', () => {
+    render(<CardDisplayConfig {...defaultProps} />);
+    expect(screen.getByText(/visible fields/i)).toBeInTheDocument();
+  });
+
+  it('should show checkboxes for fields', () => {
+    render(<CardDisplayConfig {...defaultProps} />);
+    expect(screen.getByRole('checkbox', { name: /assignee/i })).toBeInTheDocument();
+    expect(screen.getByRole('checkbox', { name: /due date/i })).toBeInTheDocument();
+  });
+
+  it('should call onVisibleFieldsChange when toggling field', () => {
+    const onVisibleFieldsChange = vi.fn();
+    render(
+      <CardDisplayConfig
+        {...defaultProps}
+        onVisibleFieldsChange={onVisibleFieldsChange}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /assignee/i }));
+
+    expect(onVisibleFieldsChange).toHaveBeenCalledWith(
+      expect.arrayContaining(['title', 'status', 'priority', 'assignee'])
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add BoardConfig dialog for customizing kanban board
- ColumnManager for adding/renaming/deleting columns
- SwimlanesConfig for grouping cards by priority/assignee/label
- WipLimitsConfig for setting work-in-progress limits per column
- CardDisplayConfig for compact/detailed card modes and visible fields

## Test plan
- [x] Run `npm test -- --run tests/ui/board-config.test.tsx` - all 28 tests pass
- [x] Verify no regressions in related tests

Closes #409

🤖 Generated with [Claude Code](https://claude.com/claude-code)