### PR TITLE
[#411] Add WCAG accessibility components

### DIFF
--- a/src/ui/components/accessibility/accessible-icon.tsx
+++ b/src/ui/components/accessibility/accessible-icon.tsx
@@ -1,0 +1,41 @@
+/**
+ * Accessible Icon component
+ * Issue #411: WCAG 2.1 AA accessibility compliance
+ */
+import * as React from 'react';
+
+export interface AccessibleIconProps {
+  children: React.ReactNode;
+  label?: string;
+  decorative?: boolean;
+}
+
+export function AccessibleIcon({
+  children,
+  label,
+  decorative = false,
+}: AccessibleIconProps) {
+  const child = React.Children.only(children);
+
+  // Clone the icon element to add aria-hidden
+  const icon = React.isValidElement(child)
+    ? React.cloneElement(child, {
+        'aria-hidden': 'true',
+        focusable: 'false',
+      } as React.Attributes)
+    : child;
+
+  if (decorative) {
+    return (
+      <span role="presentation" aria-hidden="true">
+        {icon}
+      </span>
+    );
+  }
+
+  return (
+    <span aria-label={label} role="img">
+      {icon}
+    </span>
+  );
+}

--- a/src/ui/components/accessibility/announce-context.tsx
+++ b/src/ui/components/accessibility/announce-context.tsx
@@ -1,0 +1,66 @@
+/**
+ * Announce Context for screen reader announcements
+ * Issue #411: WCAG 2.1 AA accessibility compliance
+ */
+import * as React from 'react';
+
+type Politeness = 'polite' | 'assertive';
+type AnnounceFunction = (message: string, politeness?: Politeness) => void;
+
+const AnnounceContext = React.createContext<AnnounceFunction | undefined>(
+  undefined
+);
+
+interface Announcement {
+  id: number;
+  message: string;
+  politeness: Politeness;
+}
+
+export interface AnnounceProviderProps {
+  children: React.ReactNode;
+}
+
+export function AnnounceProvider({ children }: AnnounceProviderProps) {
+  const [announcements, setAnnouncements] = React.useState<Announcement[]>([]);
+  const idRef = React.useRef(0);
+
+  const announce: AnnounceFunction = React.useCallback(
+    (message: string, politeness: Politeness = 'polite') => {
+      const id = idRef.current++;
+      setAnnouncements((prev) => [...prev, { id, message, politeness }]);
+
+      // Clear announcement after it's been read
+      setTimeout(() => {
+        setAnnouncements((prev) => prev.filter((a) => a.id !== id));
+      }, 1000);
+    },
+    []
+  );
+
+  return (
+    <AnnounceContext.Provider value={announce}>
+      {children}
+      {/* Screen reader only announcements */}
+      <div className="sr-only" aria-live="off">
+        {announcements.map((announcement) => (
+          <div
+            key={announcement.id}
+            aria-live={announcement.politeness}
+            aria-atomic="true"
+          >
+            {announcement.message}
+          </div>
+        ))}
+      </div>
+    </AnnounceContext.Provider>
+  );
+}
+
+export function useAnnounce(): AnnounceFunction {
+  const context = React.useContext(AnnounceContext);
+  if (!context) {
+    throw new Error('useAnnounce must be used within AnnounceProvider');
+  }
+  return context;
+}

--- a/src/ui/components/accessibility/error-message.tsx
+++ b/src/ui/components/accessibility/error-message.tsx
@@ -1,0 +1,25 @@
+/**
+ * Error Message component
+ * Issue #411: WCAG 2.1 AA accessibility compliance
+ */
+import * as React from 'react';
+import { cn } from '@/ui/lib/utils';
+
+export interface ErrorMessageProps {
+  id: string;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function ErrorMessage({ id, children, className }: ErrorMessageProps) {
+  return (
+    <div
+      id={id}
+      role="alert"
+      aria-live="assertive"
+      className={cn('text-sm text-destructive mt-1', className)}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/ui/components/accessibility/index.ts
+++ b/src/ui/components/accessibility/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Accessibility components
+ * Issue #411: WCAG 2.1 AA accessibility compliance
+ */
+export * from './skip-link';
+export * from './visually-hidden';
+export * from './live-region';
+export * from './accessible-icon';
+export * from './error-message';
+export * from './announce-context';

--- a/src/ui/components/accessibility/live-region.tsx
+++ b/src/ui/components/accessibility/live-region.tsx
@@ -1,0 +1,33 @@
+/**
+ * Live Region component
+ * Issue #411: WCAG 2.1 AA accessibility compliance
+ */
+import * as React from 'react';
+import { cn } from '@/ui/lib/utils';
+
+export interface LiveRegionProps {
+  children: React.ReactNode;
+  politeness?: 'polite' | 'assertive' | 'off';
+  atomic?: boolean;
+  role?: 'status' | 'alert' | 'log' | 'marquee' | 'timer';
+  className?: string;
+}
+
+export function LiveRegion({
+  children,
+  politeness = 'polite',
+  atomic = true,
+  role,
+  className,
+}: LiveRegionProps) {
+  return (
+    <div
+      aria-live={politeness}
+      aria-atomic={atomic}
+      role={role}
+      className={cn(className)}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/ui/components/accessibility/skip-link.tsx
+++ b/src/ui/components/accessibility/skip-link.tsx
@@ -1,0 +1,28 @@
+/**
+ * Skip Link component
+ * Issue #411: WCAG 2.1 AA accessibility compliance
+ */
+import * as React from 'react';
+import { cn } from '@/ui/lib/utils';
+
+export interface SkipLinkProps {
+  href: string;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function SkipLink({ href, children, className }: SkipLinkProps) {
+  return (
+    <a
+      href={href}
+      className={cn(
+        'sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50',
+        'focus:bg-background focus:text-foreground focus:px-4 focus:py-2',
+        'focus:rounded-md focus:ring-2 focus:ring-ring focus:outline-none',
+        className
+      )}
+    >
+      {children}
+    </a>
+  );
+}

--- a/src/ui/components/accessibility/visually-hidden.tsx
+++ b/src/ui/components/accessibility/visually-hidden.tsx
@@ -1,0 +1,17 @@
+/**
+ * Visually Hidden component
+ * Issue #411: WCAG 2.1 AA accessibility compliance
+ */
+import * as React from 'react';
+
+export interface VisuallyHiddenProps {
+  children: React.ReactNode;
+  as?: keyof JSX.IntrinsicElements;
+}
+
+export function VisuallyHidden({
+  children,
+  as: Component = 'span',
+}: VisuallyHiddenProps) {
+  return <Component className="sr-only">{children}</Component>;
+}

--- a/tests/ui/accessibility.test.tsx
+++ b/tests/ui/accessibility.test.tsx
@@ -1,0 +1,257 @@
+/**
+ * @vitest-environment jsdom
+ * Tests for accessibility components
+ * Issue #411: WCAG 2.1 AA accessibility compliance
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import * as React from 'react';
+
+// Components to be implemented
+import {
+  SkipLink,
+  type SkipLinkProps,
+} from '@/ui/components/accessibility/skip-link';
+import {
+  VisuallyHidden,
+  type VisuallyHiddenProps,
+} from '@/ui/components/accessibility/visually-hidden';
+import {
+  LiveRegion,
+  type LiveRegionProps,
+} from '@/ui/components/accessibility/live-region';
+import {
+  AccessibleIcon,
+  type AccessibleIconProps,
+} from '@/ui/components/accessibility/accessible-icon';
+import {
+  ErrorMessage,
+  type ErrorMessageProps,
+} from '@/ui/components/accessibility/error-message';
+import {
+  useAnnounce,
+  AnnounceProvider,
+} from '@/ui/components/accessibility/announce-context';
+
+describe('SkipLink', () => {
+  const defaultProps: SkipLinkProps = {
+    href: '#main-content',
+    children: 'Skip to main content',
+  };
+
+  it('should render skip link', () => {
+    render(<SkipLink {...defaultProps} />);
+    expect(screen.getByRole('link', { name: /skip to main/i })).toBeInTheDocument();
+  });
+
+  it('should be visually hidden by default', () => {
+    render(<SkipLink {...defaultProps} />);
+    const link = screen.getByRole('link', { name: /skip to main/i });
+    expect(link).toHaveClass('sr-only');
+  });
+
+  it('should become visible on focus', () => {
+    render(<SkipLink {...defaultProps} />);
+    const link = screen.getByRole('link', { name: /skip to main/i });
+    link.focus();
+    expect(link).toHaveClass('focus:not-sr-only');
+  });
+
+  it('should have correct href', () => {
+    render(<SkipLink {...defaultProps} />);
+    const link = screen.getByRole('link', { name: /skip to main/i });
+    expect(link).toHaveAttribute('href', '#main-content');
+  });
+
+  it('should support multiple skip links', () => {
+    render(
+      <>
+        <SkipLink href="#main">Skip to main</SkipLink>
+        <SkipLink href="#nav">Skip to navigation</SkipLink>
+      </>
+    );
+    expect(screen.getAllByRole('link')).toHaveLength(2);
+  });
+});
+
+describe('VisuallyHidden', () => {
+  const defaultProps: VisuallyHiddenProps = {
+    children: 'Hidden text',
+  };
+
+  it('should render children', () => {
+    render(<VisuallyHidden {...defaultProps} />);
+    expect(screen.getByText('Hidden text')).toBeInTheDocument();
+  });
+
+  it('should have sr-only class', () => {
+    render(<VisuallyHidden {...defaultProps} />);
+    const element = screen.getByText('Hidden text');
+    expect(element).toHaveClass('sr-only');
+  });
+
+  it('should accept custom element via as prop', () => {
+    render(<VisuallyHidden as="h1">Hidden heading</VisuallyHidden>);
+    expect(screen.getByRole('heading')).toBeInTheDocument();
+  });
+});
+
+describe('LiveRegion', () => {
+  const defaultProps: LiveRegionProps = {
+    children: 'Status message',
+  };
+
+  it('should render with aria-live', () => {
+    render(<LiveRegion {...defaultProps} />);
+    const region = screen.getByText('Status message');
+    expect(region).toHaveAttribute('aria-live', 'polite');
+  });
+
+  it('should support assertive politeness', () => {
+    render(<LiveRegion politeness="assertive">Urgent message</LiveRegion>);
+    const region = screen.getByText('Urgent message');
+    expect(region).toHaveAttribute('aria-live', 'assertive');
+  });
+
+  it('should have atomic true by default', () => {
+    render(<LiveRegion {...defaultProps} />);
+    const region = screen.getByText('Status message');
+    expect(region).toHaveAttribute('aria-atomic', 'true');
+  });
+
+  it('should support role status', () => {
+    render(<LiveRegion role="status">Status</LiveRegion>);
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it('should support role alert', () => {
+    render(<LiveRegion role="alert">Alert</LiveRegion>);
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+  });
+});
+
+describe('AccessibleIcon', () => {
+  const defaultProps: AccessibleIconProps = {
+    label: 'Close',
+    children: <svg data-testid="icon" />,
+  };
+
+  it('should render icon', () => {
+    render(<AccessibleIcon {...defaultProps} />);
+    expect(screen.getByTestId('icon')).toBeInTheDocument();
+  });
+
+  it('should have aria-label', () => {
+    render(<AccessibleIcon {...defaultProps} />);
+    const wrapper = screen.getByTestId('icon').parentElement;
+    expect(wrapper).toHaveAttribute('aria-label', 'Close');
+  });
+
+  it('should hide icon from screen readers by default', () => {
+    render(<AccessibleIcon {...defaultProps} />);
+    const icon = screen.getByTestId('icon');
+    expect(icon).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('should support decorative mode without label', () => {
+    render(
+      <AccessibleIcon decorative>
+        <svg data-testid="icon" />
+      </AccessibleIcon>
+    );
+    const wrapper = screen.getByTestId('icon').parentElement;
+    expect(wrapper).not.toHaveAttribute('aria-label');
+    expect(wrapper).toHaveAttribute('role', 'presentation');
+  });
+});
+
+describe('ErrorMessage', () => {
+  const defaultProps: ErrorMessageProps = {
+    id: 'error-1',
+    children: 'This field is required',
+  };
+
+  it('should render error message', () => {
+    render(<ErrorMessage {...defaultProps} />);
+    expect(screen.getByText('This field is required')).toBeInTheDocument();
+  });
+
+  it('should have role alert', () => {
+    render(<ErrorMessage {...defaultProps} />);
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+  });
+
+  it('should have correct id', () => {
+    render(<ErrorMessage {...defaultProps} />);
+    expect(screen.getByRole('alert')).toHaveAttribute('id', 'error-1');
+  });
+
+  it('should have error styling', () => {
+    render(<ErrorMessage {...defaultProps} />);
+    const error = screen.getByRole('alert');
+    expect(error).toHaveClass('text-destructive');
+  });
+});
+
+describe('AnnounceProvider and useAnnounce', () => {
+  function TestComponent() {
+    const announce = useAnnounce();
+    return (
+      <button onClick={() => announce('Item saved', 'polite')}>
+        Save
+      </button>
+    );
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should provide announce function', () => {
+    render(
+      <AnnounceProvider>
+        <TestComponent />
+      </AnnounceProvider>
+    );
+    expect(screen.getByRole('button')).toBeInTheDocument();
+  });
+
+  it('should create live region when announcing', async () => {
+    render(
+      <AnnounceProvider>
+        <TestComponent />
+      </AnnounceProvider>
+    );
+
+    screen.getByRole('button').click();
+
+    await waitFor(() => {
+      expect(screen.getByText('Item saved')).toBeInTheDocument();
+    });
+  });
+
+  it('should support assertive announcements', async () => {
+    function AssertiveTest() {
+      const announce = useAnnounce();
+      return (
+        <button onClick={() => announce('Error occurred', 'assertive')}>
+          Trigger
+        </button>
+      );
+    }
+
+    render(
+      <AnnounceProvider>
+        <AssertiveTest />
+      </AnnounceProvider>
+    );
+
+    screen.getByRole('button').click();
+
+    await waitFor(() => {
+      const region = screen.getByText('Error occurred');
+      expect(region).toHaveAttribute('aria-live', 'assertive');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- SkipLink for keyboard users to bypass navigation
- VisuallyHidden for screen reader only content
- LiveRegion for ARIA live announcements
- AccessibleIcon for proper icon labeling
- ErrorMessage for accessible form errors
- AnnounceProvider for programmatic announcements

## Test plan
- [x] Run `npm test -- --run tests/ui/accessibility.test.tsx` - all 24 tests pass
- [x] Verify no regressions in related tests

Closes #411

🤖 Generated with [Claude Code](https://claude.com/claude-code)