### PR TITLE
[#587] Add Twilio environment variables to compose files

### DIFF
--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -370,6 +370,10 @@ services:
       VOYAGERAI_API_KEY_FILE: ${VOYAGERAI_API_KEY_FILE:-}
       GEMINI_API_KEY: ${GEMINI_API_KEY:-}
       GEMINI_API_KEY_FILE: ${GEMINI_API_KEY_FILE:-}
+      # SMS (Twilio) - optional
+      TWILIO_ACCOUNT_SID: ${TWILIO_ACCOUNT_SID:-}
+      TWILIO_AUTH_TOKEN: ${TWILIO_AUTH_TOKEN:-}
+      TWILIO_FROM_NUMBER: ${TWILIO_FROM_NUMBER:-}
     expose:
       - "3001"
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -175,6 +175,10 @@ services:
       VOYAGERAI_API_KEY_FILE: ${VOYAGERAI_API_KEY_FILE:-}
       GEMINI_API_KEY: ${GEMINI_API_KEY:-}
       GEMINI_API_KEY_FILE: ${GEMINI_API_KEY_FILE:-}
+      # SMS (Twilio) - optional
+      TWILIO_ACCOUNT_SID: ${TWILIO_ACCOUNT_SID:-}
+      TWILIO_AUTH_TOKEN: ${TWILIO_AUTH_TOKEN:-}
+      TWILIO_FROM_NUMBER: ${TWILIO_FROM_NUMBER:-}
     ports:
       - "${API_PORT:-3000}:3000"
     healthcheck:


### PR DESCRIPTION
Closes #587

## Summary
- Added Twilio SMS environment variables to both `docker-compose.yml` and `docker-compose.traefik.yml`
- Variables added to the `api` service environment section:
  - `TWILIO_ACCOUNT_SID`
  - `TWILIO_AUTH_TOKEN`
  - `TWILIO_FROM_NUMBER`

## Test plan
- [x] Validated `docker-compose.yml` with `docker compose config`
- [x] Validated `docker-compose.traefik.yml` with `docker compose config`

Generated with Claude Code