### PR TITLE
[#412] Add mobile responsive components

### DIFF
--- a/src/ui/components/mobile/index.ts
+++ b/src/ui/components/mobile/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Mobile components
+ * Issue #412: Mobile responsive improvements
+ */
+export * from './use-mobile';
+export * from './mobile-container';
+export * from './touch-target';
+export * from './swipe-actions';
+export * from './pull-to-refresh';

--- a/src/ui/components/mobile/mobile-container.tsx
+++ b/src/ui/components/mobile/mobile-container.tsx
@@ -1,0 +1,34 @@
+/**
+ * Mobile Container component
+ * Issue #412: Mobile responsive improvements
+ */
+import * as React from 'react';
+import { cn } from '@/ui/lib/utils';
+
+export interface MobileContainerProps {
+  children: React.ReactNode;
+  safeArea?: boolean;
+  fullHeight?: boolean;
+  className?: string;
+}
+
+export function MobileContainer({
+  children,
+  safeArea = false,
+  fullHeight = false,
+  className,
+}: MobileContainerProps) {
+  return (
+    <div
+      data-testid="mobile-container"
+      className={cn(
+        'px-4 py-2 w-full',
+        fullHeight && 'min-h-screen',
+        safeArea && 'pb-safe pt-safe',
+        className
+      )}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/ui/components/mobile/pull-to-refresh.tsx
+++ b/src/ui/components/mobile/pull-to-refresh.tsx
@@ -1,0 +1,116 @@
+/**
+ * Pull to Refresh component
+ * Issue #412: Mobile responsive improvements
+ */
+import * as React from 'react';
+import { Loader2 } from 'lucide-react';
+import { cn } from '@/ui/lib/utils';
+
+export interface PullToRefreshProps {
+  onRefresh: () => Promise<void>;
+  children: React.ReactNode;
+  threshold?: number;
+  className?: string;
+}
+
+export function PullToRefresh({
+  onRefresh,
+  children,
+  threshold = 100,
+  className,
+}: PullToRefreshProps) {
+  const [pullDistance, setPullDistance] = React.useState(0);
+  const [isRefreshing, setIsRefreshing] = React.useState(false);
+  const [startY, setStartY] = React.useState(0);
+  const [isPulling, setIsPulling] = React.useState(false);
+  const containerRef = React.useRef<HTMLDivElement>(null);
+
+  const handleTouchStart = (e: React.TouchEvent) => {
+    // Only enable pull-to-refresh when scrolled to top
+    if (containerRef.current && containerRef.current.scrollTop === 0) {
+      setStartY(e.touches[0].clientY);
+      setIsPulling(true);
+    }
+  };
+
+  const handleTouchMove = (e: React.TouchEvent) => {
+    if (!isPulling || isRefreshing) return;
+
+    const currentY = e.touches[0].clientY;
+    const diff = currentY - startY;
+
+    if (diff > 0) {
+      // Apply resistance
+      const resistance = 0.5;
+      setPullDistance(diff * resistance);
+    }
+  };
+
+  const handleTouchEnd = async () => {
+    if (!isPulling) return;
+    setIsPulling(false);
+
+    if (pullDistance >= threshold && !isRefreshing) {
+      setIsRefreshing(true);
+      try {
+        await onRefresh();
+      } finally {
+        setIsRefreshing(false);
+        setPullDistance(0);
+      }
+    } else {
+      setPullDistance(0);
+    }
+  };
+
+  const showIndicator = pullDistance > 0 || isRefreshing;
+
+  return (
+    <div
+      ref={containerRef}
+      data-testid="pull-to-refresh"
+      className={cn('relative overflow-auto', className)}
+      onTouchStart={handleTouchStart}
+      onTouchMove={handleTouchMove}
+      onTouchEnd={handleTouchEnd}
+    >
+      {/* Refresh indicator */}
+      <div
+        data-testid="refresh-indicator"
+        className={cn(
+          'absolute top-0 left-0 right-0 flex items-center justify-center transition-all',
+          showIndicator ? 'visible' : 'invisible'
+        )}
+        style={{
+          height: isRefreshing ? 48 : pullDistance,
+          visibility: showIndicator ? 'visible' : 'hidden',
+        }}
+      >
+        {isRefreshing ? (
+          <Loader2
+            data-testid="refresh-loading"
+            className="h-6 w-6 animate-spin text-primary"
+          />
+        ) : (
+          <div
+            className="h-6 w-6 rounded-full border-2 border-primary transition-transform"
+            style={{
+              transform: `rotate(${(pullDistance / threshold) * 360}deg)`,
+            }}
+          />
+        )}
+      </div>
+
+      {/* Content */}
+      <div
+        className="transition-transform"
+        style={{
+          transform: `translateY(${isRefreshing ? 48 : pullDistance}px)`,
+          transition: isPulling ? 'none' : 'transform 0.2s ease-out',
+        }}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/ui/components/mobile/swipe-actions.tsx
+++ b/src/ui/components/mobile/swipe-actions.tsx
@@ -1,0 +1,136 @@
+/**
+ * Swipe Actions component
+ * Issue #412: Mobile responsive improvements
+ */
+import * as React from 'react';
+import { cn } from '@/ui/lib/utils';
+
+export interface SwipeAction {
+  label: string;
+  onAction: () => void;
+  color?: 'default' | 'destructive';
+}
+
+export interface SwipeActionsProps {
+  children: React.ReactNode;
+  leftAction?: SwipeAction;
+  rightAction?: SwipeAction;
+  threshold?: number;
+  className?: string;
+}
+
+export function SwipeActions({
+  children,
+  leftAction,
+  rightAction,
+  threshold = 50,
+  className,
+}: SwipeActionsProps) {
+  const [swipeOffset, setSwipeOffset] = React.useState(0);
+  const [startX, setStartX] = React.useState(0);
+  const [isSwiping, setIsSwiping] = React.useState(false);
+
+  const handleTouchStart = (e: React.TouchEvent) => {
+    setStartX(e.touches[0].clientX);
+    setIsSwiping(true);
+  };
+
+  const handleTouchMove = (e: React.TouchEvent) => {
+    if (!isSwiping) return;
+
+    const currentX = e.touches[0].clientX;
+    const diff = currentX - startX;
+
+    // Limit swipe distance
+    const maxSwipe = 100;
+    const clampedDiff = Math.max(-maxSwipe, Math.min(maxSwipe, diff));
+
+    // Only allow swipe if corresponding action exists
+    if (diff > 0 && !leftAction) return;
+    if (diff < 0 && !rightAction) return;
+
+    setSwipeOffset(clampedDiff);
+  };
+
+  const handleTouchEnd = () => {
+    setIsSwiping(false);
+
+    // Snap to action position or reset
+    if (Math.abs(swipeOffset) > threshold) {
+      setSwipeOffset(swipeOffset > 0 ? 80 : -80);
+    } else {
+      setSwipeOffset(0);
+    }
+  };
+
+  const resetSwipe = () => {
+    setSwipeOffset(0);
+  };
+
+  const handleLeftAction = () => {
+    leftAction?.onAction();
+    resetSwipe();
+  };
+
+  const handleRightAction = () => {
+    rightAction?.onAction();
+    resetSwipe();
+  };
+
+  return (
+    <div
+      data-testid="swipe-actions"
+      className={cn('relative overflow-hidden', className)}
+      onTouchStart={handleTouchStart}
+      onTouchMove={handleTouchMove}
+      onTouchEnd={handleTouchEnd}
+    >
+      {/* Left action (revealed on swipe right) */}
+      {leftAction && (
+        <button
+          type="button"
+          onClick={handleLeftAction}
+          className={cn(
+            'absolute left-0 top-0 bottom-0 w-20 flex items-center justify-center',
+            leftAction.color === 'destructive'
+              ? 'bg-destructive text-destructive-foreground'
+              : 'bg-primary text-primary-foreground',
+            swipeOffset > threshold ? 'visible' : 'invisible'
+          )}
+          style={{ visibility: swipeOffset > 0 ? 'visible' : 'hidden' }}
+        >
+          {leftAction.label}
+        </button>
+      )}
+
+      {/* Right action (revealed on swipe left) */}
+      {rightAction && (
+        <button
+          type="button"
+          onClick={handleRightAction}
+          className={cn(
+            'absolute right-0 top-0 bottom-0 w-20 flex items-center justify-center',
+            rightAction.color === 'destructive'
+              ? 'bg-destructive text-destructive-foreground'
+              : 'bg-primary text-primary-foreground',
+            swipeOffset < -threshold ? 'visible' : 'invisible'
+          )}
+          style={{ visibility: swipeOffset < 0 ? 'visible' : 'hidden' }}
+        >
+          {rightAction.label}
+        </button>
+      )}
+
+      {/* Main content */}
+      <div
+        className="relative bg-background transition-transform"
+        style={{
+          transform: `translateX(${swipeOffset}px)`,
+          transition: isSwiping ? 'none' : 'transform 0.2s ease-out',
+        }}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/ui/components/mobile/touch-target.tsx
+++ b/src/ui/components/mobile/touch-target.tsx
@@ -1,0 +1,37 @@
+/**
+ * Touch Target component
+ * Issue #412: Mobile responsive improvements
+ */
+import * as React from 'react';
+import { cn } from '@/ui/lib/utils';
+
+export interface TouchTargetProps {
+  children: React.ReactNode;
+  size?: 'sm' | 'md' | 'lg';
+  className?: string;
+}
+
+const sizeClasses = {
+  sm: 'min-h-9 min-w-9', // 36px
+  md: 'min-h-11 min-w-11', // 44px - recommended minimum
+  lg: 'min-h-14 min-w-14', // 56px
+};
+
+export function TouchTarget({
+  children,
+  size = 'md',
+  className,
+}: TouchTargetProps) {
+  return (
+    <div
+      data-testid="touch-target"
+      className={cn(
+        'flex items-center justify-center',
+        sizeClasses[size],
+        className
+      )}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/ui/components/mobile/use-mobile.ts
+++ b/src/ui/components/mobile/use-mobile.ts
@@ -1,0 +1,50 @@
+/**
+ * Mobile detection hooks
+ * Issue #412: Mobile responsive improvements
+ */
+import * as React from 'react';
+
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = React.useState(false);
+
+  React.useEffect(() => {
+    const mediaQuery = window.matchMedia(query);
+    setMatches(mediaQuery.matches);
+
+    const handler = (event: MediaQueryListEvent) => {
+      setMatches(event.matches);
+    };
+
+    mediaQuery.addEventListener('change', handler);
+    return () => mediaQuery.removeEventListener('change', handler);
+  }, [query]);
+
+  return matches;
+}
+
+export function useMobile(): boolean {
+  return useMediaQuery('(max-width: 768px)');
+}
+
+export function useTablet(): boolean {
+  return useMediaQuery('(min-width: 769px) and (max-width: 1024px)');
+}
+
+export function useDesktop(): boolean {
+  return useMediaQuery('(min-width: 1025px)');
+}
+
+export function useTouchDevice(): boolean {
+  const [isTouch, setIsTouch] = React.useState(false);
+
+  React.useEffect(() => {
+    setIsTouch(
+      'ontouchstart' in window ||
+        navigator.maxTouchPoints > 0 ||
+        // @ts-expect-error - msMaxTouchPoints is IE specific
+        navigator.msMaxTouchPoints > 0
+    );
+  }, []);
+
+  return isTouch;
+}

--- a/tests/ui/mobile.test.tsx
+++ b/tests/ui/mobile.test.tsx
@@ -1,0 +1,272 @@
+/**
+ * @vitest-environment jsdom
+ * Tests for mobile responsive components
+ * Issue #412: Mobile responsive improvements
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import * as React from 'react';
+
+// Components to be implemented
+import {
+  MobileContainer,
+  type MobileContainerProps,
+} from '@/ui/components/mobile/mobile-container';
+import {
+  TouchTarget,
+  type TouchTargetProps,
+} from '@/ui/components/mobile/touch-target';
+import {
+  SwipeActions,
+  type SwipeActionsProps,
+} from '@/ui/components/mobile/swipe-actions';
+import {
+  PullToRefresh,
+  type PullToRefreshProps,
+} from '@/ui/components/mobile/pull-to-refresh';
+import {
+  useMediaQuery,
+  useMobile,
+} from '@/ui/components/mobile/use-mobile';
+
+// Test wrapper for hooks
+function TestMobileHook() {
+  const isMobile = useMobile();
+  return <div data-testid="is-mobile">{isMobile ? 'true' : 'false'}</div>;
+}
+
+function TestMediaQuery({ query }: { query: string }) {
+  const matches = useMediaQuery(query);
+  return <div data-testid="matches">{matches ? 'true' : 'false'}</div>;
+}
+
+describe('MobileContainer', () => {
+  const defaultProps: MobileContainerProps = {
+    children: <div>Content</div>,
+  };
+
+  it('should render children', () => {
+    render(<MobileContainer {...defaultProps} />);
+    expect(screen.getByText('Content')).toBeInTheDocument();
+  });
+
+  it('should apply mobile-friendly padding', () => {
+    render(<MobileContainer {...defaultProps} />);
+    const container = screen.getByTestId('mobile-container');
+    expect(container).toHaveClass('px-4');
+  });
+
+  it('should support safe area insets', () => {
+    render(<MobileContainer {...defaultProps} safeArea />);
+    const container = screen.getByTestId('mobile-container');
+    expect(container).toHaveClass('pb-safe');
+  });
+
+  it('should support full height mode', () => {
+    render(<MobileContainer {...defaultProps} fullHeight />);
+    const container = screen.getByTestId('mobile-container');
+    expect(container).toHaveClass('min-h-screen');
+  });
+});
+
+describe('TouchTarget', () => {
+  const defaultProps: TouchTargetProps = {
+    children: <button>Click me</button>,
+  };
+
+  it('should render children', () => {
+    render(<TouchTarget {...defaultProps} />);
+    expect(screen.getByRole('button')).toBeInTheDocument();
+  });
+
+  it('should have minimum 44px touch target', () => {
+    render(<TouchTarget {...defaultProps} />);
+    const wrapper = screen.getByTestId('touch-target');
+    expect(wrapper).toHaveClass('min-h-11'); // 44px in Tailwind
+    expect(wrapper).toHaveClass('min-w-11');
+  });
+
+  it('should center content', () => {
+    render(<TouchTarget {...defaultProps} />);
+    const wrapper = screen.getByTestId('touch-target');
+    expect(wrapper).toHaveClass('flex');
+    expect(wrapper).toHaveClass('items-center');
+    expect(wrapper).toHaveClass('justify-center');
+  });
+
+  it('should support custom size', () => {
+    render(<TouchTarget {...defaultProps} size="lg" />);
+    const wrapper = screen.getByTestId('touch-target');
+    expect(wrapper).toHaveClass('min-h-14'); // 56px
+  });
+});
+
+describe('SwipeActions', () => {
+  const defaultProps: SwipeActionsProps = {
+    children: <div>Swipeable content</div>,
+    leftAction: { label: 'Delete', onAction: vi.fn() },
+    rightAction: { label: 'Archive', onAction: vi.fn() },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render children', () => {
+    render(<SwipeActions {...defaultProps} />);
+    expect(screen.getByText('Swipeable content')).toBeInTheDocument();
+  });
+
+  it('should show left action on swipe right', () => {
+    render(<SwipeActions {...defaultProps} />);
+    const swipeable = screen.getByTestId('swipe-actions');
+
+    fireEvent.touchStart(swipeable, { touches: [{ clientX: 0, clientY: 0 }] });
+    fireEvent.touchMove(swipeable, { touches: [{ clientX: 100, clientY: 0 }] });
+    fireEvent.touchEnd(swipeable);
+
+    expect(screen.getByText('Delete')).toBeVisible();
+  });
+
+  it('should show right action on swipe left', () => {
+    render(<SwipeActions {...defaultProps} />);
+    const swipeable = screen.getByTestId('swipe-actions');
+
+    fireEvent.touchStart(swipeable, { touches: [{ clientX: 100, clientY: 0 }] });
+    fireEvent.touchMove(swipeable, { touches: [{ clientX: 0, clientY: 0 }] });
+    fireEvent.touchEnd(swipeable);
+
+    expect(screen.getByText('Archive')).toBeVisible();
+  });
+
+  it('should call action on tap after swipe', () => {
+    const onDelete = vi.fn();
+    render(
+      <SwipeActions
+        {...defaultProps}
+        leftAction={{ label: 'Delete', onAction: onDelete }}
+      />
+    );
+    const swipeable = screen.getByTestId('swipe-actions');
+
+    fireEvent.touchStart(swipeable, { touches: [{ clientX: 0, clientY: 0 }] });
+    fireEvent.touchMove(swipeable, { touches: [{ clientX: 100, clientY: 0 }] });
+    fireEvent.touchEnd(swipeable);
+
+    fireEvent.click(screen.getByText('Delete'));
+
+    expect(onDelete).toHaveBeenCalled();
+  });
+});
+
+describe('PullToRefresh', () => {
+  const defaultProps: PullToRefreshProps = {
+    onRefresh: vi.fn(),
+    children: <div>Scrollable content</div>,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render children', () => {
+    render(<PullToRefresh {...defaultProps} />);
+    expect(screen.getByText('Scrollable content')).toBeInTheDocument();
+  });
+
+  it('should show refresh indicator on pull down', () => {
+    render(<PullToRefresh {...defaultProps} />);
+    const container = screen.getByTestId('pull-to-refresh');
+
+    fireEvent.touchStart(container, { touches: [{ clientY: 0 }] });
+    fireEvent.touchMove(container, { touches: [{ clientY: 100 }] });
+
+    expect(screen.getByTestId('refresh-indicator')).toBeVisible();
+  });
+
+  it('should call onRefresh when pulled past threshold', async () => {
+    const onRefresh = vi.fn().mockResolvedValue(undefined);
+    render(<PullToRefresh {...defaultProps} onRefresh={onRefresh} threshold={50} />);
+    const container = screen.getByTestId('pull-to-refresh');
+
+    // Mock scrollTop to be 0 (at top)
+    Object.defineProperty(container, 'scrollTop', { value: 0, writable: true });
+
+    fireEvent.touchStart(container, { touches: [{ clientY: 0 }] });
+    fireEvent.touchMove(container, { touches: [{ clientY: 200 }] }); // More than threshold * 2 (resistance)
+
+    await act(async () => {
+      fireEvent.touchEnd(container);
+    });
+
+    expect(onRefresh).toHaveBeenCalled();
+  });
+
+  it('should show loading state during refresh', async () => {
+    const onRefresh = vi.fn().mockImplementation(
+      () => new Promise((resolve) => setTimeout(resolve, 100))
+    );
+    render(<PullToRefresh {...defaultProps} onRefresh={onRefresh} threshold={50} />);
+    const container = screen.getByTestId('pull-to-refresh');
+
+    // Mock scrollTop to be 0 (at top)
+    Object.defineProperty(container, 'scrollTop', { value: 0, writable: true });
+
+    fireEvent.touchStart(container, { touches: [{ clientY: 0 }] });
+    fireEvent.touchMove(container, { touches: [{ clientY: 200 }] });
+
+    await act(async () => {
+      fireEvent.touchEnd(container);
+      // Wait for state update
+      await new Promise(resolve => setTimeout(resolve, 0));
+    });
+
+    expect(screen.getByTestId('refresh-loading')).toBeInTheDocument();
+  });
+});
+
+describe('useMobile', () => {
+  it('should return false for desktop viewport', () => {
+    // Default JSDOM viewport is 1024px
+    render(<TestMobileHook />);
+    expect(screen.getByTestId('is-mobile')).toHaveTextContent('false');
+  });
+
+  it('should detect mobile based on max-width', () => {
+    // Mock matchMedia for mobile
+    const mockMatchMedia = vi.fn().mockImplementation((query) => ({
+      matches: query.includes('max-width: 768px'),
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+    window.matchMedia = mockMatchMedia;
+
+    render(<TestMobileHook />);
+    expect(screen.getByTestId('is-mobile')).toHaveTextContent('true');
+  });
+});
+
+describe('useMediaQuery', () => {
+  it('should return match status', () => {
+    const mockMatchMedia = vi.fn().mockImplementation((query) => ({
+      matches: query.includes('min-width: 1024px'),
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+    window.matchMedia = mockMatchMedia;
+
+    render(<TestMediaQuery query="(min-width: 1024px)" />);
+    expect(screen.getByTestId('matches')).toHaveTextContent('true');
+  });
+});


### PR DESCRIPTION
## Summary
- MobileContainer with safe area support
- TouchTarget ensuring 44px minimum touch targets
- SwipeActions for swipeable list items
- PullToRefresh for mobile refresh pattern
- useMobile/useMediaQuery hooks for responsive logic

## Test plan
- [x] Run `npm test -- --run tests/ui/mobile.test.tsx` - all 19 tests pass
- [x] Verify no regressions in related tests

Closes #412

🤖 Generated with [Claude Code](https://claude.com/claude-code)