### PR TITLE
[#672] Add overflow menu to mobile nav with Timeline access

### DIFF
--- a/src/ui/components/layout/mobile-nav.tsx
+++ b/src/ui/components/layout/mobile-nav.tsx
@@ -1,15 +1,32 @@
 import * as React from 'react';
-import { Bell, Folder, Calendar, Users, Search, StickyNote } from 'lucide-react';
+import { useState } from 'react';
+import { Bell, Folder, Calendar, Users, Search, StickyNote, MoreHorizontal, X } from 'lucide-react';
 import { cn } from '@/ui/lib/utils';
 import type { NavItem } from './sidebar';
 
-const defaultNavItems: NavItem[] = [
+/**
+ * Primary nav items shown in the main mobile nav bar (4 items + More).
+ * Timeline was previously removed (#672) but is now in the overflow menu
+ * to maintain a clean 5-item layout while keeping all features accessible.
+ */
+const primaryNavItems: NavItem[] = [
   { id: 'activity', label: 'Activity', icon: Bell },
   { id: 'projects', label: 'Projects', icon: Folder },
   { id: 'notes', label: 'Notes', icon: StickyNote },
   { id: 'people', label: 'People', icon: Users },
+];
+
+/**
+ * Overflow items shown in the expandable "More" menu.
+ * Includes Timeline and Search which were removed from the primary nav.
+ */
+const overflowNavItems: NavItem[] = [
+  { id: 'timeline', label: 'Timeline', icon: Calendar },
   { id: 'search', label: 'Search', icon: Search },
 ];
+
+/** Combined items for backwards compatibility */
+const defaultNavItems: NavItem[] = [...primaryNavItems, ...overflowNavItems];
 
 export interface MobileNavProps {
   items?: NavItem[];
@@ -24,41 +41,125 @@ export function MobileNav({
   onItemClick,
   className,
 }: MobileNavProps) {
-  return (
-    <nav
-      data-testid="mobile-nav"
-      className={cn(
-        'fixed inset-x-0 bottom-0 z-50 h-16 items-center justify-around border-t border-border bg-surface',
-        'flex md:!hidden', // Force hide on desktop
-        className
-      )}
-      style={{ display: 'var(--mobile-nav-display, flex)' }}
-      role="navigation"
-      aria-label="Mobile navigation"
-    >
-      {items.map((item) => {
-        const Icon = item.icon;
-        const isActive = activeItem === item.id;
+  const [moreMenuOpen, setMoreMenuOpen] = useState(false);
 
-        return (
+  // Split items into primary (first 4) and overflow (rest)
+  // This allows custom items to be passed while maintaining the layout
+  const primary = items.slice(0, 4);
+  const overflow = items.slice(4);
+  const hasOverflow = overflow.length > 0;
+
+  // Check if active item is in overflow menu
+  const isOverflowActive = overflow.some((item) => item.id === activeItem);
+
+  const handleMoreClick = () => {
+    setMoreMenuOpen(!moreMenuOpen);
+  };
+
+  const handleItemClick = (item: NavItem) => {
+    item.onClick?.();
+    onItemClick?.(item);
+    setMoreMenuOpen(false); // Close menu after selection
+  };
+
+  return (
+    <>
+      {/* Overflow menu backdrop */}
+      {moreMenuOpen && (
+        <div
+          className="fixed inset-0 z-40 bg-black/20 md:hidden"
+          onClick={() => setMoreMenuOpen(false)}
+          aria-hidden="true"
+        />
+      )}
+
+      {/* Overflow menu panel (#672) */}
+      {moreMenuOpen && hasOverflow && (
+        <div
+          data-testid="mobile-nav-overflow"
+          className={cn(
+            'fixed inset-x-0 bottom-16 z-50 border-t border-border bg-surface p-2',
+            'flex flex-wrap gap-2 justify-center md:hidden'
+          )}
+          role="menu"
+          aria-label="More navigation options"
+        >
+          {overflow.map((item) => {
+            const Icon = item.icon;
+            const isActive = activeItem === item.id;
+
+            return (
+              <button
+                key={item.id}
+                type="button"
+                role="menuitem"
+                onClick={() => handleItemClick(item)}
+                className={cn(
+                  'flex items-center gap-2 rounded-lg px-4 py-2 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground',
+                  isActive && 'bg-primary/10 text-primary'
+                )}
+                aria-current={isActive ? 'page' : undefined}
+              >
+                <Icon className="size-4" />
+                <span className="font-medium">{item.label}</span>
+              </button>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Main mobile nav bar */}
+      <nav
+        data-testid="mobile-nav"
+        className={cn(
+          'fixed inset-x-0 bottom-0 z-50 h-16 items-center justify-around border-t border-border bg-surface',
+          'flex md:!hidden', // Force hide on desktop
+          className
+        )}
+        style={{ display: 'var(--mobile-nav-display, flex)' }}
+        role="navigation"
+        aria-label="Mobile navigation"
+      >
+        {/* Primary nav items */}
+        {primary.map((item) => {
+          const Icon = item.icon;
+          const isActive = activeItem === item.id;
+
+          return (
+            <button
+              key={item.id}
+              type="button"
+              onClick={() => handleItemClick(item)}
+              className={cn(
+                'flex flex-col items-center justify-center gap-1 px-3 py-2 text-muted-foreground transition-colors hover:text-foreground',
+                isActive && 'text-primary'
+              )}
+              aria-current={isActive ? 'page' : undefined}
+            >
+              <Icon className="size-5" />
+              <span className="text-[10px] font-medium">{item.label}</span>
+            </button>
+          );
+        })}
+
+        {/* More button (if overflow items exist) */}
+        {hasOverflow && (
           <button
-            key={item.id}
             type="button"
-            onClick={() => {
-              item.onClick?.();
-              onItemClick?.(item);
-            }}
+            onClick={handleMoreClick}
             className={cn(
               'flex flex-col items-center justify-center gap-1 px-3 py-2 text-muted-foreground transition-colors hover:text-foreground',
-              isActive && 'text-primary'
+              (moreMenuOpen || isOverflowActive) && 'text-primary'
             )}
-            aria-current={isActive ? 'page' : undefined}
+            aria-expanded={moreMenuOpen}
+            aria-haspopup="menu"
+            aria-label="More options"
           >
-            <Icon className="size-5" />
-            <span className="text-[10px] font-medium">{item.label}</span>
+            {moreMenuOpen ? <X className="size-5" /> : <MoreHorizontal className="size-5" />}
+            <span className="text-[10px] font-medium">More</span>
           </button>
-        );
-      })}
-    </nav>
+        )}
+      </nav>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
Restore Timeline and Search access in mobile navigation by adding an expandable "More" menu.

- Split nav items into primary (4: Activity, Projects, Notes, People) and overflow (Timeline, Search)
- Add "More" button that toggles an overflow menu panel above the nav bar
- Add backdrop overlay for closing menu when tapping outside
- Highlight More button when an overflow item is active
- Auto-close menu after selecting an item

This maintains a clean 5-item mobile nav layout while keeping all navigation features accessible.

Closes #672

## Test plan
- [x] Run `pnpm exec vitest run tests/ui/routing.test.tsx` - all 13 tests pass
- [x] Run `pnpm exec vitest run tests/ui/mobile.test.tsx` - all 19 tests pass
- [ ] Manual test: Tap "More" button - should show Timeline and Search options
- [ ] Manual test: Tap Timeline - should navigate to /timeline and close menu
- [ ] Manual test: Tap outside menu - should close menu

Generated with [Claude Code](https://claude.com/claude-code)