### PR TITLE
[#487] Add OpenClaw gateway to devcontainer from source

### DIFF
--- a/.devcontainer/docker-compose.devcontainer.yml
+++ b/.devcontainer/docker-compose.devcontainer.yml
@@ -9,6 +9,7 @@ services:
     volumes:
       - ..:/workspaces/openclaw-projects:cached
       - /var/run/docker.sock:/var/run/docker.sock
+      - openclaw_gateway_source:/workspaces/openclaw-gateway
     command: sleep infinity
     depends_on:
       postgres:
@@ -56,3 +57,4 @@ services:
 volumes:
   openclaw_projects_postgres_data:
   openclaw_projects_minio_data:
+  openclaw_gateway_source:

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "tailwindcss": "^4.1.18",
     "typescript": "^5.9.3",
     "vite": "^7.3.1",
-    "vitest": "^4.0.18"
+    "vitest": "^4.0.18",
+    "yaml": "^2.8.2"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.980.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -171,6 +171,9 @@ importers:
       vitest:
         specifier: ^4.0.18
         version: 4.0.18(@types/node@25.2.0)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(yaml@2.8.2)
+      yaml:
+        specifier: ^2.8.2
+        version: 2.8.2
 
   packages/openclaw-plugin:
     dependencies:

--- a/scripts/openclaw-gateway.sh
+++ b/scripts/openclaw-gateway.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Start the OpenClaw gateway in development mode (no channels, WebSocket only).
+# Usage: ./scripts/openclaw-gateway.sh [--reset]
+#
+# The gateway will bind to ws://127.0.0.1:18789 by default.
+# Set OPENCLAW_GATEWAY_PORT to change the port.
+#
+# Prerequisites:
+#   - OpenClaw source at /workspaces/openclaw-gateway (installed by postCreate.sh)
+#   - Dependencies installed (pnpm install)
+set -euo pipefail
+
+GATEWAY_DIR="/workspaces/openclaw-gateway"
+GATEWAY_PORT="${OPENCLAW_GATEWAY_PORT:-18789}"
+
+if [[ ! -f "$GATEWAY_DIR/package.json" ]]; then
+  echo "ERROR: OpenClaw gateway not found at $GATEWAY_DIR"
+  echo "Run: bash .devcontainer/postCreate.sh"
+  exit 1
+fi
+
+if [[ ! -d "$GATEWAY_DIR/node_modules" ]]; then
+  echo "Installing OpenClaw gateway dependencies..."
+  (cd "$GATEWAY_DIR" && pnpm install)
+fi
+
+echo "Starting OpenClaw gateway on port $GATEWAY_PORT (channels disabled)..."
+
+reset_flag=""
+if [[ "${1:-}" == "--reset" ]]; then
+  reset_flag="--reset"
+fi
+
+cd "$GATEWAY_DIR"
+exec env \
+  OPENCLAW_SKIP_CHANNELS=1 \
+  CLAWDBOT_SKIP_CHANNELS=1 \
+  node scripts/run-node.mjs --dev gateway \
+    --port "$GATEWAY_PORT" \
+    $reset_flag

--- a/tests/devcontainer/openclaw-gateway.test.ts
+++ b/tests/devcontainer/openclaw-gateway.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Smoke tests for OpenClaw gateway devcontainer integration.
+ *
+ * These tests verify the devcontainer configuration correctly sets up
+ * the OpenClaw gateway from source. They validate file presence and
+ * configuration structure rather than running the gateway (which requires
+ * the full devcontainer runtime).
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { parse } from 'yaml';
+
+const DEVCONTAINER_DIR = resolve(import.meta.dirname, '../../.devcontainer');
+
+describe('OpenClaw Gateway Devcontainer Configuration', () => {
+  describe('docker-compose.devcontainer.yml', () => {
+    const composePath = resolve(DEVCONTAINER_DIR, 'docker-compose.devcontainer.yml');
+
+    it('should exist', () => {
+      expect(existsSync(composePath)).toBe(true);
+    });
+
+    it('should define openclaw_gateway_source volume', () => {
+      const content = readFileSync(composePath, 'utf-8');
+      const config = parse(content);
+      expect(config.volumes).toHaveProperty('openclaw_gateway_source');
+    });
+
+    it('should mount gateway source volume in workspace service', () => {
+      const content = readFileSync(composePath, 'utf-8');
+      const config = parse(content);
+      const workspaceVolumes: string[] = config.services.workspace.volumes;
+      const gatewayMount = workspaceVolumes.find((v: string) =>
+        v.includes('openclaw_gateway_source') && v.includes('/workspaces/openclaw-gateway'),
+      );
+      expect(gatewayMount).toBeDefined();
+    });
+  });
+
+  describe('postCreate.sh', () => {
+    const postCreatePath = resolve(DEVCONTAINER_DIR, 'postCreate.sh');
+
+    it('should exist', () => {
+      expect(existsSync(postCreatePath)).toBe(true);
+    });
+
+    it('should contain install_openclaw_gateway function', () => {
+      const content = readFileSync(postCreatePath, 'utf-8');
+      expect(content).toContain('install_openclaw_gateway');
+    });
+
+    it('should clone from github.com/openclaw/openclaw', () => {
+      const content = readFileSync(postCreatePath, 'utf-8');
+      expect(content).toContain('github.com/openclaw/openclaw');
+    });
+
+    it('should install dependencies with pnpm', () => {
+      const content = readFileSync(postCreatePath, 'utf-8');
+      expect(content).toContain('pnpm install');
+    });
+
+    it('should use /workspaces/openclaw-gateway as gateway directory', () => {
+      const content = readFileSync(postCreatePath, 'utf-8');
+      expect(content).toContain('/workspaces/openclaw-gateway');
+    });
+
+    it('should call install_openclaw_gateway function', () => {
+      const content = readFileSync(postCreatePath, 'utf-8');
+      // Check that it is called (not just defined)
+      const lines = content.split('\n');
+      const callLine = lines.find(
+        (line) =>
+          line.trim() === 'install_openclaw_gateway' &&
+          !line.trim().startsWith('#') &&
+          !line.includes('()'),
+      );
+      expect(callLine).toBeDefined();
+    });
+  });
+
+  describe('scripts/openclaw-gateway.sh', () => {
+    const scriptPath = resolve(import.meta.dirname, '../../scripts/openclaw-gateway.sh');
+
+    it('should exist', () => {
+      expect(existsSync(scriptPath)).toBe(true);
+    });
+
+    it('should skip channels for dev mode', () => {
+      const content = readFileSync(scriptPath, 'utf-8');
+      expect(content).toContain('OPENCLAW_SKIP_CHANNELS=1');
+    });
+
+    it('should support configurable port via OPENCLAW_GATEWAY_PORT', () => {
+      const content = readFileSync(scriptPath, 'utf-8');
+      expect(content).toContain('OPENCLAW_GATEWAY_PORT');
+    });
+
+    it('should use default port 18789', () => {
+      const content = readFileSync(scriptPath, 'utf-8');
+      expect(content).toContain('18789');
+    });
+
+    it('should support --reset flag', () => {
+      const content = readFileSync(scriptPath, 'utf-8');
+      expect(content).toContain('--reset');
+    });
+  });
+
+  describe('devcontainer.json', () => {
+    const devcontainerPath = resolve(DEVCONTAINER_DIR, 'devcontainer.json');
+
+    it('should exist', () => {
+      expect(existsSync(devcontainerPath)).toBe(true);
+    });
+
+    it('should reference docker-compose file', () => {
+      const content = readFileSync(devcontainerPath, 'utf-8');
+      const config = JSON.parse(content);
+      expect(config.dockerComposeFile).toBe('docker-compose.devcontainer.yml');
+    });
+
+    it('should use postCreate.sh as postCreateCommand', () => {
+      const content = readFileSync(devcontainerPath, 'utf-8');
+      const config = JSON.parse(content);
+      expect(config.postCreateCommand).toContain('postCreate.sh');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #487

- Adds OpenClaw gateway source clone to devcontainer setup via `install_openclaw_gateway()` in `postCreate.sh`
- Creates `openclaw_gateway_source` named volume in docker-compose for persistent clone across rebuilds
- Mounts gateway source at `/workspaces/openclaw-gateway` in the workspace container
- Adds `scripts/openclaw-gateway.sh` helper to start gateway in dev mode (channels disabled, WebSocket only)
- Adds `yaml` dev dependency for test YAML parsing

### Key Research Findings (for #488)

During research for this spike, the actual OpenClaw plugin API types were discovered at `src/plugins/types.ts`:

- **Hook registration**: Uses `api.on('before_agent_start', handler)` — NOT `registerHook('beforeAgentStart', ...)`
- **Hook event**: `PluginHookBeforeAgentStartEvent` = `{ prompt: string, messages?: unknown[] }`
- **Hook context**: `PluginHookAgentContext` = `{ agentId?, sessionKey?, workspaceDir?, messageProvider? }`
- **Hook return**: `PluginHookBeforeAgentStartResult` = `{ systemPrompt?: string, prependContext?: string }`
- **Our plugin currently returns `{ injectedContext }` which is not in the contract**

These findings are documented in issue #487 and will inform #488 implementation.

## Test Plan

- [x] `pnpm vitest run tests/devcontainer/openclaw-gateway.test.ts` — 17 tests pass
- [x] Verifies docker-compose volume configuration
- [x] Verifies postCreate.sh contains gateway setup function
- [x] Verifies gateway startup script exists with correct configuration

## Local Validation

```
pnpm vitest run tests/devcontainer/openclaw-gateway.test.ts
```

Pre-existing typecheck failures in twilio types are unrelated.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>