### PR TITLE
[#580] Remove unused VITE_API_URL from .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -108,14 +108,6 @@ S3_SECRET_KEY=
 SEAWEEDFS_VOLUME_SIZE_LIMIT_MB=1000
 
 # =============================================================================
-# Frontend Configuration
-# =============================================================================
-
-# API URL the frontend will use for requests
-# For local development, matches API_PORT
-# VITE_API_URL=http://localhost:3000
-
-# =============================================================================
 # Email Integration (Postmark)
 # =============================================================================
 


### PR DESCRIPTION
## Summary

- Removed the misleading `VITE_API_URL` environment variable from `.env.example`

## Why this change is needed

The `VITE_API_URL` environment variable was documented in `.env.example` but was never actually used:

1. **Vite env vars are baked at BUILD time** - Setting them in Docker container environment has no effect on the bundled JavaScript
2. **The frontend uses relative paths** - API calls go to `/api/*` which nginx proxies to the API container
3. **Issue #575 implemented the correct solution** - The app container uses `API_HOST` and `API_PORT` to configure nginx's upstream proxy

This variable was misleading users into thinking they could configure the API URL at runtime.

## Test plan

- [x] Verified both compose files validate: `docker compose config`
- [x] Confirmed no other references to `VITE_API_URL` exist in the codebase
- [x] Tests pass (pre-existing failures in twilio/notebooks tests are unrelated)

Closes #580

---
Generated with [Claude Code](https://claude.com/claude-code)