### PR TITLE
[#656] Add client-side input validation before API calls

### DIFF
--- a/src/ui/lib/validation.ts
+++ b/src/ui/lib/validation.ts
@@ -1,0 +1,176 @@
+/**
+ * Client-side validation utilities for notes and notebooks.
+ *
+ * Provides early validation before API calls to:
+ * - Give faster feedback to users
+ * - Reduce unnecessary network requests
+ * - Catch obvious errors client-side
+ *
+ * Part of Epic #338, Issue #656
+ */
+
+/** Validation result type */
+export interface ValidationResult {
+  valid: boolean;
+  errors: string[];
+}
+
+/** Note validation constants */
+export const NOTE_VALIDATION = {
+  /** Maximum title length in characters */
+  MAX_TITLE_LENGTH: 500,
+  /** Maximum content length in characters (100KB of text) */
+  MAX_CONTENT_LENGTH: 100_000,
+  /** Maximum number of tags */
+  MAX_TAGS: 20,
+  /** Maximum tag length */
+  MAX_TAG_LENGTH: 50,
+} as const;
+
+/** Notebook validation constants */
+export const NOTEBOOK_VALIDATION = {
+  /** Maximum name length in characters */
+  MAX_NAME_LENGTH: 100,
+  /** Maximum description length in characters */
+  MAX_DESCRIPTION_LENGTH: 500,
+} as const;
+
+/** Email validation regex (simple but effective) */
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/**
+ * Validate note creation/update data.
+ *
+ * @param data - Note data to validate
+ * @returns Validation result with any errors
+ */
+export function validateNote(data: {
+  title: string;
+  content?: string;
+  notebookId?: string;
+  tags?: string[];
+}): ValidationResult {
+  const errors: string[] = [];
+
+  // Title validation
+  const trimmedTitle = data.title.trim();
+  if (!trimmedTitle) {
+    errors.push('Title is required');
+  } else if (trimmedTitle.length > NOTE_VALIDATION.MAX_TITLE_LENGTH) {
+    errors.push(
+      `Title must be ${NOTE_VALIDATION.MAX_TITLE_LENGTH} characters or less`
+    );
+  }
+
+  // Content validation (optional but has max length)
+  if (data.content && data.content.length > NOTE_VALIDATION.MAX_CONTENT_LENGTH) {
+    errors.push(
+      `Content must be ${NOTE_VALIDATION.MAX_CONTENT_LENGTH.toLocaleString()} characters or less`
+    );
+  }
+
+  // Notebook ID validation (if provided, must be non-empty)
+  if (data.notebookId !== undefined && data.notebookId !== null) {
+    const trimmedNotebookId = data.notebookId.trim();
+    if (trimmedNotebookId.length === 0) {
+      errors.push('Notebook ID cannot be empty');
+    }
+  }
+
+  // Tags validation
+  if (data.tags) {
+    if (data.tags.length > NOTE_VALIDATION.MAX_TAGS) {
+      errors.push(`Maximum ${NOTE_VALIDATION.MAX_TAGS} tags allowed`);
+    }
+    for (const tag of data.tags) {
+      if (tag.length > NOTE_VALIDATION.MAX_TAG_LENGTH) {
+        errors.push(
+          `Tag "${tag.slice(0, 20)}..." exceeds ${NOTE_VALIDATION.MAX_TAG_LENGTH} characters`
+        );
+        break; // Only report first tag error
+      }
+    }
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+  };
+}
+
+/**
+ * Validate notebook creation/update data.
+ *
+ * @param data - Notebook data to validate
+ * @returns Validation result with any errors
+ */
+export function validateNotebook(data: {
+  name: string;
+  description?: string;
+  color?: string;
+}): ValidationResult {
+  const errors: string[] = [];
+
+  // Name validation
+  const trimmedName = data.name.trim();
+  if (!trimmedName) {
+    errors.push('Name is required');
+  } else if (trimmedName.length > NOTEBOOK_VALIDATION.MAX_NAME_LENGTH) {
+    errors.push(
+      `Name must be ${NOTEBOOK_VALIDATION.MAX_NAME_LENGTH} characters or less`
+    );
+  }
+
+  // Description validation (optional)
+  if (
+    data.description &&
+    data.description.length > NOTEBOOK_VALIDATION.MAX_DESCRIPTION_LENGTH
+  ) {
+    errors.push(
+      `Description must be ${NOTEBOOK_VALIDATION.MAX_DESCRIPTION_LENGTH} characters or less`
+    );
+  }
+
+  // Color validation (if provided, should be valid hex color)
+  if (data.color && !/^#[0-9A-Fa-f]{6}$/.test(data.color)) {
+    errors.push('Color must be a valid hex color (e.g., #6366f1)');
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+  };
+}
+
+/**
+ * Validate email address for sharing.
+ *
+ * @param email - Email address to validate
+ * @returns Validation result with any errors
+ */
+export function validateEmail(email: string): ValidationResult {
+  const errors: string[] = [];
+
+  const trimmedEmail = email.trim();
+  if (!trimmedEmail) {
+    errors.push('Email is required');
+  } else if (!EMAIL_REGEX.test(trimmedEmail)) {
+    errors.push('Please enter a valid email address');
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+  };
+}
+
+/**
+ * Create a validation error message from a ValidationResult.
+ *
+ * @param result - Validation result
+ * @returns Combined error message or empty string if valid
+ */
+export function getValidationErrorMessage(result: ValidationResult): string {
+  if (result.valid) return '';
+  return result.errors.join('. ');
+}

--- a/src/ui/pages/NotesPage.tsx
+++ b/src/ui/pages/NotesPage.tsx
@@ -81,6 +81,10 @@ import type {
   Note as UINote,
   Notebook as UINotebook,
 } from '@/ui/components/notes/types';
+import {
+  validateNote,
+  getValidationErrorMessage,
+} from '@/ui/lib/validation';
 
 export function NotesPage(): React.JSX.Element {
   // URL params for deep linking
@@ -240,6 +244,18 @@ export function NotesPage(): React.JSX.Element {
       visibility: NoteVisibility;
       hideFromAgents: boolean;
     }) => {
+      // Client-side validation before API call (#656)
+      const validation = validateNote({
+        title: data.title,
+        content: data.content,
+        notebookId: data.notebookId,
+      });
+
+      if (!validation.valid) {
+        // Throw error with validation message for consumer to handle
+        throw new Error(getValidationErrorMessage(validation));
+      }
+
       if (view.type === 'new') {
         const body: CreateNoteBody = {
           title: data.title,


### PR DESCRIPTION
## Summary
- Create `validation.ts` module with utility functions for validating notes, notebooks, and email addresses
- Add validation constants for max lengths (title: 500 chars, content: 100K chars, tags: 20 max, etc.)
- Integrate `validateNote` into `handleSaveNote` with early error throw for consumer handling
- Add `validateNotebook` to `NotebookFormDialog` with real-time validation feedback
- Replace hardcoded color value with `DEFAULT_NOTEBOOK_COLOR` constant (also addresses #662)
- Show validation errors in UI before making unnecessary API calls

Closes #656
Closes #662

## Test Plan
- [ ] Create note with empty title - should show validation error
- [ ] Create note with title over 500 chars - should show validation error
- [ ] Create note with content over 100K chars - should show validation error
- [ ] Create notebook with empty name - should show validation error
- [ ] Create notebook with name over 100 chars - should show validation error
- [ ] Valid inputs should proceed to API call as normal

Generated with Claude Code