### PR TITLE
[#613] Add UUID validation for file ID parameter

### DIFF
--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -59,6 +59,7 @@ import {
   InvalidStateError,
   type OAuthProvider,
 } from './oauth/index.ts';
+import { isValidUUID } from './utils/validation.ts';
 
 export type ProjectsApiOptions = {
   logger?: boolean;
@@ -3332,6 +3333,12 @@ export function buildServer(options: ProjectsApiOptions = {}): FastifyInstance {
     }
 
     const params = req.params as { id: string };
+
+    // Validate file ID is a valid UUID (Issue #613)
+    if (!isValidUUID(params.id)) {
+      return reply.code(400).send({ error: 'Invalid file ID format' });
+    }
+
     const body = req.body as { expiresIn?: number; maxDownloads?: number } | null;
     const expiresIn = body?.expiresIn ?? 3600;
     const maxDownloads = body?.maxDownloads;

--- a/src/api/utils/validation.ts
+++ b/src/api/utils/validation.ts
@@ -1,0 +1,35 @@
+/**
+ * Validation utilities for API parameter validation.
+ * Part of Issue #613 - Missing UUID validation for file ID parameter.
+ *
+ * @module src/api/utils/validation
+ */
+
+/**
+ * Regular expression for validating UUID v4 format.
+ * Matches UUIDs in the format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+ * where x is a hexadecimal character (0-9, a-f, A-F).
+ *
+ * Note: This validates the format only, not that it's a specific UUID version.
+ * This is intentional as we accept any valid UUID format for flexibility.
+ */
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Validate that a string is a valid UUID.
+ *
+ * @param str - The string to validate
+ * @returns true if the string is a valid UUID format, false otherwise
+ *
+ * @example
+ * ```ts
+ * isValidUUID('00000000-0000-0000-0000-000000000000'); // true
+ * isValidUUID('ABCDEF12-3456-7890-ABCD-EF1234567890'); // true (uppercase)
+ * isValidUUID('not-a-uuid'); // false
+ * isValidUUID('123'); // false
+ * isValidUUID(''); // false
+ * ```
+ */
+export function isValidUUID(str: string): boolean {
+  return UUID_REGEX.test(str);
+}

--- a/tests/file-storage/uuid-validation.test.ts
+++ b/tests/file-storage/uuid-validation.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Tests for UUID validation on file storage API endpoints.
+ * Part of Issue #613 - Missing UUID validation for file ID parameter.
+ *
+ * These tests verify that invalid UUIDs return 400 Bad Request
+ * instead of causing database errors (500) that could leak schema info.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, beforeAll, vi } from 'vitest';
+import type { Pool } from 'pg';
+import { buildServer } from '../../src/api/server.ts';
+import { createTestPool, truncateAllTables } from '../helpers/db.ts';
+import { runMigrate } from '../helpers/migrate.ts';
+
+// Mock the file storage module
+vi.mock('../../src/api/file-storage/index.ts', async () => {
+  const actual = await vi.importActual('../../src/api/file-storage/index.ts');
+
+  // Mock storage implementation
+  const mockFiles = new Map<string, { data: Buffer; contentType: string }>();
+
+  const MockS3Storage = class {
+    async upload(key: string, data: Buffer, contentType: string): Promise<string> {
+      mockFiles.set(key, { data, contentType });
+      return key;
+    }
+
+    async download(key: string): Promise<Buffer> {
+      const file = mockFiles.get(key);
+      if (!file) throw new Error(`File not found: ${key}`);
+      return file.data;
+    }
+
+    async getSignedUrl(key: string, expiresIn: number): Promise<string> {
+      return `https://mock.s3.com/${key}?expires=${expiresIn}`;
+    }
+
+    async delete(key: string): Promise<void> {
+      mockFiles.delete(key);
+    }
+
+    async exists(key: string): Promise<boolean> {
+      return mockFiles.has(key);
+    }
+  };
+
+  return {
+    ...actual,
+    S3Storage: MockS3Storage,
+    createS3StorageFromEnv: () => new MockS3Storage(),
+  };
+});
+
+describe('UUID Validation for File Share Endpoint', () => {
+  const originalEnv = process.env;
+  let pool: Pool;
+  let app: ReturnType<typeof buildServer>;
+
+  beforeAll(async () => {
+    await runMigrate('up');
+  });
+
+  beforeEach(async () => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+    process.env.OPENCLAW_PROJECTS_AUTH_DISABLED = 'true';
+    // Set mock S3 env vars
+    process.env.S3_BUCKET = 'test-bucket';
+    process.env.S3_REGION = 'us-east-1';
+    process.env.S3_ACCESS_KEY = 'test-key';
+    process.env.S3_SECRET_KEY = 'test-secret';
+    process.env.S3_ENDPOINT = 'http://localhost:8333';
+
+    pool = createTestPool();
+    await truncateAllTables(pool);
+    app = buildServer({ logger: false });
+  });
+
+  afterEach(async () => {
+    process.env = originalEnv;
+    await pool.end();
+    await app.close();
+  });
+
+  describe('POST /api/files/:id/share', () => {
+    it('returns 400 Bad Request for "not-a-uuid"', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/files/not-a-uuid/share',
+        payload: {},
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.json().error).toContain('Invalid file ID format');
+    });
+
+    it('returns 400 Bad Request for "123"', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/files/123/share',
+        payload: {},
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.json().error).toContain('Invalid file ID format');
+    });
+
+    it('returns 400 Bad Request for "abc"', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/files/abc/share',
+        payload: {},
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.json().error).toContain('Invalid file ID format');
+    });
+
+    it('returns 400 Bad Request for empty string path', async () => {
+      // Note: Empty string in path would be /api/files//share which Fastify may handle differently
+      // This tests the closest equivalent
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/files/%20/share', // URL-encoded space
+        payload: {},
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.json().error).toContain('Invalid file ID format');
+    });
+
+    it('returns 400 Bad Request for partial UUID', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/files/12345678-1234-1234-1234/share', // Missing last segment
+        payload: {},
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.json().error).toContain('Invalid file ID format');
+    });
+
+    it('returns 400 Bad Request for UUID with invalid characters', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/files/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/share',
+        payload: {},
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.json().error).toContain('Invalid file ID format');
+    });
+
+    it('accepts valid UUID format and returns 404 for non-existent file', async () => {
+      // This test verifies that valid UUIDs pass validation
+      // and reach the database lookup (which returns 404 for non-existent files)
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/files/00000000-0000-0000-0000-000000000000/share',
+        payload: {},
+      });
+
+      // Should be 404 (file not found), NOT 400 (invalid UUID)
+      expect(response.statusCode).toBe(404);
+    });
+
+    it('accepts valid UUID with uppercase letters', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/files/ABCDEF12-3456-7890-ABCD-EF1234567890/share',
+        payload: {},
+      });
+
+      // Should be 404 (file not found), NOT 400 (invalid UUID)
+      expect(response.statusCode).toBe(404);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds UUID format validation to `POST /api/files/:id/share` endpoint
- Invalid UUIDs now return 400 Bad Request instead of 500 Internal Server Error
- Creates reusable `isValidUUID()` utility in `src/api/utils/validation.ts`

## Changes
- **New file**: `src/api/utils/validation.ts` - UUID validation utility with JSDoc documentation
- **New file**: `tests/file-storage/uuid-validation.test.ts` - Comprehensive test coverage for invalid UUID handling
- **Modified**: `src/api/server.ts` - Added UUID validation check to file share endpoint

## Test plan
- [x] Tests for invalid UUIDs ("not-a-uuid", "123", "abc", whitespace, partial UUID, invalid chars)
- [x] Tests that valid UUIDs pass validation and reach database layer
- [x] All existing file-storage tests continue to pass (40 tests total)

## Related
Part of Epic #574 (File Storage)

Closes #613

Generated with [Claude Code](https://claude.com/claude-code)