### PR TITLE
[#788] Fix test pool exhaustion

### DIFF
--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -97,7 +97,7 @@ describe('Magic-link auth + sessions', () => {
     const token = new URL(loginUrl).searchParams.get('token');
 
     // Manually expire the token in the database
-    const pool = createPool();
+    const pool = createPool({ max: 3 });
     await pool.query(
       `UPDATE auth_magic_link
           SET expires_at = now() - interval '1 minute'
@@ -205,7 +205,7 @@ describe('Magic-link auth + sessions', () => {
     const sessionCookie = cookieHeader.split(';')[0];
 
     // Manually expire the session
-    const pool = createPool();
+    const pool = createPool({ max: 3 });
     await pool.query(
       `UPDATE auth_session
           SET expires_at = now() - interval '1 minute'
@@ -244,7 +244,7 @@ describe('Magic-link auth + sessions', () => {
     const sessionCookie = cookieHeader.split(';')[0];
 
     // Manually revoke the session
-    const pool = createPool();
+    const pool = createPool({ max: 3 });
     await pool.query(
       `UPDATE auth_session
           SET revoked_at = now()

--- a/tests/bulk_operations_api.test.ts
+++ b/tests/bulk_operations_api.test.ts
@@ -1,21 +1,13 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
 import { Pool } from 'pg';
-import { existsSync } from 'fs';
+import { createTestPool } from './helpers/db.ts';
 
 describe('Bulk Operations API', () => {
   let pool: Pool;
   let testItemIds: string[] = [];
 
   beforeAll(async () => {
-    const defaultHost = existsSync('/.dockerenv') ? 'postgres' : 'localhost';
-    const host = process.env.PGHOST || defaultHost;
-    pool = new Pool({
-      host,
-      port: parseInt(process.env.PGPORT || '5432', 10),
-      user: process.env.PGUSER || 'openclaw',
-      password: process.env.PGPASSWORD || 'openclaw',
-      database: process.env.PGDATABASE || 'openclaw',
-    });
+    pool = createTestPool();
   });
 
   afterAll(async () => {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -1,20 +1,12 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { Pool } from 'pg';
-import { existsSync } from 'fs';
+import { createTestPool } from './helpers/db.ts';
 
 describe('Database connection', () => {
   let pool: Pool | undefined;
 
   beforeAll(() => {
-    const defaultHost = existsSync('/.dockerenv') ? 'postgres' : 'localhost';
-
-    pool = new Pool({
-      host: process.env.PGHOST || defaultHost,
-      port: parseInt(process.env.PGPORT || '5432'),
-      user: process.env.PGUSER || 'openclaw',
-      password: process.env.PGPASSWORD || 'openclaw',
-      database: process.env.PGDATABASE || 'openclaw',
-    });
+    pool = createTestPool();
   });
 
   afterAll(async () => {

--- a/tests/extensions.test.ts
+++ b/tests/extensions.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { Pool } from 'pg';
-import { existsSync } from 'fs';
+import { createTestPool } from './helpers/db.ts';
 import { runMigrate } from './helpers/migrate.ts';
 
 describe('Required Postgres extensions', () => {
@@ -8,16 +8,7 @@ describe('Required Postgres extensions', () => {
 
   beforeAll(async () => {
     await runMigrate('up');
-
-    const defaultHost = existsSync('/.dockerenv') ? 'postgres' : 'localhost';
-
-    pool = new Pool({
-      host: process.env.PGHOST || defaultHost,
-      port: parseInt(process.env.PGPORT || '5432', 10),
-      user: process.env.PGUSER || 'openclaw',
-      password: process.env.PGPASSWORD || 'openclaw',
-      database: process.env.PGDATABASE || 'openclaw',
-    });
+    pool = createTestPool();
   });
 
   afterAll(async () => {

--- a/tests/helpers/db.ts
+++ b/tests/helpers/db.ts
@@ -19,6 +19,7 @@ export function getPoolConfig(): PoolConfig {
     user: process.env.PGUSER || 'openclaw',
     password: process.env.PGPASSWORD || 'openclaw',
     database: process.env.PGDATABASE || 'openclaw',
+    max: 3,
   };
 }
 

--- a/tests/helpers/migrate.ts
+++ b/tests/helpers/migrate.ts
@@ -90,7 +90,7 @@ async function applySql(pool: Pool, file: string): Promise<void> {
  * Uses `schema_migrations` as the source of truth.
  */
 export async function runMigrate(direction: 'up' | 'down', steps?: number): Promise<string> {
-  const pool = new Pool({ connectionString: DATABASE_URL });
+  const pool = new Pool({ connectionString: DATABASE_URL, max: 3 });
 
   try {
     return await withAdvisoryLock(pool, async () => {

--- a/tests/migrations.test.ts
+++ b/tests/migrations.test.ts
@@ -1,22 +1,13 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { Pool } from 'pg';
-import { existsSync } from 'fs';
+import { createTestPool } from './helpers/db.ts';
 import { runMigrate, migrationCount } from './helpers/migrate.ts';
 
 describe('Migrations', () => {
   let pool: Pool;
 
   beforeAll(async () => {
-    const defaultHost = existsSync('/.dockerenv') ? 'postgres' : 'localhost';
-    const host = process.env.PGHOST || defaultHost;
-
-    pool = new Pool({
-      host,
-      port: parseInt(process.env.PGPORT || '5432', 10),
-      user: process.env.PGUSER || 'openclaw',
-      password: process.env.PGPASSWORD || 'openclaw',
-      database: process.env.PGDATABASE || 'openclaw',
-    });
+    pool = createTestPool();
 
     // Reset migrations before tests (best-effort)
     try {
@@ -93,15 +84,7 @@ describe('Migrations', () => {
     // After dropping objects, reconnect to avoid any cached query plans
     // referencing now-dropped relations.
     await pool.end();
-    const defaultHost = existsSync('/.dockerenv') ? 'postgres' : 'localhost';
-    const host = process.env.PGHOST || defaultHost;
-    pool = new Pool({
-      host,
-      port: parseInt(process.env.PGPORT || '5432', 10),
-      user: process.env.PGUSER || 'openclaw',
-      password: process.env.PGPASSWORD || 'openclaw',
-      database: process.env.PGDATABASE || 'openclaw',
-    });
+    pool = createTestPool();
 
     const result = await pool.query(`
       SELECT EXISTS (

--- a/tests/note_embeddings_api.test.ts
+++ b/tests/note_embeddings_api.test.ts
@@ -33,7 +33,7 @@ describe('Note Embeddings API', () => {
 
   beforeAll(async () => {
     app = await buildServer();
-    pool = createPool();
+    pool = createPool({ max: 3 });
 
     // Clean up any existing test data
     await pool.query(`DELETE FROM note WHERE user_email LIKE 'embed-%@example.com'`);

--- a/tests/note_search_api.test.ts
+++ b/tests/note_search_api.test.ts
@@ -38,7 +38,7 @@ describe('Note Search API', () => {
 
   beforeAll(async () => {
     app = await buildServer();
-    pool = createPool();
+    pool = createPool({ max: 3 });
 
     // Clean up any existing test data
     await pool.query(`DELETE FROM note WHERE user_email LIKE 'search-%@example.com'`);

--- a/tests/note_sharing_schema.test.ts
+++ b/tests/note_sharing_schema.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
 import { Pool } from 'pg';
-import { existsSync } from 'fs';
+import { createTestPool } from './helpers/db.ts';
 import { runMigrate } from './helpers/migrate.ts';
 
 /**
@@ -13,16 +13,7 @@ describe('Note Sharing Schema (Migration 041)', () => {
   let testNotebookId: string;
 
   beforeAll(async () => {
-    const defaultHost = existsSync('/.dockerenv') ? 'postgres' : 'localhost';
-    const host = process.env.PGHOST || defaultHost;
-
-    pool = new Pool({
-      host,
-      port: parseInt(process.env.PGPORT || '5432', 10),
-      user: process.env.PGUSER || 'openclaw',
-      password: process.env.PGPASSWORD || 'openclaw',
-      database: process.env.PGDATABASE || 'openclaw',
-    });
+    pool = createTestPool();
 
     // Ensure migrations are applied
     await runMigrate('up');

--- a/tests/note_versions_schema.test.ts
+++ b/tests/note_versions_schema.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
 import { Pool } from 'pg';
-import { existsSync } from 'fs';
+import { createTestPool } from './helpers/db.ts';
 import { runMigrate } from './helpers/migrate.ts';
 
 /**
@@ -12,16 +12,7 @@ describe('Note Versions Schema (Migration 042)', () => {
   let testNoteId: string;
 
   beforeAll(async () => {
-    const defaultHost = existsSync('/.dockerenv') ? 'postgres' : 'localhost';
-    const host = process.env.PGHOST || defaultHost;
-
-    pool = new Pool({
-      host,
-      port: parseInt(process.env.PGPORT || '5432', 10),
-      user: process.env.PGUSER || 'openclaw',
-      password: process.env.PGPASSWORD || 'openclaw',
-      database: process.env.PGDATABASE || 'openclaw',
-    });
+    pool = createTestPool();
 
     // Ensure migrations are applied
     await runMigrate('up');

--- a/tests/note_work_item_references_schema.test.ts
+++ b/tests/note_work_item_references_schema.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
 import { Pool } from 'pg';
-import { existsSync } from 'fs';
+import { createTestPool } from './helpers/db.ts';
 import { runMigrate } from './helpers/migrate.ts';
 
 /**
@@ -13,16 +13,7 @@ describe('Note Work Item References Schema (Migration 043)', () => {
   let testWorkItemId: string;
 
   beforeAll(async () => {
-    const defaultHost = existsSync('/.dockerenv') ? 'postgres' : 'localhost';
-    const host = process.env.PGHOST || defaultHost;
-
-    pool = new Pool({
-      host,
-      port: parseInt(process.env.PGPORT || '5432', 10),
-      user: process.env.PGUSER || 'openclaw',
-      password: process.env.PGPASSWORD || 'openclaw',
-      database: process.env.PGDATABASE || 'openclaw',
-    });
+    pool = createTestPool();
 
     // Ensure migrations are applied
     await runMigrate('up');

--- a/tests/notes_schema.test.ts
+++ b/tests/notes_schema.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { Pool } from 'pg';
-import { existsSync } from 'fs';
+import { createTestPool } from './helpers/db.ts';
 import { runMigrate, migrationCount } from './helpers/migrate.ts';
 
 /**
@@ -11,16 +11,7 @@ describe('Notes and Notebooks Schema (Migration 040)', () => {
   let pool: Pool;
 
   beforeAll(async () => {
-    const defaultHost = existsSync('/.dockerenv') ? 'postgres' : 'localhost';
-    const host = process.env.PGHOST || defaultHost;
-
-    pool = new Pool({
-      host,
-      port: parseInt(process.env.PGPORT || '5432', 10),
-      user: process.env.PGUSER || 'openclaw',
-      password: process.env.PGPASSWORD || 'openclaw',
-      database: process.env.PGDATABASE || 'openclaw',
-    });
+    pool = createTestPool();
 
     // Ensure migrations are applied
     await runMigrate('up');

--- a/tests/user_settings_api.test.ts
+++ b/tests/user_settings_api.test.ts
@@ -1,20 +1,12 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
 import { Pool } from 'pg';
-import { existsSync } from 'fs';
+import { createTestPool } from './helpers/db.ts';
 
 describe('User Settings API', () => {
   let pool: Pool;
 
   beforeAll(async () => {
-    const defaultHost = existsSync('/.dockerenv') ? 'postgres' : 'localhost';
-    const host = process.env.PGHOST || defaultHost;
-    pool = new Pool({
-      host,
-      port: parseInt(process.env.PGPORT || '5432', 10),
-      user: process.env.PGUSER || 'openclaw',
-      password: process.env.PGPASSWORD || 'openclaw',
-      database: process.env.PGDATABASE || 'openclaw',
-    });
+    pool = createTestPool();
   });
 
   afterAll(async () => {


### PR DESCRIPTION
## Summary

Closes #788

- Set `max: 3` on all test database pools (helpers and direct constructors)
- Consolidated 10 duplicate inline `new Pool({...})` calls across test files into the shared `createTestPool()` helper
- Set `max: 3` on the migration helper pool in `tests/helpers/migrate.ts`
- Tests using the production `createPool()` from `src/db.ts` now pass `{ max: 3 }` explicitly

**Root cause:** Each test pool defaulted to `max: 10` connections. With 268 test files running sequentially, lingering connections from prior files could exhaust PostgreSQL's 100 `max_connections` limit, causing `AggregateError` failures in pg-pool during setup/migration.

**Result:** Full test suite now passes cleanly — 267 files passed, 5341 tests passed, 0 failures (previously 36 test failures + 109 suite-level failures).

## Test plan

- [x] Full test suite passes locally: 267 passed, 1 skipped, 0 failures
- [x] All 5341 individual tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)