### PR TITLE
[#544] Implement comment inline editing

### DIFF
--- a/src/ui/components/comments/comment-thread.tsx
+++ b/src/ui/components/comments/comment-thread.tsx
@@ -7,6 +7,7 @@ import { ChevronDown, ChevronUp, MessageSquare } from 'lucide-react';
 import { Button } from '@/ui/components/ui/button';
 import { cn } from '@/ui/lib/utils';
 import { CommentCard } from './comment-card';
+import { CommentInput } from './comment-input';
 import type { Comment } from './types';
 
 export interface CommentThreadProps {
@@ -17,6 +18,9 @@ export interface CommentThreadProps {
   onEdit: (commentId: string) => void;
   onDelete: (commentId: string) => void;
   onReact?: (commentId: string, emoji: string) => void;
+  editingId?: string | null;
+  onEditSave?: (commentId: string, content: string) => void;
+  onEditCancel?: () => void;
   defaultCollapsed?: boolean;
   className?: string;
 }
@@ -29,6 +33,9 @@ export function CommentThread({
   onEdit,
   onDelete,
   onReact,
+  editingId,
+  onEditSave,
+  onEditCancel,
   defaultCollapsed = false,
   className,
 }: CommentThreadProps) {
@@ -38,14 +45,24 @@ export function CommentThread({
   return (
     <div className={cn('space-y-2', className)}>
       {/* Parent comment */}
-      <CommentCard
-        comment={comment}
-        currentUserId={currentUserId}
-        onReply={onReply}
-        onEdit={onEdit}
-        onDelete={onDelete}
-        onReact={onReact}
-      />
+      {editingId === comment.id ? (
+        <CommentInput
+          initialValue={comment.content}
+          onSubmit={(content) => onEditSave?.(comment.id, content)}
+          onCancel={onEditCancel}
+          isReply
+          placeholder="Edit comment..."
+        />
+      ) : (
+        <CommentCard
+          comment={comment}
+          currentUserId={currentUserId}
+          onReply={onReply}
+          onEdit={onEdit}
+          onDelete={onDelete}
+          onReact={onReact}
+        />
+      )}
 
       {/* Replies */}
       {hasReplies && (
@@ -74,17 +91,28 @@ export function CommentThread({
               </Button>
 
               <div data-testid="thread-replies" className="ml-8 space-y-4">
-                {replies.map((reply) => (
-                  <CommentCard
-                    key={reply.id}
-                    comment={reply}
-                    currentUserId={currentUserId}
-                    onReply={onReply}
-                    onEdit={onEdit}
-                    onDelete={onDelete}
-                    onReact={onReact}
-                  />
-                ))}
+                {replies.map((reply) =>
+                  editingId === reply.id ? (
+                    <CommentInput
+                      key={reply.id}
+                      initialValue={reply.content}
+                      onSubmit={(content) => onEditSave?.(reply.id, content)}
+                      onCancel={onEditCancel}
+                      isReply
+                      placeholder="Edit reply..."
+                    />
+                  ) : (
+                    <CommentCard
+                      key={reply.id}
+                      comment={reply}
+                      currentUserId={currentUserId}
+                      onReply={onReply}
+                      onEdit={onEdit}
+                      onDelete={onDelete}
+                      onReact={onReact}
+                    />
+                  )
+                )}
               </div>
             </>
           )}

--- a/src/ui/components/comments/comments-section.tsx
+++ b/src/ui/components/comments/comments-section.tsx
@@ -37,6 +37,7 @@ export function CommentsSection({
   className,
 }: CommentsSectionProps) {
   const [replyingTo, setReplyingTo] = React.useState<string | null>(null);
+  const [editingId, setEditingId] = React.useState<string | null>(null);
 
   // Separate top-level comments and replies
   const { topLevel, repliesByParent } = React.useMemo(() => {
@@ -77,9 +78,17 @@ export function CommentsSection({
   };
 
   const handleEdit = (commentId: string) => {
-    // This would typically open an edit modal or inline editor
-    // For now, we just call onEditComment with placeholder
-    console.log('Edit comment:', commentId);
+    setEditingId(commentId);
+    setReplyingTo(null); // Close any open reply
+  };
+
+  const handleEditSave = (commentId: string, content: string) => {
+    onEditComment(commentId, content);
+    setEditingId(null);
+  };
+
+  const handleEditCancel = () => {
+    setEditingId(null);
   };
 
   return (
@@ -128,6 +137,9 @@ export function CommentsSection({
                 onEdit={handleEdit}
                 onDelete={onDeleteComment}
                 onReact={onReact}
+                editingId={editingId}
+                onEditSave={handleEditSave}
+                onEditCancel={handleEditCancel}
               />
 
               {/* Reply input */}


### PR DESCRIPTION
## Summary
- Replace placeholder `handleEdit` (console.log) with real inline editing state
- Add `editingId` state to CommentsSection with save/cancel handlers
- Add `editingId`, `onEditSave`, `onEditCancel` props to CommentThread
- Conditionally render CommentInput in place of CommentCard when editing
- Close reply input when entering edit mode
- 9 new tests covering CommentThread and CommentsSection editing flows

Closes #544

## Test plan
- [x] All comment tests pass (48 total: 39 existing + 9 new)
- [x] Full test suite passes
- [x] Edit mode shows textarea pre-filled with comment content
- [x] Save calls onEditComment and exits edit mode
- [x] Cancel exits edit mode
- [x] Reply input closes when entering edit mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)