### PR TITLE
[#476] Add keyboard navigation and shortcuts system

### DIFF
--- a/src/ui/components/keyboard-shortcuts/KeyboardShortcutsDialog.tsx
+++ b/src/ui/components/keyboard-shortcuts/KeyboardShortcutsDialog.tsx
@@ -1,0 +1,123 @@
+/**
+ * Keyboard shortcuts help dialog.
+ *
+ * Renders a modal that lists every registered shortcut grouped by category.
+ * The dialog is opened/closed via the `open` / `onOpenChange` controlled props,
+ * typically driven by the `useKeyboardShortcuts` hook (Cmd+/).
+ */
+import * as React from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/ui/components/ui/dialog';
+import { ScrollArea } from '@/ui/components/ui/scroll-area';
+import { Separator } from '@/ui/components/ui/separator';
+import type { ShortcutDefinition } from '@/ui/hooks/use-keyboard-shortcuts';
+
+export interface KeyboardShortcutsDialogProps {
+  /** Whether the dialog is open. */
+  open: boolean;
+  /** Called when the dialog requests to close. */
+  onOpenChange: (open: boolean) => void;
+  /** The shortcut definitions to display, typically from useKeyboardShortcuts. */
+  shortcuts: ShortcutDefinition[];
+}
+
+/** Renders a single keyboard key badge. */
+function Kbd({ children }: { children: React.ReactNode }) {
+  return (
+    <kbd className="inline-flex h-5 min-w-5 items-center justify-center rounded border border-border bg-muted px-1.5 font-mono text-xs font-medium text-muted-foreground">
+      {children}
+    </kbd>
+  );
+}
+
+/**
+ * Group an array of shortcut definitions by their `group` field,
+ * preserving insertion order.
+ */
+function groupShortcuts(
+  shortcuts: ShortcutDefinition[],
+): Map<string, ShortcutDefinition[]> {
+  const groups = new Map<string, ShortcutDefinition[]>();
+  for (const shortcut of shortcuts) {
+    const existing = groups.get(shortcut.group);
+    if (existing) {
+      existing.push(shortcut);
+    } else {
+      groups.set(shortcut.group, [shortcut]);
+    }
+  }
+  return groups;
+}
+
+/**
+ * Controlled dialog component that displays all keyboard shortcuts
+ * organised into labelled groups.
+ */
+export function KeyboardShortcutsDialog({
+  open,
+  onOpenChange,
+  shortcuts,
+}: KeyboardShortcutsDialogProps): React.JSX.Element {
+  const groups = React.useMemo(() => groupShortcuts(shortcuts), [shortcuts]);
+  const groupEntries = Array.from(groups.entries());
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg" data-testid="keyboard-shortcuts-dialog">
+        <DialogHeader>
+          <DialogTitle>Keyboard Shortcuts</DialogTitle>
+          <DialogDescription>
+            Navigate and act faster with these shortcuts. Press{' '}
+            <Kbd>{'\u2318'}</Kbd> <Kbd>/</Kbd> to toggle this help.
+          </DialogDescription>
+        </DialogHeader>
+        <ScrollArea className="max-h-[60vh]">
+          <div className="space-y-6 pr-4">
+            {groupEntries.map(([groupName, items], groupIndex) => (
+              <div key={groupName}>
+                {groupIndex > 0 && <Separator className="mb-4" />}
+                <h3 className="mb-3 text-sm font-medium text-foreground">
+                  {groupName}
+                </h3>
+                <div className="space-y-2">
+                  {items.map((shortcut) => (
+                    <div
+                      key={shortcut.id}
+                      className="flex items-center justify-between py-1"
+                    >
+                      <span className="text-sm text-muted-foreground">
+                        {shortcut.description}
+                      </span>
+                      <div className="flex items-center gap-1">
+                        {shortcut.keys.map((key, i) => (
+                          <React.Fragment key={`${shortcut.id}-key-${i}`}>
+                            <Kbd>{key}</Kbd>
+                            {i < shortcut.keys.length - 1 && (
+                              <span className="text-xs text-muted-foreground">
+                                then
+                              </span>
+                            )}
+                          </React.Fragment>
+                        ))}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </ScrollArea>
+        <div className="text-center text-xs text-muted-foreground">
+          <span className="opacity-75">
+            Shortcuts are disabled when typing in text fields
+          </span>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/ui/components/keyboard-shortcuts/index.ts
+++ b/src/ui/components/keyboard-shortcuts/index.ts
@@ -1,0 +1,2 @@
+export { KeyboardShortcutsDialog } from './KeyboardShortcutsDialog';
+export type { KeyboardShortcutsDialogProps } from './KeyboardShortcutsDialog';

--- a/src/ui/hooks/use-keyboard-shortcuts.ts
+++ b/src/ui/hooks/use-keyboard-shortcuts.ts
@@ -1,0 +1,237 @@
+/**
+ * Unified keyboard shortcut registration hook.
+ *
+ * Provides a declarative API for registering global shortcuts, go-to navigation
+ * sequences, and list navigation keys. Built on top of the lower-level
+ * `useHotkeys` / `useSequentialHotkeys` primitives.
+ *
+ * @module use-keyboard-shortcuts
+ */
+import { useCallback, useRef, useEffect, useState } from 'react';
+import { useHotkeys, useSequentialHotkeys } from '@/ui/hooks/use-hotkeys';
+
+/** A single shortcut definition for display and registration purposes. */
+export interface ShortcutDefinition {
+  /** Unique identifier for the shortcut (e.g. 'global.search', 'goto.projects'). */
+  id: string;
+  /** Human-readable label for the shortcut group (Global, Navigation, etc.). */
+  group: string;
+  /** Human-readable description of what the shortcut does. */
+  description: string;
+  /** Display keys (e.g. ['Cmd', 'K'] or ['G', 'P']). */
+  keys: string[];
+}
+
+/** Callbacks for global shortcuts (Cmd+K, Cmd+N, Cmd+/, Cmd+B, Escape). */
+export interface GlobalShortcutCallbacks {
+  /** Open command palette. */
+  onOpenSearch?: () => void;
+  /** Create a new work item (quick add). */
+  onNewItem?: () => void;
+  /** Toggle the keyboard shortcuts help dialog. */
+  onToggleHelp?: () => void;
+  /** Toggle the sidebar collapsed/expanded state. */
+  onToggleSidebar?: () => void;
+}
+
+/** Callbacks for go-to navigation sequences (G then X). */
+export interface GoToShortcutCallbacks {
+  /** Navigate to a named section ('activity', 'projects', 'people', 'settings', 'dashboard'). */
+  onNavigate?: (section: string) => void;
+}
+
+/** Callbacks for list-view navigation (J, K, Enter, Escape). */
+export interface ListShortcutCallbacks {
+  /** Move selection down in a list. */
+  onMoveDown?: () => void;
+  /** Move selection up in a list. */
+  onMoveUp?: () => void;
+  /** Open the currently selected item. */
+  onOpenSelected?: () => void;
+  /** Close the current view or clear selection. */
+  onEscape?: () => void;
+}
+
+/** Combined callbacks for all keyboard shortcut categories. */
+export interface KeyboardShortcutCallbacks
+  extends GlobalShortcutCallbacks,
+    GoToShortcutCallbacks,
+    ListShortcutCallbacks {}
+
+/** Options for the useKeyboardShortcuts hook. */
+export interface UseKeyboardShortcutsOptions {
+  /** Whether shortcuts are enabled. Defaults to true. */
+  enabled?: boolean;
+}
+
+/**
+ * The complete list of keyboard shortcuts exposed by the application.
+ * Used both for registration and for rendering the help dialog.
+ */
+export const SHORTCUT_DEFINITIONS: ShortcutDefinition[] = [
+  // Global shortcuts
+  {
+    id: 'global.search',
+    group: 'Global',
+    description: 'Open command palette',
+    keys: ['\u2318', 'K'],
+  },
+  {
+    id: 'global.new-item',
+    group: 'Global',
+    description: 'Create new work item',
+    keys: ['\u2318', 'N'],
+  },
+  {
+    id: 'global.help',
+    group: 'Global',
+    description: 'Show keyboard shortcuts',
+    keys: ['\u2318', '/'],
+  },
+  {
+    id: 'global.sidebar',
+    group: 'Global',
+    description: 'Toggle sidebar',
+    keys: ['\u2318', 'B'],
+  },
+
+  // Go-to navigation
+  {
+    id: 'goto.dashboard',
+    group: 'Navigation',
+    description: 'Go to Dashboard',
+    keys: ['G', 'D'],
+  },
+  {
+    id: 'goto.activity',
+    group: 'Navigation',
+    description: 'Go to Activity',
+    keys: ['G', 'A'],
+  },
+  {
+    id: 'goto.projects',
+    group: 'Navigation',
+    description: 'Go to Projects',
+    keys: ['G', 'P'],
+  },
+  {
+    id: 'goto.people',
+    group: 'Navigation',
+    description: 'Go to People',
+    keys: ['G', 'E'],
+  },
+  {
+    id: 'goto.settings',
+    group: 'Navigation',
+    description: 'Go to Settings',
+    keys: ['G', 'S'],
+  },
+
+  // List navigation
+  {
+    id: 'list.down',
+    group: 'Lists',
+    description: 'Move down',
+    keys: ['J'],
+  },
+  {
+    id: 'list.up',
+    group: 'Lists',
+    description: 'Move up',
+    keys: ['K'],
+  },
+  {
+    id: 'list.open',
+    group: 'Lists',
+    description: 'Open selected item',
+    keys: ['Enter'],
+  },
+  {
+    id: 'list.close',
+    group: 'Lists',
+    description: 'Close / clear selection',
+    keys: ['Esc'],
+  },
+];
+
+/**
+ * State and helpers returned by useKeyboardShortcuts.
+ */
+export interface UseKeyboardShortcutsReturn {
+  /** Whether the shortcuts help dialog is currently open. */
+  helpOpen: boolean;
+  /** Open or close the help dialog programmatically. */
+  setHelpOpen: (open: boolean) => void;
+  /** The full list of shortcut definitions for rendering in the help dialog. */
+  shortcuts: ShortcutDefinition[];
+}
+
+/**
+ * Register all application-wide keyboard shortcuts and return state
+ * for the help dialog. This hook is intended to be called once at
+ * the layout level (e.g. in AppLayout).
+ *
+ * @param callbacks - Handler functions invoked when shortcuts fire
+ * @param options   - Configuration (enable/disable)
+ * @returns Help dialog state and shortcut definitions
+ */
+export function useKeyboardShortcuts(
+  callbacks: KeyboardShortcutCallbacks,
+  options: UseKeyboardShortcutsOptions = {},
+): UseKeyboardShortcutsReturn {
+  const { enabled = true } = options;
+
+  const [helpOpen, setHelpOpen] = useState(false);
+
+  // Keep stable refs for callbacks to avoid re-registering listeners
+  const cbRef = useRef(callbacks);
+  cbRef.current = callbacks;
+
+  // --- Global shortcuts ---
+
+  // Cmd+K / Ctrl+K -> open search / command palette
+  useHotkeys('meta+k', () => cbRef.current.onOpenSearch?.(), { enabled });
+  useHotkeys('ctrl+k', () => cbRef.current.onOpenSearch?.(), { enabled });
+
+  // Cmd+N / Ctrl+N -> create new work item
+  useHotkeys('meta+n', () => cbRef.current.onNewItem?.(), { enabled });
+  useHotkeys('ctrl+n', () => cbRef.current.onNewItem?.(), { enabled });
+
+  // Cmd+/ / Ctrl+/ -> toggle help
+  const toggleHelp = useCallback(() => {
+    setHelpOpen((prev) => !prev);
+    cbRef.current.onToggleHelp?.();
+  }, []);
+  useHotkeys('meta+/', toggleHelp, { enabled });
+  useHotkeys('ctrl+/', toggleHelp, { enabled });
+
+  // Cmd+B / Ctrl+B -> toggle sidebar
+  useHotkeys('meta+b', () => cbRef.current.onToggleSidebar?.(), { enabled });
+  useHotkeys('ctrl+b', () => cbRef.current.onToggleSidebar?.(), { enabled });
+
+  // --- Go-to navigation sequences ---
+
+  const goTo = useCallback(
+    (section: string) => () => cbRef.current.onNavigate?.(section),
+    [],
+  );
+
+  useSequentialHotkeys(['g', 'd'], goTo('dashboard'), { enabled });
+  useSequentialHotkeys(['g', 'a'], goTo('activity'), { enabled });
+  useSequentialHotkeys(['g', 'p'], goTo('projects'), { enabled });
+  useSequentialHotkeys(['g', 'e'], goTo('people'), { enabled });
+  useSequentialHotkeys(['g', 's'], goTo('settings'), { enabled });
+
+  // --- List navigation ---
+
+  useHotkeys('j', () => cbRef.current.onMoveDown?.(), { enabled });
+  useHotkeys('k', () => cbRef.current.onMoveUp?.(), { enabled });
+  useHotkeys('enter', () => cbRef.current.onOpenSelected?.(), { enabled });
+  useHotkeys('escape', () => cbRef.current.onEscape?.(), { enabled });
+
+  return {
+    helpOpen,
+    setHelpOpen,
+    shortcuts: SHORTCUT_DEFINITIONS,
+  };
+}

--- a/tests/ui/keyboard-shortcuts.test.tsx
+++ b/tests/ui/keyboard-shortcuts.test.tsx
@@ -1,0 +1,493 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Tests for the keyboard shortcuts system (Issue #476).
+ *
+ * Covers:
+ * - useKeyboardShortcuts hook: global shortcuts, go-to sequences, list nav
+ * - KeyboardShortcutsDialog: rendering shortcut groups and descriptions
+ * - Input-field suppression: shortcuts must not fire when the user is typing
+ */
+import * as React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, act, renderHook } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import {
+  useKeyboardShortcuts,
+  SHORTCUT_DEFINITIONS,
+  type KeyboardShortcutCallbacks,
+} from '@/ui/hooks/use-keyboard-shortcuts';
+import { KeyboardShortcutsDialog } from '@/ui/components/keyboard-shortcuts/KeyboardShortcutsDialog';
+
+// ---------------------------------------------------------------------------
+// Mock api-client (required by convention even though these tests don't call it)
+// ---------------------------------------------------------------------------
+vi.mock('@/ui/lib/api-client', () => ({
+  apiClient: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Helper: render the hook inside a wrapper that exposes callbacks
+// ---------------------------------------------------------------------------
+function HookWrapper({
+  callbacks,
+  onHelpOpen,
+}: {
+  callbacks: KeyboardShortcutCallbacks;
+  onHelpOpen?: (open: boolean) => void;
+}) {
+  const { helpOpen, setHelpOpen, shortcuts } = useKeyboardShortcuts(callbacks);
+
+  React.useEffect(() => {
+    onHelpOpen?.(helpOpen);
+  }, [helpOpen, onHelpOpen]);
+
+  return (
+    <div data-testid="hook-wrapper">
+      <span data-testid="help-open">{String(helpOpen)}</span>
+      <button data-testid="close-help" onClick={() => setHelpOpen(false)}>
+        Close
+      </button>
+      <KeyboardShortcutsDialog
+        open={helpOpen}
+        onOpenChange={setHelpOpen}
+        shortcuts={shortcuts}
+      />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useKeyboardShortcuts', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // --- Global shortcuts ---
+
+  it('fires onOpenSearch on Cmd+K', () => {
+    const onOpenSearch = vi.fn();
+    render(<HookWrapper callbacks={{ onOpenSearch }} />);
+
+    act(() => {
+      document.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'k', metaKey: true }),
+      );
+    });
+
+    expect(onOpenSearch).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires onOpenSearch on Ctrl+K', () => {
+    const onOpenSearch = vi.fn();
+    render(<HookWrapper callbacks={{ onOpenSearch }} />);
+
+    act(() => {
+      document.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'k', ctrlKey: true }),
+      );
+    });
+
+    expect(onOpenSearch).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires onNewItem on Cmd+N', () => {
+    const onNewItem = vi.fn();
+    render(<HookWrapper callbacks={{ onNewItem }} />);
+
+    act(() => {
+      document.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'n', metaKey: true }),
+      );
+    });
+
+    expect(onNewItem).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires onNewItem on Ctrl+N', () => {
+    const onNewItem = vi.fn();
+    render(<HookWrapper callbacks={{ onNewItem }} />);
+
+    act(() => {
+      document.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'n', ctrlKey: true }),
+      );
+    });
+
+    expect(onNewItem).toHaveBeenCalledTimes(1);
+  });
+
+  it('toggles helpOpen on Cmd+/', () => {
+    render(<HookWrapper callbacks={{}} />);
+
+    // Initially closed
+    expect(screen.getByTestId('help-open')).toHaveTextContent('false');
+
+    // Open
+    act(() => {
+      document.dispatchEvent(
+        new KeyboardEvent('keydown', { key: '/', metaKey: true }),
+      );
+    });
+    expect(screen.getByTestId('help-open')).toHaveTextContent('true');
+
+    // Close
+    act(() => {
+      document.dispatchEvent(
+        new KeyboardEvent('keydown', { key: '/', metaKey: true }),
+      );
+    });
+    expect(screen.getByTestId('help-open')).toHaveTextContent('false');
+  });
+
+  it('fires onToggleSidebar on Cmd+B', () => {
+    const onToggleSidebar = vi.fn();
+    render(<HookWrapper callbacks={{ onToggleSidebar }} />);
+
+    act(() => {
+      document.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'b', metaKey: true }),
+      );
+    });
+
+    expect(onToggleSidebar).toHaveBeenCalledTimes(1);
+  });
+
+  // --- Go-to navigation sequences ---
+
+  it('navigates to activity on G then A', () => {
+    const onNavigate = vi.fn();
+    render(<HookWrapper callbacks={{ onNavigate }} />);
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'g' }));
+    });
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'a' }));
+    });
+
+    expect(onNavigate).toHaveBeenCalledWith('activity');
+  });
+
+  it('navigates to projects on G then P', () => {
+    const onNavigate = vi.fn();
+    render(<HookWrapper callbacks={{ onNavigate }} />);
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'g' }));
+    });
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'p' }));
+    });
+
+    expect(onNavigate).toHaveBeenCalledWith('projects');
+  });
+
+  it('navigates to people on G then E', () => {
+    const onNavigate = vi.fn();
+    render(<HookWrapper callbacks={{ onNavigate }} />);
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'g' }));
+    });
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'e' }));
+    });
+
+    expect(onNavigate).toHaveBeenCalledWith('people');
+  });
+
+  it('navigates to settings on G then S', () => {
+    const onNavigate = vi.fn();
+    render(<HookWrapper callbacks={{ onNavigate }} />);
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'g' }));
+    });
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 's' }));
+    });
+
+    expect(onNavigate).toHaveBeenCalledWith('settings');
+  });
+
+  it('navigates to dashboard on G then D', () => {
+    const onNavigate = vi.fn();
+    render(<HookWrapper callbacks={{ onNavigate }} />);
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'g' }));
+    });
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'd' }));
+    });
+
+    expect(onNavigate).toHaveBeenCalledWith('dashboard');
+  });
+
+  // --- List navigation ---
+
+  it('fires onMoveDown on J key', () => {
+    const onMoveDown = vi.fn();
+    render(<HookWrapper callbacks={{ onMoveDown }} />);
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'j' }));
+    });
+
+    expect(onMoveDown).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires onMoveUp on K key', () => {
+    const onMoveUp = vi.fn();
+    render(<HookWrapper callbacks={{ onMoveUp }} />);
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'k' }));
+    });
+
+    expect(onMoveUp).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires onOpenSelected on Enter key', () => {
+    const onOpenSelected = vi.fn();
+    render(<HookWrapper callbacks={{ onOpenSelected }} />);
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    });
+
+    expect(onOpenSelected).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires onEscape on Escape key', () => {
+    const onEscape = vi.fn();
+    render(<HookWrapper callbacks={{ onEscape }} />);
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    });
+
+    expect(onEscape).toHaveBeenCalledTimes(1);
+  });
+
+  // --- Input field suppression ---
+
+  it('does not fire shortcuts when typing in an input field', () => {
+    const onMoveDown = vi.fn();
+    const onNewItem = vi.fn();
+    render(<HookWrapper callbacks={{ onMoveDown, onNewItem }} />);
+
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    input.focus();
+
+    act(() => {
+      input.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'j', bubbles: true }),
+      );
+    });
+    act(() => {
+      input.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'n', metaKey: true, bubbles: true }),
+      );
+    });
+
+    expect(onMoveDown).not.toHaveBeenCalled();
+    expect(onNewItem).not.toHaveBeenCalled();
+    document.body.removeChild(input);
+  });
+
+  it('does not fire shortcuts when typing in a textarea', () => {
+    const onMoveUp = vi.fn();
+    render(<HookWrapper callbacks={{ onMoveUp }} />);
+
+    const textarea = document.createElement('textarea');
+    document.body.appendChild(textarea);
+    textarea.focus();
+
+    act(() => {
+      textarea.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'k', bubbles: true }),
+      );
+    });
+
+    expect(onMoveUp).not.toHaveBeenCalled();
+    document.body.removeChild(textarea);
+  });
+
+  it('does not fire go-to sequence when typing in a select element', () => {
+    const onNavigate = vi.fn();
+    render(<HookWrapper callbacks={{ onNavigate }} />);
+
+    const select = document.createElement('select');
+    const option = document.createElement('option');
+    option.value = 'test';
+    select.appendChild(option);
+    document.body.appendChild(select);
+    select.focus();
+
+    act(() => {
+      select.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'g', bubbles: true }),
+      );
+    });
+    act(() => {
+      select.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'a', bubbles: true }),
+      );
+    });
+
+    expect(onNavigate).not.toHaveBeenCalled();
+    document.body.removeChild(select);
+  });
+
+  // --- Disabled state ---
+
+  it('does not fire shortcuts when disabled', () => {
+    const onOpenSearch = vi.fn();
+
+    function DisabledWrapper() {
+      useKeyboardShortcuts({ onOpenSearch }, { enabled: false });
+      return <div data-testid="disabled-wrapper" />;
+    }
+
+    render(<DisabledWrapper />);
+
+    act(() => {
+      document.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'k', metaKey: true }),
+      );
+    });
+
+    expect(onOpenSearch).not.toHaveBeenCalled();
+  });
+});
+
+describe('KeyboardShortcutsDialog', () => {
+  it('renders nothing when closed', () => {
+    render(
+      <KeyboardShortcutsDialog
+        open={false}
+        onOpenChange={vi.fn()}
+        shortcuts={SHORTCUT_DEFINITIONS}
+      />,
+    );
+
+    expect(screen.queryByText('Keyboard Shortcuts')).not.toBeInTheDocument();
+  });
+
+  it('renders the dialog title when open', () => {
+    render(
+      <KeyboardShortcutsDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        shortcuts={SHORTCUT_DEFINITIONS}
+      />,
+    );
+
+    expect(screen.getByText('Keyboard Shortcuts')).toBeInTheDocument();
+  });
+
+  it('displays all shortcut groups', () => {
+    render(
+      <KeyboardShortcutsDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        shortcuts={SHORTCUT_DEFINITIONS}
+      />,
+    );
+
+    expect(screen.getByText('Global')).toBeInTheDocument();
+    expect(screen.getByText('Navigation')).toBeInTheDocument();
+    expect(screen.getByText('Lists')).toBeInTheDocument();
+  });
+
+  it('displays individual shortcut descriptions', () => {
+    render(
+      <KeyboardShortcutsDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        shortcuts={SHORTCUT_DEFINITIONS}
+      />,
+    );
+
+    expect(screen.getByText('Open command palette')).toBeInTheDocument();
+    expect(screen.getByText('Create new work item')).toBeInTheDocument();
+    expect(screen.getByText('Show keyboard shortcuts')).toBeInTheDocument();
+    expect(screen.getByText('Toggle sidebar')).toBeInTheDocument();
+    expect(screen.getByText('Go to Dashboard')).toBeInTheDocument();
+    expect(screen.getByText('Go to Activity')).toBeInTheDocument();
+    expect(screen.getByText('Go to Projects')).toBeInTheDocument();
+    expect(screen.getByText('Go to People')).toBeInTheDocument();
+    expect(screen.getByText('Go to Settings')).toBeInTheDocument();
+    expect(screen.getByText('Move down')).toBeInTheDocument();
+    expect(screen.getByText('Move up')).toBeInTheDocument();
+    expect(screen.getByText('Open selected item')).toBeInTheDocument();
+    expect(screen.getByText('Close / clear selection')).toBeInTheDocument();
+  });
+
+  it('shows the disabled-in-text-fields note', () => {
+    render(
+      <KeyboardShortcutsDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        shortcuts={SHORTCUT_DEFINITIONS}
+      />,
+    );
+
+    expect(
+      screen.getByText('Shortcuts are disabled when typing in text fields'),
+    ).toBeInTheDocument();
+  });
+
+  it('calls onOpenChange when dialog is closed', () => {
+    const onOpenChange = vi.fn();
+    render(
+      <KeyboardShortcutsDialog
+        open={true}
+        onOpenChange={onOpenChange}
+        shortcuts={SHORTCUT_DEFINITIONS}
+      />,
+    );
+
+    // Close using the X button (Radix Dialog renders a close button)
+    const closeButton = screen.getByRole('button', { name: /close/i });
+    if (closeButton) {
+      fireEvent.click(closeButton);
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    }
+  });
+});
+
+describe('SHORTCUT_DEFINITIONS', () => {
+  it('contains at least 13 shortcuts', () => {
+    expect(SHORTCUT_DEFINITIONS.length).toBeGreaterThanOrEqual(13);
+  });
+
+  it('has unique IDs for every shortcut', () => {
+    const ids = SHORTCUT_DEFINITIONS.map((s) => s.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('every shortcut has a non-empty description and keys', () => {
+    for (const shortcut of SHORTCUT_DEFINITIONS) {
+      expect(shortcut.description.length).toBeGreaterThan(0);
+      expect(shortcut.keys.length).toBeGreaterThan(0);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Add `useKeyboardShortcuts` custom hook (`src/ui/hooks/use-keyboard-shortcuts.ts`) providing a unified API for registering all application keyboard shortcuts
- Add `KeyboardShortcutsDialog` component (`src/ui/components/keyboard-shortcuts/KeyboardShortcutsDialog.tsx`) showing a grouped listing of all available shortcuts
- Integrate the hook and dialog into `AppLayout` for global availability across all routes
- Global shortcuts: Cmd+K (command palette), Cmd+N (create work item), Cmd+/ (show help), Cmd+B (toggle sidebar)
- Go-to navigation sequences: G then D (dashboard), G then A (activity), G then P (projects), G then E (people), G then S (settings)
- List view shortcuts: J/K (navigate up/down), Enter (open item), Escape (close/clear)
- All shortcuts are suppressed when the user is typing in input, textarea, or select elements

## Test plan

- [x] 28 tests in `tests/ui/keyboard-shortcuts.test.tsx` covering:
  - Global shortcuts fire correct callbacks (Cmd+K, Cmd+N, Cmd+B, Cmd+/)
  - Help dialog toggles on Cmd+/
  - Go-to sequences navigate to correct sections (G+D, G+A, G+P, G+E, G+S)
  - List navigation shortcuts fire (J, K, Enter, Escape)
  - Shortcuts suppressed in input, textarea, and select elements
  - Disabled state prevents all shortcuts
  - Dialog renders all shortcut groups and descriptions
  - SHORTCUT_DEFINITIONS has unique IDs and valid entries
- [x] Existing keyboard-related tests still pass (use-hotkeys, keyboard-shortcuts-handler, keyboard-shortcuts-modal)
- [x] `pnpm app:build` succeeds

Closes #476

🤖 Generated with [Claude Code](https://claude.com/claude-code)