### PR TITLE
[#693,#695,#699,#700,#664,#676] Fix presence and error handling issues

### DIFF
--- a/src/ui/components/error-boundary.tsx
+++ b/src/ui/components/error-boundary.tsx
@@ -1,0 +1,139 @@
+/**
+ * React Error Boundary component for graceful error handling.
+ * Part of Epic #338, Issue #664.
+ *
+ * Catches JavaScript errors anywhere in the child component tree,
+ * logs those errors, and displays a fallback UI.
+ */
+
+import { Component, type ReactNode, type ErrorInfo } from 'react';
+import { AlertCircle, RefreshCw } from 'lucide-react';
+import { Button } from '@/ui/components/ui/button';
+import { Card, CardContent } from '@/ui/components/ui/card';
+
+interface ErrorBoundaryProps {
+  /** Child components to render */
+  children: ReactNode;
+  /** Optional fallback component to render on error */
+  fallback?: ReactNode;
+  /** Callback when an error is caught */
+  onError?: (error: Error, errorInfo: ErrorInfo) => void;
+  /** Optional title for the error state */
+  title?: string;
+  /** Optional description for the error state */
+  description?: string;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+}
+
+/**
+ * Error Boundary component that catches errors in child components.
+ * Required to be a class component per React documentation.
+ *
+ * @example
+ * ```tsx
+ * <ErrorBoundary
+ *   title="Something went wrong"
+ *   description="Please try refreshing the page."
+ *   onError={(error) => logError(error)}
+ * >
+ *   <SomeComponent />
+ * </ErrorBoundary>
+ * ```
+ */
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    // Update state so the next render shows the fallback UI
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    // Log in development only to avoid information leakage in production (#693)
+    if (import.meta.env.DEV) {
+      // eslint-disable-next-line no-console
+      console.error('[ErrorBoundary] Error caught:', error, errorInfo);
+    }
+
+    // Call optional error callback
+    this.props.onError?.(error, errorInfo);
+  }
+
+  handleReset = (): void => {
+    this.setState({ hasError: false, error: null });
+  };
+
+  render(): ReactNode {
+    const { hasError, error } = this.state;
+    const { children, fallback, title, description } = this.props;
+
+    if (hasError) {
+      // Use custom fallback if provided
+      if (fallback) {
+        return fallback;
+      }
+
+      // Default error UI
+      return (
+        <div
+          className="flex h-full min-h-[200px] items-center justify-center p-6"
+          data-testid="error-boundary-fallback"
+        >
+          <Card className="max-w-md">
+            <CardContent className="p-6">
+              <div className="flex flex-col items-center text-center">
+                <div className="mb-4 rounded-full bg-destructive/10 p-3">
+                  <AlertCircle className="size-6 text-destructive" aria-hidden="true" />
+                </div>
+                <h2 className="mb-2 text-lg font-semibold">
+                  {title ?? 'Something went wrong'}
+                </h2>
+                <p className="mb-4 text-sm text-muted-foreground">
+                  {description ?? 'An unexpected error occurred. Please try refreshing the page.'}
+                </p>
+                {import.meta.env.DEV && error && (
+                  <details className="mb-4 w-full text-left">
+                    <summary className="cursor-pointer text-xs text-muted-foreground">
+                      Error details
+                    </summary>
+                    <pre className="mt-2 max-h-32 overflow-auto rounded bg-muted p-2 text-xs">
+                      {error.message}
+                      {'\n'}
+                      {error.stack}
+                    </pre>
+                  </details>
+                )}
+                <div className="flex gap-2">
+                  <Button
+                    variant="outline"
+                    onClick={this.handleReset}
+                    aria-label="Try again"
+                  >
+                    <RefreshCw className="mr-2 size-4" aria-hidden="true" />
+                    Try Again
+                  </Button>
+                  <Button
+                    variant="default"
+                    onClick={() => window.location.reload()}
+                    aria-label="Refresh page"
+                  >
+                    Refresh Page
+                  </Button>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      );
+    }
+
+    return children;
+  }
+}

--- a/src/ui/components/notes/editor/lexical-editor.tsx
+++ b/src/ui/components/notes/editor/lexical-editor.tsx
@@ -1281,7 +1281,11 @@ const theme = {
 };
 
 function onError(error: Error): void {
-  console.error('[LexicalEditor]', error);
+  // Log in development only to avoid information leakage in production (#676)
+  if (import.meta.env.DEV) {
+    // eslint-disable-next-line no-console
+    console.error('[LexicalEditor]', error);
+  }
 }
 
 /**
@@ -1369,7 +1373,11 @@ function MermaidRenderer({
           if (!isMounted) return;
 
           // Show error message in the placeholder (escaped for safety)
-          console.error('[MermaidRenderer]', error);
+          // Log in development only to avoid information leakage in production (#676)
+          if (import.meta.env.DEV) {
+            // eslint-disable-next-line no-console
+            console.error('[MermaidRenderer]', error);
+          }
           const errorMessage = error instanceof Error ? error.message : 'Unknown error';
 
           // Clear placeholder

--- a/src/ui/pages/NotesPage.tsx
+++ b/src/ui/pages/NotesPage.tsx
@@ -1,6 +1,6 @@
 /**
  * Notes page component.
- * Part of Epic #338, Issues #624, #625
+ * Part of Epic #338, Issues #624, #625, #664 (Error Boundary)
  *
  * Primary notes interface with three-panel layout:
  * - Notebooks sidebar (collapsible)
@@ -15,8 +15,8 @@
  * - /notebooks/:notebookId - Notes in specific notebook
  * - /notebooks/:notebookId/notes/:noteId - Note in context of notebook
  */
-import { useState, useCallback, useMemo, useEffect, useRef } from 'react';
-import { useParams, useNavigate } from 'react-router';
+import { useState, useCallback, useMemo, useEffect, useRef, type ErrorInfo } from 'react';
+import { useParams, useNavigate, useLocation } from 'react-router';
 import { ArrowLeft } from 'lucide-react';
 import { cn, validateUrlParam } from '@/ui/lib/utils';
 import { Button } from '@/ui/components/ui/button';
@@ -35,6 +35,7 @@ import {
   EmptyState,
 } from '@/ui/components/feedback';
 import { Card, CardContent } from '@/ui/components/ui/card';
+import { ErrorBoundary } from '@/ui/components/error-boundary';
 
 // Notes components
 import {
@@ -86,7 +87,36 @@ import {
   getValidationErrorMessage,
 } from '@/ui/lib/validation';
 
+/**
+ * Error handler for the Notes page error boundary.
+ * Logs errors in development mode only (#693).
+ */
+function handleNotesPageError(error: Error, errorInfo: ErrorInfo): void {
+  // Log in development only to avoid information leakage in production
+  if (import.meta.env.DEV) {
+    // eslint-disable-next-line no-console
+    console.error('[NotesPage] Error caught by boundary:', error, errorInfo);
+  }
+  // TODO: Add error reporting service integration (#664)
+}
+
+/**
+ * Notes page with error boundary wrapper.
+ * Issue #664: Adds graceful error handling for the Notes page.
+ */
 export function NotesPage(): React.JSX.Element {
+  return (
+    <ErrorBoundary
+      title="Notes Error"
+      description="Something went wrong loading your notes. Please try again."
+      onError={handleNotesPageError}
+    >
+      <NotesPageContent />
+    </ErrorBoundary>
+  );
+}
+
+function NotesPageContent(): React.JSX.Element {
   // URL params for deep linking - validate to prevent malformed URLs
   const { noteId: rawNoteId, notebookId: rawNotebookId } = useParams<{
     noteId?: string;


### PR DESCRIPTION
## Summary

This PR addresses multiple UI component issues from Epic #338 code review:

- **#693**: Wrap console.error in production presence code with DEV checks to prevent information leakage
- **#695**: Implement 4 todo tests for useNotePresence hook (joins on mount, leaves on unmount, handles WebSocket events, updates cursor)
- **#699**: Add WebSocket reconnection logic - presence automatically re-joins when connection is restored after disconnect
- **#700**: Add stale viewer cleanup - removes viewers who haven't been seen in 5 minutes (checks every minute)
- **#664**: Add React Error Boundary to NotesPage with graceful fallback UI
- **#676**: Fix console.error in Lexical editor production error handler with DEV checks

## Changes

### `src/ui/components/notes/presence/use-note-presence.ts`
- Wrapped console.error calls in `import.meta.env.DEV` checks (#693)
- Added `previousStatusRef` to track WebSocket connection status changes (#699)
- Added reconnection effect that re-joins presence when WebSocket reconnects (#699)
- Added stale cleanup effect with 5-minute threshold and 1-minute interval (#700)

### `src/ui/components/notes/editor/lexical-editor.tsx`
- Wrapped `onError` function console.error in DEV check (#676)
- Wrapped MermaidRenderer error handler console.error in DEV check (#676)

### `src/ui/pages/NotesPage.tsx`
- Added ErrorBoundary wrapper around NotesPageContent (#664)
- Added handleNotesPageError callback with DEV-only logging (#664)

### `src/ui/components/error-boundary.tsx` (new file)
- Created reusable React Error Boundary component (#664)
- Class component with getDerivedStateFromError and componentDidCatch
- Graceful fallback UI with error details in development
- Try Again and Refresh Page buttons

### `tests/ui/note-presence.test.tsx`
- Implemented 4 previously skipped todo tests (#695)
- Tests cover: auto-join, leave on unmount, WebSocket events, cursor updates

## Test plan

- [ ] Verify presence hook tests pass
- [ ] Verify console.error calls don't appear in production builds
- [ ] Test WebSocket reconnection by simulating disconnect/reconnect
- [ ] Test stale viewer cleanup by letting a viewer become stale
- [ ] Trigger an error in NotesPage and verify ErrorBoundary catches it
- [ ] Verify error fallback UI renders correctly

Closes #693
Closes #695
Closes #699
Closes #700
Closes #664
Closes #676

🤖 Generated with [Claude Code](https://claude.com/claude-code)