### PR TITLE
[#650] Add proper types for notebook shares

### DIFF
--- a/src/ui/hooks/queries/use-notebooks.ts
+++ b/src/ui/hooks/queries/use-notebooks.ts
@@ -10,7 +10,8 @@ import type {
   Notebook,
   ListNotebooksParams,
   NotebookTreeNode,
-  SharedWithMeResponse,
+  NotebookSharesResponse,
+  NotebooksSharedWithMeResponse,
 } from '@/ui/lib/api-types.ts';
 
 /** Query key factory for notebooks. */
@@ -125,14 +126,14 @@ export function useNotebooksTree(includeNoteCounts = false) {
  * Fetch shares for a notebook.
  *
  * @param id - Notebook UUID
- * @returns TanStack Query result with shares
+ * @returns TanStack Query result with `NotebookSharesResponse`
  */
 export function useNotebookShares(id: string) {
   return useQuery({
     queryKey: notebookKeys.shares(id),
     queryFn: ({ signal }) =>
-      apiClient.get<{ notebookId: string; shares: unknown[] }>(
-        `/api/notebooks/${id}/shares`,
+      apiClient.get<NotebookSharesResponse>(
+        `/api/notebooks/${encodeURIComponent(id)}/shares`,
         { signal }
       ),
     enabled: !!id,
@@ -142,14 +143,15 @@ export function useNotebookShares(id: string) {
 /**
  * Fetch notebooks shared with the current user.
  *
- * @returns TanStack Query result with `SharedWithMeResponse`
+ * @returns TanStack Query result with `NotebooksSharedWithMeResponse`
  */
 export function useNotebooksSharedWithMe() {
   return useQuery({
     queryKey: notebookKeys.sharedWithMe(),
     queryFn: ({ signal }) =>
-      apiClient.get<SharedWithMeResponse>('/api/notebooks/shared-with-me', {
-        signal,
-      }),
+      apiClient.get<NotebooksSharedWithMeResponse>(
+        '/api/notebooks/shared-with-me',
+        { signal }
+      ),
   });
 }

--- a/src/ui/lib/api-types.ts
+++ b/src/ui/lib/api-types.ts
@@ -689,6 +689,80 @@ export interface MoveNotesResponse {
 }
 
 // ---------------------------------------------------------------------------
+// Notebook Sharing
+// ---------------------------------------------------------------------------
+
+/** Base notebook share record */
+interface BaseNotebookShare {
+  id: string;
+  notebookId: string;
+  permission: SharePermission;
+  expiresAt: string | null;
+  createdByEmail: string;
+  createdAt: string;
+  lastAccessedAt: string | null;
+}
+
+/** Notebook user share record */
+export interface NotebookUserShare extends BaseNotebookShare {
+  type: 'user';
+  sharedWithEmail: string;
+}
+
+/** Notebook link share record */
+export interface NotebookLinkShare extends BaseNotebookShare {
+  type: 'link';
+  token: string;
+}
+
+/** Union of notebook share types */
+export type NotebookShare = NotebookUserShare | NotebookLinkShare;
+
+/** Response from GET /api/notebooks/:id/shares */
+export interface NotebookSharesResponse {
+  notebookId: string;
+  shares: NotebookShare[];
+}
+
+/** Body for POST /api/notebooks/:id/share (user share) */
+export interface CreateNotebookUserShareBody {
+  email: string;
+  permission?: SharePermission;
+  expiresAt?: string | null;
+}
+
+/** Body for POST /api/notebooks/:id/share/link */
+export interface CreateNotebookLinkShareBody {
+  permission?: SharePermission;
+  expiresAt?: string | null;
+}
+
+/** Response from POST /api/notebooks/:id/share/link */
+export interface CreateNotebookLinkShareResponse extends NotebookLinkShare {
+  url: string;
+}
+
+/** Body for PUT /api/notebooks/:id/shares/:shareId */
+export interface UpdateNotebookShareBody {
+  permission?: SharePermission;
+  expiresAt?: string | null;
+}
+
+/** Entry in notebooks shared-with-me list */
+export interface NotebookSharedWithMeEntry {
+  id: string;
+  name: string;
+  sharedByEmail: string;
+  permission: SharePermission;
+  sharedAt: string;
+}
+
+/** Response from GET /api/notebooks/shared-with-me */
+export interface NotebooksSharedWithMeResponse {
+  notebooks: NotebookSharedWithMeEntry[];
+}
+
+// ---------------------------------------------------------------------------
 // Bootstrap (server-injected data)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Replaced `unknown[]` with proper `NotebookShare` type in useNotebookShares hook
- Added new types in api-types.ts:
  - `NotebookUserShare`: User-specific share with sharedWithEmail
  - `NotebookLinkShare`: Link share with token
  - `NotebookShare`: Union type (user | link)
  - `NotebookSharesResponse`: Response for shares endpoint
  - `NotebooksSharedWithMeResponse`: Response for shared-with-me endpoint
  - Supporting body types for creating/updating shares

## Test plan
- [x] Query hook tests pass
- [x] TypeScript types properly inferred

Closes #650

Generated with [Claude Code](https://claude.com/claude-code)