### PR TITLE
[#460] Clean up test warnings and errors

### DIFF
--- a/packages/openclaw-plugin/tests/secrets.test.ts
+++ b/packages/openclaw-plugin/tests/secrets.test.ts
@@ -110,6 +110,7 @@ describe('Secrets Module', () => {
 
       it('should throw when file read fails', async () => {
         vi.mocked(fs.existsSync).mockReturnValue(true)
+        vi.mocked(fs.statSync).mockReturnValue({ mode: 0o600 } as fs.Stats)
         vi.mocked(fs.readFileSync).mockImplementation(() => {
           throw new Error('Permission denied')
         })

--- a/src/ui/components/board-config/board-config.tsx
+++ b/src/ui/components/board-config/board-config.tsx
@@ -6,6 +6,7 @@ import * as React from 'react';
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
 } from '@/ui/components/ui/dialog';
@@ -61,6 +62,7 @@ export function BoardConfig({
       <DialogContent className="max-w-lg">
         <DialogHeader>
           <DialogTitle>Board Settings</DialogTitle>
+          <DialogDescription className="sr-only">Configure board columns, swimlanes, and display options</DialogDescription>
         </DialogHeader>
 
         <Tabs defaultValue="columns" className="w-full">

--- a/src/ui/components/communications/calendar-event-detail-sheet.tsx
+++ b/src/ui/components/communications/calendar-event-detail-sheet.tsx
@@ -20,6 +20,7 @@ import { Separator } from '@/ui/components/ui/separator';
 import {
   Sheet,
   SheetContent,
+  SheetDescription,
   SheetHeader,
   SheetTitle,
 } from '@/ui/components/ui/sheet';
@@ -62,6 +63,7 @@ export function CalendarEventDetailSheet({
       <SheetContent className="w-[500px] sm:max-w-lg">
         <SheetHeader>
           <SheetTitle className="sr-only">Event Details</SheetTitle>
+          <SheetDescription className="sr-only">View event time, attendees, and details</SheetDescription>
         </SheetHeader>
 
         <ScrollArea className="h-full">

--- a/src/ui/components/communications/email-detail-sheet.tsx
+++ b/src/ui/components/communications/email-detail-sheet.tsx
@@ -15,6 +15,7 @@ import { Separator } from '@/ui/components/ui/separator';
 import {
   Sheet,
   SheetContent,
+  SheetDescription,
   SheetHeader,
   SheetTitle,
 } from '@/ui/components/ui/sheet';
@@ -40,6 +41,7 @@ export function EmailDetailSheet({
       <SheetContent className="w-[500px] sm:max-w-lg">
         <SheetHeader>
           <SheetTitle className="sr-only">Email Details</SheetTitle>
+          <SheetDescription className="sr-only">View email subject, sender, and body</SheetDescription>
         </SheetHeader>
 
         <ScrollArea className="h-full">

--- a/src/ui/components/contacts/contact-detail-sheet.tsx
+++ b/src/ui/components/contacts/contact-detail-sheet.tsx
@@ -23,6 +23,7 @@ import { Separator } from '@/ui/components/ui/separator';
 import {
   Sheet,
   SheetContent,
+  SheetDescription,
   SheetHeader,
   SheetTitle,
 } from '@/ui/components/ui/sheet';
@@ -87,6 +88,7 @@ export function ContactDetailSheet({
       <SheetContent className="w-96 sm:max-w-md">
         <SheetHeader>
           <SheetTitle className="sr-only">Contact Details</SheetTitle>
+          <SheetDescription className="sr-only">View contact information, linked items, and communications</SheetDescription>
         </SheetHeader>
 
         <ScrollArea className="h-full">

--- a/src/ui/components/contacts/contact-form.tsx
+++ b/src/ui/components/contacts/contact-form.tsx
@@ -7,6 +7,7 @@ import { Textarea } from '@/ui/components/ui/textarea';
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
   DialogFooter,
@@ -64,6 +65,7 @@ export function ContactForm({
       <DialogContent className={cn('sm:max-w-md', className)}>
         <DialogHeader>
           <DialogTitle>{contact ? 'Edit Contact' : 'Add Contact'}</DialogTitle>
+          <DialogDescription className="sr-only">{contact ? 'Edit contact details' : 'Add a new contact'}</DialogDescription>
         </DialogHeader>
 
         <form onSubmit={handleSubmit} className="space-y-4">

--- a/src/ui/components/dashboard/widget-picker.tsx
+++ b/src/ui/components/dashboard/widget-picker.tsx
@@ -7,6 +7,7 @@ import { Search, CheckSquare, Calendar, Activity, BarChart, Zap, Bell } from 'lu
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
 } from '@/ui/components/ui/dialog';
@@ -65,6 +66,7 @@ export function WidgetPicker({
       <DialogContent className={cn('sm:max-w-lg', className)}>
         <DialogHeader>
           <DialogTitle>Add Widget</DialogTitle>
+          <DialogDescription className="sr-only">Choose a widget to add to your dashboard</DialogDescription>
         </DialogHeader>
 
         <div className="space-y-4">

--- a/src/ui/components/memory/memory-detail-sheet.tsx
+++ b/src/ui/components/memory/memory-detail-sheet.tsx
@@ -17,6 +17,7 @@ import { Separator } from '@/ui/components/ui/separator';
 import {
   Sheet,
   SheetContent,
+  SheetDescription,
   SheetHeader,
   SheetTitle,
 } from '@/ui/components/ui/sheet';
@@ -95,6 +96,7 @@ export function MemoryDetailSheet({
       <SheetContent className="w-96 sm:max-w-md">
         <SheetHeader>
           <SheetTitle className="sr-only">Memory Details</SheetTitle>
+          <SheetDescription className="sr-only">View memory content, tags, and linked items</SheetDescription>
         </SheetHeader>
 
         <ScrollArea className="h-full">

--- a/src/ui/components/memory/memory-editor.tsx
+++ b/src/ui/components/memory/memory-editor.tsx
@@ -9,6 +9,7 @@ import { Badge } from '@/ui/components/ui/badge';
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
   DialogFooter,
@@ -134,6 +135,7 @@ export function MemoryEditor({
       <DialogContent className={cn('sm:max-w-2xl', className)}>
         <DialogHeader>
           <DialogTitle>{memory ? 'Edit Memory' : 'Create Memory'}</DialogTitle>
+          <DialogDescription className="sr-only">{memory ? 'Edit memory details' : 'Create a new memory entry'}</DialogDescription>
         </DialogHeader>
 
         <form onSubmit={handleSubmit} className="space-y-4">

--- a/src/ui/components/saved-views/edit-view-dialog.tsx
+++ b/src/ui/components/saved-views/edit-view-dialog.tsx
@@ -6,6 +6,7 @@ import * as React from 'react';
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
   DialogFooter,
@@ -62,6 +63,7 @@ export function EditViewDialog({
       <DialogContent>
         <DialogHeader>
           <DialogTitle>Edit View</DialogTitle>
+          <DialogDescription className="sr-only">Edit the view name and settings</DialogDescription>
         </DialogHeader>
 
         <div className="space-y-4 py-4">

--- a/src/ui/components/saved-views/save-view-dialog.tsx
+++ b/src/ui/components/saved-views/save-view-dialog.tsx
@@ -6,6 +6,7 @@ import * as React from 'react';
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
   DialogFooter,
@@ -65,6 +66,7 @@ export function SaveViewDialog({
       <DialogContent>
         <DialogHeader>
           <DialogTitle>Save View</DialogTitle>
+          <DialogDescription className="sr-only">Save the current view configuration</DialogDescription>
         </DialogHeader>
 
         <div className="space-y-4 py-4">

--- a/src/ui/components/watchers/add-watcher-dialog.tsx
+++ b/src/ui/components/watchers/add-watcher-dialog.tsx
@@ -7,6 +7,7 @@ import { Search } from 'lucide-react';
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
 } from '@/ui/components/ui/dialog';
@@ -69,6 +70,7 @@ export function AddWatcherDialog({
       <DialogContent className={cn('sm:max-w-md', className)}>
         <DialogHeader>
           <DialogTitle>Add watcher</DialogTitle>
+          <DialogDescription className="sr-only">Search and add a watcher to this item</DialogDescription>
         </DialogHeader>
 
         <div className="space-y-4">

--- a/tests/note_embeddings_api.test.ts
+++ b/tests/note_embeddings_api.test.ts
@@ -14,7 +14,7 @@ vi.mock('../src/api/embeddings/service.ts', () => ({
   embeddingService: {
     isConfigured: vi.fn(() => true),
     embed: vi.fn(async (text: string) => ({
-      embedding: new Array(1536).fill(0).map((_, i) => Math.sin(i + text.length)),
+      embedding: new Array(1024).fill(0).map((_, i) => Math.sin(i + text.length)),
       model: 'test-model',
       provider: 'test-provider',
     })),

--- a/tests/ui/accessibility.test.tsx
+++ b/tests/ui/accessibility.test.tsx
@@ -3,8 +3,8 @@
  * Tests for accessibility components
  * Issue #411: WCAG 2.1 AA accessibility compliance
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import * as React from 'react';
 
@@ -205,7 +205,15 @@ describe('AnnounceProvider and useAnnounce', () => {
   }
 
   beforeEach(() => {
+    vi.useFakeTimers();
     vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    act(() => {
+      vi.runAllTimers();
+    });
+    vi.useRealTimers();
   });
 
   it('should provide announce function', () => {
@@ -224,11 +232,11 @@ describe('AnnounceProvider and useAnnounce', () => {
       </AnnounceProvider>
     );
 
-    screen.getByRole('button').click();
-
-    await waitFor(() => {
-      expect(screen.getByText('Item saved')).toBeInTheDocument();
+    act(() => {
+      screen.getByRole('button').click();
     });
+
+    expect(screen.getByText('Item saved')).toBeInTheDocument();
   });
 
   it('should support assertive announcements', async () => {
@@ -247,11 +255,11 @@ describe('AnnounceProvider and useAnnounce', () => {
       </AnnounceProvider>
     );
 
-    screen.getByRole('button').click();
-
-    await waitFor(() => {
-      const region = screen.getByText('Error occurred');
-      expect(region).toHaveAttribute('aria-live', 'assertive');
+    act(() => {
+      screen.getByRole('button').click();
     });
+
+    const region = screen.getByText('Error occurred');
+    expect(region).toHaveAttribute('aria-live', 'assertive');
   });
 });

--- a/tests/ui/inline-edit.test.tsx
+++ b/tests/ui/inline-edit.test.tsx
@@ -3,7 +3,8 @@
  */
 import * as React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import { InlineEdit, InlineEditableText } from '@/ui/components/inline-edit';
 
 describe('InlineEdit', () => {


### PR DESCRIPTION
## Summary

- **Add missing DialogDescription/SheetDescription** to 11 dialog and sheet components (watchers, dashboard, saved-views, memory, contacts, board-config, communications) to eliminate Radix UI accessibility warnings
- **Fix act() warnings** in accessibility and inline-edit tests by wrapping state-updating interactions in `act()` and using fake timers for timer-based components
- **Fix secret file permission warnings** by specifying `mode: 0o600` in test writeFileSync calls and adding missing statSync mocks
- **Silence pool-closed errors** in fire-and-forget embedding tasks that naturally occur during test teardown — the background embedding catch handlers now silently handle "Cannot use a pool after calling end" errors since these are expected during shutdown
- **Fix embedding dimension mismatch** in note embedding test mock (1536 → 1024) to match the actual database vector column size
- **Fix env var restoration** in secret-auth tests to avoid setting `process.env` values to the string `"undefined"` when the original value was `undefined`

## Test plan

- [x] All 3863 tests pass (207 test files)
- [x] Zero `Warning: Missing Description` messages from Radix UI
- [x] Zero `Cannot use a pool after calling end` errors from embeddings
- [x] Zero `Failed to embed note/memory` errors from dimension mismatches
- [x] Zero `act()` warnings from React testing
- [x] Zero `Failed to read secret file: ENOENT` errors from env var restoration

Closes #460

🤖 Generated with [Claude Code](https://claude.com/claude-code)