### PR TITLE
[#692] Fix React Rules of Hooks violation in useNotePresence

### DIFF
--- a/src/ui/components/notes/presence/use-note-presence.ts
+++ b/src/ui/components/notes/presence/use-note-presence.ts
@@ -7,7 +7,7 @@
  */
 
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { useRealtime } from '@/ui/components/realtime/realtime-context';
+import { useRealtimeOptional } from '@/ui/components/realtime/realtime-context';
 import type { RealtimeEvent } from '@/ui/components/realtime/types';
 
 /**
@@ -88,13 +88,8 @@ export function useNotePresence({
   const [isConnected, setIsConnected] = useState(false);
   const hasJoinedRef = useRef(false);
 
-  // Try to use realtime context, but gracefully degrade if not available
-  let realtimeContext: ReturnType<typeof useRealtime> | null = null;
-  try {
-    realtimeContext = useRealtime();
-  } catch {
-    // Realtime context not available, will use polling fallback
-  }
+  // Use optional realtime hook - returns null when not inside RealtimeProvider (#692)
+  const realtimeContext = useRealtimeOptional();
 
   /**
    * Join note presence via API

--- a/src/ui/components/realtime/realtime-context.tsx
+++ b/src/ui/components/realtime/realtime-context.tsx
@@ -32,6 +32,15 @@ export function useRealtime(): RealtimeContextValue {
   return context;
 }
 
+/**
+ * Optional version of useRealtime that returns null when not inside a provider.
+ * Use this when realtime functionality is optional and you need a graceful fallback.
+ * (#692: Fixes Rules of Hooks violation - hooks must be called unconditionally)
+ */
+export function useRealtimeOptional(): RealtimeContextValue | null {
+  return React.useContext(RealtimeContext);
+}
+
 interface EventHandler {
   eventType: RealtimeEventType;
   handler: (event: RealtimeEvent) => void;


### PR DESCRIPTION
## Summary
- Adds `useRealtimeOptional()` hook that returns null instead of throwing when not inside a RealtimeProvider
- Replaces the try-catch around `useRealtime()` in `useNotePresence` with the new optional hook
- Hooks are now called unconditionally at the top level as required by React's Rules of Hooks

## Problem
The previous code violated React's Rules of Hooks by wrapping `useRealtime()` in a try-catch:

```typescript
// BEFORE: Violates Rules of Hooks
try {
  realtimeContext = useRealtime();
} catch {
  // fallback
}
```

This made the hook call conditional based on whether an error occurred.

## Solution
```typescript
// AFTER: Unconditional hook call
const realtimeContext = useRealtimeOptional();
```

## Test plan
- [x] Existing presence tests pass
- [x] Hook is now called unconditionally per React's requirements
- [x] `pnpm exec vitest run tests/ui/note-presence.test.tsx` passes

Closes #692

Part of Epic #338

🤖 Generated with [Claude Code](https://claude.com/claude-code)