### PR TITLE
[#593] Fix ModSecurity image tag and port configuration

### DIFF
--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -138,7 +138,11 @@ services:
   # Uses OWASP Core Rule Set for protection against common attacks
   # Static frontend assets bypass WAF (go directly to app)
   modsecurity:
-    image: owasp/modsecurity-crs:4-apache-alpine
+    # Note: The image tag "apache-alpine" tracks CRS v4 (current latest).
+    # The previous tag "4-apache-alpine" does not exist on Docker Hub.
+    # For production stability, consider pinning to a specific version like:
+    #   owasp/modsecurity-crs:4.23.0-apache-alpine-202602050102
+    image: owasp/modsecurity-crs:apache-alpine
     container_name: openclaw-modsecurity
     restart: unless-stopped
     environment:
@@ -171,14 +175,14 @@ services:
       MODSEC_AUDIT_ENGINE: RelevantOnly
       # Error log to stdout for container logging
       ERRORLOG: "/dev/stderr"
-      # Port to listen on
-      PORT: 80
+      # Port to listen on (8080 required - container runs unprivileged)
+      PORT: 8080
       # Server name
       SERVER_NAME: modsecurity
     expose:
-      - "80"
+      - "8080"
     healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:80/healthz"]
+      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:8080/healthz"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -206,7 +210,7 @@ services:
       # Enable Traefik for ModSecurity service
       - "traefik.enable=true"
       # Service configuration (used by dynamic config)
-      - "traefik.http.services.modsecurity.loadbalancer.server.port=80"
+      - "traefik.http.services.modsecurity.loadbalancer.server.port=8080"
       - "traefik.http.services.modsecurity.loadbalancer.healthcheck.path=/healthz"
       - "traefik.http.services.modsecurity.loadbalancer.healthcheck.interval=10s"
 

--- a/docker/traefik/dynamic-config.yml.template
+++ b/docker/traefik/dynamic-config.yml.template
@@ -86,10 +86,11 @@ http:
   # Services
   services:
     # ModSecurity WAF service - proxies to API after inspection
+    # Note: Port 8080 required as the container runs unprivileged
     modsecurity-service:
       loadBalancer:
         servers:
-          - url: "http://modsecurity:80"
+          - url: "http://modsecurity:8080"
         healthCheck:
           path: /healthz
           interval: 10s


### PR DESCRIPTION
Closes #593

## Summary

- Changed image tag from non-existent `4-apache-alpine` to `apache-alpine`
- Updated PORT from 80 to 8080 (container runs unprivileged, can't bind to ports <1024)
- Updated expose, healthcheck, and Traefik labels to use port 8080
- Updated `dynamic-config.yml.template` to reference `modsecurity:8080`
- Added comment about pinning to specific versions for production stability

## Root cause

The tag `owasp/modsecurity-crs:4-apache-alpine` does not exist on Docker Hub. The correct tags are:
- `apache-alpine` - tracks latest CRS v4 (recommended)
- `4.23.0-apache-alpine-202602050102` - pinned to specific build (for production stability)

Additionally, the OWASP ModSecurity CRS container now runs unprivileged and cannot bind to ports below 1024. The default port is 8080.

## Verification

- [x] Pulled `owasp/modsecurity-crs:apache-alpine` successfully
- [x] Verified `/healthz` endpoint works internally on port 8080
- [x] Compose configuration validates successfully

## Test plan

- [ ] CI passes all checks
- [ ] Production deployment verifies ModSecurity WAF functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)