### PR TITLE
[#669] Consolidate notes route definitions using nested routes

### DIFF
--- a/src/ui/routes.tsx
+++ b/src/ui/routes.tsx
@@ -157,21 +157,21 @@ export const routes: RouteObject[] = [
         path: 'memory',
         element: lazy(MemoryPage),
       },
+      // Notes routes - consolidated using nested routes (#669)
+      // All routes render NotesPage which handles the different URL patterns
       {
         path: 'notes',
-        element: lazy(NotesPage),
-      },
-      {
-        path: 'notes/:noteId',
-        element: lazy(NotesPage),
+        children: [
+          { index: true, element: lazy(NotesPage) },
+          { path: ':noteId', element: lazy(NotesPage) },
+        ],
       },
       {
         path: 'notebooks/:notebookId',
-        element: lazy(NotesPage),
-      },
-      {
-        path: 'notebooks/:notebookId/notes/:noteId',
-        element: lazy(NotesPage),
+        children: [
+          { index: true, element: lazy(NotesPage) },
+          { path: 'notes/:noteId', element: lazy(NotesPage) },
+        ],
       },
       {
         path: 'settings',


### PR DESCRIPTION
## Summary
- Refactor 4 flat route definitions into 2 nested route trees
- Use React Router's nested route pattern with children arrays
- All routes still render NotesPage, which handles URL parameter variations

Before (4 routes):
```tsx
{ path: 'notes', element: lazy(NotesPage) },
{ path: 'notes/:noteId', element: lazy(NotesPage) },
{ path: 'notebooks/:notebookId', element: lazy(NotesPage) },
{ path: 'notebooks/:notebookId/notes/:noteId', element: lazy(NotesPage) },
```

After (2 nested routes):
```tsx
{ path: 'notes', children: [
    { index: true, element: lazy(NotesPage) },
    { path: ':noteId', element: lazy(NotesPage) },
]},
{ path: 'notebooks/:notebookId', children: [
    { index: true, element: lazy(NotesPage) },
    { path: 'notes/:noteId', element: lazy(NotesPage) },
]},
```

Closes #669

## Test plan
- [x] Run `pnpm exec vitest run tests/ui/routing.test.tsx` - all 13 tests pass
- [ ] Manual test: All notes URL patterns should work as before

Generated with [Claude Code](https://claude.com/claude-code)