### PR TITLE
[#649] Add onError callbacks to Notes/Notebooks mutation hooks

### DIFF
--- a/src/ui/hooks/mutations/use-note-mutations.ts
+++ b/src/ui/hooks/mutations/use-note-mutations.ts
@@ -4,8 +4,12 @@
  * Provides mutations for creating, updating, deleting, and restoring notes.
  * Includes cache invalidation for related queries.
  */
-import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { apiClient } from '@/ui/lib/api-client.ts';
+import {
+  useMutation,
+  useQueryClient,
+  type UseMutationOptions,
+} from '@tanstack/react-query';
+import { apiClient, type ApiRequestError } from '@/ui/lib/api-client.ts';
 import type {
   Note,
   CreateNoteBody,
@@ -16,24 +20,36 @@ import { noteKeys } from '@/ui/hooks/queries/use-notes.ts';
 import { notebookKeys } from '@/ui/hooks/queries/use-notebooks.ts';
 
 /**
+ * Options for useCreateNote mutation.
+ * Allows consumers to provide custom error handlers and other mutation options.
+ */
+export type UseCreateNoteOptions = Omit<
+  UseMutationOptions<Note, ApiRequestError, CreateNoteBody>,
+  'mutationFn'
+>;
+
+/**
  * Create a new note.
  *
+ * @param options - Optional mutation configuration including onError callback
  * @returns TanStack mutation
  *
  * @example
  * ```ts
- * const { mutate } = useCreateNote();
+ * const { mutate } = useCreateNote({
+ *   onError: (error) => toast.error(error.message),
+ * });
  * mutate({ title: 'New note', content: '# Hello' });
  * ```
  */
-export function useCreateNote() {
+export function useCreateNote(options?: UseCreateNoteOptions) {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: (body: CreateNoteBody) =>
       apiClient.post<Note>('/api/notes', body),
 
-    onSuccess: (note) => {
+    onSuccess: (note, variables, context) => {
       // Invalidate notes list queries
       queryClient.invalidateQueries({ queryKey: noteKeys.lists() });
 
@@ -44,29 +60,58 @@ export function useCreateNote() {
         });
         queryClient.invalidateQueries({ queryKey: notebookKeys.tree() });
       }
+
+      // Call consumer's onSuccess if provided
+      options?.onSuccess?.(note, variables, context);
     },
+
+    onError: options?.onError,
+    onSettled: options?.onSettled,
+    ...options,
   });
 }
+
+/** Variables for useUpdateNote mutation. */
+export interface UpdateNoteVariables {
+  /** The note ID to update. */
+  id: string;
+  /** Partial update body. */
+  body: UpdateNoteBody;
+}
+
+/**
+ * Options for useUpdateNote mutation.
+ * Allows consumers to provide custom error handlers and other mutation options.
+ */
+export type UseUpdateNoteOptions = Omit<
+  UseMutationOptions<Note, ApiRequestError, UpdateNoteVariables>,
+  'mutationFn'
+>;
 
 /**
  * Update an existing note.
  *
+ * @param options - Optional mutation configuration including onError callback
  * @returns TanStack mutation
  *
  * @example
  * ```ts
- * const { mutate } = useUpdateNote();
+ * const { mutate } = useUpdateNote({
+ *   onError: (error) => toast.error(error.message),
+ * });
  * mutate({ id: 'note-123', body: { title: 'Updated title' } });
  * ```
  */
-export function useUpdateNote() {
+export function useUpdateNote(options?: UseUpdateNoteOptions) {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({ id, body }: { id: string; body: UpdateNoteBody }) =>
-      apiClient.put<Note>(`/api/notes/${id}`, body),
+    mutationFn: ({ id, body }: UpdateNoteVariables) =>
+      apiClient.put<Note>(`/api/notes/${encodeURIComponent(id)}`, body),
 
-    onSuccess: (note, { id }) => {
+    onSuccess: (note, variables, context) => {
+      const { id } = variables;
+
       // Invalidate the specific note detail
       queryClient.invalidateQueries({ queryKey: noteKeys.detail(id) });
 
@@ -83,28 +128,48 @@ export function useUpdateNote() {
         });
         queryClient.invalidateQueries({ queryKey: notebookKeys.tree() });
       }
+
+      // Call consumer's onSuccess if provided
+      options?.onSuccess?.(note, variables, context);
     },
+
+    onError: options?.onError,
+    onSettled: options?.onSettled,
+    ...options,
   });
 }
 
 /**
+ * Options for useDeleteNote mutation.
+ * Allows consumers to provide custom error handlers and other mutation options.
+ */
+export type UseDeleteNoteOptions = Omit<
+  UseMutationOptions<void, ApiRequestError, string>,
+  'mutationFn'
+>;
+
+/**
  * Soft delete a note.
  *
+ * @param options - Optional mutation configuration including onError callback
  * @returns TanStack mutation
  *
  * @example
  * ```ts
- * const { mutate } = useDeleteNote();
+ * const { mutate } = useDeleteNote({
+ *   onError: (error) => toast.error(error.message),
+ * });
  * mutate('note-123');
  * ```
  */
-export function useDeleteNote() {
+export function useDeleteNote(options?: UseDeleteNoteOptions) {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (id: string) => apiClient.delete(`/api/notes/${id}`),
+    mutationFn: (id: string) =>
+      apiClient.delete(`/api/notes/${encodeURIComponent(id)}`),
 
-    onSuccess: (_, id) => {
+    onSuccess: (result, id, context) => {
       // Invalidate the specific note detail
       queryClient.invalidateQueries({ queryKey: noteKeys.detail(id) });
 
@@ -114,29 +179,51 @@ export function useDeleteNote() {
       // Invalidate notebook tree to update counts
       queryClient.invalidateQueries({ queryKey: notebookKeys.tree() });
       queryClient.invalidateQueries({ queryKey: notebookKeys.lists() });
+
+      // Call consumer's onSuccess if provided
+      options?.onSuccess?.(result, id, context);
     },
+
+    onError: options?.onError,
+    onSettled: options?.onSettled,
+    ...options,
   });
 }
 
 /**
+ * Options for useRestoreNote mutation.
+ * Allows consumers to provide custom error handlers and other mutation options.
+ */
+export type UseRestoreNoteOptions = Omit<
+  UseMutationOptions<Note, ApiRequestError, string>,
+  'mutationFn'
+>;
+
+/**
  * Restore a soft-deleted note.
  *
+ * @param options - Optional mutation configuration including onError callback
  * @returns TanStack mutation
  *
  * @example
  * ```ts
- * const { mutate } = useRestoreNote();
+ * const { mutate } = useRestoreNote({
+ *   onError: (error) => toast.error(error.message),
+ * });
  * mutate('note-123');
  * ```
  */
-export function useRestoreNote() {
+export function useRestoreNote(options?: UseRestoreNoteOptions) {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: (id: string) =>
-      apiClient.post<Note>(`/api/notes/${id}/restore`, {}),
+      apiClient.post<Note>(
+        `/api/notes/${encodeURIComponent(id)}/restore`,
+        {}
+      ),
 
-    onSuccess: (note, id) => {
+    onSuccess: (note, id, context) => {
       // Invalidate the specific note detail
       queryClient.invalidateQueries({ queryKey: noteKeys.detail(id) });
 
@@ -150,38 +237,78 @@ export function useRestoreNote() {
         });
         queryClient.invalidateQueries({ queryKey: notebookKeys.tree() });
       }
+
+      // Call consumer's onSuccess if provided
+      options?.onSuccess?.(note, id, context);
     },
+
+    onError: options?.onError,
+    onSettled: options?.onSettled,
+    ...options,
   });
 }
+
+/** Variables for useRestoreNoteVersion mutation. */
+export interface RestoreNoteVersionVariables {
+  /** The note ID. */
+  id: string;
+  /** The version number to restore. */
+  versionNumber: number;
+}
+
+/**
+ * Options for useRestoreNoteVersion mutation.
+ * Allows consumers to provide custom error handlers and other mutation options.
+ */
+export type UseRestoreNoteVersionOptions = Omit<
+  UseMutationOptions<
+    RestoreVersionResponse,
+    ApiRequestError,
+    RestoreNoteVersionVariables
+  >,
+  'mutationFn'
+>;
 
 /**
  * Restore a note to a previous version.
  *
+ * @param options - Optional mutation configuration including onError callback
  * @returns TanStack mutation
  *
  * @example
  * ```ts
- * const { mutate } = useRestoreNoteVersion();
+ * const { mutate } = useRestoreNoteVersion({
+ *   onError: (error) => toast.error(error.message),
+ * });
  * mutate({ id: 'note-123', versionNumber: 5 });
  * ```
  */
-export function useRestoreNoteVersion() {
+export function useRestoreNoteVersion(options?: UseRestoreNoteVersionOptions) {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({ id, versionNumber }: { id: string; versionNumber: number }) =>
+    mutationFn: ({ id, versionNumber }: RestoreNoteVersionVariables) =>
       apiClient.post<RestoreVersionResponse>(
-        `/api/notes/${id}/versions/${versionNumber}/restore`,
+        `/api/notes/${encodeURIComponent(id)}/versions/${versionNumber}/restore`,
         {}
       ),
 
-    onSuccess: (_, { id }) => {
+    onSuccess: (result, variables, context) => {
+      const { id } = variables;
+
       // Invalidate note detail and versions
       queryClient.invalidateQueries({ queryKey: noteKeys.detail(id) });
       queryClient.invalidateQueries({ queryKey: noteKeys.versions(id) });
 
       // Invalidate notes list queries
       queryClient.invalidateQueries({ queryKey: noteKeys.lists() });
+
+      // Call consumer's onSuccess if provided
+      options?.onSuccess?.(result, variables, context);
     },
+
+    onError: options?.onError,
+    onSettled: options?.onSettled,
+    ...options,
   });
 }

--- a/src/ui/hooks/mutations/use-note-sharing-mutations.ts
+++ b/src/ui/hooks/mutations/use-note-sharing-mutations.ts
@@ -4,8 +4,12 @@
  * Provides mutations for creating, updating, and revoking note shares.
  * Includes cache invalidation for related queries.
  */
-import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { apiClient } from '@/ui/lib/api-client.ts';
+import {
+  useMutation,
+  useQueryClient,
+  type UseMutationOptions,
+} from '@tanstack/react-query';
+import { apiClient, type ApiRequestError } from '@/ui/lib/api-client.ts';
 import type {
   NoteUserShare,
   CreateUserShareBody,
@@ -16,113 +20,232 @@ import type {
 } from '@/ui/lib/api-types.ts';
 import { noteKeys } from '@/ui/hooks/queries/use-notes.ts';
 
+/** Variables for useShareNoteWithUser mutation. */
+export interface ShareNoteWithUserVariables {
+  /** The note ID to share. */
+  noteId: string;
+  /** Share configuration. */
+  body: CreateUserShareBody;
+}
+
+/**
+ * Options for useShareNoteWithUser mutation.
+ * Allows consumers to provide custom error handlers and other mutation options.
+ */
+export type UseShareNoteWithUserOptions = Omit<
+  UseMutationOptions<NoteUserShare, ApiRequestError, ShareNoteWithUserVariables>,
+  'mutationFn'
+>;
+
 /**
  * Share a note with a specific user.
  *
+ * @param options - Optional mutation configuration including onError callback
  * @returns TanStack mutation
  *
  * @example
  * ```ts
- * const { mutate } = useShareNoteWithUser();
+ * const { mutate } = useShareNoteWithUser({
+ *   onError: (error) => toast.error(error.message),
+ * });
  * mutate({ noteId: 'note-123', body: { email: 'user@example.com', permission: 'read' } });
  * ```
  */
-export function useShareNoteWithUser() {
+export function useShareNoteWithUser(options?: UseShareNoteWithUserOptions) {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({ noteId, body }: { noteId: string; body: CreateUserShareBody }) =>
-      apiClient.post<NoteUserShare>(`/api/notes/${noteId}/share`, body),
+    mutationFn: ({ noteId, body }: ShareNoteWithUserVariables) =>
+      apiClient.post<NoteUserShare>(
+        `/api/notes/${encodeURIComponent(noteId)}/share`,
+        body
+      ),
 
-    onSuccess: (_, { noteId }) => {
+    onSuccess: (result, variables, context) => {
+      const { noteId } = variables;
+
       // Invalidate shares for this note
       queryClient.invalidateQueries({ queryKey: noteKeys.shares(noteId) });
 
       // Invalidate the note detail (visibility may have changed)
       queryClient.invalidateQueries({ queryKey: noteKeys.detail(noteId) });
+
+      // Call consumer's onSuccess if provided
+      options?.onSuccess?.(result, variables, context);
     },
+
+    onError: options?.onError,
+    onSettled: options?.onSettled,
+    ...options,
   });
 }
+
+/** Variables for useCreateNoteShareLink mutation. */
+export interface CreateNoteShareLinkVariables {
+  /** The note ID to create a share link for. */
+  noteId: string;
+  /** Share link configuration. */
+  body: CreateLinkShareBody;
+}
+
+/**
+ * Options for useCreateNoteShareLink mutation.
+ * Allows consumers to provide custom error handlers and other mutation options.
+ */
+export type UseCreateNoteShareLinkOptions = Omit<
+  UseMutationOptions<
+    CreateLinkShareResponse,
+    ApiRequestError,
+    CreateNoteShareLinkVariables
+  >,
+  'mutationFn'
+>;
 
 /**
  * Create a shareable link for a note.
  *
+ * @param options - Optional mutation configuration including onError callback
  * @returns TanStack mutation
  *
  * @example
  * ```ts
- * const { mutate } = useCreateNoteShareLink();
+ * const { mutate } = useCreateNoteShareLink({
+ *   onError: (error) => toast.error(error.message),
+ * });
  * mutate({ noteId: 'note-123', body: { permission: 'read', maxViews: 10 } });
  * ```
  */
-export function useCreateNoteShareLink() {
+export function useCreateNoteShareLink(options?: UseCreateNoteShareLinkOptions) {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({ noteId, body }: { noteId: string; body: CreateLinkShareBody }) =>
-      apiClient.post<CreateLinkShareResponse>(`/api/notes/${noteId}/share/link`, body),
+    mutationFn: ({ noteId, body }: CreateNoteShareLinkVariables) =>
+      apiClient.post<CreateLinkShareResponse>(
+        `/api/notes/${encodeURIComponent(noteId)}/share/link`,
+        body
+      ),
 
-    onSuccess: (_, { noteId }) => {
+    onSuccess: (result, variables, context) => {
+      const { noteId } = variables;
+
       // Invalidate shares for this note
       queryClient.invalidateQueries({ queryKey: noteKeys.shares(noteId) });
 
       // Invalidate the note detail (visibility may have changed)
       queryClient.invalidateQueries({ queryKey: noteKeys.detail(noteId) });
+
+      // Call consumer's onSuccess if provided
+      options?.onSuccess?.(result, variables, context);
     },
+
+    onError: options?.onError,
+    onSettled: options?.onSettled,
+    ...options,
   });
 }
+
+/** Variables for useUpdateNoteShare mutation. */
+export interface UpdateNoteShareVariables {
+  /** The note ID. */
+  noteId: string;
+  /** The share ID to update. */
+  shareId: string;
+  /** Updated share configuration. */
+  body: UpdateShareBody;
+}
+
+/**
+ * Options for useUpdateNoteShare mutation.
+ * Allows consumers to provide custom error handlers and other mutation options.
+ */
+export type UseUpdateNoteShareOptions = Omit<
+  UseMutationOptions<NoteShare, ApiRequestError, UpdateNoteShareVariables>,
+  'mutationFn'
+>;
 
 /**
  * Update an existing share's permission or expiration.
  *
+ * @param options - Optional mutation configuration including onError callback
  * @returns TanStack mutation
  *
  * @example
  * ```ts
- * const { mutate } = useUpdateNoteShare();
+ * const { mutate } = useUpdateNoteShare({
+ *   onError: (error) => toast.error(error.message),
+ * });
  * mutate({ noteId: 'note-123', shareId: 'share-456', body: { permission: 'read_write' } });
  * ```
  */
-export function useUpdateNoteShare() {
+export function useUpdateNoteShare(options?: UseUpdateNoteShareOptions) {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({
-      noteId,
-      shareId,
-      body,
-    }: {
-      noteId: string;
-      shareId: string;
-      body: UpdateShareBody;
-    }) => apiClient.put<NoteShare>(`/api/notes/${noteId}/shares/${shareId}`, body),
+    mutationFn: ({ noteId, shareId, body }: UpdateNoteShareVariables) =>
+      apiClient.put<NoteShare>(
+        `/api/notes/${encodeURIComponent(noteId)}/shares/${encodeURIComponent(shareId)}`,
+        body
+      ),
 
-    onSuccess: (_, { noteId }) => {
+    onSuccess: (result, variables, context) => {
+      const { noteId } = variables;
+
       // Invalidate shares for this note
       queryClient.invalidateQueries({ queryKey: noteKeys.shares(noteId) });
+
+      // Call consumer's onSuccess if provided
+      options?.onSuccess?.(result, variables, context);
     },
+
+    onError: options?.onError,
+    onSettled: options?.onSettled,
+    ...options,
   });
 }
+
+/** Variables for useRevokeNoteShare mutation. */
+export interface RevokeNoteShareVariables {
+  /** The note ID. */
+  noteId: string;
+  /** The share ID to revoke. */
+  shareId: string;
+}
+
+/**
+ * Options for useRevokeNoteShare mutation.
+ * Allows consumers to provide custom error handlers and other mutation options.
+ */
+export type UseRevokeNoteShareOptions = Omit<
+  UseMutationOptions<void, ApiRequestError, RevokeNoteShareVariables>,
+  'mutationFn'
+>;
 
 /**
  * Revoke a note share.
  *
+ * @param options - Optional mutation configuration including onError callback
  * @returns TanStack mutation
  *
  * @example
  * ```ts
- * const { mutate } = useRevokeNoteShare();
+ * const { mutate } = useRevokeNoteShare({
+ *   onError: (error) => toast.error(error.message),
+ * });
  * mutate({ noteId: 'note-123', shareId: 'share-456' });
  * ```
  */
-export function useRevokeNoteShare() {
+export function useRevokeNoteShare(options?: UseRevokeNoteShareOptions) {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({ noteId, shareId }: { noteId: string; shareId: string }) =>
-      apiClient.delete(`/api/notes/${noteId}/shares/${shareId}`),
+    mutationFn: ({ noteId, shareId }: RevokeNoteShareVariables) =>
+      apiClient.delete(
+        `/api/notes/${encodeURIComponent(noteId)}/shares/${encodeURIComponent(shareId)}`
+      ),
 
-    onSuccess: (_, { noteId }) => {
+    onSuccess: (result, variables, context) => {
+      const { noteId } = variables;
+
       // Invalidate shares for this note
       queryClient.invalidateQueries({ queryKey: noteKeys.shares(noteId) });
 
@@ -131,6 +254,13 @@ export function useRevokeNoteShare() {
 
       // Invalidate shared-with-me in case this was a share we were receiving
       queryClient.invalidateQueries({ queryKey: noteKeys.sharedWithMe() });
+
+      // Call consumer's onSuccess if provided
+      options?.onSuccess?.(result, variables, context);
     },
+
+    onError: options?.onError,
+    onSettled: options?.onSettled,
+    ...options,
   });
 }

--- a/src/ui/hooks/mutations/use-notebook-mutations.ts
+++ b/src/ui/hooks/mutations/use-notebook-mutations.ts
@@ -4,8 +4,12 @@
  * Provides mutations for creating, updating, archiving, and deleting notebooks.
  * Includes cache invalidation for related queries.
  */
-import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { apiClient } from '@/ui/lib/api-client.ts';
+import {
+  useMutation,
+  useQueryClient,
+  type UseMutationOptions,
+} from '@tanstack/react-query';
+import { apiClient, type ApiRequestError } from '@/ui/lib/api-client.ts';
 import type {
   Notebook,
   CreateNotebookBody,
@@ -17,24 +21,36 @@ import { noteKeys } from '@/ui/hooks/queries/use-notes.ts';
 import { notebookKeys } from '@/ui/hooks/queries/use-notebooks.ts';
 
 /**
+ * Options for useCreateNotebook mutation.
+ * Allows consumers to provide custom error handlers and other mutation options.
+ */
+export type UseCreateNotebookOptions = Omit<
+  UseMutationOptions<Notebook, ApiRequestError, CreateNotebookBody>,
+  'mutationFn'
+>;
+
+/**
  * Create a new notebook.
  *
+ * @param options - Optional mutation configuration including onError callback
  * @returns TanStack mutation
  *
  * @example
  * ```ts
- * const { mutate } = useCreateNotebook();
+ * const { mutate } = useCreateNotebook({
+ *   onError: (error) => toast.error(error.message),
+ * });
  * mutate({ name: 'My Notebook', icon: '📓' });
  * ```
  */
-export function useCreateNotebook() {
+export function useCreateNotebook(options?: UseCreateNotebookOptions) {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: (body: CreateNotebookBody) =>
       apiClient.post<Notebook>('/api/notebooks', body),
 
-    onSuccess: (notebook) => {
+    onSuccess: (notebook, variables, context) => {
       // Invalidate notebooks list queries
       queryClient.invalidateQueries({ queryKey: notebookKeys.lists() });
 
@@ -47,29 +63,61 @@ export function useCreateNotebook() {
           queryKey: notebookKeys.detail(notebook.parentNotebookId),
         });
       }
+
+      // Call consumer's onSuccess if provided
+      options?.onSuccess?.(notebook, variables, context);
     },
+
+    onError: options?.onError,
+    onSettled: options?.onSettled,
+    ...options,
   });
 }
+
+/** Variables for useUpdateNotebook mutation. */
+export interface UpdateNotebookVariables {
+  /** The notebook ID to update. */
+  id: string;
+  /** Partial update body. */
+  body: UpdateNotebookBody;
+}
+
+/**
+ * Options for useUpdateNotebook mutation.
+ * Allows consumers to provide custom error handlers and other mutation options.
+ */
+export type UseUpdateNotebookOptions = Omit<
+  UseMutationOptions<Notebook, ApiRequestError, UpdateNotebookVariables>,
+  'mutationFn'
+>;
 
 /**
  * Update an existing notebook.
  *
+ * @param options - Optional mutation configuration including onError callback
  * @returns TanStack mutation
  *
  * @example
  * ```ts
- * const { mutate } = useUpdateNotebook();
+ * const { mutate } = useUpdateNotebook({
+ *   onError: (error) => toast.error(error.message),
+ * });
  * mutate({ id: 'notebook-123', body: { name: 'New Name' } });
  * ```
  */
-export function useUpdateNotebook() {
+export function useUpdateNotebook(options?: UseUpdateNotebookOptions) {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({ id, body }: { id: string; body: UpdateNotebookBody }) =>
-      apiClient.put<Notebook>(`/api/notebooks/${id}`, body),
+    mutationFn: ({ id, body }: UpdateNotebookVariables) =>
+      apiClient.put<Notebook>(
+        `/api/notebooks/${encodeURIComponent(id)}`,
+        body
+      ),
 
-    onSuccess: (_, { id }) => {
+    onSuccess: (result, variables, context) => {
+      const { id } = variables;
+
       // Invalidate the specific notebook detail
       queryClient.invalidateQueries({ queryKey: notebookKeys.detail(id) });
 
@@ -78,29 +126,51 @@ export function useUpdateNotebook() {
 
       // Invalidate tree
       queryClient.invalidateQueries({ queryKey: notebookKeys.tree() });
+
+      // Call consumer's onSuccess if provided
+      options?.onSuccess?.(result, variables, context);
     },
+
+    onError: options?.onError,
+    onSettled: options?.onSettled,
+    ...options,
   });
 }
+
+/**
+ * Options for useArchiveNotebook mutation.
+ * Allows consumers to provide custom error handlers and other mutation options.
+ */
+export type UseArchiveNotebookOptions = Omit<
+  UseMutationOptions<Notebook, ApiRequestError, string>,
+  'mutationFn'
+>;
 
 /**
  * Archive a notebook.
  *
+ * @param options - Optional mutation configuration including onError callback
  * @returns TanStack mutation
  *
  * @example
  * ```ts
- * const { mutate } = useArchiveNotebook();
+ * const { mutate } = useArchiveNotebook({
+ *   onError: (error) => toast.error(error.message),
+ * });
  * mutate('notebook-123');
  * ```
  */
-export function useArchiveNotebook() {
+export function useArchiveNotebook(options?: UseArchiveNotebookOptions) {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: (id: string) =>
-      apiClient.post<Notebook>(`/api/notebooks/${id}/archive`, {}),
+      apiClient.post<Notebook>(
+        `/api/notebooks/${encodeURIComponent(id)}/archive`,
+        {}
+      ),
 
-    onSuccess: (_, id) => {
+    onSuccess: (result, id, context) => {
       // Invalidate the specific notebook detail
       queryClient.invalidateQueries({ queryKey: notebookKeys.detail(id) });
 
@@ -109,29 +179,51 @@ export function useArchiveNotebook() {
 
       // Invalidate tree
       queryClient.invalidateQueries({ queryKey: notebookKeys.tree() });
+
+      // Call consumer's onSuccess if provided
+      options?.onSuccess?.(result, id, context);
     },
+
+    onError: options?.onError,
+    onSettled: options?.onSettled,
+    ...options,
   });
 }
+
+/**
+ * Options for useUnarchiveNotebook mutation.
+ * Allows consumers to provide custom error handlers and other mutation options.
+ */
+export type UseUnarchiveNotebookOptions = Omit<
+  UseMutationOptions<Notebook, ApiRequestError, string>,
+  'mutationFn'
+>;
 
 /**
  * Unarchive a notebook.
  *
+ * @param options - Optional mutation configuration including onError callback
  * @returns TanStack mutation
  *
  * @example
  * ```ts
- * const { mutate } = useUnarchiveNotebook();
+ * const { mutate } = useUnarchiveNotebook({
+ *   onError: (error) => toast.error(error.message),
+ * });
  * mutate('notebook-123');
  * ```
  */
-export function useUnarchiveNotebook() {
+export function useUnarchiveNotebook(options?: UseUnarchiveNotebookOptions) {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: (id: string) =>
-      apiClient.post<Notebook>(`/api/notebooks/${id}/unarchive`, {}),
+      apiClient.post<Notebook>(
+        `/api/notebooks/${encodeURIComponent(id)}/unarchive`,
+        {}
+      ),
 
-    onSuccess: (_, id) => {
+    onSuccess: (result, id, context) => {
       // Invalidate the specific notebook detail
       queryClient.invalidateQueries({ queryKey: notebookKeys.detail(id) });
 
@@ -140,29 +232,60 @@ export function useUnarchiveNotebook() {
 
       // Invalidate tree
       queryClient.invalidateQueries({ queryKey: notebookKeys.tree() });
+
+      // Call consumer's onSuccess if provided
+      options?.onSuccess?.(result, id, context);
     },
+
+    onError: options?.onError,
+    onSettled: options?.onSettled,
+    ...options,
   });
 }
+
+/** Variables for useDeleteNotebook mutation. */
+export interface DeleteNotebookVariables {
+  /** The notebook ID to delete. */
+  id: string;
+  /** Whether to delete notes in the notebook. Defaults to false (moves notes to inbox). */
+  deleteNotes?: boolean;
+}
+
+/**
+ * Options for useDeleteNotebook mutation.
+ * Allows consumers to provide custom error handlers and other mutation options.
+ */
+export type UseDeleteNotebookOptions = Omit<
+  UseMutationOptions<void, ApiRequestError, DeleteNotebookVariables>,
+  'mutationFn'
+>;
 
 /**
  * Delete a notebook.
  *
+ * @param options - Optional mutation configuration including onError callback
  * @returns TanStack mutation
  *
  * @example
  * ```ts
- * const { mutate } = useDeleteNotebook();
+ * const { mutate } = useDeleteNotebook({
+ *   onError: (error) => toast.error(error.message),
+ * });
  * mutate({ id: 'notebook-123', deleteNotes: false });
  * ```
  */
-export function useDeleteNotebook() {
+export function useDeleteNotebook(options?: UseDeleteNotebookOptions) {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({ id, deleteNotes = false }: { id: string; deleteNotes?: boolean }) =>
-      apiClient.delete(`/api/notebooks/${id}${deleteNotes ? '?deleteNotes=true' : ''}`),
+    mutationFn: ({ id, deleteNotes = false }: DeleteNotebookVariables) =>
+      apiClient.delete(
+        `/api/notebooks/${encodeURIComponent(id)}${deleteNotes ? '?deleteNotes=true' : ''}`
+      ),
 
-    onSuccess: (_, { id }) => {
+    onSuccess: (result, variables, context) => {
+      const { id } = variables;
+
       // Invalidate the specific notebook detail
       queryClient.invalidateQueries({ queryKey: notebookKeys.detail(id) });
 
@@ -174,29 +297,65 @@ export function useDeleteNotebook() {
 
       // Also invalidate notes since they may have been moved or deleted
       queryClient.invalidateQueries({ queryKey: noteKeys.lists() });
+
+      // Call consumer's onSuccess if provided
+      options?.onSuccess?.(result, variables, context);
     },
+
+    onError: options?.onError,
+    onSettled: options?.onSettled,
+    ...options,
   });
 }
+
+/** Variables for useMoveNotesToNotebook mutation. */
+export interface MoveNotesToNotebookVariables {
+  /** The target notebook ID. */
+  notebookId: string;
+  /** Move/copy configuration. */
+  body: MoveNotesBody;
+}
+
+/**
+ * Options for useMoveNotesToNotebook mutation.
+ * Allows consumers to provide custom error handlers and other mutation options.
+ */
+export type UseMoveNotesToNotebookOptions = Omit<
+  UseMutationOptions<
+    MoveNotesResponse,
+    ApiRequestError,
+    MoveNotesToNotebookVariables
+  >,
+  'mutationFn'
+>;
 
 /**
  * Move or copy notes to a notebook.
  *
+ * @param options - Optional mutation configuration including onError callback
  * @returns TanStack mutation
  *
  * @example
  * ```ts
- * const { mutate } = useMoveNotesToNotebook();
+ * const { mutate } = useMoveNotesToNotebook({
+ *   onError: (error) => toast.error(error.message),
+ * });
  * mutate({ notebookId: 'notebook-123', body: { noteIds: ['note-1', 'note-2'], action: 'move' } });
  * ```
  */
-export function useMoveNotesToNotebook() {
+export function useMoveNotesToNotebook(options?: UseMoveNotesToNotebookOptions) {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({ notebookId, body }: { notebookId: string; body: MoveNotesBody }) =>
-      apiClient.post<MoveNotesResponse>(`/api/notebooks/${notebookId}/notes`, body),
+    mutationFn: ({ notebookId, body }: MoveNotesToNotebookVariables) =>
+      apiClient.post<MoveNotesResponse>(
+        `/api/notebooks/${encodeURIComponent(notebookId)}/notes`,
+        body
+      ),
 
-    onSuccess: (_, { notebookId }) => {
+    onSuccess: (result, variables, context) => {
+      const { notebookId } = variables;
+
       // Invalidate the target notebook
       queryClient.invalidateQueries({
         queryKey: notebookKeys.detail(notebookId),
@@ -208,6 +367,13 @@ export function useMoveNotesToNotebook() {
 
       // Invalidate notes since they've been moved/copied
       queryClient.invalidateQueries({ queryKey: noteKeys.lists() });
+
+      // Call consumer's onSuccess if provided
+      options?.onSuccess?.(result, variables, context);
     },
+
+    onError: options?.onError,
+    onSettled: options?.onSettled,
+    ...options,
   });
 }


### PR DESCRIPTION
## Summary
- Added typed options parameters to all Notes/Notebooks mutation hooks
- Consumers can now provide onError, onSuccess, and onSettled callbacks
- Added typed interfaces for mutation variables (UpdateNoteVariables, etc.)
- Added typed option types (UseCreateNoteOptions, UseUpdateNoteOptions, etc.)
- Proper error typing with ApiRequestError

## Test plan
- [x] All 1953 UI tests pass
- [x] TypeScript types are properly inferred
- [x] Existing functionality unchanged (backward compatible)

Closes #649

Generated with [Claude Code](https://claude.com/claude-code)