### PR TITLE
[#489] Add contact_kind enum to contacts table

### DIFF
--- a/migrations/044_contact_kind.down.sql
+++ b/migrations/044_contact_kind.down.sql
@@ -1,0 +1,31 @@
+-- Issue #489: Rollback contact_kind column and enum
+
+-- Restore the original search_vector trigger (from migration 027)
+CREATE OR REPLACE FUNCTION contact_search_update() RETURNS trigger AS $$
+BEGIN
+  NEW.search_vector := to_tsvector('english',
+    coalesce(NEW.display_name, '') || ' ' || coalesce(NEW.notes, '')
+  );
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Recreate trigger without contact_kind column reference
+DROP TRIGGER IF EXISTS contact_search_trigger ON contact;
+CREATE TRIGGER contact_search_trigger
+BEFORE INSERT OR UPDATE OF display_name, notes ON contact
+FOR EACH ROW EXECUTE FUNCTION contact_search_update();
+
+-- Drop the index
+DROP INDEX IF EXISTS idx_contact_kind;
+
+-- Drop the column
+ALTER TABLE contact DROP COLUMN IF EXISTS contact_kind;
+
+-- Drop the enum type
+DROP TYPE IF EXISTS contact_kind;
+
+-- Backfill search_vector to remove stale contact_kind data
+UPDATE contact SET search_vector = to_tsvector('english',
+  coalesce(display_name, '') || ' ' || coalesce(notes, '')
+);

--- a/migrations/044_contact_kind.up.sql
+++ b/migrations/044_contact_kind.up.sql
@@ -1,0 +1,42 @@
+-- Issue #489: Add contact_kind to contacts table
+-- Part of Epic #486 — Relationship-Aware Preferences and Memory Auto-Surfacing
+
+-- Create the contact_kind enum type
+DO $$ BEGIN
+  CREATE TYPE contact_kind AS ENUM ('person', 'organisation', 'group', 'agent');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+-- Add contact_kind column with default 'person' (backward compatible)
+ALTER TABLE contact ADD COLUMN IF NOT EXISTS contact_kind contact_kind NOT NULL DEFAULT 'person';
+
+-- Create index for filtering by contact_kind
+CREATE INDEX IF NOT EXISTS idx_contact_kind ON contact (contact_kind);
+
+-- Update the search_vector trigger to include contact_kind in full-text search.
+-- This replaces the trigger function from migration 027.
+CREATE OR REPLACE FUNCTION contact_search_update() RETURNS trigger AS $$
+BEGIN
+  NEW.search_vector := to_tsvector('english',
+    coalesce(NEW.display_name, '') || ' ' ||
+    coalesce(NEW.notes, '') || ' ' ||
+    coalesce(NEW.contact_kind::text, '')
+  );
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Recreate the trigger to fire on contact_kind changes too
+DROP TRIGGER IF EXISTS contact_search_trigger ON contact;
+CREATE TRIGGER contact_search_trigger
+BEFORE INSERT OR UPDATE OF display_name, notes, contact_kind ON contact
+FOR EACH ROW EXECUTE FUNCTION contact_search_update();
+
+-- Backfill search_vector for existing contacts to include contact_kind
+UPDATE contact SET search_vector = to_tsvector('english',
+  coalesce(display_name, '') || ' ' || coalesce(notes, '') || ' ' || coalesce(contact_kind::text, '')
+);
+
+-- Comments
+COMMENT ON COLUMN contact.contact_kind IS 'Entity type: person, organisation, group, or agent';

--- a/skills/openclaw-projects/SKILL.md
+++ b/skills/openclaw-projects/SKILL.md
@@ -306,12 +306,23 @@ POST /api/contacts
 
 ```json
 {
-  "name": "Jane Doe",
-  "email": "jane@example.com",
-  "phone": "+1234567890",
-  "notes": "Met at conference"
+  "displayName": "Jane Doe",
+  "notes": "Met at conference",
+  "contactKind": "person"
 }
 ```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `displayName` | string | Yes | Contact display name |
+| `notes` | string | No | Free-text notes |
+| `contactKind` | string | No | `person` (default), `organisation`, `group`, or `agent` |
+
+**Contact Kinds:**
+- `person` — Individual human contact (default)
+- `organisation` — Company, business, or institution
+- `group` — Household, family, team, or collective (e.g., "The Kelly Household")
+- `agent` — AI agent or automated system
 
 #### List Contacts
 
@@ -321,6 +332,9 @@ GET /api/contacts
 
 Query params:
 - `search` - Search by name/email/phone
+- `contact_kind` - Filter by kind: `person`, `organisation`, `group`, `agent` (comma-separated for multiple)
+- `limit` - Results per page (default: 50, max: 100)
+- `offset` - Pagination offset
 
 #### Get Contact
 
@@ -328,13 +342,15 @@ Query params:
 GET /api/contacts/:id
 ```
 
-Returns contact with all endpoints.
+Returns contact with all endpoints and `contact_kind`.
 
 #### Update Contact
 
 ```
 PATCH /api/contacts/:id
 ```
+
+Supports updating `contactKind` along with other fields.
 
 #### Delete Contact
 

--- a/tests/contact_kind.test.ts
+++ b/tests/contact_kind.test.ts
@@ -1,0 +1,317 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { Pool } from 'pg';
+import { runMigrate } from './helpers/migrate.js';
+import { createTestPool, truncateAllTables } from './helpers/db.js';
+import { buildServer } from '../src/api/server.js';
+
+/**
+ * Tests for contact_kind column on contacts table (issue #489).
+ *
+ * Covers:
+ * - Migration: enum type, column, index, search_vector trigger
+ * - API: create, read, list, update, filter by contact_kind
+ * - Default value: existing contacts default to 'person'
+ * - Search vector: contact_kind is included in full-text search
+ */
+describe('Contact Kind (Issue #489)', () => {
+  const app = buildServer();
+  let pool: Pool;
+
+  beforeAll(async () => {
+    await runMigrate('up');
+    pool = createTestPool();
+    await app.ready();
+  });
+
+  beforeEach(async () => {
+    await truncateAllTables(pool);
+  });
+
+  afterAll(async () => {
+    await app.close();
+    await pool.end();
+  });
+
+  describe('Database schema', () => {
+    it('has contact_kind enum type with correct values', async () => {
+      const result = await pool.query(
+        `SELECT enumlabel FROM pg_enum
+         JOIN pg_type ON pg_enum.enumtypid = pg_type.oid
+         WHERE pg_type.typname = 'contact_kind'
+         ORDER BY enumsortorder`
+      );
+
+      expect(result.rows.map((r) => r.enumlabel)).toEqual([
+        'person',
+        'organisation',
+        'group',
+        'agent',
+      ]);
+    });
+
+    it('defaults contact_kind to person', async () => {
+      const result = await pool.query(
+        `INSERT INTO contact (display_name) VALUES ('Default Kind')
+         RETURNING contact_kind::text`
+      );
+
+      expect(result.rows[0].contact_kind).toBe('person');
+    });
+
+    it('allows creating contacts of each kind', async () => {
+      const kinds = ['person', 'organisation', 'group', 'agent'] as const;
+
+      for (const kind of kinds) {
+        const result = await pool.query(
+          `INSERT INTO contact (display_name, contact_kind) VALUES ($1, $2)
+           RETURNING contact_kind::text`,
+          [`Test ${kind}`, kind]
+        );
+
+        expect(result.rows[0].contact_kind).toBe(kind);
+      }
+    });
+
+    it('rejects invalid contact_kind values', async () => {
+      await expect(
+        pool.query(
+          `INSERT INTO contact (display_name, contact_kind) VALUES ('Bad', 'robot')`
+        )
+      ).rejects.toThrow(/invalid input value for enum contact_kind/);
+    });
+
+    it('has an index on contact_kind', async () => {
+      const result = await pool.query(
+        `SELECT indexname FROM pg_indexes
+         WHERE tablename = 'contact' AND indexname = 'idx_contact_kind'`
+      );
+
+      expect(result.rows.length).toBe(1);
+    });
+
+    it('includes contact_kind in search_vector', async () => {
+      const result = await pool.query(
+        `INSERT INTO contact (display_name, contact_kind) VALUES ('Search Org', 'organisation')
+         RETURNING search_vector::text`
+      );
+
+      // search_vector should contain 'organisation' as a lexeme
+      expect(result.rows[0].search_vector).toContain('organis');
+    });
+  });
+
+  describe('POST /api/contacts', () => {
+    it('creates a contact with default contact_kind (person)', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/contacts',
+        payload: { displayName: 'Default Person' },
+      });
+
+      expect(res.statusCode).toBe(201);
+      const body = res.json() as { contact_kind: string };
+      expect(body.contact_kind).toBe('person');
+    });
+
+    it('creates contacts with explicit contact_kind values', async () => {
+      for (const [name, kind] of [
+        ['Acme Corp', 'organisation'],
+        ['The Kelly Household', 'group'],
+        ['OpenClaw Agent', 'agent'],
+      ] as const) {
+        const res = await app.inject({
+          method: 'POST',
+          url: '/api/contacts',
+          payload: { displayName: name, contactKind: kind },
+        });
+
+        expect(res.statusCode).toBe(201);
+        const body = res.json() as { contact_kind: string };
+        expect(body.contact_kind).toBe(kind);
+      }
+    });
+
+    it('rejects invalid contact_kind', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/contacts',
+        payload: { displayName: 'Bad Kind', contactKind: 'robot' },
+      });
+
+      expect(res.statusCode).toBe(400);
+    });
+  });
+
+  describe('GET /api/contacts', () => {
+    it('returns contact_kind in list response', async () => {
+      await app.inject({
+        method: 'POST',
+        url: '/api/contacts',
+        payload: { displayName: 'Listed Contact', contactKind: 'organisation' },
+      });
+
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/contacts',
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json() as {
+        contacts: Array<{ display_name: string; contact_kind: string }>;
+      };
+      expect(body.contacts.length).toBe(1);
+      expect(body.contacts[0].contact_kind).toBe('organisation');
+    });
+
+    it('filters contacts by single contact_kind', async () => {
+      // Insert directly to avoid pool pressure
+      await pool.query(
+        `INSERT INTO contact (display_name, contact_kind) VALUES
+         ('Person One', 'person'),
+         ('Org One', 'organisation'),
+         ('Group One', 'group')`
+      );
+
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/contacts?contact_kind=organisation',
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json() as {
+        contacts: Array<{ display_name: string; contact_kind: string }>;
+        total: number;
+      };
+      expect(body.contacts.length).toBe(1);
+      expect(body.contacts[0].display_name).toBe('Org One');
+      expect(body.contacts[0].contact_kind).toBe('organisation');
+      expect(body.total).toBe(1);
+    });
+
+    it('filters contacts by multiple contact_kind values', async () => {
+      await pool.query(
+        `INSERT INTO contact (display_name, contact_kind) VALUES
+         ('Person One', 'person'),
+         ('Org One', 'organisation'),
+         ('Group One', 'group')`
+      );
+
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/contacts?contact_kind=person,group',
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json() as {
+        contacts: Array<{ contact_kind: string }>;
+        total: number;
+      };
+      expect(body.total).toBe(2);
+      const kinds = body.contacts.map((c) => c.contact_kind).sort();
+      expect(kinds).toEqual(['group', 'person']);
+    });
+  });
+
+  describe('GET /api/contacts/:id', () => {
+    it('returns contact_kind in single contact response', async () => {
+      const created = await app.inject({
+        method: 'POST',
+        url: '/api/contacts',
+        payload: { displayName: 'Agent Smith', contactKind: 'agent' },
+      });
+      const { id } = created.json() as { id: string };
+
+      const res = await app.inject({
+        method: 'GET',
+        url: `/api/contacts/${id}`,
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json() as { contact_kind: string };
+      expect(body.contact_kind).toBe('agent');
+    });
+  });
+
+  describe('PATCH /api/contacts/:id', () => {
+    it('updates contact_kind', async () => {
+      const created = await app.inject({
+        method: 'POST',
+        url: '/api/contacts',
+        payload: { displayName: 'Will Become Org' },
+      });
+      const { id } = created.json() as { id: string };
+
+      const res = await app.inject({
+        method: 'PATCH',
+        url: `/api/contacts/${id}`,
+        payload: { contactKind: 'organisation' },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json() as { contact_kind: string };
+      expect(body.contact_kind).toBe('organisation');
+    });
+
+    it('rejects invalid contact_kind on update', async () => {
+      const created = await app.inject({
+        method: 'POST',
+        url: '/api/contacts',
+        payload: { displayName: 'Update Test' },
+      });
+      const { id } = created.json() as { id: string };
+
+      const res = await app.inject({
+        method: 'PATCH',
+        url: `/api/contacts/${id}`,
+        payload: { contactKind: 'invalid' },
+      });
+
+      expect(res.statusCode).toBe(400);
+    });
+  });
+
+  describe('POST /api/contacts/bulk', () => {
+    it('supports contact_kind in bulk create', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/contacts/bulk',
+        payload: {
+          contacts: [
+            { displayName: 'Person Bulk', contactKind: 'person' },
+            { displayName: 'Org Bulk', contactKind: 'organisation' },
+            { displayName: 'Group Bulk', contactKind: 'group' },
+          ],
+        },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json() as { created: number };
+      expect(body.created).toBe(3);
+
+      // Verify in DB directly
+      const dbRes = await pool.query(
+        `SELECT display_name, contact_kind::text FROM contact ORDER BY display_name`
+      );
+      expect(dbRes.rows.length).toBe(3);
+      expect(dbRes.rows.find((r) => r.display_name === 'Org Bulk')?.contact_kind).toBe('organisation');
+      expect(dbRes.rows.find((r) => r.display_name === 'Person Bulk')?.contact_kind).toBe('person');
+      expect(dbRes.rows.find((r) => r.display_name === 'Group Bulk')?.contact_kind).toBe('group');
+    });
+  });
+
+  describe('Migration rollback', () => {
+    it('down migration removes contact_kind column and enum', async () => {
+      const fs = await import('fs');
+      const path = await import('path');
+      const downPath = path.resolve(
+        __dirname,
+        '../migrations/044_contact_kind.down.sql'
+      );
+
+      expect(fs.existsSync(downPath)).toBe(true);
+      const content = fs.readFileSync(downPath, 'utf-8');
+      expect(content).toContain('DROP COLUMN');
+      expect(content).toContain('contact_kind');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #489

- Adds `contact_kind` enum type (`person`, `organisation`, `group`, `agent`) to the `contact` table
- Default value is `person` (backward compatible -- all existing contacts become people)
- Groups (households, teams) are modelled as contacts with `contact_kind = 'group'`, keeping the agent tool surface simple
- Updated `search_vector` trigger to include `contact_kind` in full-text search
- All contact API endpoints (create, list, get, update, bulk) accept and return `contact_kind`
- Contact search/filtering supports `contact_kind` filter (comma-separated for multiple values)
- Down migration safely reverses all changes

## Test plan

- [x] 17 tests covering:
  - Enum type has correct values (person, organisation, group, agent)
  - Default value is 'person'
  - Create contacts of each kind via SQL and API
  - Invalid contact_kind rejected (400)
  - List returns contact_kind
  - Single and multi-value filtering by contact_kind
  - GET single contact returns contact_kind
  - PATCH updates contact_kind
  - Bulk create supports contact_kind
  - Down migration file exists with correct content
  - search_vector includes contact_kind text
- [x] Existing contact tests pass (contacts.test.ts, contact_schema_enhancement.test.ts, migrations.test.ts)

### Local test commands run

```bash
npx vitest run tests/contact_kind.test.ts               # 17 passed
npx vitest run tests/contacts.test.ts                    # 3 passed
npx vitest run tests/contact_schema_enhancement.test.ts  # 20 passed
npx vitest run tests/migrations.test.ts                  # 4 passed
```

## Migration notes

- Migration 044 adds `contact_kind` enum and column
- `ALTER TABLE contact ADD COLUMN IF NOT EXISTS contact_kind contact_kind NOT NULL DEFAULT 'person'`
- Existing contacts automatically get `contact_kind = 'person'`
- Backfills search_vector for all existing contacts
- Down migration drops column, enum, and restores original search trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)