### PR TITLE
[#666] Add URL parameter validation for notes routes

### DIFF
--- a/src/ui/lib/utils.ts
+++ b/src/ui/lib/utils.ts
@@ -4,3 +4,34 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+/**
+ * UUID v4 validation regex pattern.
+ * Matches standard UUID format: xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx
+ * where y is 8, 9, a, or b.
+ */
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+/**
+ * Validates whether a string is a valid UUID v4.
+ * Used for URL parameter validation to prevent injection attacks
+ * and ensure API compatibility.
+ *
+ * @param value - The string to validate
+ * @returns true if the string is a valid UUID v4, false otherwise
+ */
+export function isValidUUID(value: string): boolean {
+  return UUID_REGEX.test(value);
+}
+
+/**
+ * Validates a URL parameter and returns it if valid, undefined otherwise.
+ * Provides defense-in-depth against malformed URL parameters.
+ *
+ * @param value - The URL parameter value (may be undefined)
+ * @returns The validated value if it's a valid UUID, undefined otherwise
+ */
+export function validateUrlParam(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  return isValidUUID(value) ? value : undefined;
+}

--- a/src/ui/pages/NotesPage.tsx
+++ b/src/ui/pages/NotesPage.tsx
@@ -18,7 +18,7 @@
 import { useState, useCallback, useMemo, useEffect } from 'react';
 import { useParams, useNavigate, useLocation } from 'react-router';
 import { ArrowLeft } from 'lucide-react';
-import { cn } from '@/ui/lib/utils';
+import { cn, validateUrlParam } from '@/ui/lib/utils';
 import { Button } from '@/ui/components/ui/button';
 import {
   Dialog,
@@ -83,13 +83,24 @@ import type {
 } from '@/ui/components/notes/types';
 
 export function NotesPage(): React.JSX.Element {
-  // URL params for deep linking
-  const { noteId: urlNoteId, notebookId: urlNotebookId } = useParams<{
+  // URL params for deep linking - validate to prevent malformed URLs
+  const { noteId: rawNoteId, notebookId: rawNotebookId } = useParams<{
     noteId?: string;
     notebookId?: string;
   }>();
   const navigate = useNavigate();
   const location = useLocation();
+
+  // Validate URL params - only accept valid UUIDs (#666)
+  const urlNoteId = validateUrlParam(rawNoteId);
+  const urlNotebookId = validateUrlParam(rawNotebookId);
+
+  // Redirect to /notes if URL params are invalid (#666)
+  useEffect(() => {
+    if ((rawNoteId && !urlNoteId) || (rawNotebookId && !urlNotebookId)) {
+      navigate('/notes', { replace: true });
+    }
+  }, [rawNoteId, rawNotebookId, urlNoteId, urlNotebookId, navigate]);
 
   // View state
   const [view, setView] = useState<ViewState>({ type: 'list' });

--- a/tests/ui/url-validation.test.ts
+++ b/tests/ui/url-validation.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Tests for URL parameter validation utilities.
+ * Issue #666: URL parameters used without validation
+ */
+import { describe, it, expect } from 'vitest';
+import { isValidUUID, validateUrlParam } from '@/ui/lib/utils';
+
+describe('isValidUUID', () => {
+  it('returns true for valid UUID v4', () => {
+    expect(isValidUUID('550e8400-e29b-41d4-a716-446655440000')).toBe(true);
+    expect(isValidUUID('6ba7b810-9dad-41d2-80b4-00c04fd430c8')).toBe(true);
+    expect(isValidUUID('f47ac10b-58cc-4372-a567-0e02b2c3d479')).toBe(true);
+  });
+
+  it('returns true for uppercase UUIDs', () => {
+    expect(isValidUUID('550E8400-E29B-41D4-A716-446655440000')).toBe(true);
+    expect(isValidUUID('F47AC10B-58CC-4372-A567-0E02B2C3D479')).toBe(true);
+  });
+
+  it('returns false for empty string', () => {
+    expect(isValidUUID('')).toBe(false);
+  });
+
+  it('returns false for non-UUID strings', () => {
+    expect(isValidUUID('not-a-uuid')).toBe(false);
+    expect(isValidUUID('hello-world')).toBe(false);
+    expect(isValidUUID('12345')).toBe(false);
+  });
+
+  it('returns false for path traversal attempts', () => {
+    expect(isValidUUID('../../admin')).toBe(false);
+    expect(isValidUUID('../etc/passwd')).toBe(false);
+  });
+
+  it('returns false for script injection attempts', () => {
+    expect(isValidUUID('<script>alert(1)</script>')).toBe(false);
+    expect(isValidUUID('javascript:alert(1)')).toBe(false);
+  });
+
+  it('returns false for UUID-like strings with wrong version', () => {
+    // Version 1 UUID (should fail - we only accept v4)
+    expect(isValidUUID('550e8400-e29b-11d4-a716-446655440000')).toBe(false);
+    // Version 5 UUID (should fail)
+    expect(isValidUUID('550e8400-e29b-51d4-a716-446655440000')).toBe(false);
+  });
+
+  it('returns false for UUID with wrong variant', () => {
+    // Invalid variant (c instead of 8,9,a,b)
+    expect(isValidUUID('550e8400-e29b-41d4-c716-446655440000')).toBe(false);
+  });
+
+  it('returns false for UUID without dashes', () => {
+    expect(isValidUUID('550e8400e29b41d4a716446655440000')).toBe(false);
+  });
+
+  it('returns false for partial UUIDs', () => {
+    expect(isValidUUID('550e8400-e29b')).toBe(false);
+    expect(isValidUUID('550e8400-e29b-41d4-a716')).toBe(false);
+  });
+});
+
+describe('validateUrlParam', () => {
+  it('returns the value for valid UUIDs', () => {
+    const validUUID = '550e8400-e29b-41d4-a716-446655440000';
+    expect(validateUrlParam(validUUID)).toBe(validUUID);
+  });
+
+  it('returns undefined for undefined input', () => {
+    expect(validateUrlParam(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined for invalid UUIDs', () => {
+    expect(validateUrlParam('not-a-uuid')).toBeUndefined();
+    expect(validateUrlParam('../../admin')).toBeUndefined();
+    expect(validateUrlParam('<script>')).toBeUndefined();
+  });
+
+  it('returns undefined for empty string', () => {
+    expect(validateUrlParam('')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Add `isValidUUID()` and `validateUrlParam()` utilities to validate URL parameters
- Validate noteId and notebookId params in NotesPage before use
- Redirect to /notes if invalid UUIDs are detected in URL
- Add comprehensive tests for UUID validation

This provides defense-in-depth against malformed URLs (path traversal, injection attempts, invalid UUIDs).

Closes #666

## Test plan
- [x] Run `pnpm exec vitest run tests/ui/url-validation.test.ts` - all 14 tests pass
- [x] Run `pnpm exec vitest run tests/ui/routing.test.tsx` - all 13 tests pass
- [ ] Manual test: Navigate to `/notes/not-a-uuid` - should redirect to `/notes`
- [ ] Manual test: Navigate to `/notes/550e8400-e29b-41d4-a716-446655440000` - should work normally

Generated with [Claude Code](https://claude.com/claude-code)