### PR TITLE
[#776] Add user_email to notes and notebooks API calls

### DIFF
--- a/src/ui/app/main.tsx
+++ b/src/ui/app/main.tsx
@@ -16,6 +16,7 @@ import { createRoot } from 'react-dom/client';
 import { createBrowserRouter, RouterProvider } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ThemeProvider } from '@/ui/providers/ThemeProvider';
+import { UserProvider } from '@/ui/contexts/user-context';
 import { routes } from '@/ui/routes';
 
 /** Shared QueryClient instance with default stale time and retry policy. */
@@ -41,7 +42,9 @@ createRoot(el).render(
   <React.StrictMode>
     <ThemeProvider>
       <QueryClientProvider client={queryClient}>
-        <RouterProvider router={router} />
+        <UserProvider>
+          <RouterProvider router={router} />
+        </UserProvider>
       </QueryClientProvider>
     </ThemeProvider>
   </React.StrictMode>,

--- a/src/ui/contexts/user-context.tsx
+++ b/src/ui/contexts/user-context.tsx
@@ -1,0 +1,80 @@
+/**
+ * User context for authentication state.
+ *
+ * Fetches and provides the current user's email from /api/me.
+ * Used by hooks that need to pass user identity to API endpoints.
+ */
+import React, { createContext, useContext, useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { apiClient } from '@/ui/lib/api-client.ts';
+
+interface MeResponse {
+  email: string;
+}
+
+interface UserContextValue {
+  /** Current user's email, or null if not authenticated */
+  email: string | null;
+  /** Whether the user query is loading */
+  isLoading: boolean;
+  /** Whether the user is authenticated */
+  isAuthenticated: boolean;
+}
+
+const UserContext = createContext<UserContextValue | null>(null);
+
+/**
+ * Provider component that fetches and provides user authentication state.
+ */
+export function UserProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}): React.JSX.Element {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['me'],
+    queryFn: async () => {
+      try {
+        return await apiClient.get<MeResponse>('/api/me');
+      } catch {
+        return null;
+      }
+    },
+    retry: false,
+    staleTime: 5 * 60 * 1000, // 5 minutes
+  });
+
+  const value = useMemo<UserContextValue>(
+    () => ({
+      email: data?.email ?? null,
+      isLoading,
+      isAuthenticated: !isError && !!data?.email,
+    }),
+    [data?.email, isLoading, isError]
+  );
+
+  return <UserContext.Provider value={value}>{children}</UserContext.Provider>;
+}
+
+/**
+ * Hook to access the current user's authentication state.
+ *
+ * @returns User context value with email, loading state, and auth status
+ * @throws Error if used outside UserProvider
+ */
+export function useUser(): UserContextValue {
+  const context = useContext(UserContext);
+  if (!context) {
+    throw new Error('useUser must be used within a UserProvider');
+  }
+  return context;
+}
+
+/**
+ * Hook to get just the current user's email.
+ * Returns null if not authenticated or still loading.
+ */
+export function useUserEmail(): string | null {
+  const { email } = useUser();
+  return email;
+}


### PR DESCRIPTION
## Summary
- Creates UserContext to fetch current user email from /api/me
- Adds UserProvider wrapper to main.tsx
- Updates use-notes.ts and use-notebooks.ts to include user_email in API query strings

## Problem
Notes API calls require user_email as a query parameter but the frontend wasn't passing it, causing 'user_email is required' errors when loading notes.

## Test Plan
- [x] Navigate to /app/notes - notes should load without error
- [x] Create/edit notes - API calls should include user_email parameter

Closes #776

🤖 Generated with [Claude Code](https://claude.com/claude-code)