### PR TITLE
[#792] Fix pnpm version conflict in npm-publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -24,8 +24,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -69,8 +67,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary

- Remove explicit `version: 10` from `pnpm/action-setup@v4` steps in `npm-publish.yml`
- The action will use the version from `packageManager` field in `package.json` (`pnpm@10.28.1`)

## Root Cause

`pnpm/action-setup@v4` detects both the explicit `version` parameter and the `packageManager` field in `package.json`, causing a conflict error that blocks npm publishing.

Closes #792

## Test plan

- [ ] CI passes (test, build, trivy)
- [ ] After merge, re-tag v0.0.1 to trigger npm publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)