### PR TITLE
[#530] Add extensible Traefik configuration support

### DIFF
--- a/docker/traefik/entrypoint.sh
+++ b/docker/traefik/entrypoint.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 
 # Directory paths
 SYSTEM_CONFIG_DIR="/etc/traefik/dynamic/system"
+CUSTOM_CONFIG_DIR="/etc/traefik/dynamic/custom"
 TEMPLATE_FILE="/etc/traefik/templates/dynamic-config.yml.template"
 OUTPUT_FILE="${SYSTEM_CONFIG_DIR}/config.yml"
 
@@ -53,10 +54,26 @@ generate_trusted_ips_yaml() {
     done
 }
 
+# Create required directories for dynamic configuration
+create_directories() {
+    # System config directory - managed by this script
+    mkdir -p "${SYSTEM_CONFIG_DIR}"
+
+    # Custom config directory - for user extensions
+    # Users can bind-mount their own configs here via docker-compose.override.yml
+    # Traefik watches this directory with file provider (watch: true)
+    # Malformed YAML in custom/ won't break system routes in system/
+    mkdir -p "${CUSTOM_CONFIG_DIR}"
+
+    echo "Created config directories:"
+    echo "  System: ${SYSTEM_CONFIG_DIR}"
+    echo "  Custom: ${CUSTOM_CONFIG_DIR} (for user extensions)"
+}
+
 # Generate the dynamic configuration from template
 generate_config() {
-    # Ensure output directory exists
-    mkdir -p "${SYSTEM_CONFIG_DIR}"
+    # Ensure output directories exist
+    create_directories
     
     # Set defaults for optional variables
     export TRUSTED_IPS="${TRUSTED_IPS:-}"

--- a/docker/traefik/examples/custom-route.example.yml
+++ b/docker/traefik/examples/custom-route.example.yml
@@ -1,0 +1,190 @@
+# custom-route.example.yml
+#
+# Example custom route configuration for Traefik file provider.
+# Place this file (or similar) in your traefik-custom/ directory.
+#
+# This is the secondary extension method for advanced routing needs:
+#   - Routes to external services (not in Docker)
+#   - Complex routing rules
+#   - Custom middlewares
+#   - Load balancing across multiple backends
+#
+# Usage:
+#   1. Create a traefik-custom/ directory in your project root:
+#      mkdir -p traefik-custom
+#
+#   2. Copy this example:
+#      cp docker/traefik/examples/custom-route.example.yml traefik-custom/my-routes.yml
+#
+#   3. Mount it via docker-compose.override.yml (see docker-compose.override.example.yml)
+#
+#   4. Traefik watches the directory and auto-reloads on changes
+#
+# Safety Notes:
+#   - Malformed YAML here does NOT break system routes
+#   - System routes in /etc/traefik/dynamic/system/ take precedence
+#   - Use unique router/middleware/service names to avoid conflicts
+#   - Traefik logs errors for invalid configs but keeps serving valid ones
+#
+# Reference:
+#   https://doc.traefik.io/traefik/routing/routers/
+#   https://doc.traefik.io/traefik/routing/services/
+#   https://doc.traefik.io/traefik/middlewares/overview/
+
+http:
+  # ===========================================================================
+  # Custom Middlewares
+  # ===========================================================================
+  #
+  # Define middlewares that can be used by your custom routers.
+  # Reference system middlewares with @file suffix (e.g., security-headers@file)
+  #
+  middlewares:
+    # Example: Basic auth middleware
+    # Generate credentials: htpasswd -nb user password | openssl base64
+    custom-basic-auth:
+      basicAuth:
+        users:
+          # user:password (password is "secret" - CHANGE THIS!)
+          - "user:$apr1$xyz123$abcdefghijklmnop"
+
+    # Example: IP allowlist for internal services
+    internal-only:
+      ipAllowList:
+        sourceRange:
+          - "10.0.0.0/8"
+          - "172.16.0.0/12"
+          - "192.168.0.0/16"
+          - "127.0.0.1/32"
+
+    # Example: Strip path prefix
+    strip-api-prefix:
+      stripPrefix:
+        prefixes:
+          - "/api/v1"
+
+    # Example: Add request headers
+    custom-headers:
+      headers:
+        customRequestHeaders:
+          X-Custom-Header: "my-value"
+          X-Forwarded-By: "traefik"
+
+  # ===========================================================================
+  # Custom Routers
+  # ===========================================================================
+  #
+  # Define routers that match requests and route them to services.
+  #
+  routers:
+    # Example: Route to an external monitoring service
+    # external-monitoring:
+    #   rule: "Host(`monitoring.example.com`)"
+    #   service: monitoring-service
+    #   entryPoints:
+    #     - websecure
+    #   middlewares:
+    #     - internal-only
+    #     - security-headers@file  # Reuse system middleware
+    #   tls:
+    #     certResolver: letsencrypt
+
+    # Example: Route a path prefix to a different backend
+    # legacy-api:
+    #   rule: "Host(`api.example.com`) && PathPrefix(`/v1`)"
+    #   service: legacy-api-service
+    #   entryPoints:
+    #     - websecure
+    #   middlewares:
+    #     - strip-api-prefix
+    #     - security-headers@file
+    #   tls:
+    #     certResolver: letsencrypt
+    #   # Lower priority so system routes match first
+    #   priority: 1
+
+    # Example: Internal admin panel with basic auth
+    # admin-panel:
+    #   rule: "Host(`admin.example.com`)"
+    #   service: admin-service
+    #   entryPoints:
+    #     - websecure
+    #   middlewares:
+    #     - custom-basic-auth
+    #     - internal-only
+    #     - security-headers@file
+    #   tls:
+    #     certResolver: letsencrypt
+
+  # ===========================================================================
+  # Custom Services
+  # ===========================================================================
+  #
+  # Define backend services that routers can forward requests to.
+  #
+  services:
+    # Example: External service (not in Docker)
+    # monitoring-service:
+    #   loadBalancer:
+    #     servers:
+    #       - url: "http://192.168.1.100:9090"
+    #     healthCheck:
+    #       path: /-/healthy
+    #       interval: 30s
+    #       timeout: 5s
+
+    # Example: Load balanced service with multiple backends
+    # legacy-api-service:
+    #   loadBalancer:
+    #     servers:
+    #       - url: "http://legacy-api-1:8080"
+    #       - url: "http://legacy-api-2:8080"
+    #     healthCheck:
+    #       path: /health
+    #       interval: 10s
+    #       timeout: 3s
+    #     sticky:
+    #       cookie:
+    #         name: srv_id
+    #         secure: true
+    #         httpOnly: true
+
+    # Example: Weighted round robin
+    # weighted-service:
+    #   weighted:
+    #     services:
+    #       - name: primary-backend
+    #         weight: 3
+    #       - name: canary-backend
+    #         weight: 1
+
+    # Example: Mirroring (send copy of traffic to another service)
+    # mirrored-service:
+    #   mirroring:
+    #     service: production-backend
+    #     mirrors:
+    #       - name: shadow-backend
+    #         percent: 10
+
+# ===========================================================================
+# TCP Routing (for non-HTTP protocols)
+# ===========================================================================
+#
+# Uncomment for TCP services like databases, message queues, etc.
+#
+# tcp:
+#   routers:
+#     postgres-external:
+#       rule: "HostSNI(`db.example.com`)"
+#       service: postgres-service
+#       entryPoints:
+#         - postgres
+#       tls:
+#         certResolver: letsencrypt
+#         passthrough: true
+#
+#   services:
+#     postgres-service:
+#       loadBalancer:
+#         servers:
+#           - address: "postgres:5432"

--- a/docker/traefik/examples/docker-compose.override.example.yml
+++ b/docker/traefik/examples/docker-compose.override.example.yml
@@ -1,0 +1,113 @@
+# docker-compose.override.example.yml
+#
+# Example docker-compose override file for adding custom services and Traefik routes.
+# Copy this file to docker-compose.override.yml in your project root and modify as needed.
+#
+# This file demonstrates two extension patterns:
+#   1. Docker Labels: Services register routes directly via Traefik labels
+#   2. File Provider: Mount custom YAML configs for additional routes
+#
+# Usage:
+#   cp docker/traefik/examples/docker-compose.override.example.yml docker-compose.override.yml
+#   # Edit docker-compose.override.yml
+#   docker compose -f docker-compose.traefik.yml -f docker-compose.override.yml up -d
+#
+# Safety Notes:
+#   - System routes (api, app) are defined in /etc/traefik/dynamic/system/
+#   - Custom routes go in /etc/traefik/dynamic/custom/
+#   - Malformed YAML in custom/ does NOT break system routes
+#   - System routes cannot be overridden by custom configs (Traefik uses first match)
+#   - Use unique router names to avoid conflicts
+
+services:
+  # =============================================================================
+  # Example 1: Adding a service with Docker labels (whoami test service)
+  # =============================================================================
+  #
+  # This demonstrates the primary extension method: Docker labels.
+  # Traefik's Docker provider automatically discovers labeled services.
+  #
+  whoami:
+    image: traefik/whoami:latest
+    labels:
+      # Enable Traefik for this container
+      - "traefik.enable=true"
+
+      # Define the router
+      - "traefik.http.routers.whoami.rule=Host(`whoami.${DOMAIN}`)"
+      - "traefik.http.routers.whoami.entrypoints=websecure"
+      - "traefik.http.routers.whoami.tls.certResolver=letsencrypt"
+
+      # Apply security middlewares (reuse system middlewares)
+      - "traefik.http.routers.whoami.middlewares=security-headers@file"
+
+      # Define the service (port the container listens on)
+      - "traefik.http.services.whoami.loadbalancer.server.port=80"
+    networks:
+      - traefik
+
+  # =============================================================================
+  # Example 2: Adding Grafana with Docker labels
+  # =============================================================================
+  #
+  # Real-world example: Adding a monitoring dashboard
+  #
+  # grafana:
+  #   image: grafana/grafana:latest
+  #   volumes:
+  #     - grafana-data:/var/lib/grafana
+  #   environment:
+  #     - GF_SERVER_ROOT_URL=https://grafana.${DOMAIN}
+  #     - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
+  #   labels:
+  #     - "traefik.enable=true"
+  #     - "traefik.http.routers.grafana.rule=Host(`grafana.${DOMAIN}`)"
+  #     - "traefik.http.routers.grafana.entrypoints=websecure"
+  #     - "traefik.http.routers.grafana.tls.certResolver=letsencrypt"
+  #     - "traefik.http.routers.grafana.middlewares=security-headers@file"
+  #     - "traefik.http.services.grafana.loadbalancer.server.port=3000"
+  #   networks:
+  #     - traefik
+
+  # =============================================================================
+  # Example 3: Adding Portainer with Docker labels
+  # =============================================================================
+  #
+  # Real-world example: Adding a Docker management UI
+  #
+  # portainer:
+  #   image: portainer/portainer-ce:latest
+  #   volumes:
+  #     - /var/run/docker.sock:/var/run/docker.sock:ro
+  #     - portainer-data:/data
+  #   labels:
+  #     - "traefik.enable=true"
+  #     - "traefik.http.routers.portainer.rule=Host(`portainer.${DOMAIN}`)"
+  #     - "traefik.http.routers.portainer.entrypoints=websecure"
+  #     - "traefik.http.routers.portainer.tls.certResolver=letsencrypt"
+  #     - "traefik.http.routers.portainer.middlewares=security-headers@file"
+  #     - "traefik.http.services.portainer.loadbalancer.server.port=9000"
+  #   networks:
+  #     - traefik
+
+  # =============================================================================
+  # Traefik: Mount custom config directory (File Provider extension)
+  # =============================================================================
+  #
+  # This extends the traefik service to mount a custom config directory.
+  # Use this when you need routes to external services or complex configs.
+  #
+  traefik:
+    volumes:
+      # Mount custom config directory for file provider routes
+      # Place your *.yml files in traefik-custom/ and they'll be auto-loaded
+      - ./traefik-custom:/etc/traefik/dynamic/custom:ro
+
+networks:
+  traefik:
+    external: true
+
+# Uncomment if using Grafana/Portainer examples:
+# volumes:
+#   grafana-data:
+#   portainer-data:


### PR DESCRIPTION
## Summary
- Updates entrypoint.sh to separate system and custom config directories:
  - System config: `/etc/traefik/dynamic/system/config.yml` (generated, managed)
  - Custom config: `/etc/traefik/dynamic/custom/` (empty, for user extensions)
- Adds example docker-compose.override.yml demonstrating:
  - Adding services with Docker labels (primary extension method)
  - Mounting custom config directory for file provider routes
  - Examples for whoami, Grafana, and Portainer
- Adds example custom route configuration showing:
  - Custom middlewares (basic auth, IP allowlist, strip prefix)
  - Custom routers with middleware chains
  - External service routing
  - Load balancing configurations
- Adds 3 new tests verifying custom directory behavior

## Extension Patterns

### 1. Docker Labels (Primary)
Services can register routes via Traefik Docker labels:
```yaml
services:
  myservice:
    labels:
      - "traefik.enable=true"
      - "traefik.http.routers.myservice.rule=Host(`my.example.com`)"
```

### 2. File Provider (Secondary)
Users can bind-mount custom configs:
```yaml
services:
  traefik:
    volumes:
      - ./traefik-custom:/etc/traefik/dynamic/custom:ro
```

## Safety
- Malformed YAML in `custom/` does NOT break system routes in `system/`
- System routes cannot be overridden by custom config (Traefik uses first match)
- Empty custom directory prevents accidental system route conflicts

## Test plan
- [x] System config written to `/etc/traefik/dynamic/system/`
- [x] Custom directory `/etc/traefik/dynamic/custom/` created and empty
- [x] Examples are valid YAML
- [x] All 18 entrypoint tests pass

Closes #530

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>