### PR TITLE
[#667] Add 404 handling for non-existent notes

### DIFF
--- a/src/ui/pages/NotesPage.tsx
+++ b/src/ui/pages/NotesPage.tsx
@@ -227,6 +227,21 @@ export function NotesPage(): React.JSX.Element {
     return undefined;
   }, [notes, view]);
 
+  // Check if requested note exists after data loads (#667)
+  const noteNotFound = useMemo(() => {
+    // Only check when we're in detail/history view and notes have loaded
+    if (
+      (view.type === 'detail' || view.type === 'history') &&
+      !notesLoading &&
+      !notesError &&
+      notesData
+    ) {
+      // Note requested but not found in the data
+      return !notes.find((n) => n.id === view.noteId);
+    }
+    return false;
+  }, [view, notesLoading, notesError, notesData, notes]);
+
   // Get API note for current note (needed for save operations)
   const currentApiNote = useMemo(() => {
     if (view.type === 'detail' || view.type === 'history') {
@@ -488,7 +503,18 @@ export function NotesPage(): React.JSX.Element {
             </Button>
           </div>
 
-          {view.type === 'history' && currentNote ? (
+          {/* Note not found error state (#667) */}
+          {noteNotFound && view.type !== 'new' ? (
+            <div className="flex-1 flex items-center justify-center p-6">
+              <ErrorState
+                type="not-found"
+                title="Note not found"
+                description="This note may have been deleted or you don't have access to it."
+                onRetry={handleBack}
+                retryLabel="Back to notes"
+              />
+            </div>
+          ) : view.type === 'history' && currentNote ? (
             <NoteHistoryPanel
               noteId={currentNote.id}
               onClose={handleCloseHistory}


### PR DESCRIPTION
## Summary
- Add `noteNotFound` check after notes data loads
- Show friendly ErrorState when a requested note doesn't exist
- Display "Note not found" message with description about possible deletion/access
- Provide "Back to notes" button to return to list view

This improves UX when users navigate to invalid note URLs (e.g., shared links to deleted notes).

Closes #667

## Test plan
- [x] Run `pnpm exec vitest run tests/ui/routing.test.tsx` - all 13 tests pass
- [ ] Manual test: Navigate to `/notes/550e8400-e29b-41d4-a716-446655440000` (non-existent UUID) - should show "Note not found" error
- [ ] Manual test: Navigate to valid note URL - should display note normally

Generated with [Claude Code](https://claude.com/claude-code)