### PR TITLE
[#611] Fix race condition in file share download count limiting

### DIFF
--- a/migrations/049_file_share.up.sql
+++ b/migrations/049_file_share.up.sql
@@ -61,11 +61,12 @@ CREATE OR REPLACE FUNCTION validate_file_share_token(
 DECLARE
   v_share RECORD;
 BEGIN
-  -- Find the share
+  -- Find the share (FOR UPDATE locks the row to prevent race conditions)
   SELECT fs.file_attachment_id, fs.expires_at, fs.download_count, fs.max_downloads
   INTO v_share
   FROM file_share fs
-  WHERE fs.share_token = p_token;
+  WHERE fs.share_token = p_token
+  FOR UPDATE;
 
   IF v_share IS NULL THEN
     RETURN QUERY SELECT NULL::uuid, false, 'Invalid or expired share link'::text;

--- a/tests/file-storage/file-share-race-condition.test.ts
+++ b/tests/file-storage/file-share-race-condition.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Tests for file share token validation race condition.
+ * Part of Epic #574, Issue #611.
+ *
+ * This test demonstrates and verifies the fix for a TOCTOU race condition
+ * in the validate_file_share_token function where concurrent downloads
+ * could exceed max_downloads without proper row locking.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, beforeAll } from 'vitest';
+import type { Pool } from 'pg';
+import { createTestPool, truncateAllTables } from '../helpers/db.ts';
+import { runMigrate } from '../helpers/migrate.ts';
+
+describe('File Share Race Condition Prevention', () => {
+  let pool: Pool;
+
+  beforeAll(async () => {
+    await runMigrate('up');
+  });
+
+  beforeEach(async () => {
+    pool = createTestPool();
+    await truncateAllTables(pool);
+  });
+
+  afterEach(async () => {
+    await pool.end();
+  });
+
+  /**
+   * Helper to create a file attachment and share token for testing.
+   */
+  async function createTestFileShare(
+    pool: Pool,
+    options: {
+      maxDownloads: number;
+      expiresInHours?: number;
+    }
+  ): Promise<{ fileId: string; shareToken: string }> {
+    // Create a file attachment first
+    const fileResult = await pool.query<{ id: string }>(
+      `INSERT INTO file_attachment (storage_key, original_filename, content_type, size_bytes)
+       VALUES ('test/file.txt', 'test.txt', 'text/plain', 100)
+       RETURNING id`
+    );
+    const fileId = fileResult.rows[0].id;
+
+    // Create a file share with max_downloads limit
+    const expiresAt = new Date();
+    expiresAt.setHours(expiresAt.getHours() + (options.expiresInHours ?? 1));
+
+    const shareResult = await pool.query<{ share_token: string }>(
+      `INSERT INTO file_share (file_attachment_id, share_token, expires_at, max_downloads, download_count)
+       VALUES ($1, $2, $3, $4, 0)
+       RETURNING share_token`,
+      [fileId, `test-token-${Date.now()}`, expiresAt, options.maxDownloads]
+    );
+
+    return {
+      fileId,
+      shareToken: shareResult.rows[0].share_token,
+    };
+  }
+
+  it('should allow downloads up to max_downloads limit', async () => {
+    const { shareToken } = await createTestFileShare(pool, { maxDownloads: 3 });
+
+    // First download should succeed
+    const result1 = await pool.query<{ is_valid: boolean; error_message: string | null }>(
+      'SELECT is_valid, error_message FROM validate_file_share_token($1, true)',
+      [shareToken]
+    );
+    expect(result1.rows[0].is_valid).toBe(true);
+
+    // Second download should succeed
+    const result2 = await pool.query<{ is_valid: boolean; error_message: string | null }>(
+      'SELECT is_valid, error_message FROM validate_file_share_token($1, true)',
+      [shareToken]
+    );
+    expect(result2.rows[0].is_valid).toBe(true);
+
+    // Third download should succeed (hits limit)
+    const result3 = await pool.query<{ is_valid: boolean; error_message: string | null }>(
+      'SELECT is_valid, error_message FROM validate_file_share_token($1, true)',
+      [shareToken]
+    );
+    expect(result3.rows[0].is_valid).toBe(true);
+
+    // Fourth download should fail (exceeds limit)
+    const result4 = await pool.query<{ is_valid: boolean; error_message: string | null }>(
+      'SELECT is_valid, error_message FROM validate_file_share_token($1, true)',
+      [shareToken]
+    );
+    expect(result4.rows[0].is_valid).toBe(false);
+    expect(result4.rows[0].error_message).toContain('Maximum downloads reached');
+  });
+
+  it('should prevent race condition when concurrent downloads exceed max_downloads', async () => {
+    const { shareToken } = await createTestFileShare(pool, { maxDownloads: 1 });
+
+    // Simulate concurrent access using multiple connections
+    // This test verifies that FOR UPDATE prevents the race condition
+    const pool1 = createTestPool();
+    const pool2 = createTestPool();
+    const pool3 = createTestPool();
+
+    try {
+      // Start all validations concurrently
+      // Without FOR UPDATE, all three could read download_count=0 and all succeed
+      // With FOR UPDATE, only the first should succeed
+      const [result1, result2, result3] = await Promise.all([
+        pool1.query<{ is_valid: boolean; error_message: string | null }>(
+          'SELECT is_valid, error_message FROM validate_file_share_token($1, true)',
+          [shareToken]
+        ),
+        pool2.query<{ is_valid: boolean; error_message: string | null }>(
+          'SELECT is_valid, error_message FROM validate_file_share_token($1, true)',
+          [shareToken]
+        ),
+        pool3.query<{ is_valid: boolean; error_message: string | null }>(
+          'SELECT is_valid, error_message FROM validate_file_share_token($1, true)',
+          [shareToken]
+        ),
+      ]);
+
+      // Count successful downloads
+      const successCount = [result1, result2, result3].filter(
+        (r) => r.rows[0].is_valid
+      ).length;
+
+      // With proper locking, only 1 download should succeed (max_downloads = 1)
+      expect(successCount).toBe(1);
+
+      // Verify the final download_count in the database
+      const countResult = await pool.query<{ download_count: number }>(
+        'SELECT download_count FROM file_share WHERE share_token = $1',
+        [shareToken]
+      );
+      expect(countResult.rows[0].download_count).toBe(1);
+    } finally {
+      await pool1.end();
+      await pool2.end();
+      await pool3.end();
+    }
+  });
+
+  it('should handle race condition with max_downloads of 2', async () => {
+    const { shareToken } = await createTestFileShare(pool, { maxDownloads: 2 });
+
+    // Create 5 concurrent connections all trying to download
+    const pools = await Promise.all(
+      Array.from({ length: 5 }, () => createTestPool())
+    );
+
+    try {
+      const results = await Promise.all(
+        pools.map((p) =>
+          p.query<{ is_valid: boolean; error_message: string | null }>(
+            'SELECT is_valid, error_message FROM validate_file_share_token($1, true)',
+            [shareToken]
+          )
+        )
+      );
+
+      const successCount = results.filter((r) => r.rows[0].is_valid).length;
+
+      // With proper locking, exactly 2 downloads should succeed
+      expect(successCount).toBe(2);
+
+      // Verify the final download_count
+      const countResult = await pool.query<{ download_count: number }>(
+        'SELECT download_count FROM file_share WHERE share_token = $1',
+        [shareToken]
+      );
+      expect(countResult.rows[0].download_count).toBe(2);
+    } finally {
+      await Promise.all(pools.map((p) => p.end()));
+    }
+  });
+
+  it('should return correct error message when download limit is exceeded', async () => {
+    const { shareToken } = await createTestFileShare(pool, { maxDownloads: 1 });
+
+    // First download succeeds
+    await pool.query('SELECT * FROM validate_file_share_token($1, true)', [shareToken]);
+
+    // Second download should fail with specific message
+    const result = await pool.query<{ is_valid: boolean; error_message: string }>(
+      'SELECT is_valid, error_message FROM validate_file_share_token($1, true)',
+      [shareToken]
+    );
+
+    expect(result.rows[0].is_valid).toBe(false);
+    expect(result.rows[0].error_message).toBe('Maximum downloads reached for this link');
+  });
+
+  it('should not increment count when p_increment_download is false', async () => {
+    const { shareToken } = await createTestFileShare(pool, { maxDownloads: 1 });
+
+    // Validate without incrementing (preview mode)
+    const result1 = await pool.query<{ is_valid: boolean }>(
+      'SELECT is_valid FROM validate_file_share_token($1, false)',
+      [shareToken]
+    );
+    expect(result1.rows[0].is_valid).toBe(true);
+
+    // Verify count is still 0
+    const countResult = await pool.query<{ download_count: number }>(
+      'SELECT download_count FROM file_share WHERE share_token = $1',
+      [shareToken]
+    );
+    expect(countResult.rows[0].download_count).toBe(0);
+
+    // Actual download should still work
+    const result2 = await pool.query<{ is_valid: boolean }>(
+      'SELECT is_valid FROM validate_file_share_token($1, true)',
+      [shareToken]
+    );
+    expect(result2.rows[0].is_valid).toBe(true);
+  });
+});

--- a/tests/helpers/db.ts
+++ b/tests/helpers/db.ts
@@ -71,6 +71,7 @@ const APPLICATION_TABLES = [
   'webhook_outbox',
   'internal_job',
   // File storage
+  'file_share',
   'file_attachment',
   // Embedding settings
   'embedding_usage',


### PR DESCRIPTION
## Summary
- Add `FOR UPDATE` to the SELECT statement in `validate_file_share_token()` to acquire a row lock
- Prevents TOCTOU race condition where concurrent downloads could exceed `max_downloads`
- Add comprehensive test suite that demonstrates the race condition and verifies the fix
- Add `file_share` table to test cleanup truncation list

Closes #611

## Problem
The `validate_file_share_token` function had a race condition:
1. Multiple concurrent requests could all read `download_count = 0`
2. All would pass the `download_count < max_downloads` check
3. All would increment the counter, exceeding the limit

## Solution
Add `FOR UPDATE` clause to lock the row during the read-check-update sequence, serializing concurrent access.

## Test plan
- [x] New test demonstrates race condition fails without fix (verified by running test before applying fix - got 3 successful downloads with max_downloads=1)
- [x] New test passes after applying `FOR UPDATE` fix
- [x] All existing file-storage tests pass (37 tests)
- [x] Test covers sequential downloads respecting limit
- [x] Test covers concurrent downloads with proper locking

Part of Epic #574

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)