### PR TITLE
[#543] Wire CommunicationsPage to real API

### DIFF
--- a/src/ui/hooks/queries/use-global-communications.ts
+++ b/src/ui/hooks/queries/use-global-communications.ts
@@ -1,0 +1,45 @@
+/**
+ * TanStack Query hooks for global communications data.
+ *
+ * Fetches all emails and calendar events (not scoped to a work item).
+ */
+import { useQuery } from '@tanstack/react-query';
+import { apiClient } from '@/ui/lib/api-client.ts';
+import type {
+  EmailsResponse,
+  CalendarEventsResponse,
+} from '@/ui/lib/api-types.ts';
+
+/** Query key factory for global communications. */
+export const globalCommunicationsKeys = {
+  all: ['global-communications'] as const,
+  emails: () => [...globalCommunicationsKeys.all, 'emails'] as const,
+  calendarEvents: () =>
+    [...globalCommunicationsKeys.all, 'calendar-events'] as const,
+};
+
+/**
+ * Fetch all emails.
+ *
+ * @returns TanStack Query result with `EmailsResponse`
+ */
+export function useEmails() {
+  return useQuery({
+    queryKey: globalCommunicationsKeys.emails(),
+    queryFn: ({ signal }) =>
+      apiClient.get<EmailsResponse>('/api/emails', { signal }),
+  });
+}
+
+/**
+ * Fetch all calendar events.
+ *
+ * @returns TanStack Query result with `CalendarEventsResponse`
+ */
+export function useCalendarEvents() {
+  return useQuery({
+    queryKey: globalCommunicationsKeys.calendarEvents(),
+    queryFn: ({ signal }) =>
+      apiClient.get<CalendarEventsResponse>('/api/calendar/events', { signal }),
+  });
+}

--- a/src/ui/lib/api-types.ts
+++ b/src/ui/lib/api-types.ts
@@ -346,6 +346,16 @@ export interface CommunicationsResponse {
   calendar_events: ApiCommunication[];
 }
 
+/** Response from GET /api/emails */
+export interface EmailsResponse {
+  emails: ApiCommunication[];
+}
+
+/** Response from GET /api/calendar/events */
+export interface CalendarEventsResponse {
+  events: ApiCommunication[];
+}
+
 // ---------------------------------------------------------------------------
 // Bootstrap (server-injected data)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add `useEmails()` and `useCalendarEvents()` TanStack Query hooks in `use-global-communications.ts`
- Wire CommunicationsPage to use hooks when no prop data is supplied
- Add `EmailsResponse` and `CalendarEventsResponse` API types
- Props still take precedence for testing/server-rendered data
- 7 new tests covering loading, error, prop-override, and hook-call scenarios (42 total)

Closes #543

## Test plan
- [x] 42 tests pass in communications-page.test.tsx
- [x] Full test suite passes
- [x] Loading state shown when hooks are loading (no props)
- [x] Error state shown when hooks error (no props)
- [x] Props override hook data when provided

🤖 Generated with [Claude Code](https://claude.com/claude-code)