### PR TITLE
[#648] Add URL encoding to Notes/Notebooks API hooks

### DIFF
--- a/src/ui/hooks/mutations/use-note-mutations.ts
+++ b/src/ui/hooks/mutations/use-note-mutations.ts
@@ -64,7 +64,7 @@ export function useUpdateNote() {
 
   return useMutation({
     mutationFn: ({ id, body }: { id: string; body: UpdateNoteBody }) =>
-      apiClient.put<Note>(`/api/notes/${id}`, body),
+      apiClient.put<Note>(`/api/notes/${encodeURIComponent(id)}`, body),
 
     onSuccess: (note, { id }) => {
       // Invalidate the specific note detail
@@ -102,7 +102,8 @@ export function useDeleteNote() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (id: string) => apiClient.delete(`/api/notes/${id}`),
+    mutationFn: (id: string) =>
+      apiClient.delete(`/api/notes/${encodeURIComponent(id)}`),
 
     onSuccess: (_, id) => {
       // Invalidate the specific note detail
@@ -134,7 +135,7 @@ export function useRestoreNote() {
 
   return useMutation({
     mutationFn: (id: string) =>
-      apiClient.post<Note>(`/api/notes/${id}/restore`, {}),
+      apiClient.post<Note>(`/api/notes/${encodeURIComponent(id)}/restore`, {}),
 
     onSuccess: (note, id) => {
       // Invalidate the specific note detail
@@ -171,7 +172,7 @@ export function useRestoreNoteVersion() {
   return useMutation({
     mutationFn: ({ id, versionNumber }: { id: string; versionNumber: number }) =>
       apiClient.post<RestoreVersionResponse>(
-        `/api/notes/${id}/versions/${versionNumber}/restore`,
+        `/api/notes/${encodeURIComponent(id)}/versions/${versionNumber}/restore`,
         {}
       ),
 

--- a/src/ui/hooks/mutations/use-note-sharing-mutations.ts
+++ b/src/ui/hooks/mutations/use-note-sharing-mutations.ts
@@ -32,7 +32,10 @@ export function useShareNoteWithUser() {
 
   return useMutation({
     mutationFn: ({ noteId, body }: { noteId: string; body: CreateUserShareBody }) =>
-      apiClient.post<NoteUserShare>(`/api/notes/${noteId}/share`, body),
+      apiClient.post<NoteUserShare>(
+        `/api/notes/${encodeURIComponent(noteId)}/share`,
+        body
+      ),
 
     onSuccess: (_, { noteId }) => {
       // Invalidate shares for this note
@@ -60,7 +63,10 @@ export function useCreateNoteShareLink() {
 
   return useMutation({
     mutationFn: ({ noteId, body }: { noteId: string; body: CreateLinkShareBody }) =>
-      apiClient.post<CreateLinkShareResponse>(`/api/notes/${noteId}/share/link`, body),
+      apiClient.post<CreateLinkShareResponse>(
+        `/api/notes/${encodeURIComponent(noteId)}/share/link`,
+        body
+      ),
 
     onSuccess: (_, { noteId }) => {
       // Invalidate shares for this note
@@ -95,7 +101,11 @@ export function useUpdateNoteShare() {
       noteId: string;
       shareId: string;
       body: UpdateShareBody;
-    }) => apiClient.put<NoteShare>(`/api/notes/${noteId}/shares/${shareId}`, body),
+    }) =>
+      apiClient.put<NoteShare>(
+        `/api/notes/${encodeURIComponent(noteId)}/shares/${encodeURIComponent(shareId)}`,
+        body
+      ),
 
     onSuccess: (_, { noteId }) => {
       // Invalidate shares for this note
@@ -120,7 +130,9 @@ export function useRevokeNoteShare() {
 
   return useMutation({
     mutationFn: ({ noteId, shareId }: { noteId: string; shareId: string }) =>
-      apiClient.delete(`/api/notes/${noteId}/shares/${shareId}`),
+      apiClient.delete(
+        `/api/notes/${encodeURIComponent(noteId)}/shares/${encodeURIComponent(shareId)}`
+      ),
 
     onSuccess: (_, { noteId }) => {
       // Invalidate shares for this note

--- a/src/ui/hooks/mutations/use-notebook-mutations.ts
+++ b/src/ui/hooks/mutations/use-notebook-mutations.ts
@@ -67,7 +67,7 @@ export function useUpdateNotebook() {
 
   return useMutation({
     mutationFn: ({ id, body }: { id: string; body: UpdateNotebookBody }) =>
-      apiClient.put<Notebook>(`/api/notebooks/${id}`, body),
+      apiClient.put<Notebook>(`/api/notebooks/${encodeURIComponent(id)}`, body),
 
     onSuccess: (_, { id }) => {
       // Invalidate the specific notebook detail
@@ -98,7 +98,10 @@ export function useArchiveNotebook() {
 
   return useMutation({
     mutationFn: (id: string) =>
-      apiClient.post<Notebook>(`/api/notebooks/${id}/archive`, {}),
+      apiClient.post<Notebook>(
+        `/api/notebooks/${encodeURIComponent(id)}/archive`,
+        {}
+      ),
 
     onSuccess: (_, id) => {
       // Invalidate the specific notebook detail
@@ -129,7 +132,10 @@ export function useUnarchiveNotebook() {
 
   return useMutation({
     mutationFn: (id: string) =>
-      apiClient.post<Notebook>(`/api/notebooks/${id}/unarchive`, {}),
+      apiClient.post<Notebook>(
+        `/api/notebooks/${encodeURIComponent(id)}/unarchive`,
+        {}
+      ),
 
     onSuccess: (_, id) => {
       // Invalidate the specific notebook detail
@@ -160,7 +166,9 @@ export function useDeleteNotebook() {
 
   return useMutation({
     mutationFn: ({ id, deleteNotes = false }: { id: string; deleteNotes?: boolean }) =>
-      apiClient.delete(`/api/notebooks/${id}${deleteNotes ? '?deleteNotes=true' : ''}`),
+      apiClient.delete(
+        `/api/notebooks/${encodeURIComponent(id)}${deleteNotes ? '?deleteNotes=true' : ''}`
+      ),
 
     onSuccess: (_, { id }) => {
       // Invalidate the specific notebook detail
@@ -194,7 +202,10 @@ export function useMoveNotesToNotebook() {
 
   return useMutation({
     mutationFn: ({ notebookId, body }: { notebookId: string; body: MoveNotesBody }) =>
-      apiClient.post<MoveNotesResponse>(`/api/notebooks/${notebookId}/notes`, body),
+      apiClient.post<MoveNotesResponse>(
+        `/api/notebooks/${encodeURIComponent(notebookId)}/notes`,
+        body
+      ),
 
     onSuccess: (_, { notebookId }) => {
       // Invalidate the target notebook

--- a/src/ui/hooks/queries/use-notebooks.ts
+++ b/src/ui/hooks/queries/use-notebooks.ts
@@ -96,7 +96,7 @@ export function useNotebook(
     queryKey: notebookKeys.detail(id),
     queryFn: ({ signal }) =>
       apiClient.get<Notebook>(
-        `/api/notebooks/${id}${queryString ? `?${queryString}` : ''}`,
+        `/api/notebooks/${encodeURIComponent(id)}${queryString ? `?${queryString}` : ''}`,
         { signal }
       ),
     enabled: !!id,
@@ -132,7 +132,7 @@ export function useNotebookShares(id: string) {
     queryKey: notebookKeys.shares(id),
     queryFn: ({ signal }) =>
       apiClient.get<{ notebookId: string; shares: unknown[] }>(
-        `/api/notebooks/${id}/shares`,
+        `/api/notebooks/${encodeURIComponent(id)}/shares`,
         { signal }
       ),
     enabled: !!id,

--- a/src/ui/hooks/queries/use-notes.ts
+++ b/src/ui/hooks/queries/use-notes.ts
@@ -100,7 +100,8 @@ export function useNotes(params?: ListNotesParams) {
 export function useNote(id: string) {
   return useQuery({
     queryKey: noteKeys.detail(id),
-    queryFn: ({ signal }) => apiClient.get<Note>(`/api/notes/${id}`, { signal }),
+    queryFn: ({ signal }) =>
+      apiClient.get<Note>(`/api/notes/${encodeURIComponent(id)}`, { signal }),
     enabled: !!id,
   });
 }
@@ -129,7 +130,7 @@ export function useNoteVersions(
     queryKey: noteKeys.versions(id),
     queryFn: ({ signal }) =>
       apiClient.get<NoteVersionsResponse>(
-        `/api/notes/${id}/versions${queryString ? `?${queryString}` : ''}`,
+        `/api/notes/${encodeURIComponent(id)}/versions${queryString ? `?${queryString}` : ''}`,
         { signal }
       ),
     enabled: !!id,
@@ -147,9 +148,10 @@ export function useNoteVersion(id: string, versionNumber: number) {
   return useQuery({
     queryKey: noteKeys.version(id, versionNumber),
     queryFn: ({ signal }) =>
-      apiClient.get<NoteVersion>(`/api/notes/${id}/versions/${versionNumber}`, {
-        signal,
-      }),
+      apiClient.get<NoteVersion>(
+        `/api/notes/${encodeURIComponent(id)}/versions/${versionNumber}`,
+        { signal }
+      ),
     enabled: !!id && versionNumber > 0,
   });
 }
@@ -167,7 +169,7 @@ export function useNoteVersionCompare(id: string, from: number, to: number) {
     queryKey: noteKeys.versionCompare(id, from, to),
     queryFn: ({ signal }) =>
       apiClient.get<CompareVersionsResponse>(
-        `/api/notes/${id}/versions/compare?from=${from}&to=${to}`,
+        `/api/notes/${encodeURIComponent(id)}/versions/compare?from=${from}&to=${to}`,
         { signal }
       ),
     enabled: !!id && from > 0 && to > 0 && from !== to,
@@ -184,7 +186,10 @@ export function useNoteShares(id: string) {
   return useQuery({
     queryKey: noteKeys.shares(id),
     queryFn: ({ signal }) =>
-      apiClient.get<NoteSharesResponse>(`/api/notes/${id}/shares`, { signal }),
+      apiClient.get<NoteSharesResponse>(
+        `/api/notes/${encodeURIComponent(id)}/shares`,
+        { signal }
+      ),
     enabled: !!id,
   });
 }


### PR DESCRIPTION
## Summary
- Added `encodeURIComponent()` to all URL path parameters (IDs) in Notes and Notebooks API hooks
- Prevents potential issues with IDs containing special characters like /, ?, #, etc.
- Updated query hooks: useNote, useNoteVersions, useNoteVersion, useNoteVersionCompare, useNoteShares, useNotebook, useNotebookShares
- Updated mutation hooks: useUpdateNote, useDeleteNote, useRestoreNote, useRestoreNoteVersion, useUpdateNotebook, useArchiveNotebook, useUnarchiveNotebook, useDeleteNotebook, useMoveNotesToNotebook, useShareNoteWithUser, useCreateNoteShareLink, useUpdateNoteShare, useRevokeNoteShare

## Test plan
- [x] Existing UI hook tests pass
- [x] TypeScript compiles without errors

Closes #648

Generated with [Claude Code](https://claude.com/claude-code)