### PR TITLE
[#693] Fix console.error calls in production presence code

### DIFF
--- a/src/ui/components/notes/presence/use-note-presence.ts
+++ b/src/ui/components/notes/presence/use-note-presence.ts
@@ -141,8 +141,12 @@ export function useNotePresence({
       hasJoinedRef.current = false;
       setIsConnected(false);
     } catch (err) {
-      // Don't throw on leave errors, just log
-      console.error('[NotePresence] Error leaving:', err);
+      // Don't throw on leave errors - leaving is a best-effort operation
+      // Log in development only to avoid information leakage in production
+      if (import.meta.env.DEV) {
+        // eslint-disable-next-line no-console
+        console.error('[NotePresence] Error leaving:', err);
+      }
     }
   }, [noteId, userEmail, apiUrl]);
 
@@ -161,8 +165,12 @@ export function useNotePresence({
         }
       );
     } catch (err) {
-      // Don't throw on cursor update errors, just log
-      console.error('[NotePresence] Error updating cursor:', err);
+      // Don't throw on cursor update errors - cursor updates are non-critical
+      // Log in development only to avoid information leakage in production
+      if (import.meta.env.DEV) {
+        // eslint-disable-next-line no-console
+        console.error('[NotePresence] Error updating cursor:', err);
+      }
     }
   }, [noteId, userEmail, apiUrl]);
 


### PR DESCRIPTION
## Summary
- Wrap console.error calls in development-only check (import.meta.env.DEV)
- Prevents information leakage to browser console in production
- Affects leave() and updateCursor() error handlers in useNotePresence hook

## Context
These are non-critical operations (best-effort):
- Leaving presence: If it fails, the server will timeout the user anyway
- Cursor updates: Visual feature only, failure doesn't break core functionality

## Test plan
- [ ] Verify errors are logged in development mode
- [ ] Verify errors are NOT logged in production build
- [ ] Verify presence functionality still works correctly

Closes #693

---
Generated with [Claude Code](https://claude.com/claude-code)