### PR TITLE
[#542] Implement date-range and boolean filter popovers

### DIFF
--- a/src/ui/components/filter-bar/index.ts
+++ b/src/ui/components/filter-bar/index.ts
@@ -1,4 +1,5 @@
-export { FilterBar } from './filter-bar';
+export { FilterBar, DateRangePopover, BooleanPopover } from './filter-bar';
+export type { DateRangePopoverProps, BooleanPopoverProps } from './filter-bar';
 export { useFilterState } from './use-filter-state';
 export type {
   FilterState,

--- a/tests/ui/filter-bar.test.tsx
+++ b/tests/ui/filter-bar.test.tsx
@@ -4,8 +4,14 @@
 import * as React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { FilterBar } from '@/ui/components/filter-bar';
-import type { FilterState, SavedFilter } from '@/ui/components/filter-bar/types';
+import { FilterBar, DateRangePopover, BooleanPopover } from '@/ui/components/filter-bar';
+import type {
+  FilterState,
+  SavedFilter,
+  DateRange,
+  FilterField,
+  FilterFieldConfig,
+} from '@/ui/components/filter-bar/types';
 
 describe('FilterBar', () => {
   const defaultProps = {
@@ -196,6 +202,361 @@ describe('FilterBar', () => {
 
       expect(onSaveFilter).toHaveBeenCalledWith('My Filter', filters);
     });
+  });
+});
+
+describe('DateRangePopover', () => {
+  const baseConfig: FilterFieldConfig = {
+    field: 'dueDate',
+    label: 'Due Date',
+    type: 'date-range',
+  };
+
+  const defaultProps = {
+    field: 'dueDate' as FilterField,
+    config: baseConfig,
+    value: undefined as DateRange | string | undefined,
+    onChange: vi.fn(),
+    onClose: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the date-range popover', () => {
+    render(<DateRangePopover {...defaultProps} />);
+    expect(screen.getByTestId('date-range-popover')).toBeInTheDocument();
+  });
+
+  it('displays the field label', () => {
+    render(<DateRangePopover {...defaultProps} />);
+    expect(screen.getByText('Due Date')).toBeInTheDocument();
+  });
+
+  it('shows all preset options', () => {
+    render(<DateRangePopover {...defaultProps} />);
+
+    expect(screen.getByText('Today')).toBeInTheDocument();
+    expect(screen.getByText('This Week')).toBeInTheDocument();
+    expect(screen.getByText('This Month')).toBeInTheDocument();
+    expect(screen.getByText('Overdue')).toBeInTheDocument();
+    expect(screen.getByText('Upcoming')).toBeInTheDocument();
+  });
+
+  it('shows custom range date inputs', () => {
+    render(<DateRangePopover {...defaultProps} />);
+
+    expect(screen.getByLabelText('From date')).toBeInTheDocument();
+    expect(screen.getByLabelText('To date')).toBeInTheDocument();
+  });
+
+  it('applies preset value on Apply', () => {
+    const onChange = vi.fn();
+    const onClose = vi.fn();
+    render(<DateRangePopover {...defaultProps} onChange={onChange} onClose={onClose} />);
+
+    // Click a preset
+    fireEvent.click(screen.getByText('This Week'));
+
+    // Click Apply
+    fireEvent.click(screen.getByRole('button', { name: /apply/i }));
+
+    expect(onChange).toHaveBeenCalledWith({ preset: 'this_week' });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('applies custom date range', () => {
+    const onChange = vi.fn();
+    const onClose = vi.fn();
+    render(<DateRangePopover {...defaultProps} onChange={onChange} onClose={onClose} />);
+
+    // Fill in custom dates
+    const fromInput = screen.getByLabelText('From date');
+    const toInput = screen.getByLabelText('To date');
+
+    fireEvent.change(fromInput, { target: { value: '2026-01-01' } });
+    fireEvent.change(toInput, { target: { value: '2026-01-31' } });
+
+    // Click Apply
+    fireEvent.click(screen.getByRole('button', { name: /apply/i }));
+
+    expect(onChange).toHaveBeenCalledWith({
+      preset: 'custom',
+      from: '2026-01-01',
+      to: '2026-01-31',
+    });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('applies custom range with only from date', () => {
+    const onChange = vi.fn();
+    render(<DateRangePopover {...defaultProps} onChange={onChange} />);
+
+    fireEvent.change(screen.getByLabelText('From date'), { target: { value: '2026-03-01' } });
+    fireEvent.click(screen.getByRole('button', { name: /apply/i }));
+
+    expect(onChange).toHaveBeenCalledWith({
+      preset: 'custom',
+      from: '2026-03-01',
+      to: undefined,
+    });
+  });
+
+  it('applies custom range with only to date', () => {
+    const onChange = vi.fn();
+    render(<DateRangePopover {...defaultProps} onChange={onChange} />);
+
+    fireEvent.change(screen.getByLabelText('To date'), { target: { value: '2026-03-31' } });
+    fireEvent.click(screen.getByRole('button', { name: /apply/i }));
+
+    expect(onChange).toHaveBeenCalledWith({
+      preset: 'custom',
+      from: undefined,
+      to: '2026-03-31',
+    });
+  });
+
+  it('calls onChange with undefined when Apply is clicked with no selection', () => {
+    const onChange = vi.fn();
+    render(<DateRangePopover {...defaultProps} onChange={onChange} />);
+
+    // Click Apply with nothing selected
+    fireEvent.click(screen.getByRole('button', { name: /apply/i }));
+
+    expect(onChange).toHaveBeenCalledWith(undefined);
+  });
+
+  it('cancels without calling onChange', () => {
+    const onChange = vi.fn();
+    const onClose = vi.fn();
+    render(<DateRangePopover {...defaultProps} onChange={onChange} onClose={onClose} />);
+
+    // Click a preset first
+    fireEvent.click(screen.getByText('This Month'));
+
+    // Click Cancel
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('initialises from existing DateRange value', () => {
+    render(
+      <DateRangePopover
+        {...defaultProps}
+        value={{ preset: 'this_week' }}
+      />
+    );
+
+    // The "This Week" preset button should have the active styling (font-medium)
+    const thisWeekButton = screen.getByText('This Week').closest('button');
+    expect(thisWeekButton?.className).toContain('font-medium');
+  });
+
+  it('initialises from existing string preset value', () => {
+    render(
+      <DateRangePopover
+        {...defaultProps}
+        value="overdue"
+      />
+    );
+
+    // The "Overdue" preset button should have the active styling (font-medium)
+    const overdueButton = screen.getByText('Overdue').closest('button');
+    expect(overdueButton?.className).toContain('font-medium');
+  });
+
+  it('initialises from existing custom date range', () => {
+    render(
+      <DateRangePopover
+        {...defaultProps}
+        value={{ preset: 'custom', from: '2026-02-01', to: '2026-02-28' }}
+      />
+    );
+
+    const fromInput = screen.getByLabelText('From date') as HTMLInputElement;
+    const toInput = screen.getByLabelText('To date') as HTMLInputElement;
+
+    expect(fromInput.value).toBe('2026-02-01');
+    expect(toInput.value).toBe('2026-02-28');
+  });
+
+  it('clears custom dates when a preset is selected', () => {
+    const onChange = vi.fn();
+    render(
+      <DateRangePopover
+        {...defaultProps}
+        onChange={onChange}
+        value={{ preset: 'custom', from: '2026-02-01', to: '2026-02-28' }}
+      />
+    );
+
+    // Click a preset to override the custom range
+    fireEvent.click(screen.getByText('Today'));
+
+    // Click Apply
+    fireEvent.click(screen.getByRole('button', { name: /apply/i }));
+
+    expect(onChange).toHaveBeenCalledWith({ preset: 'today' });
+  });
+
+  it('switches to custom preset when date input is changed', () => {
+    const onChange = vi.fn();
+    render(
+      <DateRangePopover
+        {...defaultProps}
+        onChange={onChange}
+        value={{ preset: 'today' }}
+      />
+    );
+
+    // The "Today" preset should initially be active
+    const todayButton = screen.getByText('Today').closest('button');
+    expect(todayButton?.className).toContain('font-medium');
+
+    // Change a date input
+    fireEvent.change(screen.getByLabelText('From date'), { target: { value: '2026-05-01' } });
+
+    // Click Apply -- should get custom preset
+    fireEvent.click(screen.getByRole('button', { name: /apply/i }));
+
+    expect(onChange).toHaveBeenCalledWith({
+      preset: 'custom',
+      from: '2026-05-01',
+      to: undefined,
+    });
+  });
+});
+
+describe('BooleanPopover', () => {
+  const baseConfig: FilterFieldConfig = {
+    field: 'hasDescription',
+    label: 'Has Description',
+    type: 'boolean',
+  };
+
+  const defaultProps = {
+    field: 'hasDescription' as FilterField,
+    config: baseConfig,
+    value: undefined as boolean | undefined,
+    onChange: vi.fn(),
+    onClose: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the boolean popover', () => {
+    render(<BooleanPopover {...defaultProps} />);
+    expect(screen.getByTestId('boolean-popover')).toBeInTheDocument();
+  });
+
+  it('displays the field label', () => {
+    render(<BooleanPopover {...defaultProps} />);
+    expect(screen.getByText('Has Description')).toBeInTheDocument();
+  });
+
+  it('shows Yes/No toggle buttons', () => {
+    render(<BooleanPopover {...defaultProps} />);
+
+    expect(screen.getByRole('button', { name: /^yes$/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^no$/i })).toBeInTheDocument();
+  });
+
+  it('applies true value when Yes is clicked and Apply pressed', () => {
+    const onChange = vi.fn();
+    const onClose = vi.fn();
+    render(<BooleanPopover {...defaultProps} onChange={onChange} onClose={onClose} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /^yes$/i }));
+    fireEvent.click(screen.getByRole('button', { name: /apply/i }));
+
+    expect(onChange).toHaveBeenCalledWith(true);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('applies false value when No is clicked and Apply pressed', () => {
+    const onChange = vi.fn();
+    const onClose = vi.fn();
+    render(<BooleanPopover {...defaultProps} onChange={onChange} onClose={onClose} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /^no$/i }));
+    fireEvent.click(screen.getByRole('button', { name: /apply/i }));
+
+    expect(onChange).toHaveBeenCalledWith(false);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('applies undefined when Apply is clicked with no selection', () => {
+    const onChange = vi.fn();
+    render(<BooleanPopover {...defaultProps} onChange={onChange} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /apply/i }));
+
+    expect(onChange).toHaveBeenCalledWith(undefined);
+  });
+
+  it('cancels without calling onChange', () => {
+    const onChange = vi.fn();
+    const onClose = vi.fn();
+    render(<BooleanPopover {...defaultProps} onChange={onChange} onClose={onClose} />);
+
+    // Click Yes to select a value
+    fireEvent.click(screen.getByRole('button', { name: /^yes$/i }));
+
+    // Click Cancel
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('initialises with existing true value', () => {
+    render(<BooleanPopover {...defaultProps} value={true} />);
+
+    // The Yes button should be the "default" variant (active state)
+    const yesButton = screen.getByRole('button', { name: /^yes$/i });
+    expect(yesButton).toHaveAttribute('data-variant', 'default');
+
+    // The No button should be the "outline" variant
+    const noButton = screen.getByRole('button', { name: /^no$/i });
+    expect(noButton).toHaveAttribute('data-variant', 'outline');
+  });
+
+  it('initialises with existing false value', () => {
+    render(<BooleanPopover {...defaultProps} value={false} />);
+
+    // The No button should be the "default" variant (active state)
+    const noButton = screen.getByRole('button', { name: /^no$/i });
+    expect(noButton).toHaveAttribute('data-variant', 'default');
+
+    // The Yes button should be the "outline" variant
+    const yesButton = screen.getByRole('button', { name: /^yes$/i });
+    expect(yesButton).toHaveAttribute('data-variant', 'outline');
+  });
+
+  it('toggles between Yes and No', () => {
+    render(<BooleanPopover {...defaultProps} />);
+
+    const yesButton = screen.getByRole('button', { name: /^yes$/i });
+    const noButton = screen.getByRole('button', { name: /^no$/i });
+
+    // Initially both should be outline
+    expect(yesButton).toHaveAttribute('data-variant', 'outline');
+    expect(noButton).toHaveAttribute('data-variant', 'outline');
+
+    // Click Yes
+    fireEvent.click(yesButton);
+    expect(yesButton).toHaveAttribute('data-variant', 'default');
+    expect(noButton).toHaveAttribute('data-variant', 'outline');
+
+    // Click No
+    fireEvent.click(noButton);
+    expect(yesButton).toHaveAttribute('data-variant', 'outline');
+    expect(noButton).toHaveAttribute('data-variant', 'default');
   });
 });
 


### PR DESCRIPTION
## Summary
- Added `DateRangePopover` with preset options (Today, This Week, This Month, Overdue, Upcoming) and custom date range inputs
- Added `BooleanPopover` with Yes/No toggle buttons and Apply/Cancel actions
- Wired both popovers into FilterBar's popover switch, replacing the "not yet implemented" placeholder
- Exported components and prop types from filter-bar index for direct testing

## Test plan
- [x] 25 new tests covering rendering, preset selection, custom date ranges, value initialization, cancel behaviour, and toggle state
- [x] All 44 filter-bar tests pass (19 existing + 25 new)
- [x] Full test suite passes with zero regressions

Closes #542

🤖 Generated with [Claude Code](https://claude.com/claude-code)