### PR TITLE
[#532] Add SeaweedFS to compose files for S3-compatible storage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,14 +19,19 @@ POSTGRES_USER=openclaw
 POSTGRES_PASSWORD=openclaw
 POSTGRES_DB=openclaw
 
-# S3-compatible storage (SeaweedFS in devcontainer, AWS S3 or SeaweedFS in production)
+# S3-compatible storage (SeaweedFS)
 # Required for file attachments functionality
-# S3_ENDPOINT=http://seaweedfs:8333
-# S3_BUCKET=openclaw
-# S3_REGION=us-east-1
-# S3_ACCESS_KEY=openclaw
-# S3_SECRET_KEY=openclaw
-# S3_FORCE_PATH_STYLE=true
+# SeaweedFS runs embedded in the compose stack on port 8333
+S3_ENDPOINT=http://seaweedfs:8333
+S3_BUCKET=openclaw
+S3_REGION=us-east-1
+S3_ACCESS_KEY=openclaw
+S3_SECRET_KEY=openclaw
+S3_FORCE_PATH_STYLE=true
+
+# SeaweedFS configuration
+# Maximum volume size in MB (default 30GB for production)
+SEAWEEDFS_VOLUME_SIZE_LIMIT_MB=30000
 
 # Optional: Postmark email (magic links)
 # If unset, the app will still work but will return the login URL in non-production only.

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -33,6 +33,26 @@ services:
       timeout: 5s
       retries: 10
 
+  seaweedfs:
+    image: chrislusf/seaweedfs:latest
+    container_name: openclaw-projects-seaweedfs
+    restart: unless-stopped
+    command: "server -s3 -s3.port=8333 -ip.bind=0.0.0.0 -master.volumeSizeLimitMB=${SEAWEEDFS_VOLUME_SIZE_LIMIT_MB:-30000} -volume.max=100"
+    ports:
+      - "127.0.0.1:8333:8333"
+    volumes:
+      - /var/project/data/openclaw-projects/seaweedfs:/data
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://127.0.0.1:9333/cluster/status"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 30s
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+
   projects:
     build:
       context: .
@@ -41,6 +61,8 @@ services:
     restart: unless-stopped
     depends_on:
       postgres:
+        condition: service_healthy
+      seaweedfs:
         condition: service_healthy
     environment:
       NODE_ENV: production
@@ -54,6 +76,14 @@ services:
       PGUSER: ${POSTGRES_USER:-openclaw}
       PGPASSWORD: ${POSTGRES_PASSWORD:-openclaw}
       PGDATABASE: ${POSTGRES_DB:-openclaw}
+
+      # S3-compatible storage (SeaweedFS)
+      S3_ENDPOINT: http://seaweedfs:8333
+      S3_BUCKET: ${S3_BUCKET:-openclaw}
+      S3_REGION: ${S3_REGION:-us-east-1}
+      S3_ACCESS_KEY: ${S3_ACCESS_KEY:-openclaw}
+      S3_SECRET_KEY: ${S3_SECRET_KEY:-openclaw}
+      S3_FORCE_PATH_STYLE: "true"
 
       # Email (Postmark)
       POSTMARK_FROM: ${POSTMARK_FROM:-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,5 +25,26 @@ services:
       timeout: 5s
       retries: 5
 
+  seaweedfs:
+    image: chrislusf/seaweedfs:latest
+    container_name: openclaw-seaweedfs
+    command: "server -s3 -s3.port=8333 -ip.bind=0.0.0.0 -master.volumeSizeLimitMB=100 -volume.max=10"
+    ports:
+      - "8333:8333"
+      - "9333:9333"
+    volumes:
+      - seaweedfs_data:/data
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://127.0.0.1:9333/cluster/status"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 30s
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+
 volumes:
   postgres_data:
+  seaweedfs_data:

--- a/tests/docker/seaweedfs-compose.test.ts
+++ b/tests/docker/seaweedfs-compose.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { parse } from 'yaml';
+
+const ROOT_DIR = resolve(__dirname, '../..');
+
+interface ComposeService {
+  image?: string;
+  command?: string | string[];
+  environment?: Record<string, string> | string[];
+  ports?: string[];
+  volumes?: string[];
+  healthcheck?: {
+    test: string[];
+    interval?: string;
+    timeout?: string;
+    retries?: number;
+    start_period?: string;
+  };
+  depends_on?: Record<string, { condition: string }> | string[];
+  security_opt?: string[];
+  cap_drop?: string[];
+  restart?: string;
+}
+
+interface ComposeVolumes {
+  [key: string]: object | null;
+}
+
+interface ComposeFile {
+  name?: string;
+  services: Record<string, ComposeService>;
+  volumes?: ComposeVolumes;
+}
+
+describe('SeaweedFS in docker-compose.yml (basic compose)', () => {
+  let compose: ComposeFile;
+
+  beforeAll(() => {
+    const content = readFileSync(resolve(ROOT_DIR, 'docker-compose.yml'), 'utf-8');
+    compose = parse(content) as ComposeFile;
+  });
+
+  describe('seaweedfs service', () => {
+    it('exists in compose file', () => {
+      expect(compose.services.seaweedfs).toBeDefined();
+    });
+
+    it('uses chrislusf/seaweedfs image', () => {
+      expect(compose.services.seaweedfs.image).toMatch(/^chrislusf\/seaweedfs/);
+    });
+
+    it('runs in single-server mode with S3 gateway', () => {
+      const command = compose.services.seaweedfs.command;
+      const cmdString = Array.isArray(command) ? command.join(' ') : command;
+      expect(cmdString).toContain('server');
+      expect(cmdString).toContain('-s3');
+      expect(cmdString).toContain('-s3.port=8333');
+      expect(cmdString).toContain('-ip.bind=0.0.0.0');
+    });
+
+    it('maps port 8333 to host (basic compose)', () => {
+      const ports = compose.services.seaweedfs.ports || [];
+      const hasS3Port = ports.some((p: string) => p.includes('8333'));
+      expect(hasS3Port).toBe(true);
+    });
+
+    it('has volume mount for data persistence', () => {
+      const volumes = compose.services.seaweedfs.volumes || [];
+      const hasDataVolume = volumes.some((v: string) => v.includes('/data'));
+      expect(hasDataVolume).toBe(true);
+    });
+
+    it('has healthcheck configured', () => {
+      const hc = compose.services.seaweedfs.healthcheck;
+      expect(hc).toBeDefined();
+      expect(hc?.test).toBeDefined();
+      expect(Array.isArray(hc?.test)).toBe(true);
+    });
+
+    it('has container hardening (security_opt)', () => {
+      expect(compose.services.seaweedfs.security_opt).toBeDefined();
+      expect(compose.services.seaweedfs.security_opt).toContain('no-new-privileges:true');
+    });
+
+    it('has container hardening (cap_drop ALL)', () => {
+      expect(compose.services.seaweedfs.cap_drop).toBeDefined();
+      expect(compose.services.seaweedfs.cap_drop).toContain('ALL');
+    });
+  });
+
+  describe('seaweedfs_data volume', () => {
+    it('is defined in volumes section', () => {
+      expect(compose.volumes).toBeDefined();
+      expect(compose.volumes?.seaweedfs_data).toBeDefined();
+    });
+  });
+});
+
+describe('SeaweedFS in docker-compose.prod.yml (production compose)', () => {
+  let compose: ComposeFile;
+
+  beforeAll(() => {
+    const content = readFileSync(resolve(ROOT_DIR, 'docker-compose.prod.yml'), 'utf-8');
+    compose = parse(content) as ComposeFile;
+  });
+
+  describe('seaweedfs service', () => {
+    it('exists in compose file', () => {
+      expect(compose.services.seaweedfs).toBeDefined();
+    });
+
+    it('uses chrislusf/seaweedfs image', () => {
+      expect(compose.services.seaweedfs.image).toMatch(/^chrislusf\/seaweedfs/);
+    });
+
+    it('runs in single-server mode with S3 gateway', () => {
+      const command = compose.services.seaweedfs.command;
+      const cmdString = Array.isArray(command) ? command.join(' ') : command;
+      expect(cmdString).toContain('server');
+      expect(cmdString).toContain('-s3');
+      expect(cmdString).toContain('-s3.port=8333');
+      expect(cmdString).toContain('-ip.bind=0.0.0.0');
+    });
+
+    it('configures volume size limit from env var', () => {
+      const command = compose.services.seaweedfs.command;
+      const cmdString = Array.isArray(command) ? command.join(' ') : command;
+      expect(cmdString).toContain('-master.volumeSizeLimitMB');
+    });
+
+    it('has volume mount for data persistence', () => {
+      const volumes = compose.services.seaweedfs.volumes || [];
+      const hasDataVolume = volumes.some((v: string) => v.includes('/data'));
+      expect(hasDataVolume).toBe(true);
+    });
+
+    it('has healthcheck configured', () => {
+      const hc = compose.services.seaweedfs.healthcheck;
+      expect(hc).toBeDefined();
+      expect(hc?.test).toBeDefined();
+      expect(Array.isArray(hc?.test)).toBe(true);
+      // Health check should target the master status endpoint
+      const testString = hc?.test.join(' ');
+      expect(testString).toContain('9333');
+    });
+
+    it('has container hardening (security_opt)', () => {
+      expect(compose.services.seaweedfs.security_opt).toBeDefined();
+      expect(compose.services.seaweedfs.security_opt).toContain('no-new-privileges:true');
+    });
+
+    it('has container hardening (cap_drop ALL)', () => {
+      expect(compose.services.seaweedfs.cap_drop).toBeDefined();
+      expect(compose.services.seaweedfs.cap_drop).toContain('ALL');
+    });
+
+    it('has restart policy', () => {
+      expect(compose.services.seaweedfs.restart).toBe('unless-stopped');
+    });
+  });
+
+  describe('projects service S3 configuration', () => {
+    it('depends on seaweedfs being healthy', () => {
+      const deps = compose.services.projects.depends_on;
+      expect(deps).toBeDefined();
+      if (typeof deps === 'object' && !Array.isArray(deps)) {
+        expect(deps.seaweedfs).toBeDefined();
+        expect(deps.seaweedfs.condition).toBe('service_healthy');
+      }
+    });
+
+    it('has S3_ENDPOINT env var pointing to seaweedfs', () => {
+      const env = compose.services.projects.environment;
+      expect(env).toBeDefined();
+      if (typeof env === 'object' && !Array.isArray(env)) {
+        expect(env.S3_ENDPOINT).toContain('seaweedfs:8333');
+      }
+    });
+
+    it('has S3_BUCKET env var configured', () => {
+      const env = compose.services.projects.environment;
+      if (typeof env === 'object' && !Array.isArray(env)) {
+        expect(env.S3_BUCKET).toBeDefined();
+      }
+    });
+
+    it('has S3_FORCE_PATH_STYLE set to true', () => {
+      const env = compose.services.projects.environment;
+      if (typeof env === 'object' && !Array.isArray(env)) {
+        expect(env.S3_FORCE_PATH_STYLE).toBe('true');
+      }
+    });
+
+    it('has S3 access credentials configured', () => {
+      const env = compose.services.projects.environment;
+      if (typeof env === 'object' && !Array.isArray(env)) {
+        expect(env.S3_ACCESS_KEY).toBeDefined();
+        expect(env.S3_SECRET_KEY).toBeDefined();
+      }
+    });
+  });
+
+  describe('seaweedfs_data volume or host path', () => {
+    it('seaweedfs uses persistent storage', () => {
+      const volumes = compose.services.seaweedfs.volumes || [];
+      // Either a named volume or a host path for /data
+      const hasStorage = volumes.some((v: string) => v.includes('/data'));
+      expect(hasStorage).toBe(true);
+    });
+  });
+});
+
+describe('.env.example contains SeaweedFS variables', () => {
+  let envContent: string;
+
+  beforeAll(() => {
+    envContent = readFileSync(resolve(ROOT_DIR, '.env.example'), 'utf-8');
+  });
+
+  it('documents SEAWEEDFS_VOLUME_SIZE_LIMIT_MB', () => {
+    expect(envContent).toContain('SEAWEEDFS_VOLUME_SIZE_LIMIT_MB');
+  });
+
+  it('documents S3_ACCESS_KEY', () => {
+    expect(envContent).toContain('S3_ACCESS_KEY');
+  });
+
+  it('documents S3_SECRET_KEY', () => {
+    expect(envContent).toContain('S3_SECRET_KEY');
+  });
+});


### PR DESCRIPTION
## Summary

- Add SeaweedFS service to `docker-compose.yml` (basic) and `docker-compose.prod.yml` (production)
- SeaweedFS runs in single-server mode bundling master + volume + filer + S3 gateway
- S3 API on port 8333 with health check on master status endpoint (port 9333)
- Container hardening with `security_opt: no-new-privileges:true` and `cap_drop: ALL`
- Auto-configure API's S3 environment variables to use SeaweedFS
- Add `SEAWEEDFS_VOLUME_SIZE_LIMIT_MB` env var to `.env.example` (default 30GB)

Closes #532

## Test Plan

- [x] Unit tests verify SeaweedFS service configuration in both compose files
- [x] Tests verify API service depends on SeaweedFS and has correct S3 env vars
- [x] Tests verify container hardening (security_opt, cap_drop)
- [x] Tests verify .env.example documents new variables
- [x] Docker compose config validates both files are syntactically correct
- [ ] Integration test: `docker compose up` starts SeaweedFS successfully
- [ ] Integration test: File upload/download via API works with SeaweedFS

## Generated with [Claude Code](https://claude.ai/code)