### PR TITLE
[#689] Move user_email from query params to body/headers

### DIFF
--- a/src/ui/components/notes/presence/use-note-presence.ts
+++ b/src/ui/components/notes/presence/use-note-presence.ts
@@ -98,16 +98,18 @@ export function useNotePresence({
 
   /**
    * Join note presence via API
+   * Security: userEmail sent in body instead of query params (#689)
    */
   const join = useCallback(async () => {
     if (hasJoinedRef.current) return;
 
     try {
       const response = await fetch(
-        `${apiUrl}/notes/${noteId}/presence?user_email=${encodeURIComponent(userEmail)}`,
+        `${apiUrl}/notes/${noteId}/presence`,
         {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ userEmail }),
         }
       );
 
@@ -128,14 +130,18 @@ export function useNotePresence({
 
   /**
    * Leave note presence via API
+   * Security: userEmail sent in header instead of query params (#689)
    */
   const leave = useCallback(async () => {
     if (!hasJoinedRef.current) return;
 
     try {
       await fetch(
-        `${apiUrl}/notes/${noteId}/presence?user_email=${encodeURIComponent(userEmail)}`,
-        { method: 'DELETE' }
+        `${apiUrl}/notes/${noteId}/presence`,
+        {
+          method: 'DELETE',
+          headers: { 'X-User-Email': userEmail },
+        }
       );
       hasJoinedRef.current = false;
       setIsConnected(false);
@@ -147,15 +153,16 @@ export function useNotePresence({
 
   /**
    * Update cursor position via API
+   * Security: userEmail sent in body instead of query params (#689)
    */
   const updateCursor = useCallback(async (position: { line: number; column: number }) => {
     try {
       await fetch(
-        `${apiUrl}/notes/${noteId}/presence/cursor?user_email=${encodeURIComponent(userEmail)}`,
+        `${apiUrl}/notes/${noteId}/presence/cursor`,
         {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ cursorPosition: position }),
+          body: JSON.stringify({ userEmail, cursorPosition: position }),
         }
       );
     } catch (err) {


### PR DESCRIPTION
## Summary
Remove user email from URL query parameters to prevent exposure in logs, browser history, and referrer headers.

## Security Concern
Email addresses in query parameters:
1. Get logged in server access logs
2. Appear in browser history
3. May be cached by proxies
4. Appear in referrer headers

## Changes

### Backend (server.ts)
| Endpoint | Before | After |
|----------|--------|-------|
| POST /api/notes/:id/presence | `?user_email=...` | `{ userEmail: ... }` in body |
| PUT /api/notes/:id/presence/cursor | `?user_email=...` | `{ userEmail: ... }` in body |
| GET /api/notes/:id/presence | `?user_email=...` | `X-User-Email` header |
| DELETE /api/notes/:id/presence | `?user_email=...` | `X-User-Email` header |

### Frontend (use-note-presence.ts)
- Updated `join()` to send userEmail in request body
- Updated `leave()` to send userEmail in X-User-Email header
- Updated `updateCursor()` to send userEmail in request body

## Test plan
- [x] Verify API endpoints accept new parameter locations
- [x] Verify frontend hook sends parameters correctly
- [ ] Integration test with running server

Closes #689

🤖 Generated with [Claude Code](https://claude.com/claude-code)