### PR TITLE
[#628] Create React Query hooks for Notes and Notebooks API

### DIFF
--- a/src/ui/hooks/mutations/use-note-mutations.ts
+++ b/src/ui/hooks/mutations/use-note-mutations.ts
@@ -1,0 +1,187 @@
+/**
+ * TanStack Query mutation hooks for notes.
+ *
+ * Provides mutations for creating, updating, deleting, and restoring notes.
+ * Includes cache invalidation for related queries.
+ */
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { apiClient } from '@/ui/lib/api-client.ts';
+import type {
+  Note,
+  CreateNoteBody,
+  UpdateNoteBody,
+  RestoreVersionResponse,
+} from '@/ui/lib/api-types.ts';
+import { noteKeys } from '@/ui/hooks/queries/use-notes.ts';
+import { notebookKeys } from '@/ui/hooks/queries/use-notebooks.ts';
+
+/**
+ * Create a new note.
+ *
+ * @returns TanStack mutation
+ *
+ * @example
+ * ```ts
+ * const { mutate } = useCreateNote();
+ * mutate({ title: 'New note', content: '# Hello' });
+ * ```
+ */
+export function useCreateNote() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (body: CreateNoteBody) =>
+      apiClient.post<Note>('/api/notes', body),
+
+    onSuccess: (note) => {
+      // Invalidate notes list queries
+      queryClient.invalidateQueries({ queryKey: noteKeys.lists() });
+
+      // If note has a notebook, invalidate notebook queries too
+      if (note.notebookId) {
+        queryClient.invalidateQueries({
+          queryKey: notebookKeys.detail(note.notebookId),
+        });
+        queryClient.invalidateQueries({ queryKey: notebookKeys.tree() });
+      }
+    },
+  });
+}
+
+/**
+ * Update an existing note.
+ *
+ * @returns TanStack mutation
+ *
+ * @example
+ * ```ts
+ * const { mutate } = useUpdateNote();
+ * mutate({ id: 'note-123', body: { title: 'Updated title' } });
+ * ```
+ */
+export function useUpdateNote() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, body }: { id: string; body: UpdateNoteBody }) =>
+      apiClient.put<Note>(`/api/notes/${id}`, body),
+
+    onSuccess: (note, { id }) => {
+      // Invalidate the specific note detail
+      queryClient.invalidateQueries({ queryKey: noteKeys.detail(id) });
+
+      // Invalidate notes list queries
+      queryClient.invalidateQueries({ queryKey: noteKeys.lists() });
+
+      // Invalidate versions since content may have changed
+      queryClient.invalidateQueries({ queryKey: noteKeys.versions(id) });
+
+      // If note has a notebook, invalidate notebook queries
+      if (note.notebookId) {
+        queryClient.invalidateQueries({
+          queryKey: notebookKeys.detail(note.notebookId),
+        });
+        queryClient.invalidateQueries({ queryKey: notebookKeys.tree() });
+      }
+    },
+  });
+}
+
+/**
+ * Soft delete a note.
+ *
+ * @returns TanStack mutation
+ *
+ * @example
+ * ```ts
+ * const { mutate } = useDeleteNote();
+ * mutate('note-123');
+ * ```
+ */
+export function useDeleteNote() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => apiClient.delete(`/api/notes/${id}`),
+
+    onSuccess: (_, id) => {
+      // Invalidate the specific note detail
+      queryClient.invalidateQueries({ queryKey: noteKeys.detail(id) });
+
+      // Invalidate notes list queries
+      queryClient.invalidateQueries({ queryKey: noteKeys.lists() });
+
+      // Invalidate notebook tree to update counts
+      queryClient.invalidateQueries({ queryKey: notebookKeys.tree() });
+      queryClient.invalidateQueries({ queryKey: notebookKeys.lists() });
+    },
+  });
+}
+
+/**
+ * Restore a soft-deleted note.
+ *
+ * @returns TanStack mutation
+ *
+ * @example
+ * ```ts
+ * const { mutate } = useRestoreNote();
+ * mutate('note-123');
+ * ```
+ */
+export function useRestoreNote() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) =>
+      apiClient.post<Note>(`/api/notes/${id}/restore`, {}),
+
+    onSuccess: (note, id) => {
+      // Invalidate the specific note detail
+      queryClient.invalidateQueries({ queryKey: noteKeys.detail(id) });
+
+      // Invalidate notes list queries
+      queryClient.invalidateQueries({ queryKey: noteKeys.lists() });
+
+      // If note has a notebook, invalidate notebook queries
+      if (note.notebookId) {
+        queryClient.invalidateQueries({
+          queryKey: notebookKeys.detail(note.notebookId),
+        });
+        queryClient.invalidateQueries({ queryKey: notebookKeys.tree() });
+      }
+    },
+  });
+}
+
+/**
+ * Restore a note to a previous version.
+ *
+ * @returns TanStack mutation
+ *
+ * @example
+ * ```ts
+ * const { mutate } = useRestoreNoteVersion();
+ * mutate({ id: 'note-123', versionNumber: 5 });
+ * ```
+ */
+export function useRestoreNoteVersion() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, versionNumber }: { id: string; versionNumber: number }) =>
+      apiClient.post<RestoreVersionResponse>(
+        `/api/notes/${id}/versions/${versionNumber}/restore`,
+        {}
+      ),
+
+    onSuccess: (_, { id }) => {
+      // Invalidate note detail and versions
+      queryClient.invalidateQueries({ queryKey: noteKeys.detail(id) });
+      queryClient.invalidateQueries({ queryKey: noteKeys.versions(id) });
+
+      // Invalidate notes list queries
+      queryClient.invalidateQueries({ queryKey: noteKeys.lists() });
+    },
+  });
+}

--- a/src/ui/hooks/mutations/use-note-sharing-mutations.ts
+++ b/src/ui/hooks/mutations/use-note-sharing-mutations.ts
@@ -1,0 +1,136 @@
+/**
+ * TanStack Query mutation hooks for note sharing.
+ *
+ * Provides mutations for creating, updating, and revoking note shares.
+ * Includes cache invalidation for related queries.
+ */
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { apiClient } from '@/ui/lib/api-client.ts';
+import type {
+  NoteUserShare,
+  CreateUserShareBody,
+  CreateLinkShareBody,
+  CreateLinkShareResponse,
+  UpdateShareBody,
+  NoteShare,
+} from '@/ui/lib/api-types.ts';
+import { noteKeys } from '@/ui/hooks/queries/use-notes.ts';
+
+/**
+ * Share a note with a specific user.
+ *
+ * @returns TanStack mutation
+ *
+ * @example
+ * ```ts
+ * const { mutate } = useShareNoteWithUser();
+ * mutate({ noteId: 'note-123', body: { email: 'user@example.com', permission: 'read' } });
+ * ```
+ */
+export function useShareNoteWithUser() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ noteId, body }: { noteId: string; body: CreateUserShareBody }) =>
+      apiClient.post<NoteUserShare>(`/api/notes/${noteId}/share`, body),
+
+    onSuccess: (_, { noteId }) => {
+      // Invalidate shares for this note
+      queryClient.invalidateQueries({ queryKey: noteKeys.shares(noteId) });
+
+      // Invalidate the note detail (visibility may have changed)
+      queryClient.invalidateQueries({ queryKey: noteKeys.detail(noteId) });
+    },
+  });
+}
+
+/**
+ * Create a shareable link for a note.
+ *
+ * @returns TanStack mutation
+ *
+ * @example
+ * ```ts
+ * const { mutate } = useCreateNoteShareLink();
+ * mutate({ noteId: 'note-123', body: { permission: 'read', maxViews: 10 } });
+ * ```
+ */
+export function useCreateNoteShareLink() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ noteId, body }: { noteId: string; body: CreateLinkShareBody }) =>
+      apiClient.post<CreateLinkShareResponse>(`/api/notes/${noteId}/share/link`, body),
+
+    onSuccess: (_, { noteId }) => {
+      // Invalidate shares for this note
+      queryClient.invalidateQueries({ queryKey: noteKeys.shares(noteId) });
+
+      // Invalidate the note detail (visibility may have changed)
+      queryClient.invalidateQueries({ queryKey: noteKeys.detail(noteId) });
+    },
+  });
+}
+
+/**
+ * Update an existing share's permission or expiration.
+ *
+ * @returns TanStack mutation
+ *
+ * @example
+ * ```ts
+ * const { mutate } = useUpdateNoteShare();
+ * mutate({ noteId: 'note-123', shareId: 'share-456', body: { permission: 'read_write' } });
+ * ```
+ */
+export function useUpdateNoteShare() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      noteId,
+      shareId,
+      body,
+    }: {
+      noteId: string;
+      shareId: string;
+      body: UpdateShareBody;
+    }) => apiClient.put<NoteShare>(`/api/notes/${noteId}/shares/${shareId}`, body),
+
+    onSuccess: (_, { noteId }) => {
+      // Invalidate shares for this note
+      queryClient.invalidateQueries({ queryKey: noteKeys.shares(noteId) });
+    },
+  });
+}
+
+/**
+ * Revoke a note share.
+ *
+ * @returns TanStack mutation
+ *
+ * @example
+ * ```ts
+ * const { mutate } = useRevokeNoteShare();
+ * mutate({ noteId: 'note-123', shareId: 'share-456' });
+ * ```
+ */
+export function useRevokeNoteShare() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ noteId, shareId }: { noteId: string; shareId: string }) =>
+      apiClient.delete(`/api/notes/${noteId}/shares/${shareId}`),
+
+    onSuccess: (_, { noteId }) => {
+      // Invalidate shares for this note
+      queryClient.invalidateQueries({ queryKey: noteKeys.shares(noteId) });
+
+      // Invalidate the note detail (visibility may have changed)
+      queryClient.invalidateQueries({ queryKey: noteKeys.detail(noteId) });
+
+      // Invalidate shared-with-me in case this was a share we were receiving
+      queryClient.invalidateQueries({ queryKey: noteKeys.sharedWithMe() });
+    },
+  });
+}

--- a/src/ui/hooks/mutations/use-notebook-mutations.ts
+++ b/src/ui/hooks/mutations/use-notebook-mutations.ts
@@ -1,0 +1,213 @@
+/**
+ * TanStack Query mutation hooks for notebooks.
+ *
+ * Provides mutations for creating, updating, archiving, and deleting notebooks.
+ * Includes cache invalidation for related queries.
+ */
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { apiClient } from '@/ui/lib/api-client.ts';
+import type {
+  Notebook,
+  CreateNotebookBody,
+  UpdateNotebookBody,
+  MoveNotesBody,
+  MoveNotesResponse,
+} from '@/ui/lib/api-types.ts';
+import { noteKeys } from '@/ui/hooks/queries/use-notes.ts';
+import { notebookKeys } from '@/ui/hooks/queries/use-notebooks.ts';
+
+/**
+ * Create a new notebook.
+ *
+ * @returns TanStack mutation
+ *
+ * @example
+ * ```ts
+ * const { mutate } = useCreateNotebook();
+ * mutate({ name: 'My Notebook', icon: '📓' });
+ * ```
+ */
+export function useCreateNotebook() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (body: CreateNotebookBody) =>
+      apiClient.post<Notebook>('/api/notebooks', body),
+
+    onSuccess: (notebook) => {
+      // Invalidate notebooks list queries
+      queryClient.invalidateQueries({ queryKey: notebookKeys.lists() });
+
+      // Invalidate tree
+      queryClient.invalidateQueries({ queryKey: notebookKeys.tree() });
+
+      // If has parent, invalidate parent notebook
+      if (notebook.parentNotebookId) {
+        queryClient.invalidateQueries({
+          queryKey: notebookKeys.detail(notebook.parentNotebookId),
+        });
+      }
+    },
+  });
+}
+
+/**
+ * Update an existing notebook.
+ *
+ * @returns TanStack mutation
+ *
+ * @example
+ * ```ts
+ * const { mutate } = useUpdateNotebook();
+ * mutate({ id: 'notebook-123', body: { name: 'New Name' } });
+ * ```
+ */
+export function useUpdateNotebook() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, body }: { id: string; body: UpdateNotebookBody }) =>
+      apiClient.put<Notebook>(`/api/notebooks/${id}`, body),
+
+    onSuccess: (_, { id }) => {
+      // Invalidate the specific notebook detail
+      queryClient.invalidateQueries({ queryKey: notebookKeys.detail(id) });
+
+      // Invalidate notebooks list queries
+      queryClient.invalidateQueries({ queryKey: notebookKeys.lists() });
+
+      // Invalidate tree
+      queryClient.invalidateQueries({ queryKey: notebookKeys.tree() });
+    },
+  });
+}
+
+/**
+ * Archive a notebook.
+ *
+ * @returns TanStack mutation
+ *
+ * @example
+ * ```ts
+ * const { mutate } = useArchiveNotebook();
+ * mutate('notebook-123');
+ * ```
+ */
+export function useArchiveNotebook() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) =>
+      apiClient.post<Notebook>(`/api/notebooks/${id}/archive`, {}),
+
+    onSuccess: (_, id) => {
+      // Invalidate the specific notebook detail
+      queryClient.invalidateQueries({ queryKey: notebookKeys.detail(id) });
+
+      // Invalidate notebooks list queries
+      queryClient.invalidateQueries({ queryKey: notebookKeys.lists() });
+
+      // Invalidate tree
+      queryClient.invalidateQueries({ queryKey: notebookKeys.tree() });
+    },
+  });
+}
+
+/**
+ * Unarchive a notebook.
+ *
+ * @returns TanStack mutation
+ *
+ * @example
+ * ```ts
+ * const { mutate } = useUnarchiveNotebook();
+ * mutate('notebook-123');
+ * ```
+ */
+export function useUnarchiveNotebook() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) =>
+      apiClient.post<Notebook>(`/api/notebooks/${id}/unarchive`, {}),
+
+    onSuccess: (_, id) => {
+      // Invalidate the specific notebook detail
+      queryClient.invalidateQueries({ queryKey: notebookKeys.detail(id) });
+
+      // Invalidate notebooks list queries
+      queryClient.invalidateQueries({ queryKey: notebookKeys.lists() });
+
+      // Invalidate tree
+      queryClient.invalidateQueries({ queryKey: notebookKeys.tree() });
+    },
+  });
+}
+
+/**
+ * Delete a notebook.
+ *
+ * @returns TanStack mutation
+ *
+ * @example
+ * ```ts
+ * const { mutate } = useDeleteNotebook();
+ * mutate({ id: 'notebook-123', deleteNotes: false });
+ * ```
+ */
+export function useDeleteNotebook() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, deleteNotes = false }: { id: string; deleteNotes?: boolean }) =>
+      apiClient.delete(`/api/notebooks/${id}${deleteNotes ? '?deleteNotes=true' : ''}`),
+
+    onSuccess: (_, { id }) => {
+      // Invalidate the specific notebook detail
+      queryClient.invalidateQueries({ queryKey: notebookKeys.detail(id) });
+
+      // Invalidate notebooks list queries
+      queryClient.invalidateQueries({ queryKey: notebookKeys.lists() });
+
+      // Invalidate tree
+      queryClient.invalidateQueries({ queryKey: notebookKeys.tree() });
+
+      // Also invalidate notes since they may have been moved or deleted
+      queryClient.invalidateQueries({ queryKey: noteKeys.lists() });
+    },
+  });
+}
+
+/**
+ * Move or copy notes to a notebook.
+ *
+ * @returns TanStack mutation
+ *
+ * @example
+ * ```ts
+ * const { mutate } = useMoveNotesToNotebook();
+ * mutate({ notebookId: 'notebook-123', body: { noteIds: ['note-1', 'note-2'], action: 'move' } });
+ * ```
+ */
+export function useMoveNotesToNotebook() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ notebookId, body }: { notebookId: string; body: MoveNotesBody }) =>
+      apiClient.post<MoveNotesResponse>(`/api/notebooks/${notebookId}/notes`, body),
+
+    onSuccess: (_, { notebookId }) => {
+      // Invalidate the target notebook
+      queryClient.invalidateQueries({
+        queryKey: notebookKeys.detail(notebookId),
+      });
+
+      // Invalidate all notebooks (source notebook may have changed)
+      queryClient.invalidateQueries({ queryKey: notebookKeys.lists() });
+      queryClient.invalidateQueries({ queryKey: notebookKeys.tree() });
+
+      // Invalidate notes since they've been moved/copied
+      queryClient.invalidateQueries({ queryKey: noteKeys.lists() });
+    },
+  });
+}

--- a/src/ui/hooks/queries/use-notebooks.ts
+++ b/src/ui/hooks/queries/use-notebooks.ts
@@ -1,0 +1,155 @@
+/**
+ * TanStack Query hooks for notebooks data fetching.
+ *
+ * Provides cached, deduplicated queries for notebooks and their tree structure.
+ */
+import { useQuery } from '@tanstack/react-query';
+import { apiClient } from '@/ui/lib/api-client.ts';
+import type {
+  NotebooksResponse,
+  Notebook,
+  ListNotebooksParams,
+  NotebookTreeNode,
+  SharedWithMeResponse,
+} from '@/ui/lib/api-types.ts';
+
+/** Query key factory for notebooks. */
+export const notebookKeys = {
+  all: ['notebooks'] as const,
+  lists: () => [...notebookKeys.all, 'list'] as const,
+  list: (params?: ListNotebooksParams) => [...notebookKeys.lists(), params] as const,
+  details: () => [...notebookKeys.all, 'detail'] as const,
+  detail: (id: string) => [...notebookKeys.details(), id] as const,
+  tree: () => [...notebookKeys.all, 'tree'] as const,
+  shares: (id: string) => [...notebookKeys.all, 'shares', id] as const,
+  sharedWithMe: () => [...notebookKeys.all, 'shared-with-me'] as const,
+};
+
+/**
+ * Build query string from ListNotebooksParams.
+ */
+function buildNotebooksQueryString(params?: ListNotebooksParams): string {
+  if (!params) return '';
+
+  const searchParams = new URLSearchParams();
+
+  if (params.parentId !== undefined) {
+    searchParams.set('parentId', params.parentId ?? 'null');
+  }
+  if (params.includeArchived) {
+    searchParams.set('includeArchived', 'true');
+  }
+  if (params.includeNoteCounts !== undefined) {
+    searchParams.set('includeNoteCounts', String(params.includeNoteCounts));
+  }
+  if (params.includeChildCounts !== undefined) {
+    searchParams.set('includeChildCounts', String(params.includeChildCounts));
+  }
+  if (params.limit !== undefined) {
+    searchParams.set('limit', String(params.limit));
+  }
+  if (params.offset !== undefined) {
+    searchParams.set('offset', String(params.offset));
+  }
+
+  const queryString = searchParams.toString();
+  return queryString ? `?${queryString}` : '';
+}
+
+/**
+ * Fetch list of notebooks with optional filters.
+ *
+ * @param params - Optional filter/pagination params
+ * @returns TanStack Query result with `NotebooksResponse`
+ */
+export function useNotebooks(params?: ListNotebooksParams) {
+  const queryString = buildNotebooksQueryString(params);
+
+  return useQuery({
+    queryKey: notebookKeys.list(params),
+    queryFn: ({ signal }) =>
+      apiClient.get<NotebooksResponse>(`/api/notebooks${queryString}`, { signal }),
+  });
+}
+
+/**
+ * Fetch a single notebook by ID.
+ *
+ * @param id - Notebook UUID
+ * @param options - Optional includes (notes, children)
+ * @returns TanStack Query result with `Notebook`
+ */
+export function useNotebook(
+  id: string,
+  options?: { includeNotes?: boolean; includeChildren?: boolean }
+) {
+  const searchParams = new URLSearchParams();
+  if (options?.includeNotes) {
+    searchParams.set('includeNotes', 'true');
+  }
+  if (options?.includeChildren) {
+    searchParams.set('includeChildren', 'true');
+  }
+  const queryString = searchParams.toString();
+
+  return useQuery({
+    queryKey: notebookKeys.detail(id),
+    queryFn: ({ signal }) =>
+      apiClient.get<Notebook>(
+        `/api/notebooks/${id}${queryString ? `?${queryString}` : ''}`,
+        { signal }
+      ),
+    enabled: !!id,
+  });
+}
+
+/**
+ * Fetch notebooks as a tree structure.
+ *
+ * @param includeNoteCounts - Whether to include note counts
+ * @returns TanStack Query result with array of `NotebookTreeNode`
+ */
+export function useNotebooksTree(includeNoteCounts = false) {
+  const queryString = includeNoteCounts ? '?includeNoteCounts=true' : '';
+
+  return useQuery({
+    queryKey: notebookKeys.tree(),
+    queryFn: ({ signal }) =>
+      apiClient.get<NotebookTreeNode[]>(`/api/notebooks/tree${queryString}`, {
+        signal,
+      }),
+  });
+}
+
+/**
+ * Fetch shares for a notebook.
+ *
+ * @param id - Notebook UUID
+ * @returns TanStack Query result with shares
+ */
+export function useNotebookShares(id: string) {
+  return useQuery({
+    queryKey: notebookKeys.shares(id),
+    queryFn: ({ signal }) =>
+      apiClient.get<{ notebookId: string; shares: unknown[] }>(
+        `/api/notebooks/${id}/shares`,
+        { signal }
+      ),
+    enabled: !!id,
+  });
+}
+
+/**
+ * Fetch notebooks shared with the current user.
+ *
+ * @returns TanStack Query result with `SharedWithMeResponse`
+ */
+export function useNotebooksSharedWithMe() {
+  return useQuery({
+    queryKey: notebookKeys.sharedWithMe(),
+    queryFn: ({ signal }) =>
+      apiClient.get<SharedWithMeResponse>('/api/notebooks/shared-with-me', {
+        signal,
+      }),
+  });
+}

--- a/src/ui/hooks/queries/use-notes.ts
+++ b/src/ui/hooks/queries/use-notes.ts
@@ -1,0 +1,205 @@
+/**
+ * TanStack Query hooks for notes data fetching.
+ *
+ * Provides cached, deduplicated queries for notes, versions, and shares.
+ */
+import { useQuery } from '@tanstack/react-query';
+import { apiClient } from '@/ui/lib/api-client.ts';
+import type {
+  NotesResponse,
+  Note,
+  ListNotesParams,
+  NoteVersionsResponse,
+  NoteVersion,
+  CompareVersionsResponse,
+  NoteSharesResponse,
+  SharedWithMeResponse,
+} from '@/ui/lib/api-types.ts';
+
+/** Query key factory for notes. */
+export const noteKeys = {
+  all: ['notes'] as const,
+  lists: () => [...noteKeys.all, 'list'] as const,
+  list: (params?: ListNotesParams) => [...noteKeys.lists(), params] as const,
+  details: () => [...noteKeys.all, 'detail'] as const,
+  detail: (id: string) => [...noteKeys.details(), id] as const,
+  versions: (id: string) => [...noteKeys.all, 'versions', id] as const,
+  version: (id: string, versionNumber: number) =>
+    [...noteKeys.versions(id), versionNumber] as const,
+  versionCompare: (id: string, from: number, to: number) =>
+    [...noteKeys.versions(id), 'compare', from, to] as const,
+  shares: (id: string) => [...noteKeys.all, 'shares', id] as const,
+  sharedWithMe: () => [...noteKeys.all, 'shared-with-me'] as const,
+};
+
+/**
+ * Build query string from ListNotesParams.
+ */
+function buildNotesQueryString(params?: ListNotesParams): string {
+  if (!params) return '';
+
+  const searchParams = new URLSearchParams();
+
+  if (params.notebookId) {
+    searchParams.set('notebookId', params.notebookId);
+  }
+  if (params.tags && params.tags.length > 0) {
+    params.tags.forEach((tag) => searchParams.append('tags', tag));
+  }
+  if (params.visibility) {
+    searchParams.set('visibility', params.visibility);
+  }
+  if (params.search) {
+    searchParams.set('search', params.search);
+  }
+  if (params.isPinned !== undefined) {
+    searchParams.set('isPinned', String(params.isPinned));
+  }
+  if (params.includeDeleted) {
+    searchParams.set('includeDeleted', 'true');
+  }
+  if (params.limit !== undefined) {
+    searchParams.set('limit', String(params.limit));
+  }
+  if (params.offset !== undefined) {
+    searchParams.set('offset', String(params.offset));
+  }
+  if (params.sortBy) {
+    searchParams.set('sortBy', params.sortBy);
+  }
+  if (params.sortOrder) {
+    searchParams.set('sortOrder', params.sortOrder);
+  }
+
+  const queryString = searchParams.toString();
+  return queryString ? `?${queryString}` : '';
+}
+
+/**
+ * Fetch list of notes with optional filters.
+ *
+ * @param params - Optional filter/pagination params
+ * @returns TanStack Query result with `NotesResponse`
+ */
+export function useNotes(params?: ListNotesParams) {
+  const queryString = buildNotesQueryString(params);
+
+  return useQuery({
+    queryKey: noteKeys.list(params),
+    queryFn: ({ signal }) =>
+      apiClient.get<NotesResponse>(`/api/notes${queryString}`, { signal }),
+  });
+}
+
+/**
+ * Fetch a single note by ID.
+ *
+ * @param id - Note UUID
+ * @returns TanStack Query result with `Note`
+ */
+export function useNote(id: string) {
+  return useQuery({
+    queryKey: noteKeys.detail(id),
+    queryFn: ({ signal }) => apiClient.get<Note>(`/api/notes/${id}`, { signal }),
+    enabled: !!id,
+  });
+}
+
+/**
+ * Fetch version history for a note.
+ *
+ * @param id - Note UUID
+ * @param options - Optional pagination
+ * @returns TanStack Query result with `NoteVersionsResponse`
+ */
+export function useNoteVersions(
+  id: string,
+  options?: { limit?: number; offset?: number }
+) {
+  const searchParams = new URLSearchParams();
+  if (options?.limit !== undefined) {
+    searchParams.set('limit', String(options.limit));
+  }
+  if (options?.offset !== undefined) {
+    searchParams.set('offset', String(options.offset));
+  }
+  const queryString = searchParams.toString();
+
+  return useQuery({
+    queryKey: noteKeys.versions(id),
+    queryFn: ({ signal }) =>
+      apiClient.get<NoteVersionsResponse>(
+        `/api/notes/${id}/versions${queryString ? `?${queryString}` : ''}`,
+        { signal }
+      ),
+    enabled: !!id,
+  });
+}
+
+/**
+ * Fetch a specific version of a note.
+ *
+ * @param id - Note UUID
+ * @param versionNumber - Version number to fetch
+ * @returns TanStack Query result with `NoteVersion`
+ */
+export function useNoteVersion(id: string, versionNumber: number) {
+  return useQuery({
+    queryKey: noteKeys.version(id, versionNumber),
+    queryFn: ({ signal }) =>
+      apiClient.get<NoteVersion>(`/api/notes/${id}/versions/${versionNumber}`, {
+        signal,
+      }),
+    enabled: !!id && versionNumber > 0,
+  });
+}
+
+/**
+ * Compare two versions of a note.
+ *
+ * @param id - Note UUID
+ * @param from - From version number
+ * @param to - To version number
+ * @returns TanStack Query result with `CompareVersionsResponse`
+ */
+export function useNoteVersionCompare(id: string, from: number, to: number) {
+  return useQuery({
+    queryKey: noteKeys.versionCompare(id, from, to),
+    queryFn: ({ signal }) =>
+      apiClient.get<CompareVersionsResponse>(
+        `/api/notes/${id}/versions/compare?from=${from}&to=${to}`,
+        { signal }
+      ),
+    enabled: !!id && from > 0 && to > 0 && from !== to,
+  });
+}
+
+/**
+ * Fetch shares for a note.
+ *
+ * @param id - Note UUID
+ * @returns TanStack Query result with `NoteSharesResponse`
+ */
+export function useNoteShares(id: string) {
+  return useQuery({
+    queryKey: noteKeys.shares(id),
+    queryFn: ({ signal }) =>
+      apiClient.get<NoteSharesResponse>(`/api/notes/${id}/shares`, { signal }),
+    enabled: !!id,
+  });
+}
+
+/**
+ * Fetch notes shared with the current user.
+ *
+ * @returns TanStack Query result with `SharedWithMeResponse`
+ */
+export function useNotesSharedWithMe() {
+  return useQuery({
+    queryKey: noteKeys.sharedWithMe(),
+    queryFn: ({ signal }) =>
+      apiClient.get<SharedWithMeResponse>('/api/notes/shared-with-me', {
+        signal,
+      }),
+  });
+}


### PR DESCRIPTION
## Summary
- Add TanStack Query hooks for complete notes/notebooks data layer
- Add query hooks for notes, notebooks, versions, shares, and shared-with-me
- Add mutation hooks with proper cache invalidation
- Add comprehensive API types for all endpoints

## Test plan
- [x] TypeScript compilation passes for new files
- [x] Notes/notebooks API tests pass
- [x] Hook patterns match existing codebase conventions
- [ ] Manual testing with NotesPage integration (issue #624)

Closes #628

🤖 Generated with [Claude Code](https://claude.com/claude-code)