### PR TITLE
[#682] Remove unused Copy and Check icon imports from lexical editor

### DIFF
--- a/src/ui/components/notes/editor/lexical-editor.tsx
+++ b/src/ui/components/notes/editor/lexical-editor.tsx
@@ -141,8 +141,6 @@ import {
   Save,
   Loader2,
   Code,
-  Copy,
-  Check,
   FileCode,
   Table,
 } from 'lucide-react';


### PR DESCRIPTION
## Summary
- Remove unused `Copy` and `Check` icon imports from lucide-react in the lexical editor component
- These icons were imported but never used in the current implementation
- Likely intended for a copy-to-clipboard feature that was not implemented

## Test plan
- [x] App builds successfully
- [x] No functional changes - only removes unused imports

Closes #682

Generated with [Claude Code](https://claude.com/claude-code)