### PR TITLE
[#592] Remove Traefik depends_on for immediate startup

### DIFF
--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -33,13 +33,10 @@ services:
     image: traefik:3.6
     container_name: openclaw-traefik
     restart: unless-stopped
-    depends_on:
-      api:
-        condition: service_healthy
-      app:
-        condition: service_healthy
-      modsecurity:
-        condition: service_healthy
+    # Note: No depends_on - Traefik starts immediately and handles unhealthy backends
+    # gracefully by returning 502/503 until services are ready. This is standard
+    # reverse proxy behavior and allows faster startup. See docs/deployment.md
+    # for details on startup behavior.
     environment:
       # Required for entrypoint script
       DOMAIN: ${DOMAIN:?DOMAIN is required}


### PR DESCRIPTION
Closes #592

## Summary

- Removed `depends_on` from the Traefik service in `docker-compose.traefik.yml`
- Traefik now starts immediately without waiting for backend services
- Returns 502/503 for backends that are not yet ready (standard reverse proxy behavior)
- Added "Startup Behavior" documentation section to `docs/deployment.md`

## Rationale

Reverse proxies should start immediately and handle unhealthy backends gracefully. The previous `depends_on` with health conditions created unnecessary startup delays:

1. **Faster startup**: Traefik can begin acquiring TLS certificates while backends start
2. **Standard behavior**: All major reverse proxies (nginx, HAProxy, Caddy) work this way
3. **Independent restarts**: Backend services can restart without affecting Traefik

## Test plan

- [x] Compose configuration validates successfully
- [ ] CI passes all checks
- [ ] Production deployment verifies startup behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)