### PR TITLE
[#659] Split NotesPage into smaller modules

### DIFF
--- a/src/ui/pages/notes/NoteHistoryPanel.tsx
+++ b/src/ui/pages/notes/NoteHistoryPanel.tsx
@@ -1,0 +1,91 @@
+/**
+ * Note history panel component.
+ * Part of Epic #338, Issue #659 (component splitting).
+ *
+ * Displays version history for a note with restore capability.
+ * Extracted from NotesPage.tsx to reduce component size.
+ */
+import { X } from 'lucide-react';
+import { Button } from '@/ui/components/ui/button';
+import {
+  Skeleton,
+  SkeletonList,
+  ErrorState,
+} from '@/ui/components/feedback';
+import { VersionHistory } from '@/ui/components/notes';
+import { useNoteVersions } from '@/ui/hooks/queries/use-notes';
+
+interface NoteHistoryPanelProps {
+  noteId: string;
+  onClose: () => void;
+}
+
+export function NoteHistoryPanel({ noteId, onClose }: NoteHistoryPanelProps) {
+  const { data: versionsData, isLoading, isError } = useNoteVersions(noteId);
+
+  if (isLoading) {
+    return (
+      <div className="flex-1 p-6">
+        <div className="flex items-center justify-between mb-4">
+          <Skeleton width={200} height={24} />
+          <Button variant="ghost" size="icon" onClick={onClose} aria-label="Close history">
+            <X className="size-4" />
+          </Button>
+        </div>
+        <SkeletonList count={5} variant="text" />
+      </div>
+    );
+  }
+
+  if (isError || !versionsData) {
+    return (
+      <div className="flex-1 p-6">
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-lg font-semibold">Version History</h2>
+          <Button variant="ghost" size="icon" onClick={onClose} aria-label="Close history">
+            <X className="size-4" />
+          </Button>
+        </div>
+        <ErrorState
+          type="generic"
+          title="Failed to load versions"
+          description="Unable to load version history for this note."
+        />
+      </div>
+    );
+  }
+
+  // Transform to UI version format
+  const versions = versionsData.versions.map((v) => ({
+    id: v.id,
+    noteId: versionsData.noteId,
+    version: v.versionNumber,
+    title: v.title,
+    content: '', // Content not in summary
+    changedBy: v.changedByEmail ?? 'Unknown',
+    changedAt: new Date(v.createdAt),
+    changeReason: v.changeType,
+  }));
+
+  return (
+    <div className="flex-1 flex flex-col overflow-hidden">
+      <div className="flex items-center justify-between p-4 border-b">
+        <h2 className="text-lg font-semibold">Version History</h2>
+        <Button variant="ghost" size="icon" onClick={onClose} aria-label="Close history">
+          <X className="size-4" />
+        </Button>
+      </div>
+      <div className="flex-1 overflow-auto">
+        <VersionHistory
+          versions={versions}
+          currentVersion={versionsData.currentVersion}
+          onRestore={(version) => {
+            // TODO: Implement restore functionality (#658)
+            // This is tracked in a separate issue
+          }}
+          className="h-full"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/ui/pages/notes/NotebookFormDialog.tsx
+++ b/src/ui/pages/notes/NotebookFormDialog.tsx
@@ -1,0 +1,142 @@
+/**
+ * Notebook form dialog component.
+ * Part of Epic #338, Issue #659 (component splitting).
+ *
+ * Extracted from NotesPage.tsx to reduce component size.
+ */
+import * as React from 'react';
+import { useState } from 'react';
+import { Button } from '@/ui/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/ui/components/ui/dialog';
+import { Input } from '@/ui/components/ui/input';
+import { Label } from '@/ui/components/ui/label';
+import { Textarea } from '@/ui/components/ui/textarea';
+import type {
+  CreateNotebookBody,
+  UpdateNotebookBody,
+} from '@/ui/lib/api-types';
+import type { Notebook as UINotebook } from '@/ui/components/notes/types';
+
+interface NotebookFormDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  notebook?: UINotebook;
+  onSubmit: (data: CreateNotebookBody | UpdateNotebookBody) => Promise<void>;
+  isSubmitting: boolean;
+}
+
+export function NotebookFormDialog({
+  open,
+  onOpenChange,
+  notebook,
+  onSubmit,
+  isSubmitting,
+}: NotebookFormDialogProps) {
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [color, setColor] = useState('#6366f1');
+
+  // Reset form when dialog opens
+  React.useEffect(() => {
+    if (open) {
+      setName(notebook?.name ?? '');
+      setDescription(notebook?.description ?? '');
+      setColor(notebook?.color ?? '#6366f1');
+    }
+  }, [open, notebook]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await onSubmit({
+      name: name.trim(),
+      description: description.trim() || undefined,
+      color,
+    });
+  };
+
+  const isValid = name.trim().length > 0;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md" data-testid="notebook-form-dialog">
+        <DialogHeader>
+          <DialogTitle>
+            {notebook ? 'Edit Notebook' : 'New Notebook'}
+          </DialogTitle>
+          <DialogDescription>
+            {notebook
+              ? 'Update the notebook details below.'
+              : 'Create a new notebook to organize your notes.'}
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="notebook-name">
+              Name <span className="text-destructive">*</span>
+            </Label>
+            <Input
+              id="notebook-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="My Notebook"
+              required
+              data-testid="notebook-name-input"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="notebook-description">Description</Label>
+            <Textarea
+              id="notebook-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Optional description..."
+              rows={2}
+              data-testid="notebook-description-input"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="notebook-color">Color</Label>
+            <div className="flex items-center gap-2">
+              <input
+                id="notebook-color"
+                type="color"
+                value={color}
+                onChange={(e) => setColor(e.target.value)}
+                className="h-9 w-12 cursor-pointer rounded border"
+                data-testid="notebook-color-input"
+              />
+              <span className="text-sm text-muted-foreground">{color}</span>
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              disabled={!isValid || isSubmitting}
+              data-testid="notebook-form-submit"
+            >
+              {notebook ? 'Save' : 'Create'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/ui/pages/notes/ShareDialogWrapper.tsx
+++ b/src/ui/pages/notes/ShareDialogWrapper.tsx
@@ -1,0 +1,57 @@
+/**
+ * Share dialog wrapper component.
+ * Part of Epic #338, Issue #659 (component splitting).
+ *
+ * Wraps the ShareDialog component with API data fetching.
+ * Extracted from NotesPage.tsx to reduce component size.
+ */
+import { useMemo } from 'react';
+import { ShareDialog } from '@/ui/components/notes';
+import { useNoteShares } from '@/ui/hooks/queries/use-notes';
+
+interface ShareDialogWrapperProps {
+  noteId: string;
+  onClose: () => void;
+  onShare: (email: string, permission: 'read' | 'read_write') => Promise<void>;
+  onRevoke: (shareId: string) => Promise<void>;
+}
+
+export function ShareDialogWrapper({
+  noteId,
+  onClose,
+  onShare,
+  onRevoke,
+}: ShareDialogWrapperProps) {
+  const { data: sharesData, isLoading } = useNoteShares(noteId);
+
+  // Transform API shares to UI shares
+  const shares = useMemo(() => {
+    if (!sharesData?.shares) return [];
+    return sharesData.shares
+      .filter((s): s is Extract<typeof s, { type: 'user' }> => s.type === 'user')
+      .map((s) => ({
+        id: s.id,
+        noteId: s.noteId,
+        sharedWithEmail: s.sharedWithEmail,
+        permission: s.permission === 'read_write' ? 'edit' as const : 'view' as const,
+        createdAt: new Date(s.createdAt),
+        createdBy: s.createdByEmail,
+      }));
+  }, [sharesData?.shares]);
+
+  return (
+    <ShareDialog
+      open={true}
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+      noteTitle="Note"
+      shares={shares}
+      onShare={async (email, permission) => {
+        await onShare(email, permission === 'edit' ? 'read_write' : 'read');
+      }}
+      onRevoke={onRevoke}
+      loading={isLoading}
+    />
+  );
+}

--- a/src/ui/pages/notes/index.ts
+++ b/src/ui/pages/notes/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Notes page components and utilities.
+ * Part of Epic #338, Issue #659 (component splitting).
+ */
+export { NotebookFormDialog } from './NotebookFormDialog';
+export { ShareDialogWrapper } from './ShareDialogWrapper';
+export { NoteHistoryPanel } from './NoteHistoryPanel';
+export { toUINote, toUINotebook } from './types';
+export type { ViewState, DialogState } from './types';

--- a/src/ui/pages/notes/types.ts
+++ b/src/ui/pages/notes/types.ts
@@ -1,0 +1,65 @@
+/**
+ * Type definitions for notes page components.
+ * Part of Epic #338, Issue #659 (component splitting).
+ */
+import type {
+  Note as ApiNote,
+  Notebook as ApiNotebook,
+} from '@/ui/lib/api-types';
+import type {
+  Note as UINote,
+  Notebook as UINotebook,
+} from '@/ui/components/notes/types';
+
+/** View state for the page */
+export type ViewState =
+  | { type: 'list' }
+  | { type: 'new' }
+  | { type: 'detail'; noteId: string }
+  | { type: 'history'; noteId: string };
+
+/** Dialog state */
+export type DialogState =
+  | { type: 'none' }
+  | { type: 'share'; noteId: string }
+  | { type: 'deleteNote'; note: UINote }
+  | { type: 'newNotebook' }
+  | { type: 'editNotebook'; notebook: UINotebook }
+  | { type: 'deleteNotebook'; notebook: UINotebook };
+
+/**
+ * Transform API Note to UI Note type.
+ * The UI components expect slightly different field names/types.
+ */
+export function toUINote(apiNote: ApiNote): UINote {
+  return {
+    id: apiNote.id,
+    title: apiNote.title,
+    content: apiNote.content,
+    notebookId: apiNote.notebookId ?? undefined,
+    notebookTitle: apiNote.notebook?.name,
+    visibility: apiNote.visibility,
+    hideFromAgents: apiNote.hideFromAgents,
+    isPinned: apiNote.isPinned,
+    tags: apiNote.tags,
+    createdAt: new Date(apiNote.createdAt),
+    updatedAt: new Date(apiNote.updatedAt),
+    createdBy: apiNote.userEmail,
+    version: apiNote.versionCount ?? 1,
+  };
+}
+
+/**
+ * Transform API Notebook to UI Notebook type.
+ */
+export function toUINotebook(apiNotebook: ApiNotebook): UINotebook {
+  return {
+    id: apiNotebook.id,
+    name: apiNotebook.name,
+    description: apiNotebook.description ?? undefined,
+    color: apiNotebook.color ?? undefined,
+    noteCount: apiNotebook.noteCount ?? 0,
+    createdAt: new Date(apiNotebook.createdAt),
+    updatedAt: new Date(apiNotebook.updatedAt),
+  };
+}


### PR DESCRIPTION
## Summary
- Extracts 3 helper components from NotesPage.tsx into separate files:
  - `NotebookFormDialog.tsx` (~120 lines) - Dialog for creating/editing notebooks
  - `ShareDialogWrapper.tsx` (~50 lines) - Wrapper for note sharing dialog
  - `NoteHistoryPanel.tsx` (~85 lines) - Version history panel
- Extracts shared types and transform functions to `types.ts`
- Creates clean barrel export via `index.ts`
- Reduces NotesPage.tsx from 908 to 612 lines (~33% reduction)

## File structure
```
src/ui/pages/
├── NotesPage.tsx (612 lines, down from 908)
└── notes/
    ├── index.ts
    ├── types.ts
    ├── NotebookFormDialog.tsx
    ├── ShareDialogWrapper.tsx
    └── NoteHistoryPanel.tsx
```

## Test plan
- [x] Routing tests pass: `pnpm exec vitest run tests/ui/routing.test.tsx`
- [x] No breaking changes to existing functionality
- [x] Components are properly exported and imported

Closes #659

Part of Epic #338

🤖 Generated with [Claude Code](https://claude.com/claude-code)