### PR TITLE
[#612] Fix Content-Disposition header injection vulnerability

### DIFF
--- a/src/api/file-storage/sharing.ts
+++ b/src/api/file-storage/sharing.ts
@@ -91,6 +91,20 @@ export class ShareLinkError extends Error {
 }
 
 /**
+ * Sanitize filename for use in Content-Disposition header.
+ * Removes control characters and escapes quotes/backslashes to prevent
+ * header injection attacks (Issue #612).
+ *
+ * @param filename - The original filename to sanitize
+ * @returns Sanitized filename safe for use in Content-Disposition header
+ */
+export function sanitizeFilenameForHeader(filename: string): string {
+  return filename
+    .replace(/[\r\n\x00-\x1f\x7f]/g, '') // Remove control characters (CR, LF, NUL, etc.)
+    .replace(/["\\]/g, (c) => '\\' + c);  // Escape quotes and backslashes
+}
+
+/**
  * Create a shareable download link for a file.
  *
  * The share mode is determined by FILE_SHARE_MODE environment variable:

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -41,6 +41,7 @@ import {
   createFileShare,
   downloadFileByShareToken,
   ShareLinkError,
+  sanitizeFilenameForHeader,
 } from './file-storage/index.ts';
 import {
   getAuthorizationUrl,
@@ -3213,10 +3214,11 @@ export function buildServer(options: ProjectsApiOptions = {}): FastifyInstance {
       const result = await downloadFile(pool, storage, params.id);
       await pool.end();
 
+      const safeFilename = sanitizeFilenameForHeader(result.metadata.originalFilename);
       return reply
         .code(200)
         .header('Content-Type', result.metadata.contentType)
-        .header('Content-Disposition', `attachment; filename="${result.metadata.originalFilename}"`)
+        .header('Content-Disposition', `attachment; filename="${safeFilename}"`)
         .header('Content-Length', result.data.length)
         .send(result.data);
     } catch (error) {
@@ -3385,10 +3387,11 @@ export function buildServer(options: ProjectsApiOptions = {}): FastifyInstance {
       const result = await downloadFileByShareToken(pool, storage, params.token);
       await pool.end();
 
+      const safeFilename = sanitizeFilenameForHeader(result.metadata.originalFilename);
       return reply
         .code(200)
         .header('Content-Type', result.metadata.contentType)
-        .header('Content-Disposition', `attachment; filename="${result.metadata.originalFilename}"`)
+        .header('Content-Disposition', `attachment; filename="${safeFilename}"`)
         .header('Content-Length', result.data.length)
         .send(result.data);
     } catch (error) {

--- a/tests/file-storage/content-disposition-sanitization.test.ts
+++ b/tests/file-storage/content-disposition-sanitization.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Tests for Content-Disposition header filename sanitization.
+ * Part of Issue #612 - Content-Disposition header injection vulnerability.
+ *
+ * Ensures filenames are properly sanitized before being used in
+ * Content-Disposition headers to prevent header injection attacks.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { sanitizeFilenameForHeader } from '../../src/api/file-storage/sharing.ts';
+
+describe('sanitizeFilenameForHeader', () => {
+  describe('quote handling', () => {
+    it('escapes double quotes in filename', () => {
+      const input = 'file"name.txt';
+      const result = sanitizeFilenameForHeader(input);
+      expect(result).toBe('file\\"name.txt');
+    });
+
+    it('escapes multiple double quotes', () => {
+      const input = '"file"name".txt';
+      const result = sanitizeFilenameForHeader(input);
+      expect(result).toBe('\\"file\\"name\\".txt');
+    });
+
+    it('escapes backslashes', () => {
+      const input = 'file\\name.txt';
+      const result = sanitizeFilenameForHeader(input);
+      expect(result).toBe('file\\\\name.txt');
+    });
+
+    it('escapes both quotes and backslashes', () => {
+      const input = 'file\\"name.txt';
+      const result = sanitizeFilenameForHeader(input);
+      expect(result).toBe('file\\\\\\"name.txt');
+    });
+  });
+
+  describe('control character removal', () => {
+    it('strips carriage return characters', () => {
+      const input = 'file\rname.txt';
+      const result = sanitizeFilenameForHeader(input);
+      expect(result).toBe('filename.txt');
+    });
+
+    it('strips newline characters', () => {
+      const input = 'file\nname.txt';
+      const result = sanitizeFilenameForHeader(input);
+      expect(result).toBe('filename.txt');
+    });
+
+    it('strips CRLF sequences', () => {
+      const input = 'file\r\nname.txt';
+      const result = sanitizeFilenameForHeader(input);
+      expect(result).toBe('filename.txt');
+    });
+
+    it('strips null bytes', () => {
+      const input = 'file\x00name.txt';
+      const result = sanitizeFilenameForHeader(input);
+      expect(result).toBe('filename.txt');
+    });
+
+    it('strips ASCII control characters 0x01-0x1f', () => {
+      const input = 'file\x01\x02\x03\x1fname.txt';
+      const result = sanitizeFilenameForHeader(input);
+      expect(result).toBe('filename.txt');
+    });
+
+    it('strips DEL character (0x7f)', () => {
+      const input = 'file\x7fname.txt';
+      const result = sanitizeFilenameForHeader(input);
+      expect(result).toBe('filename.txt');
+    });
+  });
+
+  describe('header injection prevention', () => {
+    it('prevents header injection via CRLF followed by header', () => {
+      // Attacker tries to inject a new header
+      const input = 'malicious.txt\r\nX-Injected-Header: pwned';
+      const result = sanitizeFilenameForHeader(input);
+      // Should strip CRLF, leaving the injected header name as part of filename
+      expect(result).toBe('malicious.txtX-Injected-Header: pwned');
+      expect(result).not.toContain('\r');
+      expect(result).not.toContain('\n');
+    });
+
+    it('prevents header injection via quote escape', () => {
+      // Attacker tries to break out of quoted string
+      const input = '"; X-Injected: pwned; filename="safe.txt';
+      const result = sanitizeFilenameForHeader(input);
+      expect(result).toBe('\\"; X-Injected: pwned; filename=\\"safe.txt');
+    });
+  });
+
+  describe('normal filenames', () => {
+    it('leaves normal filenames unchanged', () => {
+      const input = 'document.pdf';
+      const result = sanitizeFilenameForHeader(input);
+      expect(result).toBe('document.pdf');
+    });
+
+    it('preserves spaces in filenames', () => {
+      const input = 'my document file.pdf';
+      const result = sanitizeFilenameForHeader(input);
+      expect(result).toBe('my document file.pdf');
+    });
+
+    it('preserves Unicode characters', () => {
+      const input = 'documento-espanol-nino.pdf';
+      const result = sanitizeFilenameForHeader(input);
+      expect(result).toBe('documento-espanol-nino.pdf');
+    });
+
+    it('preserves dashes and underscores', () => {
+      const input = 'my-file_2024.pdf';
+      const result = sanitizeFilenameForHeader(input);
+      expect(result).toBe('my-file_2024.pdf');
+    });
+
+    it('handles empty string', () => {
+      const input = '';
+      const result = sanitizeFilenameForHeader(input);
+      expect(result).toBe('');
+    });
+  });
+
+  describe('combined scenarios', () => {
+    it('handles multiple issues in same filename', () => {
+      // Quotes, backslash, and control characters all present
+      const input = 'file"\\\r\nname.txt';
+      const result = sanitizeFilenameForHeader(input);
+      expect(result).toBe('file\\"\\\\name.txt');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Added `sanitizeFilenameForHeader()` function to prevent header injection attacks via malicious filenames
- The function removes control characters (CR, LF, NUL, 0x00-0x1f, 0x7f) and escapes quotes and backslashes
- Applied sanitization to both file download endpoints (`GET /api/files/:id` and `GET /api/files/shared/:token`)

## Test Plan
- [x] Added 18 unit tests covering:
  - Quote escaping (single and multiple quotes)
  - Backslash escaping
  - Control character stripping (CR, LF, CRLF, NUL, ASCII 0x01-0x1f, DEL)
  - Header injection prevention scenarios
  - Normal filename preservation (spaces, Unicode, dashes, underscores)
  - Edge cases (empty string, combined issues)

Part of Epic #574

Closes #612

---
Generated with [Claude Code](https://claude.ai/code)