### PR TITLE
[#539] Add integration tests for compose stack

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,90 @@
+# Integration Test Workflow
+# Runs end-to-end compose stack verification
+# Part of Epic #523, Issue #539
+
+name: Integration Tests
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docker-compose.yml'
+      - 'docker-compose.*.yml'
+      - 'docker/**'
+      - '.github/workflows/integration.yml'
+      - 'scripts/integration-test.sh'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'docker-compose.yml'
+      - 'docker-compose.*.yml'
+      - 'docker/**'
+      - '.github/workflows/integration.yml'
+      - 'scripts/integration-test.sh'
+  # Allow manual trigger
+  workflow_dispatch:
+    inputs:
+      timeout:
+        description: 'Timeout in seconds for waiting for services'
+        required: false
+        default: '300'
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  integration-test:
+    name: Compose Stack Integration Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    env:
+      # Test environment configuration
+      POSTGRES_PASSWORD: integrationtest123
+      COOKIE_SECRET: integrationtestsecret12345678901234567890123456
+      S3_SECRET_KEY: integrationtests3secretkey1234567890abcdef
+      API_PORT: 3000
+      FRONTEND_PORT: 8080
+      SEAWEEDFS_PORT: 8333
+      # Safe handling of workflow_dispatch input
+      INTEGRATION_TEST_TIMEOUT: ${{ github.event.inputs.timeout || '300' }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull container images
+        run: |
+          docker compose pull --quiet || echo "Some images may need to be built"
+
+      - name: Run integration tests
+        run: |
+          chmod +x scripts/integration-test.sh
+          ./scripts/integration-test.sh --timeout "$INTEGRATION_TEST_TIMEOUT"
+
+      - name: Collect logs on failure
+        if: failure()
+        run: |
+          echo "=== Docker Compose Logs ==="
+          docker compose logs --tail=100 2>/dev/null || true
+          echo ""
+          echo "=== Container Status ==="
+          docker compose ps -a 2>/dev/null || true
+
+      - name: Cleanup
+        if: always()
+        run: |
+          docker compose down -v --remove-orphans 2>/dev/null || true

--- a/scripts/integration-test.sh
+++ b/scripts/integration-test.sh
@@ -1,0 +1,394 @@
+#!/bin/bash
+# Integration test script for docker-compose stack verification
+# Part of Epic #523, Issue #539
+#
+# This script:
+# 1. Starts the basic compose stack
+# 2. Waits for all services to be healthy
+# 3. Runs health checks against API (/health endpoint)
+# 4. Verifies frontend serves HTML
+# 5. Verifies SeaweedFS S3 is accessible (simple PUT/GET object)
+# 6. Runs database migration check
+# 7. Tears down the stack
+# 8. Exits with non-zero on any failure
+#
+# Usage:
+#   ./scripts/integration-test.sh [options]
+#
+# Options:
+#   --skip-teardown    Skip tearing down the stack after tests (useful for debugging)
+#   --timeout SECONDS  Timeout for waiting for services (default: 180)
+#   --compose-file     Path to compose file (default: docker-compose.yml)
+
+set -euo pipefail
+
+# Configuration
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+COMPOSE_FILE="${PROJECT_ROOT}/docker-compose.yml"
+TIMEOUT=180
+SKIP_TEARDOWN=false
+API_PORT="${API_PORT:-3000}"
+FRONTEND_PORT="${FRONTEND_PORT:-8080}"
+SEAWEEDFS_PORT="${SEAWEEDFS_PORT:-8333}"
+
+# Test environment variables
+export POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-integrationtest123}"
+export COOKIE_SECRET="${COOKIE_SECRET:-integrationtestsecret12345678901234567890}"
+export S3_SECRET_KEY="${S3_SECRET_KEY:-integrationtests3secretkey1234567890}"
+
+# Colors for output (disabled if not a terminal)
+if [[ -t 1 ]]; then
+  RED='\033[0;31m'
+  GREEN='\033[0;32m'
+  YELLOW='\033[0;33m'
+  BLUE='\033[0;34m'
+  NC='\033[0m' # No Color
+else
+  RED=''
+  GREEN=''
+  YELLOW=''
+  BLUE=''
+  NC=''
+fi
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --skip-teardown)
+      SKIP_TEARDOWN=true
+      shift
+      ;;
+    --timeout)
+      TIMEOUT="$2"
+      shift 2
+      ;;
+    --compose-file)
+      COMPOSE_FILE="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown option: $1"
+      exit 1
+      ;;
+  esac
+done
+
+# Logging functions
+log_info() {
+  echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+log_success() {
+  echo -e "${GREEN}[PASS]${NC} $1"
+}
+
+log_warn() {
+  echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+log_error() {
+  echo -e "${RED}[FAIL]${NC} $1"
+}
+
+# Track test results
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+# Cleanup function
+cleanup() {
+  local exit_code=$?
+  if [[ "$SKIP_TEARDOWN" == "false" ]]; then
+    log_info "Tearing down compose stack..."
+    docker compose -f "$COMPOSE_FILE" down -v --remove-orphans 2>/dev/null || true
+  else
+    log_warn "Skipping teardown (--skip-teardown was specified)"
+  fi
+
+  if [[ $TESTS_FAILED -gt 0 ]]; then
+    log_error "Integration tests failed: $TESTS_FAILED failed, $TESTS_PASSED passed"
+    exit 1
+  elif [[ $exit_code -ne 0 ]]; then
+    log_error "Integration tests failed with exit code $exit_code"
+    exit $exit_code
+  else
+    log_success "All integration tests passed: $TESTS_PASSED tests"
+  fi
+}
+
+# Set trap for cleanup on exit
+trap cleanup EXIT
+
+# Check if compose file exists
+if [[ ! -f "$COMPOSE_FILE" ]]; then
+  log_error "Compose file not found: $COMPOSE_FILE"
+  exit 1
+fi
+
+log_info "Starting integration tests for compose stack"
+log_info "Compose file: $COMPOSE_FILE"
+log_info "Timeout: ${TIMEOUT}s"
+
+# =============================================================================
+# Step 1: Start the compose stack
+# =============================================================================
+log_info "Starting compose stack..."
+
+# Pull images first (speeds up subsequent runs)
+docker compose -f "$COMPOSE_FILE" pull --quiet 2>/dev/null || log_warn "Pull failed, using cached images"
+
+# Start the stack
+docker compose -f "$COMPOSE_FILE" up -d
+
+log_success "Compose stack started"
+
+# =============================================================================
+# Step 2: Wait for all services to be healthy
+# =============================================================================
+log_info "Waiting for services to become healthy (timeout: ${TIMEOUT}s)..."
+
+wait_for_healthy() {
+  local service_name=$1
+  local start_time=$(date +%s)
+
+  while true; do
+    local current_time=$(date +%s)
+    local elapsed=$((current_time - start_time))
+
+    if [[ $elapsed -ge $TIMEOUT ]]; then
+      log_error "Timeout waiting for $service_name to become healthy after ${TIMEOUT}s"
+      docker compose -f "$COMPOSE_FILE" logs "$service_name" 2>&1 | tail -50
+      return 1
+    fi
+
+    # Check container health status
+    local health_status
+    health_status=$(docker compose -f "$COMPOSE_FILE" ps --format json 2>/dev/null | \
+      jq -r --arg svc "$service_name" 'select(.Service == $svc) | .Health // .State' 2>/dev/null || echo "unknown")
+
+    if [[ "$health_status" == "healthy" ]]; then
+      return 0
+    fi
+
+    # For migrate service, check if it exited successfully
+    if [[ "$service_name" == "migrate" ]]; then
+      local exit_code
+      exit_code=$(docker compose -f "$COMPOSE_FILE" ps --format json 2>/dev/null | \
+        jq -r --arg svc "$service_name" 'select(.Service == $svc) | .ExitCode // -1' 2>/dev/null || echo "-1")
+      local state
+      state=$(docker compose -f "$COMPOSE_FILE" ps --format json 2>/dev/null | \
+        jq -r --arg svc "$service_name" 'select(.Service == $svc) | .State' 2>/dev/null || echo "unknown")
+
+      if [[ "$state" == "exited" && "$exit_code" == "0" ]]; then
+        return 0
+      elif [[ "$state" == "exited" && "$exit_code" != "0" ]]; then
+        log_error "Migration service exited with code $exit_code"
+        docker compose -f "$COMPOSE_FILE" logs migrate 2>&1 | tail -50
+        return 1
+      fi
+    fi
+
+    sleep 2
+  done
+}
+
+# Wait for database first
+log_info "  Waiting for database..."
+if wait_for_healthy "db"; then
+  log_success "  Database is healthy"
+  ((TESTS_PASSED++))
+else
+  ((TESTS_FAILED++))
+fi
+
+# Wait for SeaweedFS
+log_info "  Waiting for SeaweedFS..."
+if wait_for_healthy "seaweedfs"; then
+  log_success "  SeaweedFS is healthy"
+  ((TESTS_PASSED++))
+else
+  ((TESTS_FAILED++))
+fi
+
+# Wait for migrations to complete
+log_info "  Waiting for migrations..."
+if wait_for_healthy "migrate"; then
+  log_success "  Migrations completed successfully"
+  ((TESTS_PASSED++))
+else
+  ((TESTS_FAILED++))
+fi
+
+# Wait for API
+log_info "  Waiting for API..."
+if wait_for_healthy "api"; then
+  log_success "  API is healthy"
+  ((TESTS_PASSED++))
+else
+  ((TESTS_FAILED++))
+fi
+
+# Wait for frontend app
+log_info "  Waiting for frontend app..."
+if wait_for_healthy "app"; then
+  log_success "  Frontend app is healthy"
+  ((TESTS_PASSED++))
+else
+  ((TESTS_FAILED++))
+fi
+
+# =============================================================================
+# Step 3: Run health checks against API
+# =============================================================================
+log_info "Testing API health endpoint..."
+
+API_HEALTH_URL="http://localhost:${API_PORT}/health"
+API_RESPONSE=$(curl -sf "$API_HEALTH_URL" 2>/dev/null || echo "FAILED")
+
+if [[ "$API_RESPONSE" != "FAILED" ]]; then
+  # Check if response indicates healthy status
+  if echo "$API_RESPONSE" | jq -e '.status == "ok" or .status == "healthy" or .healthy == true' >/dev/null 2>&1; then
+    log_success "API /health endpoint returns healthy status"
+    ((TESTS_PASSED++))
+  else
+    # Accept any 200 response as healthy
+    log_success "API /health endpoint responds (200 OK)"
+    ((TESTS_PASSED++))
+  fi
+else
+  log_error "API /health endpoint is not responding at $API_HEALTH_URL"
+  ((TESTS_FAILED++))
+fi
+
+# =============================================================================
+# Step 4: Verify frontend serves HTML
+# =============================================================================
+log_info "Testing frontend serves HTML..."
+
+FRONTEND_URL="http://localhost:${FRONTEND_PORT}/"
+FRONTEND_RESPONSE=$(curl -sf "$FRONTEND_URL" 2>/dev/null || echo "FAILED")
+
+if [[ "$FRONTEND_RESPONSE" != "FAILED" ]]; then
+  # Check if response contains HTML
+  if echo "$FRONTEND_RESPONSE" | grep -qi "<!doctype html\|<html"; then
+    log_success "Frontend serves HTML content"
+    ((TESTS_PASSED++))
+  else
+    log_error "Frontend response does not contain HTML"
+    echo "Response preview: $(echo "$FRONTEND_RESPONSE" | head -c 200)"
+    ((TESTS_FAILED++))
+  fi
+else
+  log_error "Frontend is not responding at $FRONTEND_URL"
+  ((TESTS_FAILED++))
+fi
+
+# =============================================================================
+# Step 5: Verify SeaweedFS S3 is accessible
+# =============================================================================
+log_info "Testing SeaweedFS S3 storage..."
+
+# SeaweedFS in basic mode doesn't require auth for the default bucket
+S3_ENDPOINT="http://localhost:${SEAWEEDFS_PORT}"
+TEST_BUCKET="test-bucket"
+TEST_KEY="integration-test-$(date +%s).txt"
+TEST_CONTENT="Integration test content: $(date -Iseconds)"
+
+# Try to create a bucket and upload a test object using curl
+# SeaweedFS S3 API accepts standard S3 operations
+
+# First, create the bucket
+BUCKET_CREATE=$(curl -sf -X PUT "${S3_ENDPOINT}/${TEST_BUCKET}" 2>/dev/null; echo $?)
+if [[ "$BUCKET_CREATE" != "0" ]]; then
+  # Bucket might already exist, which is fine
+  log_info "  Bucket creation returned (may already exist)"
+fi
+
+# Upload a test object
+PUT_RESPONSE=$(curl -sf -X PUT \
+  -H "Content-Type: text/plain" \
+  --data "$TEST_CONTENT" \
+  "${S3_ENDPOINT}/${TEST_BUCKET}/${TEST_KEY}" 2>/dev/null && echo "OK" || echo "FAILED")
+
+if [[ "$PUT_RESPONSE" == "OK" ]]; then
+  log_success "SeaweedFS S3 PUT operation succeeded"
+  ((TESTS_PASSED++))
+
+  # Try to GET the object back
+  GET_RESPONSE=$(curl -sf "${S3_ENDPOINT}/${TEST_BUCKET}/${TEST_KEY}" 2>/dev/null || echo "FAILED")
+
+  if [[ "$GET_RESPONSE" == "$TEST_CONTENT" ]]; then
+    log_success "SeaweedFS S3 GET operation succeeded (content verified)"
+    ((TESTS_PASSED++))
+  elif [[ "$GET_RESPONSE" != "FAILED" ]]; then
+    log_success "SeaweedFS S3 GET operation succeeded"
+    ((TESTS_PASSED++))
+  else
+    log_error "SeaweedFS S3 GET operation failed"
+    ((TESTS_FAILED++))
+  fi
+
+  # Clean up: delete the test object
+  curl -sf -X DELETE "${S3_ENDPOINT}/${TEST_BUCKET}/${TEST_KEY}" 2>/dev/null || true
+else
+  log_error "SeaweedFS S3 PUT operation failed"
+  ((TESTS_FAILED++))
+  # Still count GET as failed since PUT failed
+  ((TESTS_FAILED++))
+fi
+
+# =============================================================================
+# Step 6: Run database migration check
+# =============================================================================
+log_info "Verifying database migrations..."
+
+# Check if we can connect to the database and verify schema exists
+DB_CHECK=$(docker compose -f "$COMPOSE_FILE" exec -T db \
+  psql -U "${POSTGRES_USER:-openclaw}" -d "${POSTGRES_DB:-openclaw}" \
+  -c "SELECT COUNT(*) FROM schema_migrations WHERE NOT dirty;" 2>/dev/null | grep -E '^\s*[0-9]+' | tr -d ' ' || echo "FAILED")
+
+if [[ "$DB_CHECK" != "FAILED" && "$DB_CHECK" -gt 0 ]]; then
+  log_success "Database has $DB_CHECK clean migrations applied"
+  ((TESTS_PASSED++))
+else
+  # Alternative check: see if any tables exist
+  TABLE_COUNT=$(docker compose -f "$COMPOSE_FILE" exec -T db \
+    psql -U "${POSTGRES_USER:-openclaw}" -d "${POSTGRES_DB:-openclaw}" \
+    -c "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = 'public';" 2>/dev/null | grep -E '^\s*[0-9]+' | tr -d ' ' || echo "0")
+
+  if [[ "$TABLE_COUNT" -gt 0 ]]; then
+    log_success "Database has $TABLE_COUNT tables in public schema"
+    ((TESTS_PASSED++))
+  else
+    log_error "Database migration verification failed"
+    docker compose -f "$COMPOSE_FILE" logs migrate 2>&1 | tail -30
+    ((TESTS_FAILED++))
+  fi
+fi
+
+# Check for essential tables
+ESSENTIAL_TABLES=("work_item" "contact" "user_setting")
+for table in "${ESSENTIAL_TABLES[@]}"; do
+  TABLE_EXISTS=$(docker compose -f "$COMPOSE_FILE" exec -T db \
+    psql -U "${POSTGRES_USER:-openclaw}" -d "${POSTGRES_DB:-openclaw}" \
+    -c "SELECT EXISTS(SELECT 1 FROM information_schema.tables WHERE table_name = '$table');" 2>/dev/null | grep -E '^\s*t' || echo "")
+
+  if [[ -n "$TABLE_EXISTS" ]]; then
+    log_success "Essential table '$table' exists"
+    ((TESTS_PASSED++))
+  else
+    log_error "Essential table '$table' is missing"
+    ((TESTS_FAILED++))
+  fi
+done
+
+# =============================================================================
+# Summary
+# =============================================================================
+log_info "Integration test complete"
+echo ""
+echo "======================================"
+echo "  Results: $TESTS_PASSED passed, $TESTS_FAILED failed"
+echo "======================================"
+
+# Exit code is handled by the cleanup trap


### PR DESCRIPTION
## Summary
- Adds `scripts/integration-test.sh` for end-to-end compose verification
- Tests: service health, API endpoint, frontend, SeaweedFS S3, DB migration
- Adds GitHub Actions workflow `.github/workflows/integration.yml` for CI integration

### Integration Test Script Features
- Starts the basic compose stack with test environment variables
- Waits for all services to become healthy (db, seaweedfs, migrate, api, app)
- Tests API `/health` endpoint responds correctly
- Verifies frontend serves HTML content
- Tests SeaweedFS S3 with PUT/GET object operations
- Verifies database migrations applied and essential tables exist
- Automatic cleanup on exit (success or failure)
- Configurable timeout and compose file path
- Color-coded output for easy reading

### GitHub Actions Workflow Features
- Triggers on changes to docker-compose files, docker directory, or the workflow itself
- Supports manual trigger with configurable timeout
- Collects container logs on failure for debugging
- Automatic cleanup in finally block

## Test plan
- [x] Shell script syntax valid (`bash -n`)
- [x] YAML syntax valid
- [ ] Integration test runs successfully in CI
- [ ] All services verified healthy
- [ ] Cleanup works on success and failure

Closes #539

:robot: Generated with [Claude Code](https://claude.com/claude-code)