### PR TITLE
[#410] Implement keyboard navigation throughout

### DIFF
--- a/src/ui/components/keyboard-navigation/focus-ring.tsx
+++ b/src/ui/components/keyboard-navigation/focus-ring.tsx
@@ -1,0 +1,60 @@
+/**
+ * Focus Ring component
+ * Issue #410: Implement keyboard navigation throughout
+ */
+import * as React from 'react';
+import { cn } from '@/ui/lib/utils';
+
+export interface FocusRingProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function FocusRing({ children, className }: FocusRingProps) {
+  const [isFocusVisible, setIsFocusVisible] = React.useState(false);
+  const [hadKeyboardEvent, setHadKeyboardEvent] = React.useState(false);
+
+  React.useEffect(() => {
+    const handleKeyDown = () => {
+      setHadKeyboardEvent(true);
+    };
+
+    const handleMouseDown = () => {
+      setHadKeyboardEvent(false);
+    };
+
+    document.addEventListener('keydown', handleKeyDown, true);
+    document.addEventListener('mousedown', handleMouseDown, true);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown, true);
+      document.removeEventListener('mousedown', handleMouseDown, true);
+    };
+  }, []);
+
+  const handleFocus = () => {
+    if (hadKeyboardEvent) {
+      setIsFocusVisible(true);
+    }
+  };
+
+  const handleBlur = () => {
+    setIsFocusVisible(false);
+  };
+
+  return (
+    <div
+      data-focus-visible={isFocusVisible}
+      className={cn(
+        'relative inline-flex',
+        isFocusVisible &&
+          'ring-2 ring-ring ring-offset-2 ring-offset-background rounded',
+        className
+      )}
+      onFocus={handleFocus}
+      onBlur={handleBlur}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/ui/components/keyboard-navigation/index.ts
+++ b/src/ui/components/keyboard-navigation/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Keyboard Navigation components
+ * Issue #410: Implement keyboard navigation throughout
+ */
+export * from './types';
+export * from './keyboard-navigation-context';
+export * from './keyboard-navigable-list';
+export * from './focus-ring';
+export * from './shortcut-hint';

--- a/src/ui/components/keyboard-navigation/keyboard-navigable-list.tsx
+++ b/src/ui/components/keyboard-navigation/keyboard-navigable-list.tsx
@@ -1,0 +1,112 @@
+/**
+ * Keyboard Navigable List component
+ * Issue #410: Implement keyboard navigation throughout
+ */
+import * as React from 'react';
+import { useKeyboardNavigation } from './keyboard-navigation-context';
+import type { NavigableItem } from './types';
+
+export interface KeyboardNavigableListProps {
+  items: NavigableItem[];
+  onSelect?: (item: NavigableItem) => void;
+  renderItem: (
+    item: NavigableItem,
+    index: number,
+    isFocused: boolean
+  ) => React.ReactNode;
+  className?: string;
+}
+
+export function KeyboardNavigableList({
+  items,
+  onSelect,
+  renderItem,
+  className,
+}: KeyboardNavigableListProps) {
+  const { focusedIndex, setFocusedIndex, registerShortcut } =
+    useKeyboardNavigation();
+
+  // Register navigation shortcuts
+  React.useEffect(() => {
+    const unregisterJ = registerShortcut({
+      key: 'j',
+      action: () => {
+        setFocusedIndex(Math.min(focusedIndex + 1, items.length - 1));
+      },
+      description: 'Move down',
+    });
+
+    const unregisterK = registerShortcut({
+      key: 'k',
+      action: () => {
+        setFocusedIndex(Math.max(focusedIndex - 1, 0));
+      },
+      description: 'Move up',
+    });
+
+    const unregisterDown = registerShortcut({
+      key: 'ArrowDown',
+      action: () => {
+        setFocusedIndex(Math.min(focusedIndex + 1, items.length - 1));
+      },
+      description: 'Move down',
+    });
+
+    const unregisterUp = registerShortcut({
+      key: 'ArrowUp',
+      action: () => {
+        setFocusedIndex(Math.max(focusedIndex - 1, 0));
+      },
+      description: 'Move up',
+    });
+
+    const unregisterHome = registerShortcut({
+      key: 'Home',
+      action: () => {
+        setFocusedIndex(0);
+      },
+      description: 'Go to first item',
+    });
+
+    const unregisterEnd = registerShortcut({
+      key: 'End',
+      action: () => {
+        setFocusedIndex(items.length - 1);
+      },
+      description: 'Go to last item',
+    });
+
+    const unregisterEnter = registerShortcut({
+      key: 'Enter',
+      action: () => {
+        if (focusedIndex >= 0 && focusedIndex < items.length) {
+          onSelect?.(items[focusedIndex]);
+        }
+      },
+      description: 'Select item',
+    });
+
+    return () => {
+      unregisterJ();
+      unregisterK();
+      unregisterDown();
+      unregisterUp();
+      unregisterHome();
+      unregisterEnd();
+      unregisterEnter();
+    };
+  }, [focusedIndex, items, onSelect, registerShortcut, setFocusedIndex]);
+
+  // Initialize focus on first item if not set
+  React.useEffect(() => {
+    if (focusedIndex === -1 && items.length > 0) {
+      // Don't auto-focus, wait for user to press j/k
+    }
+  }, [focusedIndex, items.length]);
+
+  return (
+    <div className={className} role="listbox" tabIndex={0}>
+      {items.map((item, index) => renderItem(item, index, index === focusedIndex))}
+    </div>
+  );
+}

--- a/src/ui/components/keyboard-navigation/keyboard-navigation-context.tsx
+++ b/src/ui/components/keyboard-navigation/keyboard-navigation-context.tsx
@@ -1,0 +1,118 @@
+/**
+ * Keyboard Navigation Context
+ * Issue #410: Implement keyboard navigation throughout
+ */
+import * as React from 'react';
+import type {
+  KeyboardNavigationContextValue,
+  KeyboardShortcut,
+} from './types';
+
+const KeyboardNavigationContext = React.createContext<
+  KeyboardNavigationContextValue | undefined
+>(undefined);
+
+interface KeyboardNavigationProviderProps {
+  children: React.ReactNode;
+  initialFocusIndex?: number;
+}
+
+function isInputElement(element: Element | null): boolean {
+  if (!element) return false;
+  const tagName = element.tagName.toLowerCase();
+  return (
+    tagName === 'input' ||
+    tagName === 'textarea' ||
+    tagName === 'select' ||
+    element.getAttribute('contenteditable') === 'true'
+  );
+}
+
+export function KeyboardNavigationProvider({
+  children,
+  initialFocusIndex = -1,
+}: KeyboardNavigationProviderProps) {
+  const [focusedIndex, setFocusedIndex] = React.useState(initialFocusIndex);
+  const [isEnabled, setEnabled] = React.useState(true);
+  const shortcutsRef = React.useRef<Map<string, KeyboardShortcut>>(new Map());
+
+  const registerShortcut = React.useCallback(
+    (shortcut: KeyboardShortcut): (() => void) => {
+      const key = shortcut.key.toLowerCase();
+      shortcutsRef.current.set(key, shortcut);
+
+      return () => {
+        shortcutsRef.current.delete(key);
+      };
+    },
+    []
+  );
+
+  React.useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (!isEnabled) return;
+
+      // Don't handle shortcuts when typing in input fields
+      if (isInputElement(document.activeElement)) {
+        return;
+      }
+
+      const key = event.key.toLowerCase();
+      const shortcut = shortcutsRef.current.get(key);
+
+      if (shortcut) {
+        // Check modifiers if required
+        if (shortcut.modifiers?.length) {
+          const hasAllModifiers = shortcut.modifiers.every((mod) => {
+            switch (mod) {
+              case 'ctrl':
+                return event.ctrlKey;
+              case 'alt':
+                return event.altKey;
+              case 'shift':
+                return event.shiftKey;
+              case 'meta':
+                return event.metaKey;
+              default:
+                return false;
+            }
+          });
+          if (!hasAllModifiers) return;
+        }
+
+        event.preventDefault();
+        shortcut.action();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isEnabled]);
+
+  const value: KeyboardNavigationContextValue = React.useMemo(
+    () => ({
+      focusedIndex,
+      setFocusedIndex,
+      registerShortcut,
+      isEnabled,
+      setEnabled,
+    }),
+    [focusedIndex, registerShortcut, isEnabled]
+  );
+
+  return (
+    <KeyboardNavigationContext.Provider value={value}>
+      {children}
+    </KeyboardNavigationContext.Provider>
+  );
+}
+
+export function useKeyboardNavigation(): KeyboardNavigationContextValue {
+  const context = React.useContext(KeyboardNavigationContext);
+  if (!context) {
+    throw new Error(
+      'useKeyboardNavigation must be used within KeyboardNavigationProvider'
+    );
+  }
+  return context;
+}

--- a/src/ui/components/keyboard-navigation/shortcut-hint.tsx
+++ b/src/ui/components/keyboard-navigation/shortcut-hint.tsx
@@ -1,0 +1,58 @@
+/**
+ * Shortcut Hint component
+ * Issue #410: Implement keyboard navigation throughout
+ */
+import * as React from 'react';
+import { cn } from '@/ui/lib/utils';
+import { MODIFIER_SYMBOLS } from './types';
+
+export interface ShortcutHintProps {
+  keys: string[];
+  description: string;
+  compact?: boolean;
+  className?: string;
+}
+
+function formatKey(key: string): string {
+  return MODIFIER_SYMBOLS[key] || key;
+}
+
+export function ShortcutHint({
+  keys,
+  description,
+  compact = false,
+  className,
+}: ShortcutHintProps) {
+  return (
+    <div
+      data-testid="shortcut-hint"
+      data-compact={compact}
+      className={cn(
+        'flex items-center gap-2',
+        compact ? 'text-xs' : 'text-sm',
+        className
+      )}
+    >
+      <div className="flex items-center gap-1">
+        {keys.map((key, index) => (
+          <React.Fragment key={index}>
+            <kbd
+              className={cn(
+                'inline-flex items-center justify-center rounded border border-border bg-muted font-mono',
+                compact
+                  ? 'min-w-5 h-5 px-1 text-[10px]'
+                  : 'min-w-6 h-6 px-1.5 text-xs'
+              )}
+            >
+              {formatKey(key)}
+            </kbd>
+            {index < keys.length - 1 && (
+              <span className="text-muted-foreground">+</span>
+            )}
+          </React.Fragment>
+        ))}
+      </div>
+      <span className="text-muted-foreground">{description}</span>
+    </div>
+  );
+}

--- a/src/ui/components/keyboard-navigation/types.ts
+++ b/src/ui/components/keyboard-navigation/types.ts
@@ -1,0 +1,36 @@
+/**
+ * Types for keyboard navigation
+ * Issue #410: Implement keyboard navigation throughout
+ */
+
+export interface NavigableItem {
+  id: string;
+  label: string;
+  disabled?: boolean;
+}
+
+export interface KeyboardShortcut {
+  key: string;
+  modifiers?: Array<'ctrl' | 'alt' | 'shift' | 'meta'>;
+  action: () => void;
+  description: string;
+  scope?: string;
+}
+
+export interface KeyboardNavigationContextValue {
+  focusedIndex: number;
+  setFocusedIndex: (index: number) => void;
+  registerShortcut: (shortcut: KeyboardShortcut) => () => void;
+  isEnabled: boolean;
+  setEnabled: (enabled: boolean) => void;
+}
+
+export type ModifierKey = 'Cmd' | 'Ctrl' | 'Alt' | 'Shift' | 'Meta';
+
+export const MODIFIER_SYMBOLS: Record<string, string> = {
+  Cmd: '⌘',
+  Meta: '⌘',
+  Ctrl: '⌃',
+  Alt: '⌥',
+  Shift: '⇧',
+};

--- a/tests/ui/keyboard-navigation.test.tsx
+++ b/tests/ui/keyboard-navigation.test.tsx
@@ -1,0 +1,329 @@
+/**
+ * @vitest-environment jsdom
+ * Tests for keyboard navigation
+ * Issue #410: Implement keyboard navigation throughout
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import * as React from 'react';
+
+// Components to be implemented
+import {
+  KeyboardNavigationProvider,
+  useKeyboardNavigation,
+} from '@/ui/components/keyboard-navigation/keyboard-navigation-context';
+import {
+  KeyboardNavigableList,
+  type KeyboardNavigableListProps,
+} from '@/ui/components/keyboard-navigation/keyboard-navigable-list';
+import {
+  FocusRing,
+  type FocusRingProps,
+} from '@/ui/components/keyboard-navigation/focus-ring';
+import {
+  ShortcutHint,
+  type ShortcutHintProps,
+} from '@/ui/components/keyboard-navigation/shortcut-hint';
+import type { NavigableItem } from '@/ui/components/keyboard-navigation/types';
+
+// Test component that uses the hook
+function TestKeyboardConsumer({
+  onAction,
+}: {
+  onAction?: (action: string) => void;
+}) {
+  const { focusedIndex, setFocusedIndex, registerShortcut } =
+    useKeyboardNavigation();
+
+  React.useEffect(() => {
+    const unregister = registerShortcut({
+      key: 'n',
+      action: () => onAction?.('new'),
+      description: 'Create new item',
+    });
+    return unregister;
+  }, [registerShortcut, onAction]);
+
+  return (
+    <div data-testid="consumer">
+      <span data-testid="focused-index">{focusedIndex}</span>
+      <button onClick={() => setFocusedIndex(5)}>Set Focus</button>
+    </div>
+  );
+}
+
+describe('KeyboardNavigationProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should provide context to children', () => {
+    render(
+      <KeyboardNavigationProvider>
+        <TestKeyboardConsumer />
+      </KeyboardNavigationProvider>
+    );
+
+    expect(screen.getByTestId('consumer')).toBeInTheDocument();
+  });
+
+  it('should track focused index', () => {
+    render(
+      <KeyboardNavigationProvider>
+        <TestKeyboardConsumer />
+      </KeyboardNavigationProvider>
+    );
+
+    expect(screen.getByTestId('focused-index')).toHaveTextContent('-1');
+
+    fireEvent.click(screen.getByText('Set Focus'));
+
+    expect(screen.getByTestId('focused-index')).toHaveTextContent('5');
+  });
+
+  it('should handle registered shortcuts', () => {
+    const onAction = vi.fn();
+    render(
+      <KeyboardNavigationProvider>
+        <TestKeyboardConsumer onAction={onAction} />
+      </KeyboardNavigationProvider>
+    );
+
+    fireEvent.keyDown(document, { key: 'n' });
+
+    expect(onAction).toHaveBeenCalledWith('new');
+  });
+
+  it('should not trigger shortcuts when input focused', () => {
+    const onAction = vi.fn();
+    render(
+      <KeyboardNavigationProvider>
+        <TestKeyboardConsumer onAction={onAction} />
+        <input data-testid="input" />
+      </KeyboardNavigationProvider>
+    );
+
+    const input = screen.getByTestId('input');
+    input.focus();
+    fireEvent.keyDown(input, { key: 'n' });
+
+    expect(onAction).not.toHaveBeenCalled();
+  });
+});
+
+describe('KeyboardNavigableList', () => {
+  const mockItems: NavigableItem[] = [
+    { id: 'item-1', label: 'Item 1' },
+    { id: 'item-2', label: 'Item 2' },
+    { id: 'item-3', label: 'Item 3' },
+  ];
+
+  const defaultProps: KeyboardNavigableListProps = {
+    items: mockItems,
+    onSelect: vi.fn(),
+    renderItem: (item, index, isFocused) => (
+      <div key={item.id} data-focused={isFocused}>
+        {item.label}
+      </div>
+    ),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render all items', () => {
+    render(
+      <KeyboardNavigationProvider>
+        <KeyboardNavigableList {...defaultProps} />
+      </KeyboardNavigationProvider>
+    );
+
+    expect(screen.getByText('Item 1')).toBeInTheDocument();
+    expect(screen.getByText('Item 2')).toBeInTheDocument();
+    expect(screen.getByText('Item 3')).toBeInTheDocument();
+  });
+
+  it('should navigate down with j key', () => {
+    render(
+      <KeyboardNavigationProvider>
+        <KeyboardNavigableList {...defaultProps} />
+      </KeyboardNavigationProvider>
+    );
+
+    fireEvent.keyDown(document, { key: 'j' });
+
+    const item1 = screen.getByText('Item 1').closest('[data-focused]');
+    expect(item1).toHaveAttribute('data-focused', 'true');
+  });
+
+  it('should navigate up with k key', () => {
+    render(
+      <KeyboardNavigationProvider initialFocusIndex={1}>
+        <KeyboardNavigableList {...defaultProps} />
+      </KeyboardNavigationProvider>
+    );
+
+    fireEvent.keyDown(document, { key: 'k' });
+
+    const item1 = screen.getByText('Item 1').closest('[data-focused]');
+    expect(item1).toHaveAttribute('data-focused', 'true');
+  });
+
+  it('should navigate with arrow keys', () => {
+    render(
+      <KeyboardNavigationProvider>
+        <KeyboardNavigableList {...defaultProps} />
+      </KeyboardNavigationProvider>
+    );
+
+    fireEvent.keyDown(document, { key: 'ArrowDown' });
+
+    const item1 = screen.getByText('Item 1').closest('[data-focused]');
+    expect(item1).toHaveAttribute('data-focused', 'true');
+  });
+
+  it('should select item on enter', () => {
+    const onSelect = vi.fn();
+    render(
+      <KeyboardNavigationProvider initialFocusIndex={0}>
+        <KeyboardNavigableList {...defaultProps} onSelect={onSelect} />
+      </KeyboardNavigationProvider>
+    );
+
+    fireEvent.keyDown(document, { key: 'Enter' });
+
+    expect(onSelect).toHaveBeenCalledWith(mockItems[0]);
+  });
+
+  it('should not go below last item', () => {
+    render(
+      <KeyboardNavigationProvider initialFocusIndex={2}>
+        <KeyboardNavigableList {...defaultProps} />
+      </KeyboardNavigationProvider>
+    );
+
+    fireEvent.keyDown(document, { key: 'j' });
+    fireEvent.keyDown(document, { key: 'j' });
+
+    const item3 = screen.getByText('Item 3').closest('[data-focused]');
+    expect(item3).toHaveAttribute('data-focused', 'true');
+  });
+
+  it('should not go above first item', () => {
+    render(
+      <KeyboardNavigationProvider initialFocusIndex={0}>
+        <KeyboardNavigableList {...defaultProps} />
+      </KeyboardNavigationProvider>
+    );
+
+    fireEvent.keyDown(document, { key: 'k' });
+
+    const item1 = screen.getByText('Item 1').closest('[data-focused]');
+    expect(item1).toHaveAttribute('data-focused', 'true');
+  });
+
+  it('should go to first item on home key', () => {
+    render(
+      <KeyboardNavigationProvider initialFocusIndex={2}>
+        <KeyboardNavigableList {...defaultProps} />
+      </KeyboardNavigationProvider>
+    );
+
+    fireEvent.keyDown(document, { key: 'Home' });
+
+    const item1 = screen.getByText('Item 1').closest('[data-focused]');
+    expect(item1).toHaveAttribute('data-focused', 'true');
+  });
+
+  it('should go to last item on end key', () => {
+    render(
+      <KeyboardNavigationProvider initialFocusIndex={0}>
+        <KeyboardNavigableList {...defaultProps} />
+      </KeyboardNavigationProvider>
+    );
+
+    fireEvent.keyDown(document, { key: 'End' });
+
+    const item3 = screen.getByText('Item 3').closest('[data-focused]');
+    expect(item3).toHaveAttribute('data-focused', 'true');
+  });
+});
+
+describe('FocusRing', () => {
+  const defaultProps: FocusRingProps = {
+    children: <button>Click me</button>,
+  };
+
+  it('should render children', () => {
+    render(<FocusRing {...defaultProps} />);
+    expect(screen.getByRole('button')).toBeInTheDocument();
+  });
+
+  it('should show focus ring when child is focused', () => {
+    render(<FocusRing {...defaultProps} />);
+
+    const button = screen.getByRole('button');
+    button.focus();
+
+    // Check that focus ring wrapper exists
+    const wrapper = button.closest('[data-focus-visible]');
+    expect(wrapper).toBeInTheDocument();
+  });
+
+  it('should not show focus ring on mouse click', () => {
+    render(<FocusRing {...defaultProps} />);
+
+    const button = screen.getByRole('button');
+    fireEvent.mouseDown(button);
+    fireEvent.click(button);
+
+    const wrapper = button.closest('[data-focus-visible]');
+    expect(wrapper).toHaveAttribute('data-focus-visible', 'false');
+  });
+
+  it('should apply custom className', () => {
+    render(<FocusRing {...defaultProps} className="custom-class" />);
+
+    const wrapper = screen.getByRole('button').closest('.custom-class');
+    expect(wrapper).toBeInTheDocument();
+  });
+});
+
+describe('ShortcutHint', () => {
+  const defaultProps: ShortcutHintProps = {
+    keys: ['Cmd', 'K'],
+    description: 'Open search',
+  };
+
+  it('should render shortcut keys', () => {
+    render(<ShortcutHint {...defaultProps} />);
+    expect(screen.getByText('⌘')).toBeInTheDocument();
+    expect(screen.getByText('K')).toBeInTheDocument();
+  });
+
+  it('should show description', () => {
+    render(<ShortcutHint {...defaultProps} />);
+    expect(screen.getByText('Open search')).toBeInTheDocument();
+  });
+
+  it('should render single key shortcuts', () => {
+    render(<ShortcutHint keys={['J']} description="Move down" />);
+    expect(screen.getByText('J')).toBeInTheDocument();
+    expect(screen.getByText('Move down')).toBeInTheDocument();
+  });
+
+  it('should format modifier keys correctly', () => {
+    render(<ShortcutHint keys={['Ctrl', 'Shift', 'P']} description="Command" />);
+    expect(screen.getByText('⌃')).toBeInTheDocument();
+    expect(screen.getByText('⇧')).toBeInTheDocument();
+    expect(screen.getByText('P')).toBeInTheDocument();
+  });
+
+  it('should handle compact mode', () => {
+    render(<ShortcutHint {...defaultProps} compact />);
+    const container = screen.getByTestId('shortcut-hint');
+    expect(container).toHaveAttribute('data-compact', 'true');
+  });
+});


### PR DESCRIPTION
## Summary
- Add KeyboardNavigationProvider context for managing shortcuts
- KeyboardNavigableList with j/k/arrow key navigation
- FocusRing for visual keyboard focus indication
- ShortcutHint for displaying keyboard shortcuts
- Shortcuts disabled when typing in input fields

## Test plan
- [x] Run `npm test -- --run tests/ui/keyboard-navigation.test.tsx` - all 22 tests pass
- [x] Verify no regressions in related tests

Closes #410

🤖 Generated with [Claude Code](https://claude.com/claude-code)