### PR TITLE
[#626] Add Notes to sidebar navigation

### DIFF
--- a/src/ui/components/layout/mobile-nav.tsx
+++ b/src/ui/components/layout/mobile-nav.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
-import { Bell, Folder, Calendar, Users, Search } from 'lucide-react';
+import { Bell, Folder, Calendar, Users, Search, StickyNote } from 'lucide-react';
 import { cn } from '@/ui/lib/utils';
 import type { NavItem } from './sidebar';
 
 const defaultNavItems: NavItem[] = [
   { id: 'activity', label: 'Activity', icon: Bell },
   { id: 'projects', label: 'Projects', icon: Folder },
-  { id: 'timeline', label: 'Timeline', icon: Calendar },
+  { id: 'notes', label: 'Notes', icon: StickyNote },
   { id: 'people', label: 'People', icon: Users },
   { id: 'search', label: 'Search', icon: Search },
 ];

--- a/src/ui/components/layout/sidebar.tsx
+++ b/src/ui/components/layout/sidebar.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Bell, Folder, Calendar, Users, Search, Settings, ChevronLeft, ChevronRight, Plus } from 'lucide-react';
+import { Bell, Folder, Calendar, Users, Search, Settings, ChevronLeft, ChevronRight, Plus, StickyNote } from 'lucide-react';
 import { cn } from '@/ui/lib/utils';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/ui/components/ui/tooltip';
 import { ScrollArea } from '@/ui/components/ui/scroll-area';
@@ -15,6 +15,7 @@ export interface NavItem {
 const defaultNavItems: NavItem[] = [
   { id: 'activity', label: 'Activity', icon: Bell },
   { id: 'projects', label: 'Projects', icon: Folder },
+  { id: 'notes', label: 'Notes', icon: StickyNote },
   { id: 'timeline', label: 'Timeline', icon: Calendar },
   { id: 'people', label: 'People', icon: Users },
 ];

--- a/src/ui/layouts/app-layout.tsx
+++ b/src/ui/layouts/app-layout.tsx
@@ -29,6 +29,8 @@ function pathToSection(pathname: string): string {
   if (pathname.startsWith('/timeline')) return 'timeline';
   if (pathname.startsWith('/contacts')) return 'people';
   if (pathname.startsWith('/communications')) return 'communications';
+  if (pathname.startsWith('/notes')) return 'notes';
+  if (pathname.startsWith('/notebooks')) return 'notes';
   if (pathname.startsWith('/settings')) return 'settings';
   if (pathname.startsWith('/search')) return 'search';
   if (pathname.startsWith('/work-items') || pathname.startsWith('/kanban'))
@@ -44,6 +46,7 @@ const sectionRoutes: Record<string, string> = {
   timeline: '/timeline',
   people: '/contacts',
   communications: '/communications',
+  notes: '/notes',
   settings: '/settings',
 };
 
@@ -72,6 +75,39 @@ function deriveBreadcrumbs(
   }
   if (pathname.startsWith('/settings')) {
     return [{ id: 'settings', label: 'Settings' }];
+  }
+
+  // Notes routes
+  if (pathname.startsWith('/notes') || pathname.startsWith('/notebooks')) {
+    const notesCrumbs: BreadcrumbItem[] = [
+      { id: 'notes', label: 'Notes', href: '/notes' },
+    ];
+
+    // /notebooks/:notebookId/notes/:noteId
+    const notebookNoteMatch = /^\/notebooks\/([^/]+)\/notes\/([^/]+)\/?$/.exec(pathname);
+    if (notebookNoteMatch) {
+      notesCrumbs.push(
+        { id: 'notebook', label: 'Notebook', href: `/notebooks/${notebookNoteMatch[1]}` },
+        { id: 'note', label: 'Note' },
+      );
+      return notesCrumbs;
+    }
+
+    // /notebooks/:notebookId
+    const notebookMatch = /^\/notebooks\/([^/]+)\/?$/.exec(pathname);
+    if (notebookMatch) {
+      notesCrumbs.push({ id: 'notebook', label: 'Notebook' });
+      return notesCrumbs;
+    }
+
+    // /notes/:noteId
+    const noteMatch = /^\/notes\/([^/]+)\/?$/.exec(pathname);
+    if (noteMatch) {
+      notesCrumbs.push({ id: 'note', label: 'Note' });
+      return notesCrumbs;
+    }
+
+    return notesCrumbs;
   }
 
   const crumbs: BreadcrumbItem[] = [


### PR DESCRIPTION
## Summary

Adds Notes to the application sidebar navigation for easy access.

**Changes:**
- `app-layout.tsx`: Add notes/notebooks path handling to `pathToSection()` and `sectionRoutes`
- `app-layout.tsx`: Add breadcrumb derivation for notes routes (`/notes`, `/notes/:noteId`, `/notebooks/:notebookId`, `/notebooks/:notebookId/notes/:noteId`)
- `sidebar.tsx`: Add Notes nav item with `StickyNote` icon between Projects and Timeline
- `mobile-nav.tsx`: Add Notes to mobile navigation (replaced Timeline to maintain 5 items)

## Test plan

- [x] All 4998 existing tests pass
- [x] Frontend build succeeds
- [ ] Notes appears in desktop sidebar
- [ ] Clicking Notes navigates to /notes
- [ ] Active state shows when on notes pages
- [ ] Breadcrumbs work for notes routes
- [ ] Notes appears in mobile navigation

Closes #626

🤖 Generated with [Claude Code](https://claude.com/claude-code)