### PR TITLE
[#684] Remove unused imports from @lexical/table and related modules

### DIFF
--- a/src/ui/components/notes/editor/lexical-editor.tsx
+++ b/src/ui/components/notes/editor/lexical-editor.tsx
@@ -41,8 +41,6 @@ import {
   CodeHighlightNode,
   registerCodeHighlighting,
   $createCodeNode,
-  CODE_LANGUAGE_FRIENDLY_NAME_MAP,
-  getLanguageFriendlyName,
 } from '@lexical/code';
 import {
   $getSelection,
@@ -59,19 +57,10 @@ import {
 import { $setBlocksType } from '@lexical/selection';
 import { $createHeadingNode, $createQuoteNode } from '@lexical/rich-text';
 import { TOGGLE_LINK_COMMAND } from '@lexical/link';
-import { $getNodeByKey } from 'lexical';
 import {
   TableNode,
   TableRowNode,
   TableCellNode,
-  $createTableNodeWithDimensions,
-  $insertTableColumn,
-  $insertTableRow,
-  $deleteTableColumn,
-  $deleteTableRowAtIndex,
-  $getTableColumnIndexFromTableCellNode,
-  $getTableRowIndexFromTableCellNode,
-  registerTablePlugin,
   INSERT_TABLE_COMMAND,
 } from '@lexical/table';
 import { TablePlugin } from '@lexical/react/LexicalTablePlugin';


### PR DESCRIPTION
## Summary
- Remove unused imports from `@lexical/table`: `$createTableNodeWithDimensions`, `$insertTableColumn`, `$insertTableRow`, `$deleteTableColumn`, `$deleteTableRowAtIndex`, `$getTableColumnIndexFromTableCellNode`, `$getTableRowIndexFromTableCellNode`, `registerTablePlugin`
- Remove unused imports from `@lexical/code`: `CODE_LANGUAGE_FRIENDLY_NAME_MAP`, `getLanguageFriendlyName`
- Remove unused import from `lexical`: `$getNodeByKey`

These utilities were imported but never used. They could be useful for future row/column editing features but are not needed in the current implementation.

## Test plan
- [x] App builds successfully
- [x] No functional changes - only removes unused imports

Closes #684

Generated with [Claude Code](https://claude.com/claude-code)