### PR TITLE
[#551] Fix migration version collision and dev-setup.sh tracking

### DIFF
--- a/migrations/045_memory_tags.down.sql
+++ b/migrations/045_memory_tags.down.sql
@@ -1,4 +1,4 @@
--- Migration 044 down: Remove tags from memory table
+-- Migration 045 down: Remove tags from memory table
 -- Reverses Issue #492 changes
 
 -- Drop the GIN index

--- a/migrations/045_memory_tags.up.sql
+++ b/migrations/045_memory_tags.up.sql
@@ -1,4 +1,4 @@
--- Migration 044: Add tags to memory table
+-- Migration 045: Add tags to memory table
 -- Part of Epic #486, Issue #492
 -- Enables structured tag-based filtering alongside semantic search
 

--- a/migrations/046_relationship_types.down.sql
+++ b/migrations/046_relationship_types.down.sql
@@ -1,4 +1,4 @@
--- Migration 044 Down: Remove Relationship Types
+-- Migration 046 Down: Remove Relationship Types
 -- Part of Epic #486, Issue #490
 
 -- Drop triggers first

--- a/migrations/046_relationship_types.up.sql
+++ b/migrations/046_relationship_types.up.sql
@@ -1,4 +1,4 @@
--- Migration 044: Relationship Types
+-- Migration 046: Relationship Types
 -- Part of Epic #486, Issue #490
 -- Creates the relationship_type reference table pre-seeded with common types.
 -- Relationship types define how contacts relate to each other.

--- a/migrations/047_relationships.down.sql
+++ b/migrations/047_relationships.down.sql
@@ -1,4 +1,4 @@
--- Migration 045 Down: Remove Relationships
+-- Migration 047 Down: Remove Relationships
 -- Part of Epic #486, Issue #491
 
 -- Drop triggers first

--- a/migrations/047_relationships.up.sql
+++ b/migrations/047_relationships.up.sql
@@ -1,4 +1,4 @@
--- Migration 045: Relationships
+-- Migration 047: Relationships
 -- Part of Epic #486, Issue #491
 -- Creates the relationship table connecting contacts via relationship types.
 -- Supports directional, symmetric, and group membership relationships.

--- a/migrations/048_memory_relationship_id.down.sql
+++ b/migrations/048_memory_relationship_id.down.sql
@@ -1,4 +1,4 @@
--- Migration 046 Down: Remove relationship_id scope from memory table
+-- Migration 048 Down: Remove relationship_id scope from memory table
 -- Part of Epic #486, Issue #493
 
 DROP INDEX IF EXISTS idx_memory_relationship_id;

--- a/migrations/048_memory_relationship_id.up.sql
+++ b/migrations/048_memory_relationship_id.up.sql
@@ -1,4 +1,4 @@
--- Migration 046: Add relationship_id scope to memory table
+-- Migration 048: Add relationship_id scope to memory table
 -- Part of Epic #486, Issue #493
 -- Allows memories to be scoped to specific relationships (e.g., "Troy and Alex's anniversary is March 15").
 


### PR DESCRIPTION
## Summary
- Renumber three colliding migration files with prefix `044` to unique versions (044, 045, 046), and cascade `045→047`, `046→048`
- Fix `dev-setup.sh` to create/populate `schema_migrations` table and use `ON_ERROR_STOP=1` for reliable migration application

## Root Cause
Three migration files (`044_contact_kind`, `044_memory_tags`, `044_relationship_types`) shared the same version prefix. The test helper `listMigrations()` groups by version number, so only the last file alphabetically (`044_relationship_types`) survived in the migration map. This caused `tests/migrations.test.ts` down/up cycles to lose `contact_kind` and `memory_tags` changes, resulting in cascading HTTP 500 errors across 24+ test files.

## Test plan
- [x] `dev-setup.sh --reset --seed` applies all 48 migrations successfully
- [x] Full test suite: 4649+ passing (remaining 2-4 failures are pre-existing unrelated issues)
- [x] `pnpm app:build` succeeds
- [x] Individual test files pass in isolation
- [x] Migration down/up cycles preserve all schema changes

Closes #551

🤖 Generated with [Claude Code](https://claude.com/claude-code)