### PR TITLE
[#590] Fix Traefik entrypoint.sh for Alpine (POSIX sh)

### DIFF
--- a/docker/traefik/entrypoint.sh
+++ b/docker/traefik/entrypoint.sh
@@ -1,5 +1,7 @@
-#!/bin/bash
-set -euo pipefail
+#!/bin/sh
+set -eu
+# Enable pipefail if available (bash/zsh), ignore on POSIX sh
+( set -o pipefail 2>/dev/null ) && set -o pipefail || true
 
 # Traefik dynamic config entrypoint script
 # Generates dynamic configuration from environment variables using envsubst


### PR DESCRIPTION
Closes #590

## Summary

- Changed shebang from `#!/bin/bash` to `#!/bin/sh`
- Removed `pipefail` from the `set` command (not POSIX-compliant)
- Added guarded pipefail that attempts to enable if available, silently ignores if not
- Script now works with Alpine's `/bin/sh` (busybox ash)

The `traefik:3.6` image is Alpine-based and does not include bash. This change ensures the entrypoint script runs correctly with POSIX sh.

## Test plan

- [x] Script passes `sh -n` syntax check
- [x] Pipefail guard tested - works in both bash (enables) and sh (skips gracefully)
- [ ] CI validates compose configuration
- [ ] Production deployment with Traefik verifies entrypoint works

🤖 Generated with [Claude Code](https://claude.com/claude-code)