### PR TITLE
[#622] Fix migration rollback and test state corruption

### DIFF
--- a/migrations/044_contact_kind.down.sql
+++ b/migrations/044_contact_kind.down.sql
@@ -19,11 +19,26 @@ FOR EACH ROW EXECUTE FUNCTION contact_search_update();
 -- Drop the index
 DROP INDEX IF EXISTS idx_contact_kind;
 
+-- Drop dependent views first (they use SELECT * and include contact_kind)
+DROP VIEW IF EXISTS contact_active;
+DROP VIEW IF EXISTS contact_trash;
+
 -- Drop the column
 ALTER TABLE contact DROP COLUMN IF EXISTS contact_kind;
 
 -- Drop the enum type
 DROP TYPE IF EXISTS contact_kind;
+
+-- Recreate the views (from migration 035_soft_delete) without contact_kind
+CREATE OR REPLACE VIEW contact_active AS
+SELECT *
+FROM contact
+WHERE deleted_at IS NULL;
+
+CREATE OR REPLACE VIEW contact_trash AS
+SELECT *
+FROM contact
+WHERE deleted_at IS NOT NULL;
 
 -- Backfill search_vector to remove stale contact_kind data
 UPDATE contact SET search_vector = to_tsvector('english',

--- a/tests/migrations.test.ts
+++ b/tests/migrations.test.ts
@@ -27,6 +27,13 @@ describe('Migrations', () => {
   });
 
   afterAll(async () => {
+    // Re-apply migrations to leave database in a clean state for other tests
+    // This is critical because the rollback test leaves the DB empty
+    try {
+      await runMigrate('up');
+    } catch (error) {
+      console.error('[migrations.test.ts] Failed to re-apply migrations in afterAll:', error);
+    }
     await pool.end();
   });
 


### PR DESCRIPTION
## Summary

- Fix migration 044 down script to properly handle dependent views when dropping contact_kind column
- Fix migrations.test.ts to re-apply migrations after rollback test, leaving database in clean state

## Root Cause

The migration rollback test (`rolls back migrations and removes table + helpers`) was leaving the database in an empty state. Subsequent tests depended on:
- `internal_job_enqueue` function (migration 012)
- `enqueue_due_nudges` function (migration 012)
- `embedding_settings` singleton row (migration 037)

These were gone after the rollback test ran, causing 134+ test failures.

## Changes

### migrations/044_contact_kind.down.sql
- Drop `contact_active` and `contact_trash` views before dropping `contact_kind` column
- Recreate views after column drop (they use `SELECT *` so they auto-adapt)

### tests/migrations.test.ts
- Add `afterAll` hook to re-apply all migrations
- Ensures database is in clean state for tests that run afterward

## Test Plan

- [x] `pnpm run test` - all 4998 tests pass
- [x] Migration rollback test passes
- [x] Database functions and singleton rows are preserved after test suite

Closes #622

---
Generated with [Claude Code](https://claude.com/claude-code)