### PR TITLE
[#796] DB migration: skill_store_schedule table

### DIFF
--- a/migrations/051_skill_store_schedule.down.sql
+++ b/migrations/051_skill_store_schedule.down.sql
@@ -1,0 +1,18 @@
+-- Migration 051: Skill Store Schedule Schema (Rollback)
+-- Part of Epic #794, Issue #796
+-- WARNING: This will permanently delete all skill store schedules
+
+-- Remove pgcron job
+DO $do$
+BEGIN
+  PERFORM cron.unschedule('skill_store_schedule_enqueue');
+EXCEPTION WHEN OTHERS THEN NULL;
+END $do$;
+
+-- Remove table first (cascades triggers)
+DROP TABLE IF EXISTS skill_store_schedule;
+
+-- Remove functions (safe now that dependent triggers/table are gone)
+DROP FUNCTION IF EXISTS enqueue_skill_store_scheduled_jobs();
+DROP FUNCTION IF EXISTS update_skill_store_schedule_updated_at();
+DROP FUNCTION IF EXISTS validate_cron_frequency();

--- a/migrations/051_skill_store_schedule.up.sql
+++ b/migrations/051_skill_store_schedule.up.sql
@@ -1,0 +1,205 @@
+-- Migration 051: Skill Store Schedule Schema
+-- Part of Epic #794, Issue #796
+-- Creates recurring skill processing schedules that trigger webhooks via pgcron
+
+-- ============================================================================
+-- SKILL_STORE_SCHEDULE TABLE
+-- ============================================================================
+-- Recurring cron schedules that fire webhooks to OpenClaw for periodic
+-- skill processing (e.g., newsletter generation, data aggregation)
+
+CREATE TABLE IF NOT EXISTS skill_store_schedule (
+  id uuid PRIMARY KEY DEFAULT new_uuid(),
+
+  -- Scope
+  skill_id text NOT NULL,
+  collection text,  -- optional: scope schedule to a specific collection
+
+  -- Schedule definition
+  cron_expression text NOT NULL,
+  timezone text NOT NULL DEFAULT 'UTC',  -- IANA timezone name (e.g., 'America/New_York')
+
+  -- Webhook configuration
+  webhook_url text NOT NULL,
+  webhook_headers jsonb NOT NULL DEFAULT '{}'::jsonb,
+  payload_template jsonb NOT NULL DEFAULT '{}'::jsonb,
+
+  -- State
+  enabled boolean NOT NULL DEFAULT true,
+  max_retries integer NOT NULL DEFAULT 5,
+  last_run_status text CHECK (last_run_status IN ('success', 'failed', 'skipped')),
+  last_run_at timestamptz,
+  next_run_at timestamptz,
+
+  -- Timestamps
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- ============================================================================
+-- CONSTRAINTS
+-- ============================================================================
+
+-- Prevent duplicate schedules for the same skill + collection + cron
+CREATE UNIQUE INDEX idx_skill_store_schedule_unique
+  ON skill_store_schedule (skill_id, collection, cron_expression)
+  WHERE collection IS NOT NULL;
+
+CREATE UNIQUE INDEX idx_skill_store_schedule_unique_no_collection
+  ON skill_store_schedule (skill_id, cron_expression)
+  WHERE collection IS NULL;
+
+-- Validate cron expression frequency: reject expressions firing more than every 5 minutes.
+-- This validates common patterns: */N or N in the minute field where N < 5.
+-- More complex patterns pass but are handled at application layer.
+CREATE OR REPLACE FUNCTION validate_cron_frequency()
+RETURNS trigger AS $$
+DECLARE
+  minute_part text;
+BEGIN
+  -- Extract minute field (first part of cron expression)
+  minute_part := split_part(NEW.cron_expression, ' ', 1);
+
+  -- Reject */N where N < 5 (fires too frequently)
+  IF minute_part ~ '^\*/[0-4]$' THEN
+    RAISE EXCEPTION 'Cron expression fires more frequently than every 5 minutes: %', NEW.cron_expression
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  -- Reject bare * in minute field with * in hour field (every minute)
+  IF minute_part = '*' AND split_part(NEW.cron_expression, ' ', 2) = '*' THEN
+    RAISE EXCEPTION 'Cron expression fires every minute (too frequent): %', NEW.cron_expression
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER skill_store_schedule_cron_frequency_check
+  BEFORE INSERT OR UPDATE ON skill_store_schedule
+  FOR EACH ROW EXECUTE FUNCTION validate_cron_frequency();
+
+-- ============================================================================
+-- INDEXES
+-- ============================================================================
+
+CREATE INDEX idx_skill_store_schedule_skill_id
+  ON skill_store_schedule (skill_id);
+
+CREATE INDEX idx_skill_store_schedule_enabled
+  ON skill_store_schedule (enabled)
+  WHERE enabled = true;
+
+CREATE INDEX idx_skill_store_schedule_next_run
+  ON skill_store_schedule (next_run_at)
+  WHERE enabled = true AND next_run_at IS NOT NULL;
+
+-- ============================================================================
+-- TRIGGERS
+-- ============================================================================
+
+-- Auto-update updated_at
+CREATE OR REPLACE FUNCTION update_skill_store_schedule_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER skill_store_schedule_updated_at_trigger
+  BEFORE UPDATE ON skill_store_schedule
+  FOR EACH ROW EXECUTE FUNCTION update_skill_store_schedule_updated_at();
+
+-- ============================================================================
+-- JOB ENQUEUE FUNCTION
+-- ============================================================================
+
+-- Finds due schedules and enqueues internal_job entries.
+-- Called by pgcron every minute.
+CREATE OR REPLACE FUNCTION enqueue_skill_store_scheduled_jobs()
+RETURNS integer
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_count integer := 0;
+  v_schedule RECORD;
+  v_minute_bucket text;
+  v_idem_key text;
+BEGIN
+  FOR v_schedule IN
+    SELECT id, skill_id, collection, webhook_url, webhook_headers,
+           payload_template, max_retries, last_run_at, last_run_status
+    FROM skill_store_schedule
+    WHERE enabled = true
+      AND (
+        next_run_at IS NULL
+        OR next_run_at <= now()
+      )
+      -- Overlap prevention: skip if previous run still in progress
+      -- (last_run_status IS NULL means never run OR currently running)
+      AND NOT (
+        last_run_status IS NULL
+        AND last_run_at IS NOT NULL
+        AND last_run_at > now() - interval '1 hour'
+      )
+  LOOP
+    -- Use minute-granularity idempotency key to prevent duplicate jobs
+    v_minute_bucket := to_char(now(), 'YYYY-MM-DD-HH24-MI');
+    v_idem_key := 'skill_schedule:' || v_schedule.id::text || ':' || v_minute_bucket;
+
+    PERFORM internal_job_enqueue(
+      'skill_store.scheduled_process',
+      now(),
+      jsonb_build_object(
+        'schedule_id', v_schedule.id::text,
+        'skill_id', v_schedule.skill_id,
+        'collection', v_schedule.collection,
+        'webhook_url', v_schedule.webhook_url,
+        'webhook_headers', v_schedule.webhook_headers,
+        'payload_template', v_schedule.payload_template,
+        'max_retries', v_schedule.max_retries,
+        'triggered_at', now()::text
+      ),
+      v_idem_key
+    );
+
+    -- Mark schedule as running (null status = in progress)
+    UPDATE skill_store_schedule
+    SET last_run_at = now(),
+        last_run_status = NULL
+    WHERE id = v_schedule.id;
+
+    v_count := v_count + 1;
+  END LOOP;
+
+  RETURN v_count;
+END;
+$$;
+
+COMMENT ON FUNCTION enqueue_skill_store_scheduled_jobs IS 'Finds due skill store schedules and enqueues processing jobs with idempotency';
+
+-- Register pgcron job (idempotent)
+DO $do$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'skill_store_schedule_enqueue') THEN
+    PERFORM cron.schedule(
+      'skill_store_schedule_enqueue',
+      '*/1 * * * *',
+      $cmd$SELECT enqueue_skill_store_scheduled_jobs();$cmd$
+    );
+  END IF;
+END $do$;
+
+-- ============================================================================
+-- COMMENTS
+-- ============================================================================
+
+COMMENT ON TABLE skill_store_schedule IS 'Recurring cron schedules for skill processing via webhooks';
+COMMENT ON COLUMN skill_store_schedule.cron_expression IS 'Standard 5-field cron expression (min hour dom month dow)';
+COMMENT ON COLUMN skill_store_schedule.timezone IS 'IANA timezone for cron evaluation (e.g., America/New_York)';
+COMMENT ON COLUMN skill_store_schedule.webhook_url IS 'URL to call when schedule fires';
+COMMENT ON COLUMN skill_store_schedule.payload_template IS 'Template merged with runtime data (skill_id, collection, schedule_id, triggered_at)';
+COMMENT ON COLUMN skill_store_schedule.max_retries IS 'Max consecutive failures before auto-disabling schedule';
+COMMENT ON COLUMN skill_store_schedule.last_run_status IS 'NULL = never run or currently running, success/failed/skipped';

--- a/tests/helpers/db.ts
+++ b/tests/helpers/db.ts
@@ -69,6 +69,7 @@ const APPLICATION_TABLES = [
   'note',
   'notebook',
   // Skill Store (Epic #794)
+  'skill_store_schedule',
   'skill_store_item',
   // Async/queue tables (no FKs today, but still want consistent cleanup)
   'webhook_outbox',

--- a/tests/skill_store_schedule_migration.test.ts
+++ b/tests/skill_store_schedule_migration.test.ts
@@ -1,0 +1,382 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { Pool } from 'pg';
+import { runMigrate } from './helpers/migrate.ts';
+import { createTestPool, truncateAllTables } from './helpers/db.ts';
+
+/**
+ * Tests for skill_store_schedule migration (issue #796).
+ *
+ * Covers:
+ * - Table creation with all columns and correct types
+ * - Unique constraint on (skill_id, collection, cron_expression)
+ * - Cron frequency validation (reject < 5 minutes)
+ * - Job enqueue function with idempotency and overlap prevention
+ * - pgcron job registration
+ * - Updated_at trigger
+ */
+describe('Skill Store Schedule Migration (Issue #796)', () => {
+  let pool: Pool;
+
+  beforeAll(async () => {
+    await runMigrate('up');
+    pool = createTestPool();
+  });
+
+  beforeEach(async () => {
+    await truncateAllTables(pool);
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  describe('Table structure', () => {
+    it('creates skill_store_schedule table', async () => {
+      const result = await pool.query(
+        `SELECT tablename FROM pg_tables
+         WHERE schemaname = 'public' AND tablename = 'skill_store_schedule'`
+      );
+      expect(result.rows).toHaveLength(1);
+    });
+
+    it('has all required columns with correct types', async () => {
+      const result = await pool.query(
+        `SELECT column_name, data_type, is_nullable, column_default
+         FROM information_schema.columns
+         WHERE table_name = 'skill_store_schedule'
+         ORDER BY ordinal_position`
+      );
+
+      const columns = new Map(
+        result.rows.map((r) => [r.column_name, r])
+      );
+
+      expect(columns.get('id')?.data_type).toBe('uuid');
+      expect(columns.get('skill_id')?.is_nullable).toBe('NO');
+      expect(columns.get('collection')?.is_nullable).toBe('YES');
+      expect(columns.get('cron_expression')?.is_nullable).toBe('NO');
+      expect(columns.get('timezone')?.is_nullable).toBe('NO');
+      expect(columns.get('webhook_url')?.is_nullable).toBe('NO');
+      expect(columns.get('webhook_headers')?.data_type).toBe('jsonb');
+      expect(columns.get('payload_template')?.data_type).toBe('jsonb');
+      expect(columns.get('enabled')?.is_nullable).toBe('NO');
+      expect(columns.get('max_retries')?.is_nullable).toBe('NO');
+      expect(columns.get('last_run_status')?.is_nullable).toBe('YES');
+      expect(columns.has('last_run_at')).toBe(true);
+      expect(columns.has('next_run_at')).toBe(true);
+      expect(columns.has('created_at')).toBe(true);
+      expect(columns.has('updated_at')).toBe(true);
+    });
+  });
+
+  describe('Default values', () => {
+    it('defaults timezone to UTC', async () => {
+      const result = await pool.query(
+        `INSERT INTO skill_store_schedule (skill_id, cron_expression, webhook_url)
+         VALUES ('test-skill', '0 9 * * *', 'https://example.com/hook')
+         RETURNING timezone`
+      );
+      expect(result.rows[0].timezone).toBe('UTC');
+    });
+
+    it('defaults enabled to true', async () => {
+      const result = await pool.query(
+        `INSERT INTO skill_store_schedule (skill_id, cron_expression, webhook_url)
+         VALUES ('test-skill', '0 9 * * *', 'https://example.com/hook')
+         RETURNING enabled`
+      );
+      expect(result.rows[0].enabled).toBe(true);
+    });
+
+    it('defaults max_retries to 5', async () => {
+      const result = await pool.query(
+        `INSERT INTO skill_store_schedule (skill_id, cron_expression, webhook_url)
+         VALUES ('test-skill', '0 9 * * *', 'https://example.com/hook')
+         RETURNING max_retries`
+      );
+      expect(result.rows[0].max_retries).toBe(5);
+    });
+
+    it('defaults webhook_headers and payload_template to empty objects', async () => {
+      const result = await pool.query(
+        `INSERT INTO skill_store_schedule (skill_id, cron_expression, webhook_url)
+         VALUES ('test-skill', '0 9 * * *', 'https://example.com/hook')
+         RETURNING webhook_headers, payload_template`
+      );
+      expect(result.rows[0].webhook_headers).toEqual({});
+      expect(result.rows[0].payload_template).toEqual({});
+    });
+  });
+
+  describe('Unique constraint', () => {
+    it('prevents duplicate (skill_id, collection, cron_expression)', async () => {
+      await pool.query(
+        `INSERT INTO skill_store_schedule (skill_id, collection, cron_expression, webhook_url)
+         VALUES ('s1', 'articles', '0 9 * * *', 'https://example.com/hook')`
+      );
+
+      await expect(
+        pool.query(
+          `INSERT INTO skill_store_schedule (skill_id, collection, cron_expression, webhook_url)
+           VALUES ('s1', 'articles', '0 9 * * *', 'https://example.com/hook2')`
+        )
+      ).rejects.toThrow(/duplicate key/);
+    });
+
+    it('allows same cron in different collections', async () => {
+      await pool.query(
+        `INSERT INTO skill_store_schedule (skill_id, collection, cron_expression, webhook_url)
+         VALUES ('s1', 'articles', '0 9 * * *', 'https://example.com/hook')`
+      );
+
+      const result = await pool.query(
+        `INSERT INTO skill_store_schedule (skill_id, collection, cron_expression, webhook_url)
+         VALUES ('s1', 'newsletters', '0 9 * * *', 'https://example.com/hook')
+         RETURNING id`
+      );
+      expect(result.rows).toHaveLength(1);
+    });
+
+    it('handles NULL collection uniqueness correctly', async () => {
+      await pool.query(
+        `INSERT INTO skill_store_schedule (skill_id, cron_expression, webhook_url)
+         VALUES ('s1', '0 9 * * *', 'https://example.com/hook')`
+      );
+
+      await expect(
+        pool.query(
+          `INSERT INTO skill_store_schedule (skill_id, cron_expression, webhook_url)
+           VALUES ('s1', '0 9 * * *', 'https://example.com/hook2')`
+        )
+      ).rejects.toThrow(/duplicate key/);
+    });
+  });
+
+  describe('Cron frequency validation', () => {
+    it('allows cron expressions >= 5 minutes', async () => {
+      const validExpressions = [
+        '*/5 * * * *',
+        '*/10 * * * *',
+        '0 * * * *',
+        '0 9 * * *',
+        '30 8 * * 1-5',
+        '0 0 1 * *',
+      ];
+
+      for (const expr of validExpressions) {
+        const result = await pool.query(
+          `INSERT INTO skill_store_schedule (skill_id, cron_expression, webhook_url)
+           VALUES ($1, $2, 'https://example.com/hook')
+           RETURNING id`,
+          [`skill-${expr.replace(/[^a-z0-9]/g, '')}`, expr]
+        );
+        expect(result.rows).toHaveLength(1);
+      }
+    });
+
+    it('rejects cron expressions < 5 minutes', async () => {
+      const invalidExpressions = [
+        '*/1 * * * *',
+        '*/2 * * * *',
+        '*/3 * * * *',
+        '*/4 * * * *',
+      ];
+
+      for (const expr of invalidExpressions) {
+        await expect(
+          pool.query(
+            `INSERT INTO skill_store_schedule (skill_id, cron_expression, webhook_url)
+             VALUES ('test-skill', $1, 'https://example.com/hook')`,
+            [expr]
+          )
+        ).rejects.toThrow(/fires more frequently than every 5 minutes/);
+      }
+    });
+
+    it('rejects every-minute cron (* * * * *)', async () => {
+      await expect(
+        pool.query(
+          `INSERT INTO skill_store_schedule (skill_id, cron_expression, webhook_url)
+           VALUES ('test-skill', '* * * * *', 'https://example.com/hook')`
+        )
+      ).rejects.toThrow(/fires every minute/);
+    });
+  });
+
+  describe('last_run_status constraint', () => {
+    it('accepts valid status values', async () => {
+      for (const status of ['success', 'failed', 'skipped']) {
+        const result = await pool.query(
+          `INSERT INTO skill_store_schedule (skill_id, cron_expression, webhook_url, last_run_status)
+           VALUES ($1, '0 9 * * *', 'https://example.com/hook', $2)
+           RETURNING last_run_status`,
+          [`skill-${status}`, status]
+        );
+        expect(result.rows[0].last_run_status).toBe(status);
+      }
+    });
+
+    it('rejects invalid status values', async () => {
+      await expect(
+        pool.query(
+          `INSERT INTO skill_store_schedule (skill_id, cron_expression, webhook_url, last_run_status)
+           VALUES ('test', '0 9 * * *', 'https://example.com/hook', 'invalid')`
+        )
+      ).rejects.toThrow(/last_run_status/);
+    });
+
+    it('allows NULL status (never run or in progress)', async () => {
+      const result = await pool.query(
+        `INSERT INTO skill_store_schedule (skill_id, cron_expression, webhook_url)
+         VALUES ('test-skill', '0 9 * * *', 'https://example.com/hook')
+         RETURNING last_run_status`
+      );
+      expect(result.rows[0].last_run_status).toBeNull();
+    });
+  });
+
+  describe('Updated_at trigger', () => {
+    it('auto-updates updated_at on modification', async () => {
+      const insert = await pool.query(
+        `INSERT INTO skill_store_schedule (skill_id, cron_expression, webhook_url)
+         VALUES ('test-skill', '0 9 * * *', 'https://example.com/hook')
+         RETURNING id, updated_at`
+      );
+      const { id, updated_at: original } = insert.rows[0];
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      const update = await pool.query(
+        `UPDATE skill_store_schedule SET enabled = false WHERE id = $1
+         RETURNING updated_at`,
+        [id]
+      );
+
+      expect(new Date(update.rows[0].updated_at).getTime()).toBeGreaterThan(
+        new Date(original).getTime()
+      );
+    });
+  });
+
+  describe('Job enqueue function', () => {
+    it('enqueues jobs for due schedules', async () => {
+      await pool.query(
+        `INSERT INTO skill_store_schedule
+         (skill_id, collection, cron_expression, webhook_url, next_run_at)
+         VALUES ('news-skill', 'articles', '0 */12 * * *', 'https://example.com/hook',
+                 now() - interval '1 minute')`
+      );
+
+      const result = await pool.query(
+        `SELECT enqueue_skill_store_scheduled_jobs() as count`
+      );
+      expect(parseInt(result.rows[0].count)).toBe(1);
+
+      const jobs = await pool.query(
+        `SELECT kind, payload FROM internal_job
+         WHERE kind = 'skill_store.scheduled_process'`
+      );
+      expect(jobs.rows).toHaveLength(1);
+      expect(jobs.rows[0].payload.skill_id).toBe('news-skill');
+      expect(jobs.rows[0].payload.collection).toBe('articles');
+    });
+
+    it('skips disabled schedules', async () => {
+      await pool.query(
+        `INSERT INTO skill_store_schedule
+         (skill_id, cron_expression, webhook_url, enabled, next_run_at)
+         VALUES ('test-skill', '0 9 * * *', 'https://example.com/hook', false,
+                 now() - interval '1 minute')`
+      );
+
+      const result = await pool.query(
+        `SELECT enqueue_skill_store_scheduled_jobs() as count`
+      );
+      expect(parseInt(result.rows[0].count)).toBe(0);
+    });
+
+    it('provides idempotency (no duplicate jobs in same minute)', async () => {
+      await pool.query(
+        `INSERT INTO skill_store_schedule
+         (skill_id, cron_expression, webhook_url, next_run_at)
+         VALUES ('test-skill', '0 9 * * *', 'https://example.com/hook',
+                 now() - interval '1 minute')`
+      );
+
+      await pool.query(`SELECT enqueue_skill_store_scheduled_jobs()`);
+
+      await pool.query(
+        `UPDATE skill_store_schedule
+         SET last_run_at = NULL, last_run_status = 'success'
+         WHERE skill_id = 'test-skill'`
+      );
+
+      await pool.query(`SELECT enqueue_skill_store_scheduled_jobs()`);
+
+      const jobs = await pool.query(
+        `SELECT count(*) FROM internal_job
+         WHERE kind = 'skill_store.scheduled_process'`
+      );
+      expect(parseInt(jobs.rows[0].count)).toBe(1);
+    });
+
+    it('implements overlap prevention', async () => {
+      await pool.query(
+        `INSERT INTO skill_store_schedule
+         (skill_id, cron_expression, webhook_url, last_run_at, last_run_status, next_run_at)
+         VALUES ('test-skill', '0 9 * * *', 'https://example.com/hook',
+                 now() - interval '5 minutes', NULL,
+                 now() - interval '1 minute')`
+      );
+
+      const result = await pool.query(
+        `SELECT enqueue_skill_store_scheduled_jobs() as count`
+      );
+      expect(parseInt(result.rows[0].count)).toBe(0);
+    });
+
+    it('does not prevent overlap for old runs (> 1 hour)', async () => {
+      await pool.query(
+        `INSERT INTO skill_store_schedule
+         (skill_id, cron_expression, webhook_url, last_run_at, last_run_status, next_run_at)
+         VALUES ('test-skill', '0 9 * * *', 'https://example.com/hook',
+                 now() - interval '2 hours', NULL,
+                 now() - interval '1 minute')`
+      );
+
+      const result = await pool.query(
+        `SELECT enqueue_skill_store_scheduled_jobs() as count`
+      );
+      expect(parseInt(result.rows[0].count)).toBe(1);
+    });
+  });
+
+  describe('pgcron job', () => {
+    it('registers skill_store_schedule_enqueue cron job', async () => {
+      const result = await pool.query(
+        `SELECT jobname, schedule FROM cron.job
+         WHERE jobname = 'skill_store_schedule_enqueue'`
+      );
+      expect(result.rows).toHaveLength(1);
+      expect(result.rows[0].schedule).toBe('*/1 * * * *');
+    });
+  });
+
+  describe('Indexes', () => {
+    it('has all required indexes', async () => {
+      const result = await pool.query(
+        `SELECT indexname FROM pg_indexes
+         WHERE tablename = 'skill_store_schedule'
+         ORDER BY indexname`
+      );
+
+      const indexNames = result.rows.map((r) => r.indexname);
+
+      expect(indexNames).toContain('idx_skill_store_schedule_skill_id');
+      expect(indexNames).toContain('idx_skill_store_schedule_enabled');
+      expect(indexNames).toContain('idx_skill_store_schedule_next_run');
+      expect(indexNames).toContain('idx_skill_store_schedule_unique');
+      expect(indexNames).toContain('idx_skill_store_schedule_unique_no_collection');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Creates migration 051 with `skill_store_schedule` table for recurring skill processing
- Timezone-aware cron scheduling (IANA timezone names, defaults to UTC)
- Webhook URL + headers + payload template for OpenClaw hook integration
- Schedule state: enabled/disabled, max_retries, last_run_status, overlap detection
- Unique constraints on (skill_id, collection, cron_expression) with NULL-safe handling
- Trigger-based cron frequency validation (rejects expressions < 5 minutes)
- `enqueue_skill_store_scheduled_jobs()` with minute-granularity idempotency keys
- Overlap prevention (skips schedules where previous run is in progress < 1 hour)
- pgcron job runs every minute to enqueue due schedules
- 23 integration tests + rollback test passes
- Added skill_store_schedule to test helper truncation list

## Test plan

- [x] All 23 integration tests pass
- [x] Migration rollback test passes
- [x] Tested against real PostgreSQL with pg_cron

Closes #796

🤖 Generated with [Claude Code](https://claude.com/claude-code)