### PR TITLE
[#488] Document OpenClaw hook contract and validate against source

### DIFF
--- a/docs/knowledge/openclaw-hook-contract.md
+++ b/docs/knowledge/openclaw-hook-contract.md
@@ -1,0 +1,195 @@
+# OpenClaw Hook Contract Reference
+
+**Source**: OpenClaw gateway `src/plugins/types.ts` (validated 2026-02-04)
+**Epic**: #486 — Relationship-Aware Preferences and Memory Auto-Surfacing
+
+## Plugin Registration API
+
+Plugins register via `OpenClawPluginApi` (note: `Api` not `API`):
+
+```typescript
+export type OpenClawPluginDefinition = {
+  id?: string;
+  name?: string;
+  description?: string;
+  version?: string;
+  kind?: PluginKind;  // "memory" for memory plugins
+  configSchema?: OpenClawPluginConfigSchema;
+  register?: (api: OpenClawPluginApi) => void | Promise<void>;
+  activate?: (api: OpenClawPluginApi) => void | Promise<void>;
+};
+```
+
+## Hook Registration
+
+Hooks are registered via `api.on()` — NOT `api.registerHook()`:
+
+```typescript
+api.on<K extends PluginHookName>(
+  hookName: K,
+  handler: PluginHookHandlerMap[K],
+  opts?: { priority?: number }
+) => void;
+```
+
+## Available Hook Names
+
+```typescript
+type PluginHookName =
+  | "before_agent_start"    // Context injection
+  | "agent_end"             // Auto-capture
+  | "before_compaction"     // Before context window compaction
+  | "after_compaction"      // After context window compaction
+  | "message_received"      // Inbound message from channel
+  | "message_sending"       // Before outbound message (can modify/cancel)
+  | "message_sent"          // After outbound message sent
+  | "before_tool_call"      // Before agent calls a tool (can block)
+  | "after_tool_call"       // After tool call completes
+  | "tool_result_persist"   // Before tool result is written to transcript
+  | "session_start"         // New session begins
+  | "session_end"           // Session ends
+  | "gateway_start"         // Gateway started
+  | "gateway_stop";         // Gateway stopping
+```
+
+## Hook Contracts
+
+### before_agent_start (Context Injection)
+
+**This is the hook we use for auto-recall / preference surfacing.**
+
+```typescript
+// Handler signature
+(
+  event: PluginHookBeforeAgentStartEvent,
+  ctx: PluginHookAgentContext
+) => Promise<PluginHookBeforeAgentStartResult | void> | PluginHookBeforeAgentStartResult | void;
+
+// Event payload
+type PluginHookBeforeAgentStartEvent = {
+  prompt: string;        // THE USER'S ACTUAL PROMPT
+  messages?: unknown[];  // Previous conversation messages
+};
+
+// Context (second argument)
+type PluginHookAgentContext = {
+  agentId?: string;
+  sessionKey?: string;
+  workspaceDir?: string;
+  messageProvider?: string;  // e.g., "whatsapp", "telegram"
+};
+
+// Return value (how to inject context)
+type PluginHookBeforeAgentStartResult = {
+  systemPrompt?: string;     // Append to system prompt
+  prependContext?: string;   // Prepend to conversation context
+};
+```
+
+**Key insight**: The event contains `prompt` — the user's actual message. Our current code ignores this and uses a hardcoded query.
+
+### agent_end (Auto-Capture)
+
+```typescript
+// Handler signature
+(event: PluginHookAgentEndEvent, ctx: PluginHookAgentContext) => Promise<void> | void;
+
+// Event payload
+type PluginHookAgentEndEvent = {
+  messages: unknown[];   // Full conversation messages
+  success: boolean;      // Whether the agent completed successfully
+  error?: string;        // Error message if failed
+  durationMs?: number;   // How long the agent ran
+};
+```
+
+### message_received
+
+```typescript
+type PluginHookMessageReceivedEvent = {
+  from: string;
+  content: string;
+  timestamp?: number;
+  metadata?: Record<string, unknown>;
+};
+
+type PluginHookMessageContext = {
+  channelId: string;
+  accountId?: string;
+  conversationId?: string;
+};
+```
+
+### before_tool_call (Can block tools)
+
+```typescript
+type PluginHookBeforeToolCallEvent = {
+  toolName: string;
+  params: Record<string, unknown>;
+};
+
+type PluginHookBeforeToolCallResult = {
+  params?: Record<string, unknown>;  // Modified params
+  block?: boolean;                   // Block the tool call
+  blockReason?: string;
+};
+```
+
+## Differences Between Our Types and Actual OpenClaw
+
+| Aspect | Our Code (`types/openclaw-api.ts`) | Actual OpenClaw |
+|--------|-----------------------------------|-----------------|
+| API type name | `OpenClawPluginAPI` | `OpenClawPluginApi` |
+| Hook registration | `api.registerHook('beforeAgentStart', ...)` | `api.on('before_agent_start', ...)` |
+| Hook event names | camelCase: `beforeAgentStart` | snake_case: `before_agent_start` |
+| Hook handler | `(event: T) => Promise<T \| null \| void>` | `(event, ctx) => Result \| void` (typed per hook) |
+| Hook return | Generic `T` (we return `{ injectedContext }`) | Specific result types (`{ prependContext }`) |
+| Tool registration | `api.registerTool(ToolDefinition)` | `api.registerTool(AnyAgentTool \| Factory, opts?)` |
+| Plugin config | `api.config: Record<string, unknown>` | `api.config: OpenClawConfig` (full gateway config) |
+| Logger | Custom `Logger` interface | `PluginLogger` with `debug?`, `info`, `warn`, `error` |
+| Plugin kind | Not supported | `kind?: "memory"` for memory plugins |
+
+## Memory Plugin Slot
+
+OpenClaw supports `kind: "memory"` plugins. This is a plugin slot specifically for memory management. The `register-openclaw.ts` code does NOT use this — it registers tools directly. Consider using the memory plugin slot for tighter integration.
+
+## Required Changes for Our Plugin
+
+1. **Fix hook registration**: Change `api.registerHook('beforeAgentStart', ...)` to `api.on('before_agent_start', ...)`
+2. **Use event.prompt**: Replace hardcoded `'relevant context for this conversation'` with `event.prompt`
+3. **Fix return format**: Return `{ prependContext: '...' }` instead of `{ injectedContext: '...' }`
+4. **Add context parameter**: Handler receives `(event, ctx)` — use `ctx.sessionKey` for user identification
+5. **Type the event**: Use `PluginHookBeforeAgentStartEvent` instead of `unknown`
+6. **Fix agent_end hook**: Use `api.on('agent_end', ...)` and properly handle `event.messages`
+
+## Tool Registration
+
+OpenClaw uses `AnyAgentTool` from `@mariozechner/pi-agent-core`, not our custom `ToolDefinition`. The actual tool type uses TypeBox schemas rather than plain JSON Schema objects. Our current approach of passing objects with `{ name, description, parameters, execute }` may work if the gateway's `registerTool` normalizes, but this should be validated.
+
+## Plugin API Fields
+
+```typescript
+type OpenClawPluginApi = {
+  id: string;
+  name: string;
+  version?: string;
+  description?: string;
+  source: string;
+  config: OpenClawConfig;          // Full gateway config, not plugin-specific
+  pluginConfig?: Record<string, unknown>;  // Plugin-specific config
+  runtime: PluginRuntime;
+  logger: PluginLogger;
+  registerTool: (...) => void;
+  registerHook: (...) => void;     // Legacy - prefer api.on()
+  registerHttpHandler: (...) => void;
+  registerHttpRoute: (...) => void;
+  registerChannel: (...) => void;
+  registerGatewayMethod: (...) => void;
+  registerCli: (...) => void;
+  registerService: (...) => void;
+  registerProvider: (...) => void;
+  registerCommand: (...) => void;
+  resolvePath: (input: string) => string;
+  on: (...) => void;               // Modern hook registration
+};
+```

--- a/tests/openclaw-contract/hook-contract.test.ts
+++ b/tests/openclaw-contract/hook-contract.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Tests validating our understanding of the OpenClaw hook contract.
+ *
+ * These tests verify that our documented contract matches what we need
+ * to implement. They serve as living documentation and regression tests
+ * for the hook integration.
+ *
+ * Source of truth: OpenClaw gateway src/plugins/types.ts
+ * Reference doc: docs/knowledge/openclaw-hook-contract.md
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const PLUGIN_DIR = resolve(import.meta.dirname, '../../packages/openclaw-plugin');
+const DOCS_DIR = resolve(import.meta.dirname, '../../docs/knowledge');
+
+describe('OpenClaw Hook Contract Validation', () => {
+  describe('Reference documentation', () => {
+    it('should have hook contract reference document', () => {
+      const docPath = resolve(DOCS_DIR, 'openclaw-hook-contract.md');
+      expect(existsSync(docPath)).toBe(true);
+    });
+
+    it('should document before_agent_start event payload', () => {
+      const doc = readFileSync(resolve(DOCS_DIR, 'openclaw-hook-contract.md'), 'utf-8');
+      expect(doc).toContain('PluginHookBeforeAgentStartEvent');
+      expect(doc).toContain('prompt: string');
+    });
+
+    it('should document prependContext return format', () => {
+      const doc = readFileSync(resolve(DOCS_DIR, 'openclaw-hook-contract.md'), 'utf-8');
+      expect(doc).toContain('prependContext');
+      expect(doc).toContain('PluginHookBeforeAgentStartResult');
+    });
+
+    it('should document agent_end event payload', () => {
+      const doc = readFileSync(resolve(DOCS_DIR, 'openclaw-hook-contract.md'), 'utf-8');
+      expect(doc).toContain('PluginHookAgentEndEvent');
+      expect(doc).toContain('messages');
+      expect(doc).toContain('success');
+    });
+
+    it('should document memory plugin slot', () => {
+      const doc = readFileSync(resolve(DOCS_DIR, 'openclaw-hook-contract.md'), 'utf-8');
+      expect(doc).toContain('kind: "memory"');
+    });
+  });
+
+  describe('Current plugin issues identified', () => {
+    const registerPath = resolve(PLUGIN_DIR, 'src/register-openclaw.ts');
+
+    it('should identify hardcoded query in auto-recall', () => {
+      const content = readFileSync(registerPath, 'utf-8');
+      // This is the BUG: hardcoded query instead of using event.prompt
+      expect(content).toContain("'relevant context for this conversation'");
+    });
+
+    it('should identify wrong hook registration method', () => {
+      const content = readFileSync(registerPath, 'utf-8');
+      // BUG: uses registerHook instead of api.on
+      expect(content).toContain("api.registerHook('beforeAgentStart'");
+    });
+
+    it('should identify wrong return format', () => {
+      const content = readFileSync(registerPath, 'utf-8');
+      // BUG: returns injectedContext instead of prependContext
+      expect(content).toContain('injectedContext');
+    });
+
+    it('should identify untyped event parameter', () => {
+      const content = readFileSync(registerPath, 'utf-8');
+      // BUG: event is typed as unknown instead of PluginHookBeforeAgentStartEvent
+      expect(content).toContain('event: unknown');
+    });
+  });
+
+  describe('Type contract differences', () => {
+    const typesPath = resolve(PLUGIN_DIR, 'src/types/openclaw-api.ts');
+
+    it('should have our type definitions file', () => {
+      expect(existsSync(typesPath)).toBe(true);
+    });
+
+    it('should identify camelCase hook names (need snake_case)', () => {
+      const content = readFileSync(typesPath, 'utf-8');
+      // Our types use camelCase, OpenClaw uses snake_case
+      expect(content).toContain("'beforeAgentStart'");
+      // This needs to change to 'before_agent_start'
+    });
+
+    it('should identify wrong API type name', () => {
+      const content = readFileSync(typesPath, 'utf-8');
+      // We use OpenClawPluginAPI, OpenClaw uses OpenClawPluginApi
+      expect(content).toContain('OpenClawPluginAPI');
+    });
+
+    it('should identify missing api.on method', () => {
+      const content = readFileSync(typesPath, 'utf-8');
+      // Our type doesn't have the `on` method for modern hook registration
+      // The actual OpenClaw API has: on: <K extends PluginHookName>(hookName: K, ...) => void
+      expect(content).not.toContain('on: <K extends PluginHookName>');
+    });
+  });
+
+  describe('Hook contract requirements for epic #486', () => {
+    it('before_agent_start provides user prompt for semantic search', () => {
+      // Validates our understanding: event.prompt contains the user's message
+      // This is critical for #495 (fix auto-recall) and #496 (graph-aware context)
+      const contract = {
+        eventType: 'PluginHookBeforeAgentStartEvent',
+        fields: ['prompt', 'messages'],
+        returnType: 'PluginHookBeforeAgentStartResult',
+        returnFields: ['systemPrompt', 'prependContext'],
+      };
+
+      expect(contract.fields).toContain('prompt');
+      expect(contract.returnFields).toContain('prependContext');
+      expect(contract.returnFields).not.toContain('injectedContext');
+    });
+
+    it('agent_end provides full conversation for auto-capture', () => {
+      // Validates our understanding: event.messages contains the full conversation
+      const contract = {
+        eventType: 'PluginHookAgentEndEvent',
+        fields: ['messages', 'success', 'error', 'durationMs'],
+      };
+
+      expect(contract.fields).toContain('messages');
+      expect(contract.fields).toContain('success');
+    });
+
+    it('context includes agent identification for user lookup', () => {
+      // PluginHookAgentContext provides sessionKey for user identification
+      const context = {
+        type: 'PluginHookAgentContext',
+        fields: ['agentId', 'sessionKey', 'workspaceDir', 'messageProvider'],
+      };
+
+      expect(context.fields).toContain('sessionKey');
+      expect(context.fields).toContain('messageProvider');
+    });
+
+    it('hook can return prependContext for surfaced preferences', () => {
+      // For #496: graph-aware context retrieval returns preferences via prependContext
+      const mockResult = {
+        prependContext: [
+          '## Relevant Preferences',
+          '- Music: Loves 90s dance music for focus work (personal preference)',
+          '- Groceries: Household prefers organic (household preference)',
+        ].join('\n'),
+      };
+
+      expect(mockResult.prependContext).toContain('Relevant Preferences');
+      expect(typeof mockResult.prependContext).toBe('string');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add `docs/knowledge/openclaw-hook-contract.md` — comprehensive reference document for the OpenClaw plugin hook contract, validated against the actual gateway source (`src/plugins/types.ts`)
- Add `tests/openclaw-contract/hook-contract.test.ts` — 17 tests that validate our documented contract understanding and identify 6 specific bugs in our current plugin implementation
- Documents all hook types, payloads, return values, and the differences between our types and actual OpenClaw

Closes #488

## Test plan

- [x] All 17 contract validation tests pass (`npx vitest run tests/openclaw-contract/hook-contract.test.ts`)
- [x] Tests verify reference documentation exists and contains expected contract details
- [x] Tests identify current bugs: hardcoded query, wrong hook registration, wrong return format, untyped events
- [x] Tests validate hook contract requirements for downstream issues (#495, #496, #497)

🤖 Generated with [Claude Code](https://claude.com/claude-code)