### PR TITLE
[#625] Add /notes routes to application router

### DIFF
--- a/src/ui/components/notebooks/notebooks-sidebar.tsx
+++ b/src/ui/components/notebooks/notebooks-sidebar.tsx
@@ -15,7 +15,7 @@ import {
   FileText,
   FolderOpen,
 } from 'lucide-react';
-import { cn } from '@/lib/utils';
+import { cn } from '@/ui/lib/utils';
 import { Button } from '@/ui/components/ui/button';
 import { ScrollArea } from '@/ui/components/ui/scroll-area';
 import {

--- a/src/ui/components/notes/detail/note-detail.tsx
+++ b/src/ui/components/notes/detail/note-detail.tsx
@@ -21,7 +21,7 @@ import {
   Loader2,
   BookOpen,
 } from 'lucide-react';
-import { cn } from '@/lib/utils';
+import { cn } from '@/ui/lib/utils';
 import { Button } from '@/ui/components/ui/button';
 import { Input } from '@/ui/components/ui/input';
 import { Badge } from '@/ui/components/ui/badge';

--- a/src/ui/components/notes/editor/note-editor.tsx
+++ b/src/ui/components/notes/editor/note-editor.tsx
@@ -13,7 +13,7 @@
  */
 
 import React, { useState, useCallback, useRef, useEffect } from 'react';
-import { cn } from '@/lib/utils';
+import { cn } from '@/ui/lib/utils';
 import { Button } from '@/ui/components/ui/button';
 import {
   Bold,

--- a/src/ui/components/notes/history/version-history.tsx
+++ b/src/ui/components/notes/history/version-history.tsx
@@ -15,7 +15,7 @@ import {
   Loader2,
   X,
 } from 'lucide-react';
-import { cn } from '@/lib/utils';
+import { cn } from '@/ui/lib/utils';
 import { Button } from '@/ui/components/ui/button';
 import { Badge } from '@/ui/components/ui/badge';
 import { ScrollArea } from '@/ui/components/ui/scroll-area';

--- a/src/ui/components/notes/list/note-card.tsx
+++ b/src/ui/components/notes/list/note-card.tsx
@@ -18,7 +18,7 @@ import {
   Users,
   Globe,
 } from 'lucide-react';
-import { cn } from '@/lib/utils';
+import { cn } from '@/ui/lib/utils';
 import { Badge } from '@/ui/components/ui/badge';
 import { Button } from '@/ui/components/ui/button';
 import {

--- a/src/ui/components/notes/list/notes-list.tsx
+++ b/src/ui/components/notes/list/notes-list.tsx
@@ -5,7 +5,7 @@
 
 import React, { useState, useMemo } from 'react';
 import { Search, Plus, FileText, SlidersHorizontal, X } from 'lucide-react';
-import { cn } from '@/lib/utils';
+import { cn } from '@/ui/lib/utils';
 import { Button } from '@/ui/components/ui/button';
 import { Input } from '@/ui/components/ui/input';
 import { ScrollArea } from '@/ui/components/ui/scroll-area';

--- a/src/ui/components/notes/shared/shared-note-page.tsx
+++ b/src/ui/components/notes/shared/shared-note-page.tsx
@@ -22,7 +22,7 @@ import {
   Eye,
   Edit,
 } from 'lucide-react';
-import { cn } from '@/lib/utils';
+import { cn } from '@/ui/lib/utils';
 import { Button } from '@/ui/components/ui/button';
 import { Badge } from '@/ui/components/ui/badge';
 import {

--- a/src/ui/components/notes/sharing/share-dialog.tsx
+++ b/src/ui/components/notes/sharing/share-dialog.tsx
@@ -15,7 +15,7 @@ import {
   Lock,
   Loader2,
 } from 'lucide-react';
-import { cn } from '@/lib/utils';
+import { cn } from '@/ui/lib/utils';
 import { Button } from '@/ui/components/ui/button';
 import { Input } from '@/ui/components/ui/input';
 import { Label } from '@/ui/components/ui/label';

--- a/src/ui/routes.tsx
+++ b/src/ui/routes.tsx
@@ -59,6 +59,9 @@ const SearchPage = React.lazy(() =>
 const NotFoundPage = React.lazy(() =>
   import('@/ui/pages/NotFoundPage.js').then((m) => ({ default: m.NotFoundPage }))
 );
+const NotesPage = React.lazy(() =>
+  import('@/ui/pages/NotesPage.js').then((m) => ({ default: m.NotesPage }))
+);
 
 /** Loading fallback shown while lazy-loaded pages are being fetched. */
 function PageLoader(): React.JSX.Element {
@@ -153,6 +156,22 @@ export const routes: RouteObject[] = [
       {
         path: 'memory',
         element: lazy(MemoryPage),
+      },
+      {
+        path: 'notes',
+        element: lazy(NotesPage),
+      },
+      {
+        path: 'notes/:noteId',
+        element: lazy(NotesPage),
+      },
+      {
+        path: 'notebooks/:notebookId',
+        element: lazy(NotesPage),
+      },
+      {
+        path: 'notebooks/:notebookId/notes/:noteId',
+        element: lazy(NotesPage),
       },
       {
         path: 'settings',


### PR DESCRIPTION
## Summary

Adds notes-related routes to the application router with URL-based navigation.

**Routes added:**
- `/notes` - All notes view
- `/notes/:noteId` - Direct link to specific note
- `/notebooks/:notebookId` - Notes filtered by notebook
- `/notebooks/:notebookId/notes/:noteId` - Note within notebook context

**Changes:**
- Add lazy-loaded NotesPage import to routes.tsx
- Add four new route definitions for notes navigation
- Update NotesPage to use `useParams`, `useNavigate`, and `useLocation`
- Sync URL with state on note selection, back navigation, save, and delete
- Fix import paths from `@/lib/utils` to `@/ui/lib/utils` across 9 components

## Test plan

- [x] All 4998 existing tests pass
- [x] Frontend build succeeds (`pnpm app:build`)
- [ ] Navigate to `/notes` shows all notes
- [ ] Navigate to `/notes/:noteId` opens specific note
- [ ] Navigate to `/notebooks/:notebookId` filters by notebook
- [ ] URL updates when selecting notes
- [ ] Back button behavior correct

Closes #625

🤖 Generated with [Claude Code](https://claude.com/claude-code)