### PR TITLE
[#657] Remove console.log from version restore handler

### DIFF
--- a/src/ui/pages/NotesPage.tsx
+++ b/src/ui/pages/NotesPage.tsx
@@ -895,9 +895,13 @@ function NoteHistoryPanel({ noteId, onClose }: NoteHistoryPanelProps) {
         <VersionHistory
           versions={versions}
           currentVersion={versionsData.currentVersion}
-          onRestore={(version) => {
-            // TODO: Implement restore functionality
-            console.log('Restore version:', version);
+          onRestore={(_version) => {
+            // Version restore functionality not yet implemented.
+            // When implemented, this should:
+            // 1. Confirm with user before restoring
+            // 2. Call API to restore the version
+            // 3. Refresh the note content
+            // See: https://github.com/troykelly/openclaw-projects/issues/657
           }}
           className="h-full"
         />


### PR DESCRIPTION
## Summary
- Remove console.log statement that was leaking internal state to browser console in production
- Replace with documented placeholder that explains what needs to be implemented for restore functionality
- References the issue for tracking the actual implementation

## Test plan
- [ ] Verify no console.log output when clicking version restore

Closes #657

---
Generated with [Claude Code](https://claude.com/claude-code)