### PR TITLE
[#650] Add proper types for notebook shares and E2E tests

### DIFF
--- a/src/ui/hooks/queries/use-notebooks.ts
+++ b/src/ui/hooks/queries/use-notebooks.ts
@@ -11,6 +11,7 @@ import type {
   ListNotebooksParams,
   NotebookTreeNode,
   SharedWithMeResponse,
+  NotebookSharesResponse,
 } from '@/ui/lib/api-types.ts';
 
 /** Query key factory for notebooks. */
@@ -136,7 +137,7 @@ export function useNotebookShares(id: string) {
   return useQuery({
     queryKey: notebookKeys.shares(id),
     queryFn: ({ signal }) =>
-      apiClient.get<{ notebookId: string; shares: unknown[] }>(
+      apiClient.get<NotebookSharesResponse>(
         `/api/notebooks/${encodeURIComponent(id)}/shares`,
         { signal }
       ),

--- a/src/ui/lib/api-types.ts
+++ b/src/ui/lib/api-types.ts
@@ -689,6 +689,80 @@ export interface MoveNotesResponse {
 }
 
 // ---------------------------------------------------------------------------
+// Notebook Sharing
+// ---------------------------------------------------------------------------
+
+/** Base notebook share record */
+interface BaseNotebookShare {
+  id: string;
+  notebookId: string;
+  permission: SharePermission;
+  expiresAt: string | null;
+  createdByEmail: string;
+  createdAt: string;
+  lastAccessedAt: string | null;
+}
+
+/** Notebook user share record */
+export interface NotebookUserShare extends BaseNotebookShare {
+  type: 'user';
+  sharedWithEmail: string;
+}
+
+/** Notebook link share record */
+export interface NotebookLinkShare extends BaseNotebookShare {
+  type: 'link';
+  token: string;
+}
+
+/** Union of notebook share types */
+export type NotebookShare = NotebookUserShare | NotebookLinkShare;
+
+/** Response from GET /api/notebooks/:id/shares */
+export interface NotebookSharesResponse {
+  notebookId: string;
+  shares: NotebookShare[];
+}
+
+/** Body for POST /api/notebooks/:id/share (user share) */
+export interface CreateNotebookUserShareBody {
+  email: string;
+  permission?: SharePermission;
+  expiresAt?: string | null;
+}
+
+/** Body for POST /api/notebooks/:id/share/link */
+export interface CreateNotebookLinkShareBody {
+  permission?: SharePermission;
+  expiresAt?: string | null;
+}
+
+/** Response from POST /api/notebooks/:id/share/link */
+export interface CreateNotebookLinkShareResponse extends NotebookLinkShare {
+  url: string;
+}
+
+/** Body for PUT /api/notebooks/:id/shares/:shareId */
+export interface UpdateNotebookShareBody {
+  permission?: SharePermission;
+  expiresAt?: string | null;
+}
+
+/** Entry in shared-with-me notebooks list */
+export interface NotebookSharedWithMeEntry {
+  id: string;
+  name: string;
+  sharedByEmail: string;
+  permission: SharePermission;
+  sharedAt: string;
+}
+
+/** Response from GET /api/notebooks/shared-with-me */
+export interface NotebooksSharedWithMeResponse {
+  notebooks: NotebookSharedWithMeEntry[];
+}
+
+// ---------------------------------------------------------------------------
 // Bootstrap (server-injected data)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Add `NotebookShare` types (`NotebookUserShare`, `NotebookLinkShare`) to `api-types.ts`
- Add `NotebookSharesResponse`, `NotebooksSharedWithMeResponse` types
- Add body types for creating/updating notebook shares
- Replace `unknown[]` with `NotebookSharesResponse` in `useNotebookShares` hook
- Add comprehensive response types to E2E tests:
  - `NoteResponse`, `NotebookResponse` for core entities
  - `NoteShareResponse`, `LinkShareResponse` for sharing
  - `NoteVersionResponse`, `VersionCompareResponse` for versioning
  - `NotesListResponse`, `NotebooksListResponse` for list endpoints
  - `SearchResponse`, `ErrorResponse`, `MoveNotesResponse` for other operations
- Update ~60 `json()` calls to use typed `json<T>()` pattern

## Test plan
- [x] `pnpm run build` passes (no new type errors)
- [x] `pnpm test tests/notebooks_api.test.ts` passes (43/43)
- [x] `pnpm test tests/notes_e2e.test.ts` passes (40/45 - same as main)
- [x] Type inference works correctly in IDE

Closes #650
Closes #707

---
Generated with [Claude Code](https://claude.com/claude-code)