### PR TITLE
[#701] Add UUID validation for noteId in presence API

### DIFF
--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -11140,12 +11140,19 @@ export function buildServer(options: ProjectsApiOptions = {}): FastifyInstance {
   // POST /api/notes/:id/presence - Join note presence (start viewing)
   // Security: user_email moved from query params to body (#689)
   // Type validation added (#697)
+  // UUID validation added (#701)
   app.post('/api/notes/:id/presence', async (req, reply) => {
     const {
       joinNotePresence,
     } = await import('./notes/index.ts');
 
     const params = req.params as { id: string };
+
+    // Validate noteId is a valid UUID (#701)
+    if (!isValidUUID(params.id)) {
+      return reply.code(400).send({ error: 'Invalid note ID format' });
+    }
+
     const body = req.body as {
       userEmail?: unknown;
       cursorPosition?: unknown;
@@ -11203,12 +11210,19 @@ export function buildServer(options: ProjectsApiOptions = {}): FastifyInstance {
   // DELETE /api/notes/:id/presence - Leave note presence (stop viewing)
   // Security: user_email moved from query params to X-User-Email header (#689)
   // Type validation added (#697)
+  // UUID validation added (#701)
   app.delete('/api/notes/:id/presence', async (req, reply) => {
     const {
       leaveNotePresence,
     } = await import('./notes/index.ts');
 
     const params = req.params as { id: string };
+
+    // Validate noteId is a valid UUID (#701)
+    if (!isValidUUID(params.id)) {
+      return reply.code(400).send({ error: 'Invalid note ID format' });
+    }
+
     const userEmailHeader = req.headers['x-user-email'];
 
     // Validate header is a string (not array) and non-empty (#697)
@@ -11230,12 +11244,19 @@ export function buildServer(options: ProjectsApiOptions = {}): FastifyInstance {
   // GET /api/notes/:id/presence - Get current viewers
   // Security: user_email moved from query params to X-User-Email header (#689)
   // Type validation added (#697)
+  // UUID validation added (#701)
   app.get('/api/notes/:id/presence', async (req, reply) => {
     const {
       getNotePresence,
     } = await import('./notes/index.ts');
 
     const params = req.params as { id: string };
+
+    // Validate noteId is a valid UUID (#701)
+    if (!isValidUUID(params.id)) {
+      return reply.code(400).send({ error: 'Invalid note ID format' });
+    }
+
     const userEmailHeader = req.headers['x-user-email'];
 
     // Validate header is a string (not array) and non-empty (#697)
@@ -11263,12 +11284,19 @@ export function buildServer(options: ProjectsApiOptions = {}): FastifyInstance {
   // PUT /api/notes/:id/presence/cursor - Update cursor position
   // Security: user_email moved from query params to body (#689)
   // Type validation added (#697)
+  // UUID validation added (#701)
   app.put('/api/notes/:id/presence/cursor', async (req, reply) => {
     const {
       updateCursorPosition,
     } = await import('./notes/index.ts');
 
     const params = req.params as { id: string };
+
+    // Validate noteId is a valid UUID (#701)
+    if (!isValidUUID(params.id)) {
+      return reply.code(400).send({ error: 'Invalid note ID format' });
+    }
+
     const body = req.body as {
       userEmail?: unknown;
       cursorPosition?: unknown;

--- a/tests/note_presence_uuid_validation.test.ts
+++ b/tests/note_presence_uuid_validation.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Tests for UUID validation in note presence API endpoints.
+ * Part of Issue #701.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { Pool } from 'pg';
+import { buildServer } from '../src/api/server.ts';
+import { runMigrate } from './helpers/migrate.ts';
+import { createTestPool, truncateAllTables } from './helpers/db.ts';
+
+describe('Note Presence API - UUID Validation (Issue #701)', () => {
+  const app = buildServer();
+  let pool: Pool;
+  const testUserEmail = 'test@example.com';
+  const validUUID = '00000000-0000-0000-0000-000000000000';
+  const invalidUUIDs = [
+    'not-a-uuid',
+    '123',
+    '',
+    'ZZZZZ-ZZZZZ-ZZZZZ-ZZZZZ-ZZZZZ',
+    '00000000-0000-0000-0000-00000000000g', // Invalid hex char
+    '00000000-0000-0000-0000-0000000000000', // Too long
+    '00000000-0000-0000-0000-00000000000', // Too short
+    'sql-injection-attempt',
+    "'; DROP TABLE notes; --",
+    '../../../etc/passwd',
+  ];
+
+  beforeAll(async () => {
+    await runMigrate('up');
+    pool = createTestPool();
+    await app.ready();
+  });
+
+  beforeEach(async () => {
+    await truncateAllTables(pool);
+  });
+
+  afterAll(async () => {
+    await app.close();
+    await pool.end();
+  });
+
+  describe('POST /api/notes/:id/presence - UUID Validation', () => {
+    for (const invalidId of invalidUUIDs) {
+      it(`returns 400 for invalid UUID: "${invalidId.slice(0, 30)}..."`, async () => {
+        const res = await app.inject({
+          method: 'POST',
+          url: `/api/notes/${encodeURIComponent(invalidId)}/presence`,
+          payload: { userEmail: testUserEmail },
+        });
+
+        expect(res.statusCode).toBe(400);
+        expect(res.json().error).toContain('Invalid note ID format');
+      });
+    }
+
+    it('accepts valid UUID format', async () => {
+      // Create a note first
+      const noteResult = await pool.query(
+        `INSERT INTO note (user_email, title, content)
+         VALUES ($1, 'Test Note', 'Test content')
+         RETURNING id::text as id`,
+        [testUserEmail]
+      );
+      const noteId = (noteResult.rows[0] as { id: string }).id;
+
+      const res = await app.inject({
+        method: 'POST',
+        url: `/api/notes/${noteId}/presence`,
+        payload: { userEmail: testUserEmail },
+      });
+
+      expect(res.statusCode).toBe(200);
+    });
+  });
+
+  describe('DELETE /api/notes/:id/presence - UUID Validation', () => {
+    for (const invalidId of invalidUUIDs) {
+      it(`returns 400 for invalid UUID: "${invalidId.slice(0, 30)}..."`, async () => {
+        const res = await app.inject({
+          method: 'DELETE',
+          url: `/api/notes/${encodeURIComponent(invalidId)}/presence`,
+          headers: { 'x-user-email': testUserEmail },
+        });
+
+        expect(res.statusCode).toBe(400);
+        expect(res.json().error).toContain('Invalid note ID format');
+      });
+    }
+
+    it('accepts valid UUID format', async () => {
+      // Create a note first
+      const noteResult = await pool.query(
+        `INSERT INTO note (user_email, title, content)
+         VALUES ($1, 'Test Note', 'Test content')
+         RETURNING id::text as id`,
+        [testUserEmail]
+      );
+      const noteId = (noteResult.rows[0] as { id: string }).id;
+
+      const res = await app.inject({
+        method: 'DELETE',
+        url: `/api/notes/${noteId}/presence`,
+        headers: { 'x-user-email': testUserEmail },
+      });
+
+      expect(res.statusCode).toBe(204);
+    });
+  });
+
+  describe('GET /api/notes/:id/presence - UUID Validation', () => {
+    for (const invalidId of invalidUUIDs) {
+      it(`returns 400 for invalid UUID: "${invalidId.slice(0, 30)}..."`, async () => {
+        const res = await app.inject({
+          method: 'GET',
+          url: `/api/notes/${encodeURIComponent(invalidId)}/presence`,
+          headers: { 'x-user-email': testUserEmail },
+        });
+
+        expect(res.statusCode).toBe(400);
+        expect(res.json().error).toContain('Invalid note ID format');
+      });
+    }
+
+    it('accepts valid UUID format', async () => {
+      // Create a note first
+      const noteResult = await pool.query(
+        `INSERT INTO note (user_email, title, content)
+         VALUES ($1, 'Test Note', 'Test content')
+         RETURNING id::text as id`,
+        [testUserEmail]
+      );
+      const noteId = (noteResult.rows[0] as { id: string }).id;
+
+      const res = await app.inject({
+        method: 'GET',
+        url: `/api/notes/${noteId}/presence`,
+        headers: { 'x-user-email': testUserEmail },
+      });
+
+      expect(res.statusCode).toBe(200);
+    });
+  });
+
+  describe('PUT /api/notes/:id/presence/cursor - UUID Validation', () => {
+    for (const invalidId of invalidUUIDs) {
+      it(`returns 400 for invalid UUID: "${invalidId.slice(0, 30)}..."`, async () => {
+        const res = await app.inject({
+          method: 'PUT',
+          url: `/api/notes/${encodeURIComponent(invalidId)}/presence/cursor`,
+          payload: {
+            userEmail: testUserEmail,
+            cursorPosition: { line: 1, column: 1 },
+          },
+        });
+
+        expect(res.statusCode).toBe(400);
+        expect(res.json().error).toContain('Invalid note ID format');
+      });
+    }
+
+    it('accepts valid UUID format', async () => {
+      // Create a note first
+      const noteResult = await pool.query(
+        `INSERT INTO note (user_email, title, content)
+         VALUES ($1, 'Test Note', 'Test content')
+         RETURNING id::text as id`,
+        [testUserEmail]
+      );
+      const noteId = (noteResult.rows[0] as { id: string }).id;
+
+      // Join presence first
+      await app.inject({
+        method: 'POST',
+        url: `/api/notes/${noteId}/presence`,
+        payload: { userEmail: testUserEmail },
+      });
+
+      const res = await app.inject({
+        method: 'PUT',
+        url: `/api/notes/${noteId}/presence/cursor`,
+        payload: {
+          userEmail: testUserEmail,
+          cursorPosition: { line: 1, column: 1 },
+        },
+      });
+
+      expect(res.statusCode).toBe(204);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add isValidUUID() validation for noteId parameter in all presence endpoints
- POST /api/notes/:id/presence
- DELETE /api/notes/:id/presence
- GET /api/notes/:id/presence
- PUT /api/notes/:id/presence/cursor

## Test plan
- [x] New tests in `tests/note_presence_uuid_validation.test.ts` (44 tests)
- [x] Tests verify invalid UUIDs return 400 "Invalid note ID format"
- [x] Tests include SQL injection attempts, path traversal, malformed strings
- [x] Tests verify valid UUIDs are accepted

Closes #701

Generated with [Claude Code](https://claude.com/claude-code)