### PR TITLE
[#662] Replace hardcoded default color value with constant

### DIFF
--- a/src/ui/lib/constants.ts
+++ b/src/ui/lib/constants.ts
@@ -1,0 +1,37 @@
+/**
+ * UI constants for the notes application.
+ *
+ * Centralizes magic values to improve maintainability and consistency.
+ *
+ * Part of Epic #338, Issue #662
+ */
+
+/**
+ * Default color for new notebooks.
+ * This is the indigo-500 color from Tailwind's palette.
+ */
+export const DEFAULT_NOTEBOOK_COLOR = '#6366f1';
+
+/**
+ * Color palette options for notebooks.
+ * These are commonly used colors that work well for categorization.
+ */
+export const NOTEBOOK_COLOR_PALETTE = [
+  '#6366f1', // indigo-500 (default)
+  '#8b5cf6', // violet-500
+  '#a855f7', // purple-500
+  '#ec4899', // pink-500
+  '#ef4444', // red-500
+  '#f97316', // orange-500
+  '#eab308', // yellow-500
+  '#22c55e', // green-500
+  '#14b8a6', // teal-500
+  '#06b6d4', // cyan-500
+  '#3b82f6', // blue-500
+  '#64748b', // slate-500
+] as const;
+
+/**
+ * Auto-dismiss timeout for temporary notifications (in milliseconds).
+ */
+export const NOTIFICATION_TIMEOUT_MS = 5000;

--- a/src/ui/pages/NotesPage.tsx
+++ b/src/ui/pages/NotesPage.tsx
@@ -81,6 +81,7 @@ import type {
   Note as UINote,
   Notebook as UINotebook,
 } from '@/ui/components/notes/types';
+import { DEFAULT_NOTEBOOK_COLOR } from '@/ui/lib/constants';
 
 /**
  * Transform API Note to UI Note type.
@@ -684,14 +685,14 @@ function NotebookFormDialog({
 }: NotebookFormDialogProps) {
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
-  const [color, setColor] = useState('#6366f1');
+  const [color, setColor] = useState(DEFAULT_NOTEBOOK_COLOR);
 
   // Reset form when dialog opens
   React.useEffect(() => {
     if (open) {
       setName(notebook?.name ?? '');
       setDescription(notebook?.description ?? '');
-      setColor(notebook?.color ?? '#6366f1');
+      setColor(notebook?.color ?? DEFAULT_NOTEBOOK_COLOR);
     }
   }, [open, notebook]);
 


### PR DESCRIPTION
## Summary
- Create `constants.ts` module for centralizing UI constants
- Add `DEFAULT_NOTEBOOK_COLOR` constant replacing hardcoded `#6366f1`
- Add `NOTEBOOK_COLOR_PALETTE` for potential future color picker enhancement
- Add `NOTIFICATION_TIMEOUT_MS` for standardizing auto-dismiss timing
- Update `NotebookFormDialog` to use the constant instead of magic string

Closes #662

## Test Plan
- [ ] Create new notebook - should default to indigo color (#6366f1)
- [ ] Edit existing notebook without color - should default to indigo
- [ ] Edit existing notebook with color - should show existing color

Generated with Claude Code