### PR TITLE
[#799] Embedding integration for skill store items

### DIFF
--- a/src/api/embeddings/index.ts
+++ b/src/api/embeddings/index.ts
@@ -9,6 +9,7 @@ export * from './service.ts';
 export * from './memory-integration.ts';
 export * from './message-integration.ts';
 export * from './note-integration.ts';
+export * from './skill-store-integration.ts';
 export * from './health.ts';
 export * from './settings.ts';
 export { createProvider, VoyageAIProvider, OpenAIProvider, GeminiProvider } from './providers/index.ts';

--- a/src/api/embeddings/skill-store-integration.ts
+++ b/src/api/embeddings/skill-store-integration.ts
@@ -1,0 +1,370 @@
+/**
+ * Skill Store embedding integration with embedding service.
+ *
+ * This module provides functions to generate and update embeddings
+ * for skill_store_item records, with graceful degradation if embedding fails.
+ *
+ * Part of Epic #794, Issue #799.
+ */
+
+import type { Pool } from 'pg';
+import { embeddingService } from './service.ts';
+import { EmbeddingError } from './errors.ts';
+import type { InternalJob, JobProcessorResult } from '../jobs/types.ts';
+
+/** Embedding status for skill store item records. */
+export type SkillStoreEmbeddingStatus = 'complete' | 'pending' | 'failed';
+
+/** Shape of a skill store item row for embedding purposes. */
+export interface SkillStoreItemForEmbedding {
+  id: string;
+  title: string | null;
+  summary: string | null;
+  content: string | null;
+  embedding_status: string;
+}
+
+/** Stats returned by getSkillStoreEmbeddingStats. */
+export interface SkillStoreEmbeddingStatsResult {
+  total: number;
+  byStatus: {
+    complete: number;
+    pending: number;
+    failed: number;
+  };
+  provider: string | null;
+  model: string | null;
+}
+
+/** Result from backfillSkillStoreEmbeddings. */
+export interface SkillStoreBackfillResult {
+  enqueued: number;
+  skipped: number;
+}
+
+/**
+ * Build embedding text from skill store item fields.
+ *
+ * Priority: summary (preferred) or content (fallback), with title prepended.
+ * This matches the issue spec: "Embedding text derived from: summary (preferred)
+ * or content (fallback), with title prepended."
+ */
+export function buildSkillStoreEmbeddingText(item: {
+  title: string | null;
+  summary: string | null;
+  content: string | null;
+}): string {
+  const bodyText = item.summary ?? item.content ?? '';
+  if (item.title && bodyText) {
+    return `${item.title}\n\n${bodyText}`;
+  }
+  return item.title ?? bodyText;
+}
+
+/**
+ * Generate and store embedding for a skill store item.
+ *
+ * Called after item creation/update. Generates an embedding
+ * asynchronously and updates the record. If embedding fails, the record
+ * is still valid but marked as 'failed' status.
+ *
+ * @param pool Database pool
+ * @param itemId The skill store item ID
+ * @param content The content to embed
+ * @returns The embedding status
+ */
+export async function generateSkillStoreItemEmbedding(
+  pool: Pool,
+  itemId: string,
+  content: string
+): Promise<SkillStoreEmbeddingStatus> {
+  // Check if embedding service is configured
+  if (!embeddingService.isConfigured()) {
+    // Mark as pending — can be backfilled later
+    await pool.query(
+      `UPDATE skill_store_item SET embedding_status = 'pending' WHERE id = $1`,
+      [itemId]
+    );
+    return 'pending';
+  }
+
+  try {
+    const result = await embeddingService.embed(content);
+
+    if (!result) {
+      await pool.query(
+        `UPDATE skill_store_item SET embedding_status = 'pending' WHERE id = $1`,
+        [itemId]
+      );
+      return 'pending';
+    }
+
+    // Store embedding in database
+    await pool.query(
+      `UPDATE skill_store_item
+       SET embedding = $1::vector,
+           embedding_model = $2,
+           embedding_provider = $3,
+           embedding_status = 'complete'
+       WHERE id = $4`,
+      [
+        `[${result.embedding.join(',')}]`,
+        result.model,
+        result.provider,
+        itemId,
+      ]
+    );
+
+    return 'complete';
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    // Pool-closed errors are expected during shutdown/test teardown
+    if (msg.includes('Cannot use a pool after calling end')) {
+      return 'failed';
+    }
+    // Log error but don't fail the request
+    console.error(
+      `[Embeddings] Failed to embed skill store item ${itemId}:`,
+      error instanceof EmbeddingError
+        ? error.toSafeString()
+        : msg
+    );
+
+    // Mark as failed (may also fail if pool is closed, ignore that)
+    await pool.query(
+      `UPDATE skill_store_item SET embedding_status = 'failed' WHERE id = $1`,
+      [itemId]
+    ).catch(() => {});
+
+    return 'failed';
+  }
+}
+
+/**
+ * Enqueue an embedding job for a skill store item.
+ *
+ * Creates an internal_job entry with kind='skill_store.embed'.
+ * Uses idempotency key to prevent duplicate jobs for the same item.
+ *
+ * @param pool Database pool
+ * @param itemId The skill store item ID
+ */
+export async function enqueueSkillStoreEmbedJob(
+  pool: Pool,
+  itemId: string
+): Promise<void> {
+  const idempotencyKey = `skill_store.embed:${itemId}`;
+
+  await pool.query(
+    `INSERT INTO internal_job (kind, payload, idempotency_key)
+     VALUES ('skill_store.embed', $1::jsonb, $2)
+     ON CONFLICT ON CONSTRAINT internal_job_kind_idempotency_uniq DO NOTHING`,
+    [
+      JSON.stringify({ item_id: itemId }),
+      idempotencyKey,
+    ]
+  );
+}
+
+/**
+ * Handle a skill_store.embed job.
+ *
+ * 1. Fetches the item
+ * 2. Builds embedding text from title + summary/content
+ * 3. Generates and stores embedding
+ */
+export async function handleSkillStoreEmbedJob(
+  pool: Pool,
+  job: InternalJob
+): Promise<JobProcessorResult> {
+  const payload = job.payload as { item_id?: string };
+
+  if (!payload.item_id) {
+    return {
+      success: false,
+      error: 'Invalid job payload: missing item_id',
+    };
+  }
+
+  // Fetch item — handle invalid UUID gracefully
+  let result;
+  try {
+    result = await pool.query(
+      `SELECT id::text as id, title, summary, content, embedding_status
+       FROM skill_store_item
+       WHERE id = $1 AND deleted_at IS NULL`,
+      [payload.item_id]
+    );
+  } catch (error) {
+    const err = error as Error;
+    // Handle invalid UUID format
+    if (err.message.includes('invalid input syntax for type uuid')) {
+      return {
+        success: false,
+        error: `Skill store item ${payload.item_id} not found (invalid ID format)`,
+      };
+    }
+    throw error;
+  }
+
+  if (result.rows.length === 0) {
+    return {
+      success: false,
+      error: `Skill store item ${payload.item_id} not found`,
+    };
+  }
+
+  const item = result.rows[0] as SkillStoreItemForEmbedding;
+
+  // Skip if already complete
+  if (item.embedding_status === 'complete') {
+    return { success: true };
+  }
+
+  // Build content for embedding
+  const text = buildSkillStoreEmbeddingText(item);
+
+  if (!text || text.trim().length === 0) {
+    // Nothing to embed — mark as pending (no text content)
+    return { success: true };
+  }
+
+  // Generate embedding
+  const status = await generateSkillStoreItemEmbedding(pool, item.id, text);
+
+  // If status is pending (no provider), that's still success
+  // Job will be retried later or via backfill
+  if (status === 'failed') {
+    return {
+      success: false,
+      error: 'Failed to generate embedding',
+    };
+  }
+
+  console.log(
+    `[Embeddings] Skill store item ${item.id}: status=${status}`
+  );
+
+  return { success: true };
+}
+
+/**
+ * Trigger embedding for a skill store item asynchronously (non-blocking).
+ * This should be called from item create/update operations.
+ *
+ * Enqueues an internal_job rather than firing the embedding inline,
+ * to avoid N concurrent API calls during bulk operations.
+ *
+ * @param pool Database pool
+ * @param itemId The skill store item ID
+ */
+export function triggerSkillStoreItemEmbedding(
+  pool: Pool,
+  itemId: string
+): void {
+  // Enqueue async — don't wait for result
+  enqueueSkillStoreEmbedJob(pool, itemId).catch((err) => {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (msg.includes('Cannot use a pool after calling end')) return;
+    console.error(`[Embeddings] Failed to enqueue skill store embed job for ${itemId}:`, msg);
+  });
+}
+
+/**
+ * Backfill embeddings for skill store items with pending or failed status.
+ *
+ * Instead of calling the embedding API directly, this enqueues internal_job
+ * entries to be processed by the job processor, avoiding N concurrent API calls.
+ *
+ * @param pool Database pool
+ * @param options Backfill options
+ * @returns Number of items enqueued and skipped
+ */
+export async function backfillSkillStoreEmbeddings(
+  pool: Pool,
+  options: {
+    batchSize?: number;
+  } = {}
+): Promise<SkillStoreBackfillResult> {
+  const { batchSize = 100 } = options;
+
+  // Find items with pending or failed embedding status that have text content
+  const result = await pool.query(
+    `SELECT id::text as id, title, summary, content
+     FROM skill_store_item
+     WHERE deleted_at IS NULL
+       AND (embedding_status IS NULL OR embedding_status IN ('pending', 'failed'))
+     ORDER BY created_at ASC
+     LIMIT $1`,
+    [batchSize]
+  );
+
+  let enqueued = 0;
+  let skipped = 0;
+
+  for (const row of result.rows as Array<{ id: string; title: string | null; summary: string | null; content: string | null }>) {
+    const text = buildSkillStoreEmbeddingText(row);
+
+    if (!text || text.trim().length === 0) {
+      skipped++;
+      continue;
+    }
+
+    await enqueueSkillStoreEmbedJob(pool, row.id);
+    enqueued++;
+  }
+
+  return { enqueued, skipped };
+}
+
+/**
+ * Get embedding statistics for skill store items.
+ *
+ * @param pool Database pool
+ * @returns Embedding statistics by status
+ */
+export async function getSkillStoreEmbeddingStats(
+  pool: Pool
+): Promise<SkillStoreEmbeddingStatsResult> {
+  // Get counts by status (excluding soft-deleted items)
+  const statusResult = await pool.query(`
+    SELECT
+      embedding_status,
+      COUNT(*) as count
+    FROM skill_store_item
+    WHERE deleted_at IS NULL
+    GROUP BY embedding_status
+  `);
+
+  const byStatus = {
+    complete: 0,
+    pending: 0,
+    failed: 0,
+  };
+
+  let total = 0;
+  for (const row of statusResult.rows) {
+    const status = row.embedding_status as SkillStoreEmbeddingStatus | null;
+    const count = parseInt(row.count, 10);
+    total += count;
+
+    if (status === 'complete') {
+      byStatus.complete = count;
+    } else if (status === 'failed') {
+      byStatus.failed = count;
+    } else {
+      // null or 'pending'
+      byStatus.pending += count;
+    }
+  }
+
+  // Get current provider/model info
+  const configSummary = embeddingService.getConfig();
+
+  return {
+    total,
+    byStatus,
+    provider: configSummary?.provider ?? null,
+    model: configSummary?.model ?? null,
+  };
+}

--- a/src/api/jobs/processor.ts
+++ b/src/api/jobs/processor.ts
@@ -20,6 +20,7 @@ import {
 import { handleSmsSendJob } from '../twilio/sms-outbound.ts';
 import { handleEmailSendJob } from '../postmark/email-outbound.ts';
 import { handleMessageEmbedJob } from '../embeddings/message-integration.ts';
+import { handleSkillStoreEmbedJob } from '../embeddings/skill-store-integration.ts';
 
 const LOCK_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 const MAX_RETRIES = 5;
@@ -236,6 +237,8 @@ function getJobHandler(
       return (job) => handleEmailSendJob(pool, job);
     case 'message.embed':
       return (job) => handleMessageEmbedJob(pool, job);
+    case 'skill_store.embed':
+      return (job) => handleSkillStoreEmbedJob(pool, job);
     default:
       return null;
   }

--- a/tests/skill_store_embedding.test.ts
+++ b/tests/skill_store_embedding.test.ts
@@ -1,0 +1,493 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import { Pool } from 'pg';
+import { runMigrate } from './helpers/migrate.ts';
+import { createTestPool, truncateAllTables } from './helpers/db.ts';
+
+/**
+ * Tests for skill store embedding integration (issue #799).
+ *
+ * Covers:
+ * - generateSkillStoreItemEmbedding: generate and store embedding for a skill store item
+ * - handleSkillStoreEmbedJob: job handler for skill_store.embed jobs
+ * - backfillSkillStoreEmbeddings: backfill items with pending embedding status
+ * - getSkillStoreEmbeddingStats: return pending/complete/failed counts
+ * - Embedding text derivation: summary (preferred) or content (fallback), with title prepended
+ * - Status tracking: pending → complete or failed
+ * - Bulk operations via internal_job entries
+ */
+describe('Skill Store Embedding Integration (Issue #799)', () => {
+  let pool: Pool;
+
+  beforeAll(async () => {
+    await runMigrate('up');
+    pool = createTestPool();
+  });
+
+  beforeEach(async () => {
+    await truncateAllTables(pool);
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  // Helper to insert a skill store item and return its ID
+  async function insertItem(overrides: {
+    skill_id?: string;
+    title?: string;
+    summary?: string;
+    content?: string;
+    collection?: string;
+    key?: string;
+    embedding_status?: string;
+    tags?: string[];
+    status?: string;
+  } = {}): Promise<string> {
+    const result = await pool.query(
+      `INSERT INTO skill_store_item (skill_id, collection, key, title, summary, content, embedding_status, tags, status)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, COALESCE($9::skill_store_item_status, 'active'))
+       RETURNING id::text as id`,
+      [
+        overrides.skill_id ?? 'test-skill',
+        overrides.collection ?? '_default',
+        overrides.key ?? null,
+        overrides.title ?? null,
+        overrides.summary ?? null,
+        overrides.content ?? null,
+        overrides.embedding_status ?? 'pending',
+        overrides.tags ?? [],
+        overrides.status ?? null,
+      ]
+    );
+    return result.rows[0].id;
+  }
+
+  describe('generateSkillStoreItemEmbedding', () => {
+    it('generates embedding and updates item status', async () => {
+      const { generateSkillStoreItemEmbedding } = await import(
+        '../src/api/embeddings/skill-store-integration.ts'
+      );
+      const { embeddingService } = await import(
+        '../src/api/embeddings/service.ts'
+      );
+
+      const itemId = await insertItem({
+        title: 'Test Item',
+        summary: 'A test summary',
+      });
+
+      const status = await generateSkillStoreItemEmbedding(pool, itemId, 'Test Item\n\nA test summary');
+
+      if (embeddingService.isConfigured()) {
+        // If provider is configured, should succeed
+        expect(status).toBe('complete');
+        const row = await pool.query(
+          `SELECT embedding_status, embedding IS NOT NULL as has_embedding
+           FROM skill_store_item WHERE id = $1`,
+          [itemId]
+        );
+        expect(row.rows[0].embedding_status).toBe('complete');
+        expect(row.rows[0].has_embedding).toBe(true);
+      } else {
+        // If no provider, mark as pending for backfill
+        expect(status).toBe('pending');
+        const row = await pool.query(
+          `SELECT embedding_status FROM skill_store_item WHERE id = $1`,
+          [itemId]
+        );
+        expect(row.rows[0].embedding_status).toBe('pending');
+      }
+    });
+
+    it('handles non-existent item IDs without throwing', async () => {
+      const { generateSkillStoreItemEmbedding } = await import(
+        '../src/api/embeddings/skill-store-integration.ts'
+      );
+
+      // Use a valid UUID format but non-existent item
+      // The function updates 0 rows but doesn't throw
+      const status = await generateSkillStoreItemEmbedding(
+        pool,
+        '00000000-0000-0000-0000-000000000000',
+        'some content'
+      );
+      // Should not throw; returns some valid status
+      expect(['pending', 'failed', 'complete']).toContain(status);
+    });
+  });
+
+  describe('buildEmbeddingText', () => {
+    it('uses title + summary when summary is available', async () => {
+      const { buildSkillStoreEmbeddingText } = await import(
+        '../src/api/embeddings/skill-store-integration.ts'
+      );
+
+      const text = buildSkillStoreEmbeddingText({
+        title: 'My Title',
+        summary: 'My Summary',
+        content: 'Full content here',
+      });
+      expect(text).toBe('My Title\n\nMy Summary');
+    });
+
+    it('uses title + content when summary is not available', async () => {
+      const { buildSkillStoreEmbeddingText } = await import(
+        '../src/api/embeddings/skill-store-integration.ts'
+      );
+
+      const text = buildSkillStoreEmbeddingText({
+        title: 'My Title',
+        summary: null,
+        content: 'Full content here',
+      });
+      expect(text).toBe('My Title\n\nFull content here');
+    });
+
+    it('uses summary alone when title is not available', async () => {
+      const { buildSkillStoreEmbeddingText } = await import(
+        '../src/api/embeddings/skill-store-integration.ts'
+      );
+
+      const text = buildSkillStoreEmbeddingText({
+        title: null,
+        summary: 'My Summary',
+        content: null,
+      });
+      expect(text).toBe('My Summary');
+    });
+
+    it('uses content alone when both title and summary are missing', async () => {
+      const { buildSkillStoreEmbeddingText } = await import(
+        '../src/api/embeddings/skill-store-integration.ts'
+      );
+
+      const text = buildSkillStoreEmbeddingText({
+        title: null,
+        summary: null,
+        content: 'Just content',
+      });
+      expect(text).toBe('Just content');
+    });
+
+    it('returns empty string when all fields are null', async () => {
+      const { buildSkillStoreEmbeddingText } = await import(
+        '../src/api/embeddings/skill-store-integration.ts'
+      );
+
+      const text = buildSkillStoreEmbeddingText({
+        title: null,
+        summary: null,
+        content: null,
+      });
+      expect(text).toBe('');
+    });
+  });
+
+  describe('handleSkillStoreEmbedJob', () => {
+    it('returns failure for missing item_id in payload', async () => {
+      const { handleSkillStoreEmbedJob } = await import(
+        '../src/api/embeddings/skill-store-integration.ts'
+      );
+
+      const result = await handleSkillStoreEmbedJob(pool, {
+        id: 'job-1',
+        kind: 'skill_store.embed',
+        runAt: new Date(),
+        payload: {},
+        attempts: 0,
+        lastError: null,
+        lockedAt: null,
+        lockedBy: null,
+        completedAt: null,
+        idempotencyKey: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('missing item_id');
+    });
+
+    it('returns failure for non-existent item', async () => {
+      const { handleSkillStoreEmbedJob } = await import(
+        '../src/api/embeddings/skill-store-integration.ts'
+      );
+
+      const result = await handleSkillStoreEmbedJob(pool, {
+        id: 'job-2',
+        kind: 'skill_store.embed',
+        runAt: new Date(),
+        payload: { item_id: '00000000-0000-0000-0000-000000000000' },
+        attempts: 0,
+        lastError: null,
+        lockedAt: null,
+        lockedBy: null,
+        completedAt: null,
+        idempotencyKey: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('not found');
+    });
+
+    it('skips items already marked as complete', async () => {
+      const { handleSkillStoreEmbedJob } = await import(
+        '../src/api/embeddings/skill-store-integration.ts'
+      );
+
+      const itemId = await insertItem({
+        title: 'Already embedded',
+        summary: 'Already has embedding',
+        embedding_status: 'complete',
+      });
+
+      const result = await handleSkillStoreEmbedJob(pool, {
+        id: 'job-3',
+        kind: 'skill_store.embed',
+        runAt: new Date(),
+        payload: { item_id: itemId },
+        attempts: 0,
+        lastError: null,
+        lockedAt: null,
+        lockedBy: null,
+        completedAt: null,
+        idempotencyKey: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it('processes a valid item and sets embedding status', async () => {
+      const { handleSkillStoreEmbedJob } = await import(
+        '../src/api/embeddings/skill-store-integration.ts'
+      );
+
+      const itemId = await insertItem({
+        title: 'Test Item',
+        summary: 'Test summary for embedding',
+        embedding_status: 'pending',
+      });
+
+      const result = await handleSkillStoreEmbedJob(pool, {
+        id: 'job-4',
+        kind: 'skill_store.embed',
+        runAt: new Date(),
+        payload: { item_id: itemId },
+        attempts: 0,
+        lastError: null,
+        lockedAt: null,
+        lockedBy: null,
+        completedAt: null,
+        idempotencyKey: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      // With no embedding service configured, it should succeed
+      // but leave status as pending
+      expect(result.success).toBe(true);
+    });
+
+    it('handles invalid UUID format gracefully', async () => {
+      const { handleSkillStoreEmbedJob } = await import(
+        '../src/api/embeddings/skill-store-integration.ts'
+      );
+
+      const result = await handleSkillStoreEmbedJob(pool, {
+        id: 'job-5',
+        kind: 'skill_store.embed',
+        runAt: new Date(),
+        payload: { item_id: 'not-a-uuid' },
+        attempts: 0,
+        lastError: null,
+        lockedAt: null,
+        lockedBy: null,
+        completedAt: null,
+        idempotencyKey: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('not found');
+    });
+  });
+
+  describe('enqueueSkillStoreEmbedJob', () => {
+    it('creates an internal_job entry with correct kind', async () => {
+      const { enqueueSkillStoreEmbedJob } = await import(
+        '../src/api/embeddings/skill-store-integration.ts'
+      );
+
+      const itemId = await insertItem({
+        title: 'Enqueue test',
+        summary: 'Test item for enqueue',
+      });
+
+      await enqueueSkillStoreEmbedJob(pool, itemId);
+
+      const jobs = await pool.query(
+        `SELECT kind, payload FROM internal_job
+         WHERE kind = 'skill_store.embed'`
+      );
+      expect(jobs.rows).toHaveLength(1);
+      expect(jobs.rows[0].kind).toBe('skill_store.embed');
+      expect((jobs.rows[0].payload as Record<string, unknown>).item_id).toBe(itemId);
+    });
+
+    it('uses idempotency key to prevent duplicate jobs', async () => {
+      const { enqueueSkillStoreEmbedJob } = await import(
+        '../src/api/embeddings/skill-store-integration.ts'
+      );
+
+      const itemId = await insertItem({
+        title: 'Dedup test',
+        summary: 'Test deduplication',
+      });
+
+      // Enqueue twice with the same item
+      await enqueueSkillStoreEmbedJob(pool, itemId);
+      await enqueueSkillStoreEmbedJob(pool, itemId);
+
+      const jobs = await pool.query(
+        `SELECT count(*) FROM internal_job
+         WHERE kind = 'skill_store.embed'
+         AND payload->>'item_id' = $1`,
+        [itemId]
+      );
+      // Should only have 1 job due to idempotency
+      expect(parseInt(jobs.rows[0].count, 10)).toBe(1);
+    });
+  });
+
+  describe('getSkillStoreEmbeddingStats', () => {
+    it('returns correct counts by status', async () => {
+      const { getSkillStoreEmbeddingStats } = await import(
+        '../src/api/embeddings/skill-store-integration.ts'
+      );
+
+      // Insert items with different statuses
+      await insertItem({ title: 'Complete 1', embedding_status: 'complete' });
+      await insertItem({ title: 'Complete 2', embedding_status: 'complete' });
+      await insertItem({ title: 'Pending 1', embedding_status: 'pending' });
+      await insertItem({ title: 'Failed 1', embedding_status: 'failed' });
+
+      const stats = await getSkillStoreEmbeddingStats(pool);
+
+      expect(stats.total).toBe(4);
+      expect(stats.byStatus.complete).toBe(2);
+      expect(stats.byStatus.pending).toBe(1);
+      expect(stats.byStatus.failed).toBe(1);
+    });
+
+    it('excludes soft-deleted items', async () => {
+      const { getSkillStoreEmbeddingStats } = await import(
+        '../src/api/embeddings/skill-store-integration.ts'
+      );
+
+      await insertItem({ title: 'Active', embedding_status: 'complete' });
+
+      const deletedId = await insertItem({ title: 'Deleted', embedding_status: 'complete' });
+      await pool.query(
+        `UPDATE skill_store_item SET deleted_at = now() WHERE id = $1`,
+        [deletedId]
+      );
+
+      const stats = await getSkillStoreEmbeddingStats(pool);
+      expect(stats.total).toBe(1);
+      expect(stats.byStatus.complete).toBe(1);
+    });
+
+    it('returns provider info', async () => {
+      const { getSkillStoreEmbeddingStats } = await import(
+        '../src/api/embeddings/skill-store-integration.ts'
+      );
+
+      const stats = await getSkillStoreEmbeddingStats(pool);
+      // Provider may or may not be configured in test env
+      expect(stats).toHaveProperty('provider');
+      expect(stats).toHaveProperty('model');
+    });
+  });
+
+  describe('backfillSkillStoreEmbeddings', () => {
+    it('enqueues jobs for items with pending status', async () => {
+      const { backfillSkillStoreEmbeddings } = await import(
+        '../src/api/embeddings/skill-store-integration.ts'
+      );
+
+      await insertItem({ title: 'Pending 1', summary: 'Need embedding', embedding_status: 'pending' });
+      await insertItem({ title: 'Pending 2', content: 'Also need embedding', embedding_status: 'pending' });
+      await insertItem({ title: 'Complete', summary: 'Already done', embedding_status: 'complete' });
+
+      const result = await backfillSkillStoreEmbeddings(pool, { batchSize: 100 });
+
+      expect(result.enqueued).toBe(2);
+
+      // Verify internal_job entries were created
+      const jobs = await pool.query(
+        `SELECT count(*) FROM internal_job WHERE kind = 'skill_store.embed'`
+      );
+      expect(parseInt(jobs.rows[0].count, 10)).toBe(2);
+    });
+
+    it('also enqueues jobs for failed items', async () => {
+      const { backfillSkillStoreEmbeddings } = await import(
+        '../src/api/embeddings/skill-store-integration.ts'
+      );
+
+      await insertItem({ title: 'Failed 1', summary: 'Retry me', embedding_status: 'failed' });
+
+      const result = await backfillSkillStoreEmbeddings(pool, { batchSize: 100 });
+
+      expect(result.enqueued).toBe(1);
+    });
+
+    it('skips items without any text content', async () => {
+      const { backfillSkillStoreEmbeddings } = await import(
+        '../src/api/embeddings/skill-store-integration.ts'
+      );
+
+      // Item with no title, summary, or content
+      await insertItem({ embedding_status: 'pending' });
+
+      const result = await backfillSkillStoreEmbeddings(pool, { batchSize: 100 });
+
+      expect(result.enqueued).toBe(0);
+      expect(result.skipped).toBe(1);
+    });
+
+    it('respects batchSize limit', async () => {
+      const { backfillSkillStoreEmbeddings } = await import(
+        '../src/api/embeddings/skill-store-integration.ts'
+      );
+
+      for (let i = 0; i < 5; i++) {
+        await insertItem({ title: `Item ${i}`, summary: `Summary ${i}`, embedding_status: 'pending' });
+      }
+
+      const result = await backfillSkillStoreEmbeddings(pool, { batchSize: 3 });
+
+      expect(result.enqueued).toBe(3);
+    });
+
+    it('excludes soft-deleted items', async () => {
+      const { backfillSkillStoreEmbeddings } = await import(
+        '../src/api/embeddings/skill-store-integration.ts'
+      );
+
+      const id = await insertItem({ title: 'Deleted Item', summary: 'Will be deleted', embedding_status: 'pending' });
+      await pool.query(`UPDATE skill_store_item SET deleted_at = now() WHERE id = $1`, [id]);
+
+      await insertItem({ title: 'Active Item', summary: 'Still here', embedding_status: 'pending' });
+
+      const result = await backfillSkillStoreEmbeddings(pool, { batchSize: 100 });
+
+      expect(result.enqueued).toBe(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Wire skill store items into the existing embedding pipeline following the memory/message/note integration patterns
- Embedding text derived from: summary (preferred) or content (fallback), with title prepended
- Bulk operations use `internal_job` entries (kind='skill_store.embed') to avoid N concurrent API calls
- Status tracking: pending -> complete or failed
- Admin endpoints for monitoring and backfill
- Job handler registered in processor for `skill_store.embed` kind

## Changes

- **`src/api/embeddings/skill-store-integration.ts`** (new): Core integration module with:
  - `generateSkillStoreItemEmbedding()` — generate and store embedding
  - `buildSkillStoreEmbeddingText()` — derive embedding text from item fields
  - `handleSkillStoreEmbedJob()` — job handler for internal_job processing
  - `enqueueSkillStoreEmbedJob()` — async enqueue with idempotency
  - `triggerSkillStoreItemEmbedding()` — non-blocking trigger for CRUD operations
  - `backfillSkillStoreEmbeddings()` — bulk enqueue pending/failed items
  - `getSkillStoreEmbeddingStats()` — embedding status counts
- **`src/api/embeddings/index.ts`**: Export new module
- **`src/api/jobs/processor.ts`**: Register `skill_store.embed` job handler
- **`src/api/server.ts`**: Add admin endpoints:
  - `GET /api/admin/skill-store/embeddings/status`
  - `POST /api/admin/skill-store/embeddings/backfill`
- **`tests/skill_store_embedding.test.ts`** (new): 22 integration tests

## Test plan

- [x] All 22 integration tests pass against real PostgreSQL
- [x] Migration tests still pass
- [x] Tests cover: embedding generation, text derivation, job handling, backfill, stats, idempotency

Closes #799