### PR TITLE
[#671] Show actual note/notebook names in breadcrumbs

### DIFF
--- a/src/ui/hooks/queries/use-notebooks.ts
+++ b/src/ui/hooks/queries/use-notebooks.ts
@@ -60,15 +60,20 @@ function buildNotebooksQueryString(params?: ListNotebooksParams): string {
  * Fetch list of notebooks with optional filters.
  *
  * @param params - Optional filter/pagination params
+ * @param options - Optional query options (e.g., enabled)
  * @returns TanStack Query result with `NotebooksResponse`
  */
-export function useNotebooks(params?: ListNotebooksParams) {
+export function useNotebooks(
+  params?: ListNotebooksParams,
+  options?: { enabled?: boolean }
+) {
   const queryString = buildNotebooksQueryString(params);
 
   return useQuery({
     queryKey: notebookKeys.list(params),
     queryFn: ({ signal }) =>
       apiClient.get<NotebooksResponse>(`/api/notebooks${queryString}`, { signal }),
+    enabled: options?.enabled,
   });
 }
 

--- a/src/ui/hooks/queries/use-notes.ts
+++ b/src/ui/hooks/queries/use-notes.ts
@@ -79,15 +79,20 @@ function buildNotesQueryString(params?: ListNotesParams): string {
  * Fetch list of notes with optional filters.
  *
  * @param params - Optional filter/pagination params
+ * @param options - Optional query options (e.g., enabled)
  * @returns TanStack Query result with `NotesResponse`
  */
-export function useNotes(params?: ListNotesParams) {
+export function useNotes(
+  params?: ListNotesParams,
+  options?: { enabled?: boolean }
+) {
   const queryString = buildNotesQueryString(params);
 
   return useQuery({
     queryKey: noteKeys.list(params),
     queryFn: ({ signal }) =>
       apiClient.get<NotesResponse>(`/api/notes${queryString}`, { signal }),
+    enabled: options?.enabled,
   });
 }
 


### PR DESCRIPTION
## Summary
- Replace generic 'Notebook' and 'Note' breadcrumb labels with actual names
- Add `NotesBreadcrumbContext` interface for passing names to breadcrumb derivation
- Update `deriveBreadcrumbs` to use context for note/notebook names
- Add queries in AppLayout to fetch note/notebook data when on notes routes
- Add `enabled` option to `useNotes` and `useNotebooks` hooks for conditional fetching

Before: `Notes > Notebook > Note`
After: `Notes > My Project Notebook > Meeting Notes 2026-01-15`

Closes #671

## Test plan
- [x] Run `pnpm exec vitest run tests/ui/routing.test.tsx` - all 13 tests pass
- [ ] Manual test: Navigate to `/notes/:noteId` - breadcrumb shows actual note title
- [ ] Manual test: Navigate to `/notebooks/:notebookId` - breadcrumb shows actual notebook name
- [ ] Manual test: Navigate to `/notebooks/:notebookId/notes/:noteId` - both names shown

Generated with [Claude Code](https://claude.com/claude-code)