### PR TITLE
[#480] Add accessibility audit and WCAG 2.1 AA compliance

### DIFF
--- a/src/ui/components/a11y/RouteAnnouncer.tsx
+++ b/src/ui/components/a11y/RouteAnnouncer.tsx
@@ -1,0 +1,111 @@
+/**
+ * RouteAnnouncer component for screen reader users.
+ *
+ * Announces route changes via an `aria-live="assertive"` region so
+ * assistive technology users know when the page content has changed.
+ * Also manages focus by moving it to the main content area after
+ * each navigation, mimicking the behaviour of a full page load.
+ *
+ * @see Issue #480 - WCAG 2.1 AA compliance
+ */
+import * as React from 'react';
+import { useLocation } from 'react-router';
+
+/** Map pathname prefixes to human-readable page titles. */
+const PAGE_TITLES: Record<string, string> = {
+  '/dashboard': 'Dashboard',
+  '/activity': 'Activity',
+  '/work-items': 'Projects',
+  '/kanban': 'Kanban Board',
+  '/timeline': 'Timeline',
+  '/contacts': 'People',
+  '/communications': 'Communications',
+  '/memory': 'Memory',
+  '/settings': 'Settings',
+};
+
+/**
+ * Derive a human-readable page title from the current pathname.
+ * Falls back to a capitalised version of the first path segment.
+ */
+function getPageTitle(pathname: string): string {
+  // Exact or prefix match
+  for (const [prefix, title] of Object.entries(PAGE_TITLES)) {
+    if (pathname === prefix || pathname.startsWith(`${prefix}/`)) {
+      return title;
+    }
+  }
+
+  // Fallback: capitalise first path segment
+  const segment = pathname.split('/').filter(Boolean)[0];
+  if (segment) {
+    return segment.charAt(0).toUpperCase() + segment.slice(1).replace(/-/g, ' ');
+  }
+  return 'Page';
+}
+
+export interface RouteAnnouncerProps {
+  /** Optional app name prepended to the page title. */
+  appName?: string;
+  /**
+   * ID of the main content element to focus on route change.
+   * Defaults to "main-content".
+   */
+  mainContentId?: string;
+}
+
+/**
+ * Invisible live region that announces page changes to screen readers
+ * and moves focus to the main content area.
+ */
+export function RouteAnnouncer({
+  appName = 'OpenClaw Projects',
+  mainContentId = 'main-content',
+}: RouteAnnouncerProps): React.JSX.Element {
+  const location = useLocation();
+  const [announcement, setAnnouncement] = React.useState('');
+  const isFirstRender = React.useRef(true);
+
+  React.useEffect(() => {
+    // Skip the initial render so we don't announce the first page load
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      // Still update document.title on initial load
+      const title = getPageTitle(location.pathname);
+      document.title = `${title} - ${appName}`;
+      return;
+    }
+
+    const title = getPageTitle(location.pathname);
+
+    // Update document.title
+    document.title = `${title} - ${appName}`;
+
+    // Announce the navigation to screen readers
+    setAnnouncement(`Navigated to ${title}`);
+
+    // Move focus to the main content area for keyboard users
+    const mainContent = document.getElementById(mainContentId);
+    if (mainContent) {
+      // Ensure the element can receive focus
+      if (!mainContent.hasAttribute('tabindex')) {
+        mainContent.setAttribute('tabindex', '-1');
+      }
+      mainContent.focus({ preventScroll: true });
+    }
+  }, [location.pathname, appName, mainContentId]);
+
+  return (
+    <div
+      role="status"
+      aria-live="assertive"
+      aria-atomic="true"
+      className="sr-only"
+      data-testid="route-announcer"
+    >
+      {announcement}
+    </div>
+  );
+}
+
+export { getPageTitle };

--- a/src/ui/components/a11y/SkipLink.tsx
+++ b/src/ui/components/a11y/SkipLink.tsx
@@ -1,0 +1,59 @@
+/**
+ * SkipLink component for keyboard-only users.
+ *
+ * Renders a visually hidden anchor that becomes visible on focus,
+ * allowing keyboard users to bypass repetitive navigation and jump
+ * directly to the main content area.
+ *
+ * @see Issue #480 - WCAG 2.1 AA compliance
+ */
+import * as React from 'react';
+import { cn } from '@/ui/lib/utils';
+
+export interface SkipLinkProps {
+  /** The target element ID to jump to (without the # prefix). */
+  targetId: string;
+  /** Label shown to screen readers and visible on focus. */
+  label?: string;
+  /** Additional CSS class names. */
+  className?: string;
+}
+
+/**
+ * Skip link that is visually hidden until focused.
+ *
+ * On click, the browser scrolls to the element whose `id` matches
+ * `targetId` and moves focus there, letting keyboard users skip
+ * past the sidebar and header.
+ */
+export function SkipLink({
+  targetId,
+  label = 'Skip to main content',
+  className,
+}: SkipLinkProps): React.JSX.Element {
+  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    e.preventDefault();
+    const target = document.getElementById(targetId);
+    if (target) {
+      target.focus();
+      target.scrollIntoView({ behavior: 'smooth' });
+    }
+  };
+
+  return (
+    <a
+      href={`#${targetId}`}
+      onClick={handleClick}
+      className={cn(
+        'sr-only focus:not-sr-only',
+        'fixed top-4 left-4 z-[100]',
+        'rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground',
+        'focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+        'transition-opacity',
+        className,
+      )}
+    >
+      {label}
+    </a>
+  );
+}

--- a/src/ui/components/a11y/index.ts
+++ b/src/ui/components/a11y/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Accessibility (a11y) components for WCAG 2.1 AA compliance.
+ * @see Issue #480
+ */
+export { SkipLink, type SkipLinkProps } from './SkipLink';
+export { RouteAnnouncer, type RouteAnnouncerProps, getPageTitle } from './RouteAnnouncer';

--- a/src/ui/hooks/use-document-title.ts
+++ b/src/ui/hooks/use-document-title.ts
@@ -1,0 +1,36 @@
+/**
+ * Hook for updating the document title reactively.
+ *
+ * Sets `document.title` on mount and whenever the provided title
+ * string changes. Restores the previous title on unmount so that
+ * nested title updates compose correctly.
+ *
+ * @see Issue #480 - WCAG 2.1 AA compliance
+ */
+import { useEffect, useRef } from 'react';
+
+/**
+ * Set the browser document title. The previous title is restored
+ * when the component that uses this hook unmounts.
+ *
+ * @param title - The desired page title (the suffix " - OpenClaw Projects" is appended automatically).
+ * @param options.restoreOnUnmount - Whether to restore the previous title on unmount. Defaults to true.
+ */
+export function useDocumentTitle(
+  title: string,
+  options: { restoreOnUnmount?: boolean } = {},
+): void {
+  const { restoreOnUnmount = true } = options;
+  const previousTitle = useRef(document.title);
+
+  useEffect(() => {
+    const fullTitle = title ? `${title} - OpenClaw Projects` : 'OpenClaw Projects';
+    document.title = fullTitle;
+
+    return () => {
+      if (restoreOnUnmount) {
+        document.title = previousTitle.current;
+      }
+    };
+  }, [title, restoreOnUnmount]);
+}


### PR DESCRIPTION
## Summary

- Add `SkipLink` component (`src/ui/components/a11y/SkipLink.tsx`) for keyboard users to bypass navigation and jump directly to main content
- Add `RouteAnnouncer` component (`src/ui/components/a11y/RouteAnnouncer.tsx`) that announces route changes to screen readers via `aria-live="assertive"`, updates `document.title`, and manages focus on navigation
- Add `useDocumentTitle` hook (`src/ui/hooks/use-document-title.ts`) for programmatic document title management with unmount restoration
- Update `AppShell` to add `id="main-content"` and `tabIndex={-1}` to the `<main>` element for skip link targeting and programmatic focus
- Integrate `SkipLink` and `RouteAnnouncer` into `AppLayout` for app-wide accessibility
- Write 51 comprehensive tests covering all WCAG 2.1 AA requirements

## WCAG 2.1 AA requirements addressed

- **Skip link to main content**: SkipLink component with focus management
- **Proper heading hierarchy**: h1 per page verified in tests
- **Landmark regions**: `<nav>`, `<main>`, `<aside>`, `<header>` all present and verified
- **Page title updates on route change**: RouteAnnouncer updates `document.title`
- **Focus moves to main content on route change**: RouteAnnouncer manages focus
- **Visible focus indicators**: All interactive elements use `focus:ring-2` styles
- **Route changes announced to screen readers**: `aria-live="assertive"` region
- **Form error messages associated via `aria-describedby`**: ErrorMessage component with id
- **Keyboard navigation**: All interactive elements are keyboard accessible with proper aria attributes

## Test plan

- [x] Skip link renders with correct href and sr-only/focus:not-sr-only classes
- [x] Skip link moves focus to target element on click
- [x] Route announcer renders aria-live assertive region
- [x] Route announcer updates document.title on navigation
- [x] Route announcer announces navigation text to screen readers
- [x] Route announcer moves focus to main-content on route change
- [x] useDocumentTitle sets title on mount and restores on unmount
- [x] Landmark regions verified: main, nav, aside, header
- [x] main element has id="main-content" and tabindex="-1"
- [x] Sidebar buttons are keyboard focusable with accessible labels
- [x] Active nav items have aria-current="page"
- [x] ErrorMessage renders with role="alert" and proper id for aria-describedby
- [x] All 51 tests pass
- [x] Build succeeds with `pnpm app:build`

Closes #480

🤖 Generated with [Claude Code](https://claude.com/claude-code)