### PR TITLE
[#708] Add explicit timeout configuration to E2E tests

### DIFF
--- a/tests/notes_e2e.test.ts
+++ b/tests/notes_e2e.test.ts
@@ -11,13 +11,24 @@
  * - Version history
  */
 
-import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
 import { Pool } from 'pg';
 import { buildServer } from '../src/api/server.ts';
 import { runMigrate } from './helpers/migrate.ts';
 import { createTestPool, truncateAllTables } from './helpers/db.ts';
 
+/**
+ * E2E test timeout configuration.
+ * E2E tests involve database operations and HTTP requests which can be slow,
+ * especially on CI runners. Set explicit timeouts to prevent flaky test failures.
+ */
+const E2E_TEST_TIMEOUT = 30_000; // 30 seconds per test
+const E2E_HOOK_TIMEOUT = 60_000; // 60 seconds for setup/teardown hooks
+
 describe('Notes E2E Integration (Epic #338, Issue #627)', () => {
+  // Configure timeout for this test suite
+  vi.setConfig({ testTimeout: E2E_TEST_TIMEOUT, hookTimeout: E2E_HOOK_TIMEOUT });
+
   const app = buildServer();
   let pool: Pool;
 


### PR DESCRIPTION
## Summary
Add explicit timeout configuration to E2E tests to prevent flaky failures on slower CI runners.

## Changes
- **tests/notes_e2e.test.ts**: Added timeout configuration:
  - `E2E_TEST_TIMEOUT` (30 seconds) for individual test cases
  - `E2E_HOOK_TIMEOUT` (60 seconds) for beforeAll/afterAll hooks
  - Documentation explaining timeout rationale

## Why this matters
- E2E tests involve database operations and HTTP requests which can be slow
- Without explicit timeouts, tests may fail inconsistently on slower CI runners
- Hanging tests are hard to debug without explicit timeout configuration

## Test plan
- [ ] Run `pnpm test tests/notes_e2e.test.ts` - tests complete within configured timeouts

Closes #708

---
Generated with [Claude Code](https://claude.com/claude-code)