### PR TITLE
[#661] Add aria-labels to icon buttons for accessibility

### DIFF
--- a/src/ui/pages/NotesPage.tsx
+++ b/src/ui/pages/NotesPage.tsx
@@ -844,7 +844,7 @@ function NoteHistoryPanel({ noteId, onClose }: NoteHistoryPanelProps) {
       <div className="flex-1 p-6">
         <div className="flex items-center justify-between mb-4">
           <Skeleton width={200} height={24} />
-          <Button variant="ghost" size="icon" onClick={onClose}>
+          <Button variant="ghost" size="icon" onClick={onClose} aria-label="Close version history">
             <X className="size-4" />
           </Button>
         </div>
@@ -858,7 +858,7 @@ function NoteHistoryPanel({ noteId, onClose }: NoteHistoryPanelProps) {
       <div className="flex-1 p-6">
         <div className="flex items-center justify-between mb-4">
           <h2 className="text-lg font-semibold">Version History</h2>
-          <Button variant="ghost" size="icon" onClick={onClose}>
+          <Button variant="ghost" size="icon" onClick={onClose} aria-label="Close version history">
             <X className="size-4" />
           </Button>
         </div>
@@ -887,7 +887,7 @@ function NoteHistoryPanel({ noteId, onClose }: NoteHistoryPanelProps) {
     <div className="flex-1 flex flex-col overflow-hidden">
       <div className="flex items-center justify-between p-4 border-b">
         <h2 className="text-lg font-semibold">Version History</h2>
-        <Button variant="ghost" size="icon" onClick={onClose}>
+        <Button variant="ghost" size="icon" onClick={onClose} aria-label="Close version history">
           <X className="size-4" />
         </Button>
       </div>


### PR DESCRIPTION
## Summary
- Add aria-label="Close version history" to all 3 close buttons in NoteHistoryPanel
- Addresses WCAG 2.1 Level A requirement for accessible names on interactive elements
- Screen readers will now announce "Close version history button" instead of just "button"

## Test plan
- [ ] Test with screen reader (VoiceOver/NVDA) - buttons should announce "Close version history"
- [ ] Verify buttons still function correctly

Closes #661

---
Generated with [Claude Code](https://claude.com/claude-code)