### PR TITLE
[#494] Create relationship agent tools for OpenClaw plugin

### DIFF
--- a/packages/openclaw-plugin/src/tools/index.ts
+++ b/packages/openclaw-plugin/src/tools/index.ts
@@ -174,6 +174,22 @@ export {
   type NoteToolOptions,
 } from './notes.js'
 
+// Relationship tools
+export {
+  createRelationshipSetTool,
+  createRelationshipQueryTool,
+  RelationshipSetParamsSchema,
+  RelationshipQueryParamsSchema,
+  type RelationshipSetParams,
+  type RelationshipQueryParams,
+  type RelationshipSetTool,
+  type RelationshipQueryTool,
+  type RelationshipSetResult,
+  type RelationshipQueryResult,
+  type RelatedContact,
+  type RelationshipToolOptions,
+} from './relationships.js'
+
 // Notebook tools
 export {
   createNotebookListTool,

--- a/packages/openclaw-plugin/src/tools/relationships.ts
+++ b/packages/openclaw-plugin/src/tools/relationships.ts
@@ -1,0 +1,425 @@
+/**
+ * Relationship management tools implementation.
+ * Provides relationship_set and relationship_query tools for OpenClaw agents.
+ * Part of Epic #486, Issue #494
+ *
+ * These tools give agents a simple interface to manage the relationship graph
+ * without needing to understand types, directionality, or inverses.
+ */
+
+import { z } from 'zod'
+import type { ApiClient } from '../api-client.js'
+import type { Logger } from '../logger.js'
+import type { PluginConfig } from '../config.js'
+
+// ==================== Shared utilities ====================
+
+/**
+ * Strip HTML tags from a string.
+ * Also removes content inside script and style tags for security.
+ */
+function stripHtml(text: string): string {
+  return text
+    .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
+    .replace(/<style\b[^<]*(?:(?!<\/style>)<[^<]*)*<\/style>/gi, '')
+    .replace(/<[^>]*>/g, '')
+    .trim()
+}
+
+/**
+ * Sanitize text input to remove control characters.
+ */
+function sanitizeText(text: string): string {
+  const sanitized = text.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, '')
+  return sanitized.trim()
+}
+
+/**
+ * Create a sanitized error message that doesn't expose internal details.
+ */
+function sanitizeErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    const message = error.message
+      .replace(/\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b/g, '[host]')
+      .replace(/:\d{2,5}\b/g, '')
+      .replace(/\b(?:localhost|internal[-\w]*)\b/gi, '[internal]')
+
+    if (message.includes('[internal]') || message.includes('[host]')) {
+      return 'Operation failed. Please try again.'
+    }
+
+    return message
+  }
+  return 'An unexpected error occurred.'
+}
+
+// ==================== relationship_set ====================
+
+/** Parameters for relationship_set tool */
+export const RelationshipSetParamsSchema = z.object({
+  contact_a: z
+    .string()
+    .min(1, 'First contact name or ID is required')
+    .max(200, 'Contact reference must be 200 characters or less'),
+  contact_b: z
+    .string()
+    .min(1, 'Second contact name or ID is required')
+    .max(200, 'Contact reference must be 200 characters or less'),
+  relationship: z
+    .string()
+    .min(1, 'Relationship description is required')
+    .max(200, 'Relationship description must be 200 characters or less'),
+  notes: z
+    .string()
+    .max(2000, 'Notes must be 2000 characters or less')
+    .optional(),
+})
+export type RelationshipSetParams = z.infer<typeof RelationshipSetParamsSchema>
+
+/** API response shape for relationship set */
+interface RelationshipSetApiResponse {
+  relationship: { id: string }
+  contactA: { id: string; displayName: string }
+  contactB: { id: string; displayName: string }
+  relationshipType: { id: string; name: string; label: string }
+  created: boolean
+}
+
+/** Successful set result */
+export interface RelationshipSetSuccess {
+  success: true
+  data: {
+    content: string
+    details: {
+      relationshipId: string
+      created: boolean
+      contactA: { id: string; displayName: string }
+      contactB: { id: string; displayName: string }
+      relationshipType: { id: string; name: string; label: string }
+      userId: string
+    }
+  }
+}
+
+/** Failed result */
+export interface RelationshipFailure {
+  success: false
+  error: string
+}
+
+export type RelationshipSetResult = RelationshipSetSuccess | RelationshipFailure
+
+/** Tool configuration */
+export interface RelationshipToolOptions {
+  client: ApiClient
+  logger: Logger
+  config: PluginConfig
+  userId: string
+}
+
+/** Tool definition */
+export interface RelationshipSetTool {
+  name: string
+  description: string
+  parameters: typeof RelationshipSetParamsSchema
+  execute: (params: RelationshipSetParams) => Promise<RelationshipSetResult>
+}
+
+/**
+ * Creates the relationship_set tool.
+ * Records a relationship between two people, groups, or organisations.
+ * The system handles directionality and type matching automatically.
+ */
+export function createRelationshipSetTool(options: RelationshipToolOptions): RelationshipSetTool {
+  const { client, logger, userId } = options
+
+  return {
+    name: 'relationship_set',
+    description:
+      "Record a relationship between two people, groups, or organisations. Examples: 'Troy is Alex\\'s partner', 'Sam is a member of The Kelly Household', 'Troy works for Acme Corp'. The system handles directionality and type matching automatically.",
+    parameters: RelationshipSetParamsSchema,
+
+    async execute(params: RelationshipSetParams): Promise<RelationshipSetResult> {
+      // Validate parameters
+      const parseResult = RelationshipSetParamsSchema.safeParse(params)
+      if (!parseResult.success) {
+        const errorMessage = parseResult.error.errors
+          .map((e) => `${e.path.join('.')}: ${e.message}`)
+          .join(', ')
+        return { success: false, error: errorMessage }
+      }
+
+      const { contact_a, contact_b, relationship, notes } = parseResult.data
+
+      // Sanitize inputs
+      const sanitizedContactA = stripHtml(sanitizeText(contact_a))
+      const sanitizedContactB = stripHtml(sanitizeText(contact_b))
+      const sanitizedRelationship = stripHtml(sanitizeText(relationship))
+      const sanitizedNotes = notes ? sanitizeText(notes) : undefined
+
+      if (sanitizedContactA.length === 0) {
+        return { success: false, error: 'First contact reference cannot be empty after sanitization' }
+      }
+      if (sanitizedContactB.length === 0) {
+        return { success: false, error: 'Second contact reference cannot be empty after sanitization' }
+      }
+      if (sanitizedRelationship.length === 0) {
+        return { success: false, error: 'Relationship description cannot be empty after sanitization' }
+      }
+
+      // Log without PII
+      logger.info('relationship_set invoked', {
+        userId,
+        contactALength: sanitizedContactA.length,
+        contactBLength: sanitizedContactB.length,
+        relationshipLength: sanitizedRelationship.length,
+        hasNotes: !!sanitizedNotes,
+      })
+
+      try {
+        const body: Record<string, unknown> = {
+          contactA: sanitizedContactA,
+          contactB: sanitizedContactB,
+          relationshipType: sanitizedRelationship,
+        }
+        if (sanitizedNotes) {
+          body.notes = sanitizedNotes
+        }
+
+        const response = await client.post<RelationshipSetApiResponse>(
+          '/api/relationships/set',
+          body,
+          { userId }
+        )
+
+        if (!response.success) {
+          logger.error('relationship_set API error', {
+            userId,
+            status: response.error.status,
+            code: response.error.code,
+          })
+          return {
+            success: false,
+            error: response.error.message || 'Failed to set relationship',
+          }
+        }
+
+        const { relationship: rel, contactA: resolvedA, contactB: resolvedB, relationshipType, created } = response.data
+
+        const content = created
+          ? `Recorded: ${resolvedA.displayName} [${relationshipType.label}] ${resolvedB.displayName}`
+          : `Relationship already exists: ${resolvedA.displayName} [${relationshipType.label}] ${resolvedB.displayName}`
+
+        logger.debug('relationship_set completed', {
+          userId,
+          relationshipId: rel.id,
+          created,
+        })
+
+        return {
+          success: true,
+          data: {
+            content,
+            details: {
+              relationshipId: rel.id,
+              created,
+              contactA: resolvedA,
+              contactB: resolvedB,
+              relationshipType,
+              userId,
+            },
+          },
+        }
+      } catch (error) {
+        logger.error('relationship_set failed', {
+          userId,
+          error: error instanceof Error ? error.message : String(error),
+        })
+        return { success: false, error: sanitizeErrorMessage(error) }
+      }
+    },
+  }
+}
+
+// ==================== relationship_query ====================
+
+/** Parameters for relationship_query tool */
+export const RelationshipQueryParamsSchema = z.object({
+  contact: z
+    .string()
+    .min(1, 'Contact name or ID is required')
+    .max(200, 'Contact reference must be 200 characters or less'),
+  type_filter: z
+    .string()
+    .max(200, 'Type filter must be 200 characters or less')
+    .optional(),
+})
+export type RelationshipQueryParams = z.infer<typeof RelationshipQueryParamsSchema>
+
+/** Related contact entry from API */
+export interface RelatedContact {
+  contactId: string
+  contactName: string
+  contactKind: string
+  relationshipId: string
+  relationshipTypeName: string
+  relationshipTypeLabel: string
+  isDirectional: boolean
+  notes: string | null
+}
+
+/** API response shape for relationship query */
+interface RelationshipQueryApiResponse {
+  contactId: string
+  contactName: string
+  relatedContacts: RelatedContact[]
+}
+
+/** Successful query result */
+export interface RelationshipQuerySuccess {
+  success: true
+  data: {
+    content: string
+    details: {
+      contactId: string
+      contactName: string
+      relatedContacts: RelatedContact[]
+      userId: string
+    }
+  }
+}
+
+export type RelationshipQueryResult = RelationshipQuerySuccess | RelationshipFailure
+
+/** Tool definition */
+export interface RelationshipQueryTool {
+  name: string
+  description: string
+  parameters: typeof RelationshipQueryParamsSchema
+  execute: (params: RelationshipQueryParams) => Promise<RelationshipQueryResult>
+}
+
+/**
+ * Creates the relationship_query tool.
+ * Queries a contact's relationships, returning all connections
+ * including family, partners, group memberships, and professional links.
+ * Handles directional relationships automatically.
+ */
+export function createRelationshipQueryTool(options: RelationshipToolOptions): RelationshipQueryTool {
+  const { client, logger, userId } = options
+
+  return {
+    name: 'relationship_query',
+    description:
+      "Query a contact's relationships. Returns all relationships including family, partners, group memberships, professional connections, etc. Handles directional relationships automatically.",
+    parameters: RelationshipQueryParamsSchema,
+
+    async execute(params: RelationshipQueryParams): Promise<RelationshipQueryResult> {
+      // Validate parameters
+      const parseResult = RelationshipQueryParamsSchema.safeParse(params)
+      if (!parseResult.success) {
+        const errorMessage = parseResult.error.errors
+          .map((e) => `${e.path.join('.')}: ${e.message}`)
+          .join(', ')
+        return { success: false, error: errorMessage }
+      }
+
+      const { contact, type_filter } = parseResult.data
+
+      // Sanitize input
+      const sanitizedContact = stripHtml(sanitizeText(contact))
+
+      if (sanitizedContact.length === 0) {
+        return { success: false, error: 'Contact reference cannot be empty after sanitization' }
+      }
+
+      // Log without PII
+      logger.info('relationship_query invoked', {
+        userId,
+        contactLength: sanitizedContact.length,
+        hasTypeFilter: !!type_filter,
+      })
+
+      try {
+        const queryParams = new URLSearchParams({
+          contact: sanitizedContact,
+        })
+        if (type_filter) {
+          queryParams.set('type_filter', type_filter)
+        }
+
+        const response = await client.get<RelationshipQueryApiResponse>(
+          `/api/relationships/query?${queryParams.toString()}`,
+          { userId }
+        )
+
+        if (!response.success) {
+          if (response.error.code === 'NOT_FOUND') {
+            return { success: false, error: 'Contact not found.' }
+          }
+          logger.error('relationship_query API error', {
+            userId,
+            status: response.error.status,
+            code: response.error.code,
+          })
+          return {
+            success: false,
+            error: response.error.message || 'Failed to query relationships',
+          }
+        }
+
+        const { contactId, contactName, relatedContacts } = response.data
+
+        if (relatedContacts.length === 0) {
+          return {
+            success: true,
+            data: {
+              content: `No relationships found for ${contactName}.`,
+              details: {
+                contactId,
+                contactName,
+                relatedContacts: [],
+                userId,
+              },
+            },
+          }
+        }
+
+        // Format relationships as a readable list
+        const lines = [`Relationships for ${contactName}:`]
+        for (const rel of relatedContacts) {
+          const kindTag = rel.contactKind !== 'person' ? ` [${rel.contactKind}]` : ''
+          const notesTag = rel.notes ? ` -- ${rel.notes}` : ''
+          lines.push(`- ${rel.relationshipTypeLabel}: ${rel.contactName}${kindTag}${notesTag}`)
+        }
+
+        const content = lines.join('\n')
+
+        logger.debug('relationship_query completed', {
+          userId,
+          contactId,
+          relatedCount: relatedContacts.length,
+        })
+
+        return {
+          success: true,
+          data: {
+            content,
+            details: {
+              contactId,
+              contactName,
+              relatedContacts,
+              userId,
+            },
+          },
+        }
+      } catch (error) {
+        logger.error('relationship_query failed', {
+          userId,
+          error: error instanceof Error ? error.message : String(error),
+        })
+        return { success: false, error: sanitizeErrorMessage(error) }
+      }
+    },
+  }
+}

--- a/packages/openclaw-plugin/tests/register-openclaw.test.ts
+++ b/packages/openclaw-plugin/tests/register-openclaw.test.ts
@@ -51,10 +51,10 @@ describe('OpenClaw 2026 API Registration', () => {
   })
 
   describe('registration', () => {
-    it('should register all 17 tools', async () => {
+    it('should register all 19 tools', async () => {
       await registerOpenClaw(mockApi)
 
-      expect(registeredTools).toHaveLength(17)
+      expect(registeredTools).toHaveLength(19)
       const toolNames = registeredTools.map((t) => t.name)
       expect(toolNames).toContain('memory_recall')
       expect(toolNames).toContain('memory_store')
@@ -73,6 +73,8 @@ describe('OpenClaw 2026 API Registration', () => {
       expect(toolNames).toContain('message_search')
       expect(toolNames).toContain('thread_list')
       expect(toolNames).toContain('thread_get')
+      expect(toolNames).toContain('relationship_set')
+      expect(toolNames).toContain('relationship_query')
     })
 
     it('should register beforeAgentStart hook when autoRecall is true', async () => {
@@ -112,7 +114,7 @@ describe('OpenClaw 2026 API Registration', () => {
       expect(mockApi.logger.info).toHaveBeenCalledWith(
         'OpenClaw Projects plugin registered',
         expect.objectContaining({
-          toolCount: 17,
+          toolCount: 19,
         })
       )
     })
@@ -141,6 +143,14 @@ describe('OpenClaw 2026 API Registration', () => {
 
       const contactCreate = registeredTools.find((t) => t.name === 'contact_create')
       expect(contactCreate?.parameters.required).toContain('name')
+
+      const relationshipSet = registeredTools.find((t) => t.name === 'relationship_set')
+      expect(relationshipSet?.parameters.required).toContain('contact_a')
+      expect(relationshipSet?.parameters.required).toContain('contact_b')
+      expect(relationshipSet?.parameters.required).toContain('relationship')
+
+      const relationshipQuery = registeredTools.find((t) => t.name === 'relationship_query')
+      expect(relationshipQuery?.parameters.required).toContain('contact')
     })
 
     it('should have executable functions', async () => {
@@ -171,6 +181,8 @@ describe('OpenClaw 2026 API Registration', () => {
       expect(schemas.messageSearch).toBeDefined()
       expect(schemas.threadList).toBeDefined()
       expect(schemas.threadGet).toBeDefined()
+      expect(schemas.relationshipSet).toBeDefined()
+      expect(schemas.relationshipQuery).toBeDefined()
     })
 
     it('should have valid schema structure', () => {

--- a/packages/openclaw-plugin/tests/tools/relationships.test.ts
+++ b/packages/openclaw-plugin/tests/tools/relationships.test.ts
@@ -1,0 +1,1194 @@
+/**
+ * Tests for relationship management tools.
+ * Covers relationship_set and relationship_query.
+ * Part of Epic #486, Issue #494
+ */
+
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import {
+  createRelationshipSetTool,
+  createRelationshipQueryTool,
+  RelationshipSetParamsSchema,
+  RelationshipQueryParamsSchema,
+  type RelationshipSetParams,
+  type RelationshipQueryParams,
+} from '../../src/tools/relationships.js'
+import type { ApiClient } from '../../src/api-client.js'
+import type { Logger } from '../../src/logger.js'
+import type { PluginConfig } from '../../src/config.js'
+
+describe('relationship tools', () => {
+  const mockLogger: Logger = {
+    namespace: 'test',
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }
+
+  const mockConfig: PluginConfig = {
+    apiUrl: 'https://api.example.com',
+    apiKey: 'test-key',
+    autoRecall: true,
+    autoCapture: true,
+    userScoping: 'agent',
+    maxRecallMemories: 5,
+    minRecallScore: 0.7,
+    timeout: 30000,
+    maxRetries: 3,
+    debug: false,
+  }
+
+  const mockApiClient = {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    healthCheck: vi.fn(),
+  } as unknown as ApiClient
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // ==================== relationship_set ====================
+
+  describe('relationship_set', () => {
+    describe('tool metadata', () => {
+      it('should have correct name', () => {
+        const tool = createRelationshipSetTool({
+          client: mockApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'agent-1',
+        })
+        expect(tool.name).toBe('relationship_set')
+      })
+
+      it('should have a descriptive description', () => {
+        const tool = createRelationshipSetTool({
+          client: mockApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'agent-1',
+        })
+        expect(tool.description.length).toBeGreaterThan(20)
+        expect(tool.description).toContain('relationship')
+      })
+
+      it('should have valid zod parameter schema', () => {
+        const tool = createRelationshipSetTool({
+          client: mockApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'agent-1',
+        })
+        expect(tool.parameters).toBe(RelationshipSetParamsSchema)
+      })
+    })
+
+    describe('parameter validation', () => {
+      it('should require contact_a parameter', async () => {
+        const tool = createRelationshipSetTool({
+          client: mockApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'agent-1',
+        })
+
+        const result = await tool.execute({
+          contact_b: 'Alex',
+          relationship: 'partner',
+        } as RelationshipSetParams)
+        expect(result.success).toBe(false)
+      })
+
+      it('should require contact_b parameter', async () => {
+        const tool = createRelationshipSetTool({
+          client: mockApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'agent-1',
+        })
+
+        const result = await tool.execute({
+          contact_a: 'Troy',
+          relationship: 'partner',
+        } as RelationshipSetParams)
+        expect(result.success).toBe(false)
+      })
+
+      it('should require relationship parameter', async () => {
+        const tool = createRelationshipSetTool({
+          client: mockApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'agent-1',
+        })
+
+        const result = await tool.execute({
+          contact_a: 'Troy',
+          contact_b: 'Alex',
+        } as RelationshipSetParams)
+        expect(result.success).toBe(false)
+      })
+
+      it('should reject empty contact_a', async () => {
+        const tool = createRelationshipSetTool({
+          client: mockApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'agent-1',
+        })
+
+        const result = await tool.execute({
+          contact_a: '',
+          contact_b: 'Alex',
+          relationship: 'partner',
+        })
+        expect(result.success).toBe(false)
+      })
+
+      it('should reject empty contact_b', async () => {
+        const tool = createRelationshipSetTool({
+          client: mockApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'agent-1',
+        })
+
+        const result = await tool.execute({
+          contact_a: 'Troy',
+          contact_b: '',
+          relationship: 'partner',
+        })
+        expect(result.success).toBe(false)
+      })
+
+      it('should reject empty relationship', async () => {
+        const tool = createRelationshipSetTool({
+          client: mockApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'agent-1',
+        })
+
+        const result = await tool.execute({
+          contact_a: 'Troy',
+          contact_b: 'Alex',
+          relationship: '',
+        })
+        expect(result.success).toBe(false)
+      })
+
+      it('should accept valid parameters with notes', async () => {
+        const mockPost = vi.fn().mockResolvedValue({
+          success: true,
+          data: {
+            relationship: { id: 'rel-1' },
+            contactA: { id: 'ca-1', displayName: 'Troy' },
+            contactB: { id: 'cb-1', displayName: 'Alex' },
+            relationshipType: { id: 'rt-1', name: 'partner', label: 'Partner' },
+            created: true,
+          },
+        })
+        const client = { ...mockApiClient, post: mockPost }
+
+        const tool = createRelationshipSetTool({
+          client: client as unknown as ApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'agent-1',
+        })
+
+        const result = await tool.execute({
+          contact_a: 'Troy',
+          contact_b: 'Alex',
+          relationship: 'partner',
+          notes: 'They got together in 2020',
+        })
+
+        expect(result.success).toBe(true)
+      })
+
+      it('should reject contact_a over 200 characters', async () => {
+        const tool = createRelationshipSetTool({
+          client: mockApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'agent-1',
+        })
+
+        const result = await tool.execute({
+          contact_a: 'a'.repeat(201),
+          contact_b: 'Alex',
+          relationship: 'partner',
+        })
+        expect(result.success).toBe(false)
+      })
+
+      it('should reject relationship over 200 characters', async () => {
+        const tool = createRelationshipSetTool({
+          client: mockApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'agent-1',
+        })
+
+        const result = await tool.execute({
+          contact_a: 'Troy',
+          contact_b: 'Alex',
+          relationship: 'a'.repeat(201),
+        })
+        expect(result.success).toBe(false)
+      })
+    })
+
+    describe('API interaction', () => {
+      it('should call POST /api/relationships/set with correct body', async () => {
+        const mockPost = vi.fn().mockResolvedValue({
+          success: true,
+          data: {
+            relationship: { id: 'rel-1' },
+            contactA: { id: 'ca-1', displayName: 'Troy' },
+            contactB: { id: 'cb-1', displayName: 'Alex' },
+            relationshipType: { id: 'rt-1', name: 'partner', label: 'Partner' },
+            created: true,
+          },
+        })
+        const client = { ...mockApiClient, post: mockPost }
+
+        const tool = createRelationshipSetTool({
+          client: client as unknown as ApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'agent-1',
+        })
+
+        await tool.execute({
+          contact_a: 'Troy',
+          contact_b: 'Alex',
+          relationship: 'partner',
+          notes: 'Since 2020',
+        })
+
+        expect(mockPost).toHaveBeenCalledWith(
+          '/api/relationships/set',
+          expect.objectContaining({
+            contactA: 'Troy',
+            contactB: 'Alex',
+            relationshipType: 'partner',
+            notes: 'Since 2020',
+          }),
+          expect.objectContaining({ userId: 'agent-1' })
+        )
+      })
+    })
+
+    describe('response formatting', () => {
+      it('should return confirmation for newly created relationship', async () => {
+        const mockPost = vi.fn().mockResolvedValue({
+          success: true,
+          data: {
+            relationship: { id: 'rel-1' },
+            contactA: { id: 'ca-1', displayName: 'Troy' },
+            contactB: { id: 'cb-1', displayName: 'Alex' },
+            relationshipType: { id: 'rt-1', name: 'partner', label: 'Partner' },
+            created: true,
+          },
+        })
+        const client = { ...mockApiClient, post: mockPost }
+
+        const tool = createRelationshipSetTool({
+          client: client as unknown as ApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'agent-1',
+        })
+
+        const result = await tool.execute({
+          contact_a: 'Troy',
+          contact_b: 'Alex',
+          relationship: 'partner',
+        })
+
+        expect(result.success).toBe(true)
+        if (result.success) {
+          expect(result.data.content).toContain('Troy')
+          expect(result.data.content).toContain('Alex')
+          expect(result.data.content).toContain('Partner')
+          expect(result.data.details.relationshipId).toBe('rel-1')
+          expect(result.data.details.created).toBe(true)
+          expect(result.data.details.contactA.id).toBe('ca-1')
+          expect(result.data.details.contactB.id).toBe('cb-1')
+        }
+      })
+
+      it('should indicate when relationship already exists', async () => {
+        const mockPost = vi.fn().mockResolvedValue({
+          success: true,
+          data: {
+            relationship: { id: 'rel-existing' },
+            contactA: { id: 'ca-1', displayName: 'Troy' },
+            contactB: { id: 'cb-1', displayName: 'Alex' },
+            relationshipType: { id: 'rt-1', name: 'partner', label: 'Partner' },
+            created: false,
+          },
+        })
+        const client = { ...mockApiClient, post: mockPost }
+
+        const tool = createRelationshipSetTool({
+          client: client as unknown as ApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'agent-1',
+        })
+
+        const result = await tool.execute({
+          contact_a: 'Troy',
+          contact_b: 'Alex',
+          relationship: 'partner',
+        })
+
+        expect(result.success).toBe(true)
+        if (result.success) {
+          expect(result.data.content).toContain('already exists')
+          expect(result.data.details.created).toBe(false)
+        }
+      })
+    })
+
+    describe('error handling', () => {
+      it('should handle API errors gracefully', async () => {
+        const mockPost = vi.fn().mockResolvedValue({
+          success: false,
+          error: { status: 500, message: 'Server error', code: 'SERVER_ERROR' },
+        })
+        const client = { ...mockApiClient, post: mockPost }
+
+        const tool = createRelationshipSetTool({
+          client: client as unknown as ApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'agent-1',
+        })
+
+        const result = await tool.execute({
+          contact_a: 'Troy',
+          contact_b: 'Alex',
+          relationship: 'partner',
+        })
+        expect(result.success).toBe(false)
+      })
+
+      it('should handle contact resolution failures', async () => {
+        const mockPost = vi.fn().mockResolvedValue({
+          success: false,
+          error: {
+            status: 400,
+            message: 'Contact "Unknown" cannot be resolved',
+            code: 'CLIENT_ERROR',
+          },
+        })
+        const client = { ...mockApiClient, post: mockPost }
+
+        const tool = createRelationshipSetTool({
+          client: client as unknown as ApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'agent-1',
+        })
+
+        const result = await tool.execute({
+          contact_a: 'Unknown',
+          contact_b: 'Alex',
+          relationship: 'partner',
+        })
+        expect(result.success).toBe(false)
+        if (!result.success) {
+          expect(result.error).toContain('cannot be resolved')
+        }
+      })
+
+      it('should handle network errors', async () => {
+        const mockPost = vi.fn().mockRejectedValue(new Error('Network error'))
+        const client = { ...mockApiClient, post: mockPost }
+
+        const tool = createRelationshipSetTool({
+          client: client as unknown as ApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'agent-1',
+        })
+
+        const result = await tool.execute({
+          contact_a: 'Troy',
+          contact_b: 'Alex',
+          relationship: 'partner',
+        })
+        expect(result.success).toBe(false)
+      })
+
+      it('should not expose internal details in error messages', async () => {
+        const mockPost = vi.fn().mockRejectedValue(
+          new Error('Connection refused to internal-db:5432')
+        )
+        const client = { ...mockApiClient, post: mockPost }
+
+        const tool = createRelationshipSetTool({
+          client: client as unknown as ApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'agent-1',
+        })
+
+        const result = await tool.execute({
+          contact_a: 'Troy',
+          contact_b: 'Alex',
+          relationship: 'partner',
+        })
+
+        expect(result.success).toBe(false)
+        if (!result.success) {
+          expect(result.error).not.toContain('5432')
+          expect(result.error).not.toContain('internal-db')
+        }
+      })
+    })
+
+    describe('input sanitization', () => {
+      it('should strip HTML tags from contact names', async () => {
+        const mockPost = vi.fn().mockResolvedValue({
+          success: true,
+          data: {
+            relationship: { id: 'rel-1' },
+            contactA: { id: 'ca-1', displayName: 'Troy' },
+            contactB: { id: 'cb-1', displayName: 'Alex' },
+            relationshipType: { id: 'rt-1', name: 'partner', label: 'Partner' },
+            created: true,
+          },
+        })
+        const client = { ...mockApiClient, post: mockPost }
+
+        const tool = createRelationshipSetTool({
+          client: client as unknown as ApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'agent-1',
+        })
+
+        await tool.execute({
+          contact_a: '<script>alert("xss")</script>Troy',
+          contact_b: 'Alex',
+          relationship: 'partner',
+        })
+
+        expect(mockPost).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            contactA: 'Troy',
+          }),
+          expect.any(Object)
+        )
+      })
+
+      it('should strip control characters from notes', async () => {
+        const mockPost = vi.fn().mockResolvedValue({
+          success: true,
+          data: {
+            relationship: { id: 'rel-1' },
+            contactA: { id: 'ca-1', displayName: 'Troy' },
+            contactB: { id: 'cb-1', displayName: 'Alex' },
+            relationshipType: { id: 'rt-1', name: 'partner', label: 'Partner' },
+            created: true,
+          },
+        })
+        const client = { ...mockApiClient, post: mockPost }
+
+        const tool = createRelationshipSetTool({
+          client: client as unknown as ApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'agent-1',
+        })
+
+        await tool.execute({
+          contact_a: 'Troy',
+          contact_b: 'Alex',
+          relationship: 'partner',
+          notes: 'Since\x002020',
+        })
+
+        expect(mockPost).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            notes: 'Since2020',
+          }),
+          expect.any(Object)
+        )
+      })
+    })
+
+    describe('PII handling', () => {
+      it('should not log contact names at info level', async () => {
+        const mockPost = vi.fn().mockResolvedValue({
+          success: true,
+          data: {
+            relationship: { id: 'rel-1' },
+            contactA: { id: 'ca-1', displayName: 'Troy' },
+            contactB: { id: 'cb-1', displayName: 'Alex' },
+            relationshipType: { id: 'rt-1', name: 'partner', label: 'Partner' },
+            created: true,
+          },
+        })
+        const client = { ...mockApiClient, post: mockPost }
+
+        const tool = createRelationshipSetTool({
+          client: client as unknown as ApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'agent-1',
+        })
+
+        await tool.execute({
+          contact_a: 'Troy Kelly',
+          contact_b: 'Alex Smith',
+          relationship: 'partner',
+        })
+
+        for (const call of (mockLogger.info as ReturnType<typeof vi.fn>).mock.calls) {
+          const logMessage = JSON.stringify(call)
+          expect(logMessage).not.toContain('Troy Kelly')
+          expect(logMessage).not.toContain('Alex Smith')
+        }
+      })
+    })
+
+    describe('user scoping', () => {
+      it('should include userId in API calls', async () => {
+        const mockPost = vi.fn().mockResolvedValue({
+          success: true,
+          data: {
+            relationship: { id: 'rel-1' },
+            contactA: { id: 'ca-1', displayName: 'Troy' },
+            contactB: { id: 'cb-1', displayName: 'Alex' },
+            relationshipType: { id: 'rt-1', name: 'partner', label: 'Partner' },
+            created: true,
+          },
+        })
+        const client = { ...mockApiClient, post: mockPost }
+
+        const tool = createRelationshipSetTool({
+          client: client as unknown as ApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'custom-user',
+        })
+
+        await tool.execute({
+          contact_a: 'Troy',
+          contact_b: 'Alex',
+          relationship: 'partner',
+        })
+
+        expect(mockPost).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.any(Object),
+          expect.objectContaining({ userId: 'custom-user' })
+        )
+      })
+    })
+  })
+
+  // ==================== relationship_query ====================
+
+  describe('relationship_query', () => {
+    describe('tool metadata', () => {
+      it('should have correct name', () => {
+        const tool = createRelationshipQueryTool({
+          client: mockApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'agent-1',
+        })
+        expect(tool.name).toBe('relationship_query')
+      })
+
+      it('should have a descriptive description', () => {
+        const tool = createRelationshipQueryTool({
+          client: mockApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'agent-1',
+        })
+        expect(tool.description.length).toBeGreaterThan(20)
+        expect(tool.description).toContain('relationship')
+      })
+
+      it('should have valid zod parameter schema', () => {
+        const tool = createRelationshipQueryTool({
+          client: mockApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'agent-1',
+        })
+        expect(tool.parameters).toBe(RelationshipQueryParamsSchema)
+      })
+    })
+
+    describe('parameter validation', () => {
+      it('should require contact parameter', async () => {
+        const tool = createRelationshipQueryTool({
+          client: mockApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'agent-1',
+        })
+
+        const result = await tool.execute({} as RelationshipQueryParams)
+        expect(result.success).toBe(false)
+      })
+
+      it('should reject empty contact', async () => {
+        const tool = createRelationshipQueryTool({
+          client: mockApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'agent-1',
+        })
+
+        const result = await tool.execute({ contact: '' })
+        expect(result.success).toBe(false)
+      })
+
+      it('should accept contact name', async () => {
+        const mockGet = vi.fn().mockResolvedValue({
+          success: true,
+          data: {
+            contactId: 'c-1',
+            contactName: 'Troy',
+            relatedContacts: [],
+          },
+        })
+        const client = { ...mockApiClient, get: mockGet }
+
+        const tool = createRelationshipQueryTool({
+          client: client as unknown as ApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'agent-1',
+        })
+
+        await tool.execute({ contact: 'Troy' })
+        expect(mockGet).toHaveBeenCalled()
+      })
+
+      it('should accept contact UUID', async () => {
+        const mockGet = vi.fn().mockResolvedValue({
+          success: true,
+          data: {
+            contactId: '123e4567-e89b-12d3-a456-426614174000',
+            contactName: 'Troy',
+            relatedContacts: [],
+          },
+        })
+        const client = { ...mockApiClient, get: mockGet }
+
+        const tool = createRelationshipQueryTool({
+          client: client as unknown as ApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'agent-1',
+        })
+
+        await tool.execute({ contact: '123e4567-e89b-12d3-a456-426614174000' })
+        expect(mockGet).toHaveBeenCalled()
+      })
+
+      it('should accept optional type_filter', async () => {
+        const mockGet = vi.fn().mockResolvedValue({
+          success: true,
+          data: {
+            contactId: 'c-1',
+            contactName: 'Troy',
+            relatedContacts: [],
+          },
+        })
+        const client = { ...mockApiClient, get: mockGet }
+
+        const tool = createRelationshipQueryTool({
+          client: client as unknown as ApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'agent-1',
+        })
+
+        await tool.execute({ contact: 'Troy', type_filter: 'partner' })
+        expect(mockGet).toHaveBeenCalledWith(
+          expect.stringContaining('type_filter=partner'),
+          expect.any(Object)
+        )
+      })
+
+      it('should reject contact over 200 characters', async () => {
+        const tool = createRelationshipQueryTool({
+          client: mockApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'agent-1',
+        })
+
+        const result = await tool.execute({ contact: 'a'.repeat(201) })
+        expect(result.success).toBe(false)
+      })
+    })
+
+    describe('API interaction', () => {
+      it('should call GET /api/relationships/query with contact parameter', async () => {
+        const mockGet = vi.fn().mockResolvedValue({
+          success: true,
+          data: {
+            contactId: 'c-1',
+            contactName: 'Troy',
+            relatedContacts: [],
+          },
+        })
+        const client = { ...mockApiClient, get: mockGet }
+
+        const tool = createRelationshipQueryTool({
+          client: client as unknown as ApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'agent-1',
+        })
+
+        await tool.execute({ contact: 'Troy' })
+
+        expect(mockGet).toHaveBeenCalledWith(
+          expect.stringContaining('/api/relationships/query'),
+          expect.objectContaining({ userId: 'agent-1' })
+        )
+        expect(mockGet).toHaveBeenCalledWith(
+          expect.stringContaining('contact=Troy'),
+          expect.any(Object)
+        )
+      })
+    })
+
+    describe('response formatting', () => {
+      it('should format relationships as readable list', async () => {
+        const mockGet = vi.fn().mockResolvedValue({
+          success: true,
+          data: {
+            contactId: 'c-1',
+            contactName: 'Troy',
+            relatedContacts: [
+              {
+                contactId: 'c-2',
+                contactName: 'Alex',
+                contactKind: 'person',
+                relationshipId: 'r-1',
+                relationshipTypeName: 'partner',
+                relationshipTypeLabel: 'Partner',
+                isDirectional: false,
+                notes: null,
+              },
+              {
+                contactId: 'c-3',
+                contactName: 'Sam',
+                contactKind: 'person',
+                relationshipId: 'r-2',
+                relationshipTypeName: 'parent_of',
+                relationshipTypeLabel: 'Parent Of',
+                isDirectional: true,
+                notes: null,
+              },
+            ],
+          },
+        })
+        const client = { ...mockApiClient, get: mockGet }
+
+        const tool = createRelationshipQueryTool({
+          client: client as unknown as ApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'agent-1',
+        })
+
+        const result = await tool.execute({ contact: 'Troy' })
+
+        expect(result.success).toBe(true)
+        if (result.success) {
+          expect(result.data.content).toContain('Troy')
+          expect(result.data.content).toContain('Alex')
+          expect(result.data.content).toContain('Partner')
+          expect(result.data.content).toContain('Sam')
+          expect(result.data.content).toContain('Parent Of')
+          expect(result.data.details.contactId).toBe('c-1')
+          expect(result.data.details.relatedContacts).toHaveLength(2)
+        }
+      })
+
+      it('should handle empty relationships', async () => {
+        const mockGet = vi.fn().mockResolvedValue({
+          success: true,
+          data: {
+            contactId: 'c-1',
+            contactName: 'Troy',
+            relatedContacts: [],
+          },
+        })
+        const client = { ...mockApiClient, get: mockGet }
+
+        const tool = createRelationshipQueryTool({
+          client: client as unknown as ApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'agent-1',
+        })
+
+        const result = await tool.execute({ contact: 'Troy' })
+
+        expect(result.success).toBe(true)
+        if (result.success) {
+          expect(result.data.content).toContain('No relationships found')
+        }
+      })
+
+      it('should include group memberships in results', async () => {
+        const mockGet = vi.fn().mockResolvedValue({
+          success: true,
+          data: {
+            contactId: 'c-1',
+            contactName: 'Troy',
+            relatedContacts: [
+              {
+                contactId: 'g-1',
+                contactName: 'The Kelly Household',
+                contactKind: 'group',
+                relationshipId: 'r-1',
+                relationshipTypeName: 'member_of',
+                relationshipTypeLabel: 'Member Of',
+                isDirectional: true,
+                notes: null,
+              },
+            ],
+          },
+        })
+        const client = { ...mockApiClient, get: mockGet }
+
+        const tool = createRelationshipQueryTool({
+          client: client as unknown as ApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'agent-1',
+        })
+
+        const result = await tool.execute({ contact: 'Troy' })
+
+        expect(result.success).toBe(true)
+        if (result.success) {
+          expect(result.data.content).toContain('The Kelly Household')
+          expect(result.data.content).toContain('Member Of')
+        }
+      })
+
+      it('should show inverse-resolved relationships correctly', async () => {
+        const mockGet = vi.fn().mockResolvedValue({
+          success: true,
+          data: {
+            contactId: 'c-2',
+            contactName: 'Sam',
+            relatedContacts: [
+              {
+                contactId: 'c-1',
+                contactName: 'Troy',
+                contactKind: 'person',
+                relationshipId: 'r-2',
+                relationshipTypeName: 'child_of',
+                relationshipTypeLabel: 'Child Of',
+                isDirectional: true,
+                notes: null,
+              },
+            ],
+          },
+        })
+        const client = { ...mockApiClient, get: mockGet }
+
+        const tool = createRelationshipQueryTool({
+          client: client as unknown as ApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'agent-1',
+        })
+
+        const result = await tool.execute({ contact: 'Sam' })
+
+        expect(result.success).toBe(true)
+        if (result.success) {
+          expect(result.data.content).toContain('Troy')
+          expect(result.data.content).toContain('Child Of')
+        }
+      })
+    })
+
+    describe('error handling', () => {
+      it('should handle API errors gracefully', async () => {
+        const mockGet = vi.fn().mockResolvedValue({
+          success: false,
+          error: { status: 500, message: 'Server error', code: 'SERVER_ERROR' },
+        })
+        const client = { ...mockApiClient, get: mockGet }
+
+        const tool = createRelationshipQueryTool({
+          client: client as unknown as ApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'agent-1',
+        })
+
+        const result = await tool.execute({ contact: 'Troy' })
+        expect(result.success).toBe(false)
+      })
+
+      it('should handle contact not found', async () => {
+        const mockGet = vi.fn().mockResolvedValue({
+          success: false,
+          error: {
+            status: 404,
+            message: 'Contact not found',
+            code: 'NOT_FOUND',
+          },
+        })
+        const client = { ...mockApiClient, get: mockGet }
+
+        const tool = createRelationshipQueryTool({
+          client: client as unknown as ApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'agent-1',
+        })
+
+        const result = await tool.execute({ contact: 'Unknown' })
+        expect(result.success).toBe(false)
+        if (!result.success) {
+          expect(result.error).toContain('not found')
+        }
+      })
+
+      it('should handle network errors', async () => {
+        const mockGet = vi.fn().mockRejectedValue(new Error('Network error'))
+        const client = { ...mockApiClient, get: mockGet }
+
+        const tool = createRelationshipQueryTool({
+          client: client as unknown as ApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'agent-1',
+        })
+
+        const result = await tool.execute({ contact: 'Troy' })
+        expect(result.success).toBe(false)
+      })
+
+      it('should not expose internal details in error messages', async () => {
+        const mockGet = vi.fn().mockRejectedValue(
+          new Error('Connection refused to internal-db:5432')
+        )
+        const client = { ...mockApiClient, get: mockGet }
+
+        const tool = createRelationshipQueryTool({
+          client: client as unknown as ApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'agent-1',
+        })
+
+        const result = await tool.execute({ contact: 'Troy' })
+
+        expect(result.success).toBe(false)
+        if (!result.success) {
+          expect(result.error).not.toContain('5432')
+          expect(result.error).not.toContain('internal-db')
+        }
+      })
+    })
+
+    describe('PII handling', () => {
+      it('should not log contact names at info level', async () => {
+        const mockGet = vi.fn().mockResolvedValue({
+          success: true,
+          data: {
+            contactId: 'c-1',
+            contactName: 'Troy Kelly',
+            relatedContacts: [],
+          },
+        })
+        const client = { ...mockApiClient, get: mockGet }
+
+        const tool = createRelationshipQueryTool({
+          client: client as unknown as ApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'agent-1',
+        })
+
+        await tool.execute({ contact: 'Troy Kelly' })
+
+        for (const call of (mockLogger.info as ReturnType<typeof vi.fn>).mock.calls) {
+          const logMessage = JSON.stringify(call)
+          expect(logMessage).not.toContain('Troy Kelly')
+        }
+      })
+    })
+
+    describe('user scoping', () => {
+      it('should include userId in API calls', async () => {
+        const mockGet = vi.fn().mockResolvedValue({
+          success: true,
+          data: {
+            contactId: 'c-1',
+            contactName: 'Troy',
+            relatedContacts: [],
+          },
+        })
+        const client = { ...mockApiClient, get: mockGet }
+
+        const tool = createRelationshipQueryTool({
+          client: client as unknown as ApiClient,
+          logger: mockLogger,
+          config: mockConfig,
+          userId: 'custom-user',
+        })
+
+        await tool.execute({ contact: 'Troy' })
+
+        expect(mockGet).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({ userId: 'custom-user' })
+        )
+      })
+    })
+  })
+
+  // ==================== round-trip tests ====================
+
+  describe('round-trip: set then query', () => {
+    it('should create a relationship and then query it back', async () => {
+      const mockPost = vi.fn().mockResolvedValue({
+        success: true,
+        data: {
+          relationship: { id: 'rel-roundtrip' },
+          contactA: { id: 'ca-1', displayName: 'Troy' },
+          contactB: { id: 'cb-1', displayName: 'Alex' },
+          relationshipType: { id: 'rt-1', name: 'partner', label: 'Partner' },
+          created: true,
+        },
+      })
+      const mockGet = vi.fn().mockResolvedValue({
+        success: true,
+        data: {
+          contactId: 'ca-1',
+          contactName: 'Troy',
+          relatedContacts: [
+            {
+              contactId: 'cb-1',
+              contactName: 'Alex',
+              contactKind: 'person',
+              relationshipId: 'rel-roundtrip',
+              relationshipTypeName: 'partner',
+              relationshipTypeLabel: 'Partner',
+              isDirectional: false,
+              notes: null,
+            },
+          ],
+        },
+      })
+      const client = { ...mockApiClient, post: mockPost, get: mockGet }
+
+      const setTool = createRelationshipSetTool({
+        client: client as unknown as ApiClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId: 'agent-1',
+      })
+
+      const queryTool = createRelationshipQueryTool({
+        client: client as unknown as ApiClient,
+        logger: mockLogger,
+        config: mockConfig,
+        userId: 'agent-1',
+      })
+
+      // Step 1: Set the relationship
+      const setResult = await setTool.execute({
+        contact_a: 'Troy',
+        contact_b: 'Alex',
+        relationship: 'partner',
+      })
+      expect(setResult.success).toBe(true)
+
+      // Step 2: Query the relationship
+      const queryResult = await queryTool.execute({ contact: 'Troy' })
+      expect(queryResult.success).toBe(true)
+
+      if (queryResult.success) {
+        expect(queryResult.data.details.relatedContacts).toHaveLength(1)
+        const related = queryResult.data.details.relatedContacts[0]
+        expect(related.contactName).toBe('Alex')
+        expect(related.relationshipTypeName).toBe('partner')
+      }
+    })
+  })
+
+  // ==================== schema validation tests ====================
+
+  describe('Zod schema validation', () => {
+    it('RelationshipSetParamsSchema should validate correct input', () => {
+      const result = RelationshipSetParamsSchema.safeParse({
+        contact_a: 'Troy',
+        contact_b: 'Alex',
+        relationship: 'partner',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('RelationshipSetParamsSchema should accept optional notes', () => {
+      const result = RelationshipSetParamsSchema.safeParse({
+        contact_a: 'Troy',
+        contact_b: 'Alex',
+        relationship: 'partner',
+        notes: 'Since 2020',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('RelationshipSetParamsSchema should reject missing required fields', () => {
+      const result = RelationshipSetParamsSchema.safeParse({
+        contact_a: 'Troy',
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('RelationshipQueryParamsSchema should validate correct input', () => {
+      const result = RelationshipQueryParamsSchema.safeParse({
+        contact: 'Troy',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('RelationshipQueryParamsSchema should accept optional type_filter', () => {
+      const result = RelationshipQueryParamsSchema.safeParse({
+        contact: 'Troy',
+        type_filter: 'partner',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('RelationshipQueryParamsSchema should reject missing contact', () => {
+      const result = RelationshipQueryParamsSchema.safeParse({})
+      expect(result.success).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
## Summary
Registers `relationship_set` and `relationship_query` tools for OpenClaw agents, giving them a simple interface to manage the relationship graph.

- **relationship_set**: Record relationships between contacts with smart type matching, contact resolution, and automatic directionality handling
- **relationship_query**: Query a contact's relationships with automatic inverse resolution and group membership traversal

Both tools include:
- Zod parameter validation schemas
- JSON Schema definitions for OpenClaw gateway registration  
- Input sanitization (HTML stripping, control character removal)
- PII-safe logging (no contact names at info level)
- Comprehensive error handling with sanitized error messages
- User scoping via API client

Closes #494

## Test plan
- [x] relationship_set creates relationships via smart matching (mock API)
- [x] relationship_query returns relationships with inverse resolution
- [x] Group membership queries work
- [x] Tool schemas are valid (Zod + JSON Schema)
- [x] Round-trip create then query
- [x] Parameter validation (required fields, length limits)
- [x] Input sanitization (XSS, control chars)
- [x] Error handling (API errors, network errors, contact resolution failures)
- [x] PII handling (no contact names in info logs)
- [x] User scoping in API calls
- [x] Registration test updated (19 tools, schema exports)
- [x] All 758 existing plugin tests pass (no regressions)

## Files changed
- `packages/openclaw-plugin/src/tools/relationships.ts` -- NEW: relationship_set and relationship_query tools
- `packages/openclaw-plugin/src/tools/index.ts` -- barrel export for new tools
- `packages/openclaw-plugin/src/register-openclaw.ts` -- register tools with OpenClaw gateway (schemas, handlers, definitions)
- `packages/openclaw-plugin/tests/tools/relationships.test.ts` -- NEW: 50 tests for relationship tools
- `packages/openclaw-plugin/tests/register-openclaw.test.ts` -- updated for 19 tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)