### PR TITLE
[#633] Add LaTeX math rendering to note editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "cmdk": "^1.1.1",
     "fastify": "^5.7.2",
     "highlight.js": "^11.11.1",
+    "katex": "^0.16.28",
     "lexical": "^0.40.0",
     "lucide-react": "^0.563.0",
     "mermaid": "^11.12.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,6 +134,9 @@ importers:
       highlight.js:
         specifier: ^11.11.1
         version: 11.11.1
+      katex:
+        specifier: ^0.16.28
+        version: 0.16.28
       lexical:
         specifier: ^0.40.0
         version: 0.40.0

--- a/src/ui/app.css
+++ b/src/ui/app.css
@@ -472,4 +472,36 @@ html {
   .dark .mermaid-diagram.mermaid-error {
     filter: none;
   }
+
+  /* KaTeX math styles (#633) */
+  .math-block {
+    overflow-x: auto;
+    padding: 1rem;
+  }
+
+  .math-inline {
+    display: inline-block;
+    vertical-align: middle;
+  }
+
+  .math-error {
+    font-family: monospace;
+    font-size: 0.875rem;
+  }
+
+  /* KaTeX dark mode adjustments */
+  .dark .katex {
+    color: var(--color-foreground);
+  }
+
+  .dark .katex .mord,
+  .dark .katex .mop,
+  .dark .katex .mbin,
+  .dark .katex .mrel,
+  .dark .katex .mopen,
+  .dark .katex .mclose,
+  .dark .katex .mpunct,
+  .dark .katex .minner {
+    color: var(--color-foreground);
+  }
 }

--- a/tests/frontend/css-build.test.ts
+++ b/tests/frontend/css-build.test.ts
@@ -16,10 +16,13 @@ describe('Tailwind CSS Build', () => {
   let cssContent: string;
 
   beforeAll(() => {
-    // Find the CSS file in the build output
+    // Find the main CSS file in the build output.
+    // The main CSS file starts with "index-" and contains the Tailwind utilities.
+    // Other CSS files (like NotesPage-*.css) may contain component-specific styles.
     const assetsDir = join(__dirname, '../../src/api/static/app/assets');
     const files = readdirSync(assetsDir);
-    const cssFile = files.find(f => f.endsWith('.css'));
+    const cssFile = files.find(f => f.startsWith('index-') && f.endsWith('.css'))
+      || files.find(f => f.endsWith('.css'));
 
     if (!cssFile) {
       throw new Error('No CSS file found in build output. Run `pnpm app:build` first.');

--- a/tests/ui/lexical-editor.test.tsx
+++ b/tests/ui/lexical-editor.test.tsx
@@ -318,4 +318,97 @@ graph TD;
       expect(maliciousScripts.length).toBe(0);
     });
   });
+
+  // LaTeX math tests for Issue #633
+  describe('LaTeX math (#633)', () => {
+    it('renders inline math with single dollar signs', () => {
+      const mathContent = 'The equation $E = mc^2$ is famous.';
+      render(<LexicalNoteEditor mode="preview" initialContent={mathContent} />);
+
+      // Should render a math-inline span with katex content
+      const mathElement = document.querySelector('.math-inline');
+      expect(mathElement).toBeInTheDocument();
+      expect(mathElement?.querySelector('.katex')).toBeInTheDocument();
+    });
+
+    it('renders block math with double dollar signs', () => {
+      const mathContent = '$$\\int_0^\\infty e^{-x^2} dx$$';
+      render(<LexicalNoteEditor mode="preview" initialContent={mathContent} />);
+
+      // Should render a math-block div with katex content
+      const mathElement = document.querySelector('.math-block');
+      expect(mathElement).toBeInTheDocument();
+      expect(mathElement?.querySelector('.katex-display')).toBeInTheDocument();
+    });
+
+    it('renders Greek letters', () => {
+      const mathContent = '$\\alpha + \\beta = \\gamma$';
+      render(<LexicalNoteEditor mode="preview" initialContent={mathContent} />);
+
+      const mathElement = document.querySelector('.math-inline .katex');
+      expect(mathElement).toBeInTheDocument();
+    });
+
+    it('renders fractions', () => {
+      const mathContent = '$\\frac{1}{2}$';
+      render(<LexicalNoteEditor mode="preview" initialContent={mathContent} />);
+
+      const mathElement = document.querySelector('.math-inline .katex');
+      expect(mathElement).toBeInTheDocument();
+      // KaTeX renders fractions - check for fraction-related content
+      // The class name varies between versions, so just verify katex rendered
+      expect(mathElement?.textContent).toContain('1');
+      expect(mathElement?.textContent).toContain('2');
+    });
+
+    it('renders sums and integrals', () => {
+      const mathContent = '$$\\sum_{i=0}^{n} i^2$$';
+      render(<LexicalNoteEditor mode="preview" initialContent={mathContent} />);
+
+      const mathElement = document.querySelector('.math-block .katex');
+      expect(mathElement).toBeInTheDocument();
+    });
+
+    it('handles multiple math expressions', () => {
+      const mathContent = 'Inline $x$ and $y$ with block $$z = x + y$$';
+      render(<LexicalNoteEditor mode="preview" initialContent={mathContent} />);
+
+      // Should have two inline math and one block math
+      const inlineMath = document.querySelectorAll('.math-inline');
+      const blockMath = document.querySelectorAll('.math-block');
+
+      expect(inlineMath.length).toBe(2);
+      expect(blockMath.length).toBe(1);
+    });
+
+    it('has accessible role=math attribute', () => {
+      const mathContent = '$E = mc^2$';
+      render(<LexicalNoteEditor mode="preview" initialContent={mathContent} />);
+
+      const mathElement = document.querySelector('[role="math"]');
+      expect(mathElement).toBeInTheDocument();
+    });
+
+    it('does not process dollar signs in code blocks', () => {
+      const codeContent = '```javascript\nconst price = $100;\n```';
+      render(<LexicalNoteEditor mode="preview" initialContent={codeContent} />);
+
+      // Should render as code, not math
+      const codeElement = document.querySelector('code.hljs');
+      expect(codeElement).toBeInTheDocument();
+      // Should not have any math elements
+      const mathElements = document.querySelectorAll('.math-inline, .math-block');
+      expect(mathElements.length).toBe(0);
+    });
+
+    it('handles invalid LaTeX gracefully', () => {
+      // Invalid LaTeX that would throw an error
+      const invalidMath = '$\\invalidcommand$';
+      render(<LexicalNoteEditor mode="preview" initialContent={invalidMath} />);
+
+      // Should render something (KaTeX's throwOnError: false handles this)
+      const mathElement = document.querySelector('.math-inline');
+      expect(mathElement).toBeInTheDocument();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Adds KaTeX library for fast LaTeX math rendering in notes
- Supports both inline math (`$...$`) and block math (`$$...$$`)
- Renders Greek letters, fractions, integrals, sums, and other common LaTeX
- Includes accessible `role="math"` attributes for screen reader support
- Adds CSS styles with dark mode support
- Uses `throwOnError: false` and `trust: false` for secure error handling
- Adds 9 new tests covering math rendering functionality

## Test plan

- [x] Verify inline math (`$E=mc^2$`) renders correctly
- [x] Verify block math (`$$\int_0^\infty...$$`) renders centered
- [x] Verify Greek letters render correctly
- [x] Verify fractions, sums, and integrals work
- [x] Verify dollar signs in code blocks are not processed as math
- [x] Verify invalid LaTeX is handled gracefully
- [x] Verify dark mode support
- [x] Run `pnpm exec vitest run tests/ui/lexical-editor.test.tsx` - all 34 tests pass

Closes #633

🤖 Generated with [Claude Code](https://claude.com/claude-code)