### PR TITLE
[#800] Add skill store plugin tools: put, get, list, delete

### DIFF
--- a/packages/openclaw-plugin/src/tools/index.ts
+++ b/packages/openclaw-plugin/src/tools/index.ts
@@ -221,6 +221,26 @@ export {
   type FileShareToolOptions,
 } from './file-share.js'
 
+// Skill Store tools (Issue #800)
+export {
+  createSkillStorePutTool,
+  createSkillStoreGetTool,
+  createSkillStoreListTool,
+  createSkillStoreDeleteTool,
+  SkillStorePutParamsSchema,
+  SkillStoreGetParamsSchema,
+  SkillStoreListParamsSchema,
+  SkillStoreDeleteParamsSchema,
+  type SkillStorePutParams,
+  type SkillStoreGetParams,
+  type SkillStoreListParams,
+  type SkillStoreDeleteParams,
+  type SkillStoreTool,
+  type SkillStoreToolResult,
+  type SkillStoreItem,
+  type SkillStoreToolOptions,
+} from './skill-store.js'
+
 /** Tool factory types */
 export interface ToolFactoryOptions {
   // Common options for tool factories

--- a/packages/openclaw-plugin/src/tools/skill-store.ts
+++ b/packages/openclaw-plugin/src/tools/skill-store.ts
@@ -1,0 +1,626 @@
+/**
+ * Skill Store tools for OpenClaw plugin (Issue #800).
+ *
+ * Provides CRUD operations for skill-scoped persistent storage:
+ * - skill_store_put: Create or upsert items
+ * - skill_store_get: Get by ID or composite key
+ * - skill_store_list: List/filter/paginate items
+ * - skill_store_delete: Soft delete by ID or composite key
+ */
+
+import { z } from 'zod'
+import type { ApiClient } from '../api-client.js'
+import type { Logger } from '../logger.js'
+import type { PluginConfig } from '../config.js'
+
+/** Maximum serialized size of the data field (1MB). */
+const DATA_MAX_BYTES = 1_048_576
+
+/** Patterns that may indicate credentials in content fields. */
+const CREDENTIAL_PATTERNS = [
+  /sk-[a-zA-Z0-9]{20,}/i,
+  /api[_-]?key[:\s]*[a-zA-Z0-9]{16,}/i,
+  /password[:\s]*\S{8,}/i,
+  /secret[_-]?key[:\s]*[a-zA-Z0-9]{16,}/i,
+  /bearer\s+[a-zA-Z0-9._-]{20,}/i,
+]
+
+/**
+ * Validate skill_id format: alphanumeric, hyphens, underscores, max 100 chars.
+ */
+const SkillIdSchema = z
+  .string()
+  .min(1, 'skill_id cannot be empty')
+  .max(100, 'skill_id must be 100 characters or less')
+  .regex(/^[a-zA-Z0-9_-]+$/, 'skill_id must contain only alphanumeric characters, hyphens, and underscores')
+
+/** Zod schema for skill_store_put parameters */
+export const SkillStorePutParamsSchema = z.object({
+  skill_id: SkillIdSchema,
+  collection: z.string().max(200).optional(),
+  key: z.string().max(500).optional(),
+  title: z.string().max(500).optional(),
+  summary: z.string().max(2000).optional(),
+  content: z.string().max(50000).optional(),
+  data: z.record(z.unknown()).optional(),
+  media_url: z.string().url().optional(),
+  media_type: z.string().max(100).optional(),
+  source_url: z.string().url().optional(),
+  tags: z.array(z.string().max(100)).max(50).optional(),
+  priority: z.number().int().min(0).max(100).optional(),
+  expires_at: z.string().datetime().optional(),
+  pinned: z.boolean().optional(),
+  user_email: z.string().email().optional(),
+})
+export type SkillStorePutParams = z.infer<typeof SkillStorePutParamsSchema>
+
+/** Zod schema for skill_store_get parameters */
+export const SkillStoreGetParamsSchema = z.object({
+  id: z.string().uuid().optional(),
+  skill_id: SkillIdSchema.optional(),
+  collection: z.string().max(200).optional(),
+  key: z.string().max(500).optional(),
+})
+export type SkillStoreGetParams = z.infer<typeof SkillStoreGetParamsSchema>
+
+/** Zod schema for skill_store_list parameters */
+export const SkillStoreListParamsSchema = z.object({
+  skill_id: SkillIdSchema,
+  collection: z.string().max(200).optional(),
+  status: z.enum(['active', 'archived', 'processing']).optional(),
+  tags: z.array(z.string().max(100)).optional(),
+  since: z.string().datetime().optional(),
+  limit: z.number().int().min(1).max(200).optional(),
+  offset: z.number().int().min(0).optional(),
+  order_by: z.enum(['created_at', 'updated_at', 'title', 'priority']).optional(),
+  user_email: z.string().email().optional(),
+})
+export type SkillStoreListParams = z.infer<typeof SkillStoreListParamsSchema>
+
+/** Zod schema for skill_store_delete parameters */
+export const SkillStoreDeleteParamsSchema = z.object({
+  id: z.string().uuid().optional(),
+  skill_id: SkillIdSchema.optional(),
+  collection: z.string().max(200).optional(),
+  key: z.string().max(500).optional(),
+})
+export type SkillStoreDeleteParams = z.infer<typeof SkillStoreDeleteParamsSchema>
+
+/** Skill store item response from API */
+export interface SkillStoreItem {
+  id: string
+  skill_id: string
+  collection: string
+  key: string | null
+  title: string | null
+  summary: string | null
+  content: string | null
+  data: Record<string, unknown>
+  media_url: string | null
+  media_type: string | null
+  source_url: string | null
+  status: string
+  tags: string[]
+  priority: number | null
+  expires_at: string | null
+  pinned: boolean
+  user_email: string | null
+  created_at: string
+  updated_at: string
+}
+
+/** Tool result types */
+export interface SkillStoreToolSuccess {
+  success: true
+  data: {
+    content: string
+    details: Record<string, unknown>
+  }
+}
+
+export interface SkillStoreToolFailure {
+  success: false
+  error: string
+}
+
+export type SkillStoreToolResult = SkillStoreToolSuccess | SkillStoreToolFailure
+
+/** Tool options */
+export interface SkillStoreToolOptions {
+  client: ApiClient
+  logger: Logger
+  config: PluginConfig
+  userId: string
+}
+
+/** Tool definition interface */
+export interface SkillStoreTool {
+  name: string
+  description: string
+  parameters: z.ZodType
+  execute: (params: Record<string, unknown>) => Promise<SkillStoreToolResult>
+}
+
+/**
+ * Sanitize text input to remove control characters.
+ */
+function sanitizeText(text: string): string {
+  return text.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, '').trim()
+}
+
+/**
+ * Check if text may contain credentials.
+ */
+function mayContainCredentials(text: string): boolean {
+  return CREDENTIAL_PATTERNS.some((pattern) => pattern.test(text))
+}
+
+/**
+ * Sanitize error message to not expose internal details.
+ */
+function sanitizeErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    const message = error.message
+      .replace(/\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b/g, '[host]')
+      .replace(/:\d{2,5}\b/g, '')
+      .replace(/\b(?:localhost|internal[-\w]*)\b/gi, '[internal]')
+
+    if (message.includes('[internal]') || message.includes('[host]')) {
+      return 'Operation failed. Please try again.'
+    }
+
+    return message
+  }
+  return 'An unexpected error occurred.'
+}
+
+/**
+ * Truncate text for display preview.
+ */
+function truncateForPreview(text: string, maxLength = 100): string {
+  if (text.length <= maxLength) return text
+  return text.substring(0, maxLength) + '...'
+}
+
+/**
+ * Create the skill_store_put tool.
+ */
+export function createSkillStorePutTool(options: SkillStoreToolOptions): SkillStoreTool {
+  const { client, logger, userId } = options
+
+  return {
+    name: 'skill_store_put',
+    description:
+      'Store or update data in the skill store. Use for persisting skill state, configuration, cached results, or any structured data. When a key is provided, existing items with the same (skill_id, collection, key) are updated.',
+    parameters: SkillStorePutParamsSchema,
+
+    async execute(params: Record<string, unknown>): Promise<SkillStoreToolResult> {
+      const parseResult = SkillStorePutParamsSchema.safeParse(params)
+      if (!parseResult.success) {
+        const errorMessage = parseResult.error.errors
+          .map((e) => `${e.path.join('.')}: ${e.message}`)
+          .join(', ')
+        return { success: false, error: errorMessage }
+      }
+
+      const validated = parseResult.data
+
+      // Validate data size
+      if (validated.data !== undefined) {
+        const serialized = JSON.stringify(validated.data)
+        if (serialized.length > DATA_MAX_BYTES) {
+          return {
+            success: false,
+            error: `data field exceeds maximum size of 1MB (${serialized.length} bytes)`,
+          }
+        }
+      }
+
+      // Check for potential credentials in content fields
+      const textFields = [validated.title, validated.summary, validated.content].filter(Boolean) as string[]
+      for (const text of textFields) {
+        if (mayContainCredentials(text)) {
+          logger.warn('Potential credential detected in skill_store_put', {
+            userId,
+            skillId: validated.skill_id,
+            textLength: text.length,
+          })
+        }
+      }
+
+      // Sanitize text fields
+      const payload: Record<string, unknown> = {
+        skill_id: validated.skill_id,
+      }
+
+      if (validated.collection) payload.collection = validated.collection
+      if (validated.key) payload.key = validated.key
+      if (validated.title) payload.title = sanitizeText(validated.title)
+      if (validated.summary) payload.summary = sanitizeText(validated.summary)
+      if (validated.content) payload.content = sanitizeText(validated.content)
+      if (validated.data !== undefined) payload.data = validated.data
+      if (validated.media_url) payload.media_url = validated.media_url
+      if (validated.media_type) payload.media_type = validated.media_type
+      if (validated.source_url) payload.source_url = validated.source_url
+      if (validated.tags) payload.tags = validated.tags
+      if (validated.priority !== undefined) payload.priority = validated.priority
+      if (validated.expires_at) payload.expires_at = validated.expires_at
+      if (validated.pinned !== undefined) payload.pinned = validated.pinned
+      if (validated.user_email) payload.user_email = validated.user_email
+
+      logger.info('skill_store_put invoked', {
+        userId,
+        skillId: validated.skill_id,
+        collection: validated.collection,
+        key: validated.key,
+        hasData: validated.data !== undefined,
+      })
+
+      try {
+        const response = await client.post<SkillStoreItem>(
+          '/api/skill-store/items',
+          payload,
+          { userId }
+        )
+
+        if (!response.success) {
+          logger.error('skill_store_put API error', {
+            userId,
+            status: response.error.status,
+            code: response.error.code,
+          })
+          return {
+            success: false,
+            error: response.error.message || 'Failed to store item',
+          }
+        }
+
+        const item = response.data
+        const keyInfo = item.key ? ` (key: ${item.key})` : ''
+        const titleInfo = item.title ? `: "${truncateForPreview(item.title)}"` : ''
+        const content = `Stored item in ${item.collection}${keyInfo}${titleInfo} (ID: ${item.id})`
+
+        return {
+          success: true,
+          data: {
+            content,
+            details: {
+              id: item.id,
+              skill_id: item.skill_id,
+              collection: item.collection,
+              key: item.key,
+              status: item.status,
+              userId,
+            },
+          },
+        }
+      } catch (error) {
+        logger.error('skill_store_put failed', {
+          userId,
+          error: error instanceof Error ? error.message : String(error),
+        })
+        return { success: false, error: sanitizeErrorMessage(error) }
+      }
+    },
+  }
+}
+
+/**
+ * Create the skill_store_get tool.
+ */
+export function createSkillStoreGetTool(options: SkillStoreToolOptions): SkillStoreTool {
+  const { client, logger, userId } = options
+
+  return {
+    name: 'skill_store_get',
+    description:
+      'Retrieve an item from the skill store by ID or by composite key (skill_id + collection + key). Returns the full item including data payload.',
+    parameters: SkillStoreGetParamsSchema,
+
+    async execute(params: Record<string, unknown>): Promise<SkillStoreToolResult> {
+      const parseResult = SkillStoreGetParamsSchema.safeParse(params)
+      if (!parseResult.success) {
+        const errorMessage = parseResult.error.errors
+          .map((e) => `${e.path.join('.')}: ${e.message}`)
+          .join(', ')
+        return { success: false, error: errorMessage }
+      }
+
+      const validated = parseResult.data
+
+      // Must provide either id or (skill_id + key)
+      if (!validated.id && (!validated.skill_id || !validated.key)) {
+        return {
+          success: false,
+          error: 'Either id or (skill_id + key) must be provided',
+        }
+      }
+
+      logger.info('skill_store_get invoked', {
+        userId,
+        id: validated.id,
+        skillId: validated.skill_id,
+        key: validated.key,
+      })
+
+      try {
+        let response
+
+        if (validated.id) {
+          response = await client.get<SkillStoreItem>(
+            `/api/skill-store/items/${validated.id}`,
+            { userId }
+          )
+        } else {
+          const queryParams = new URLSearchParams({
+            skill_id: validated.skill_id!,
+            key: validated.key!,
+          })
+          if (validated.collection) {
+            queryParams.set('collection', validated.collection)
+          }
+          response = await client.get<SkillStoreItem>(
+            `/api/skill-store/items/by-key?${queryParams}`,
+            { userId }
+          )
+        }
+
+        if (!response.success) {
+          if (response.error.status === 404) {
+            return { success: false, error: 'Item not found' }
+          }
+          return {
+            success: false,
+            error: response.error.message || 'Failed to get item',
+          }
+        }
+
+        const item = response.data
+        const lines: string[] = []
+        lines.push(`Item: ${item.id} [${item.status}]`)
+        if (item.title) lines.push(`Title: ${item.title}`)
+        if (item.summary) lines.push(`Summary: ${item.summary}`)
+        if (item.content) lines.push(`Content: ${truncateForPreview(item.content, 200)}`)
+        lines.push(`Collection: ${item.collection}`)
+        if (item.key) lines.push(`Key: ${item.key}`)
+        if (item.tags.length > 0) lines.push(`Tags: ${item.tags.join(', ')}`)
+        if (Object.keys(item.data).length > 0) {
+          lines.push(`Data: ${truncateForPreview(JSON.stringify(item.data), 500)}`)
+        }
+
+        return {
+          success: true,
+          data: {
+            content: lines.join('\n'),
+            details: { item, userId },
+          },
+        }
+      } catch (error) {
+        logger.error('skill_store_get failed', {
+          userId,
+          error: error instanceof Error ? error.message : String(error),
+        })
+        return { success: false, error: sanitizeErrorMessage(error) }
+      }
+    },
+  }
+}
+
+/**
+ * Create the skill_store_list tool.
+ */
+export function createSkillStoreListTool(options: SkillStoreToolOptions): SkillStoreTool {
+  const { client, logger, userId } = options
+
+  return {
+    name: 'skill_store_list',
+    description:
+      'List items in the skill store with filtering and pagination. Requires skill_id. Can filter by collection, status, tags, date range, and user email.',
+    parameters: SkillStoreListParamsSchema,
+
+    async execute(params: Record<string, unknown>): Promise<SkillStoreToolResult> {
+      const parseResult = SkillStoreListParamsSchema.safeParse(params)
+      if (!parseResult.success) {
+        const errorMessage = parseResult.error.errors
+          .map((e) => `${e.path.join('.')}: ${e.message}`)
+          .join(', ')
+        return { success: false, error: errorMessage }
+      }
+
+      const validated = parseResult.data
+
+      logger.info('skill_store_list invoked', {
+        userId,
+        skillId: validated.skill_id,
+        collection: validated.collection,
+        limit: validated.limit,
+      })
+
+      try {
+        const queryParams = new URLSearchParams({
+          skill_id: validated.skill_id,
+        })
+
+        if (validated.collection) queryParams.set('collection', validated.collection)
+        if (validated.status) queryParams.set('status', validated.status)
+        if (validated.tags && validated.tags.length > 0) queryParams.set('tags', validated.tags.join(','))
+        if (validated.since) queryParams.set('since', validated.since)
+        if (validated.limit !== undefined) queryParams.set('limit', String(validated.limit))
+        if (validated.offset !== undefined) queryParams.set('offset', String(validated.offset))
+        if (validated.order_by) queryParams.set('order_by', validated.order_by)
+        if (validated.user_email) queryParams.set('user_email', validated.user_email)
+
+        const response = await client.get<{
+          items: SkillStoreItem[]
+          total: number
+          has_more: boolean
+        }>(
+          `/api/skill-store/items?${queryParams}`,
+          { userId }
+        )
+
+        if (!response.success) {
+          return {
+            success: false,
+            error: response.error.message || 'Failed to list items',
+          }
+        }
+
+        const { items, total, has_more } = response.data
+
+        const content = items.length > 0
+          ? items
+              .map((item) => {
+                const key = item.key ? ` (key: ${item.key})` : ''
+                const title = item.title ? `: ${item.title}` : ''
+                return `- [${item.status}] ${item.collection}${key}${title}`
+              })
+              .join('\n')
+          : 'No items found.'
+
+        const summary = `Found ${total} item${total !== 1 ? 's' : ''}${has_more ? ' (more available)' : ''}`
+
+        return {
+          success: true,
+          data: {
+            content: `${summary}\n${content}`,
+            details: { items, total, has_more, userId },
+          },
+        }
+      } catch (error) {
+        logger.error('skill_store_list failed', {
+          userId,
+          error: error instanceof Error ? error.message : String(error),
+        })
+        return { success: false, error: sanitizeErrorMessage(error) }
+      }
+    },
+  }
+}
+
+/**
+ * Create the skill_store_delete tool.
+ */
+export function createSkillStoreDeleteTool(options: SkillStoreToolOptions): SkillStoreTool {
+  const { client, logger, userId } = options
+
+  return {
+    name: 'skill_store_delete',
+    description:
+      'Delete an item from the skill store by ID or by composite key (skill_id + collection + key). Performs a soft delete by default.',
+    parameters: SkillStoreDeleteParamsSchema,
+
+    async execute(params: Record<string, unknown>): Promise<SkillStoreToolResult> {
+      const parseResult = SkillStoreDeleteParamsSchema.safeParse(params)
+      if (!parseResult.success) {
+        const errorMessage = parseResult.error.errors
+          .map((e) => `${e.path.join('.')}: ${e.message}`)
+          .join(', ')
+        return { success: false, error: errorMessage }
+      }
+
+      const validated = parseResult.data
+
+      // Must provide either id or (skill_id + key)
+      if (!validated.id && (!validated.skill_id || !validated.key)) {
+        return {
+          success: false,
+          error: 'Either id or (skill_id + key) must be provided',
+        }
+      }
+
+      logger.info('skill_store_delete invoked', {
+        userId,
+        id: validated.id,
+        skillId: validated.skill_id,
+        key: validated.key,
+      })
+
+      try {
+        if (validated.id) {
+          // Delete by ID
+          const response = await client.delete(
+            `/api/skill-store/items/${validated.id}`,
+            { userId }
+          )
+
+          if (!response.success) {
+            if (response.error.status === 404) {
+              return { success: false, error: 'Item not found' }
+            }
+            return {
+              success: false,
+              error: response.error.message || 'Failed to delete item',
+            }
+          }
+
+          return {
+            success: true,
+            data: {
+              content: `Deleted item ${validated.id}`,
+              details: { id: validated.id, userId },
+            },
+          }
+        }
+
+        // Delete by key: first look up the item, then delete by ID
+        const queryParams = new URLSearchParams({
+          skill_id: validated.skill_id!,
+          key: validated.key!,
+        })
+        if (validated.collection) {
+          queryParams.set('collection', validated.collection)
+        }
+
+        const getResponse = await client.get<SkillStoreItem>(
+          `/api/skill-store/items/by-key?${queryParams}`,
+          { userId }
+        )
+
+        if (!getResponse.success) {
+          if (getResponse.error.status === 404) {
+            return { success: false, error: 'Item not found' }
+          }
+          return {
+            success: false,
+            error: getResponse.error.message || 'Failed to find item for deletion',
+          }
+        }
+
+        const itemId = getResponse.data.id
+
+        const deleteResponse = await client.delete(
+          `/api/skill-store/items/${itemId}`,
+          { userId }
+        )
+
+        if (!deleteResponse.success) {
+          return {
+            success: false,
+            error: deleteResponse.error.message || 'Failed to delete item',
+          }
+        }
+
+        return {
+          success: true,
+          data: {
+            content: `Deleted item ${validated.key} from ${validated.collection || '_default'} (ID: ${itemId})`,
+            details: {
+              id: itemId,
+              skill_id: validated.skill_id,
+              collection: validated.collection,
+              key: validated.key,
+              userId,
+            },
+          },
+        }
+      } catch (error) {
+        logger.error('skill_store_delete failed', {
+          userId,
+          error: error instanceof Error ? error.message : String(error),
+        })
+        return { success: false, error: sanitizeErrorMessage(error) }
+      }
+    },
+  }
+}

--- a/packages/openclaw-plugin/tests/register-openclaw.test.ts
+++ b/packages/openclaw-plugin/tests/register-openclaw.test.ts
@@ -66,10 +66,10 @@ describe('OpenClaw 2026 API Registration', () => {
   })
 
   describe('registration', () => {
-    it('should register all 20 tools', async () => {
+    it('should register all 24 tools', async () => {
       await registerOpenClaw(mockApi)
 
-      expect(registeredTools).toHaveLength(20)
+      expect(registeredTools).toHaveLength(24)
       const toolNames = registeredTools.map((t) => t.name)
       expect(toolNames).toContain('memory_recall')
       expect(toolNames).toContain('memory_store')
@@ -91,6 +91,10 @@ describe('OpenClaw 2026 API Registration', () => {
       expect(toolNames).toContain('relationship_set')
       expect(toolNames).toContain('relationship_query')
       expect(toolNames).toContain('file_share')
+      expect(toolNames).toContain('skill_store_put')
+      expect(toolNames).toContain('skill_store_get')
+      expect(toolNames).toContain('skill_store_list')
+      expect(toolNames).toContain('skill_store_delete')
     })
 
     it('should register before_agent_start hook via api.on() when autoRecall is true', async () => {
@@ -140,7 +144,7 @@ describe('OpenClaw 2026 API Registration', () => {
       expect(mockApi.logger.info).toHaveBeenCalledWith(
         'OpenClaw Projects plugin registered',
         expect.objectContaining({
-          toolCount: 20,
+          toolCount: 24,
         })
       )
     })

--- a/packages/openclaw-plugin/tests/tools/skill-store.test.ts
+++ b/packages/openclaw-plugin/tests/tools/skill-store.test.ts
@@ -1,0 +1,603 @@
+/**
+ * Tests for skill store tools (Issue #800).
+ *
+ * Covers:
+ * - skill_store_put: parameter validation, data size, credential detection, API calls
+ * - skill_store_get: by ID, by composite key, not found
+ * - skill_store_list: filtering, pagination
+ * - skill_store_delete: by ID, by composite key, not found
+ */
+
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import {
+  createSkillStorePutTool,
+  createSkillStoreGetTool,
+  createSkillStoreListTool,
+  createSkillStoreDeleteTool,
+  SkillStorePutParamsSchema,
+  SkillStoreGetParamsSchema,
+  SkillStoreListParamsSchema,
+  SkillStoreDeleteParamsSchema,
+} from '../../src/tools/skill-store.js'
+import type { ApiClient } from '../../src/api-client.js'
+import type { Logger } from '../../src/logger.js'
+import type { PluginConfig } from '../../src/config.js'
+
+describe('Skill Store Tools (Issue #800)', () => {
+  const mockLogger: Logger = {
+    namespace: 'test',
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }
+
+  const mockConfig: PluginConfig = {
+    apiUrl: 'https://api.example.com',
+    apiKey: 'test-key',
+    autoRecall: true,
+    autoCapture: true,
+    userScoping: 'agent',
+    maxRecallMemories: 5,
+    minRecallScore: 0.7,
+    timeout: 30000,
+    maxRetries: 3,
+    debug: false,
+  }
+
+  const mockApiClient = {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    healthCheck: vi.fn(),
+  } as unknown as ApiClient
+
+  const toolOptions = {
+    client: mockApiClient,
+    logger: mockLogger,
+    config: mockConfig,
+    userId: 'agent-1',
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // ── skill_store_put ──────────────────────────────────────────────────
+
+  describe('skill_store_put', () => {
+    const tool = createSkillStorePutTool(toolOptions)
+
+    describe('tool metadata', () => {
+      it('has correct name', () => {
+        expect(tool.name).toBe('skill_store_put')
+      })
+
+      it('has description', () => {
+        expect(tool.description).toBeDefined()
+        expect(tool.description.length).toBeGreaterThan(10)
+      })
+
+      it('has parameter schema', () => {
+        expect(tool.parameters).toBeDefined()
+      })
+    })
+
+    describe('parameter validation', () => {
+      it('requires skill_id', async () => {
+        const result = await tool.execute({ title: 'No skill' })
+        expect(result.success).toBe(false)
+        if (!result.success) {
+          expect(result.error).toContain('skill_id')
+        }
+      })
+
+      it('rejects empty skill_id', async () => {
+        const result = await tool.execute({ skill_id: '' })
+        expect(result.success).toBe(false)
+      })
+
+      it('rejects skill_id with invalid characters', async () => {
+        const result = await tool.execute({ skill_id: 'has spaces!' })
+        expect(result.success).toBe(false)
+        if (!result.success) {
+          expect(result.error).toContain('skill_id')
+        }
+      })
+
+      it('rejects skill_id over 100 chars', async () => {
+        const result = await tool.execute({ skill_id: 'a'.repeat(101) })
+        expect(result.success).toBe(false)
+      })
+
+      it('accepts valid skill_id formats', () => {
+        expect(SkillStorePutParamsSchema.safeParse({ skill_id: 'my-skill' }).success).toBe(true)
+        expect(SkillStorePutParamsSchema.safeParse({ skill_id: 'my_skill_2' }).success).toBe(true)
+        expect(SkillStorePutParamsSchema.safeParse({ skill_id: 'CamelCase' }).success).toBe(true)
+      })
+
+      it('rejects data exceeding 1MB', async () => {
+        vi.mocked(mockApiClient.post).mockResolvedValue({
+          success: true,
+          data: { id: '123' },
+        })
+
+        const result = await tool.execute({
+          skill_id: 'test',
+          data: { big: 'x'.repeat(1_048_577) },
+        })
+        expect(result.success).toBe(false)
+        if (!result.success) {
+          expect(result.error).toContain('1MB')
+        }
+      })
+    })
+
+    describe('credential detection', () => {
+      it('warns on potential credentials in content', async () => {
+        vi.mocked(mockApiClient.post).mockResolvedValue({
+          success: true,
+          data: {
+            id: '123',
+            skill_id: 'test',
+            collection: '_default',
+            key: null,
+            title: null,
+            summary: null,
+            content: 'sk-abcdefghijklmnopqrstuvwxyz',
+            data: {},
+            status: 'active',
+            tags: [],
+            created_at: '2026-01-01T00:00:00Z',
+            updated_at: '2026-01-01T00:00:00Z',
+          },
+        })
+
+        await tool.execute({
+          skill_id: 'test',
+          content: 'sk-abcdefghijklmnopqrstuvwxyz',
+        })
+
+        expect(mockLogger.warn).toHaveBeenCalledWith(
+          'Potential credential detected in skill_store_put',
+          expect.objectContaining({ userId: 'agent-1' })
+        )
+      })
+    })
+
+    describe('API interaction', () => {
+      it('calls POST /api/skill-store/items', async () => {
+        vi.mocked(mockApiClient.post).mockResolvedValue({
+          success: true,
+          data: {
+            id: 'item-uuid',
+            skill_id: 'my-skill',
+            collection: 'config',
+            key: 'settings',
+            title: 'My Settings',
+            summary: null,
+            content: null,
+            data: { theme: 'dark' },
+            status: 'active',
+            tags: [],
+            pinned: false,
+            created_at: '2026-01-01T00:00:00Z',
+            updated_at: '2026-01-01T00:00:00Z',
+          },
+        })
+
+        const result = await tool.execute({
+          skill_id: 'my-skill',
+          collection: 'config',
+          key: 'settings',
+          title: 'My Settings',
+          data: { theme: 'dark' },
+        })
+
+        expect(result.success).toBe(true)
+        expect(mockApiClient.post).toHaveBeenCalledWith(
+          '/api/skill-store/items',
+          expect.objectContaining({
+            skill_id: 'my-skill',
+            collection: 'config',
+            key: 'settings',
+            title: 'My Settings',
+            data: { theme: 'dark' },
+          }),
+          { userId: 'agent-1' }
+        )
+
+        if (result.success) {
+          expect(result.data.content).toContain('item-uuid')
+          expect(result.data.details.id).toBe('item-uuid')
+        }
+      })
+
+      it('handles API errors', async () => {
+        vi.mocked(mockApiClient.post).mockResolvedValue({
+          success: false,
+          error: { status: 500, message: 'Server error', code: 'SERVER_ERROR' },
+        })
+
+        const result = await tool.execute({ skill_id: 'my-skill' })
+        expect(result.success).toBe(false)
+      })
+    })
+  })
+
+  // ── skill_store_get ──────────────────────────────────────────────────
+
+  describe('skill_store_get', () => {
+    const tool = createSkillStoreGetTool(toolOptions)
+
+    describe('tool metadata', () => {
+      it('has correct name', () => {
+        expect(tool.name).toBe('skill_store_get')
+      })
+    })
+
+    describe('parameter validation', () => {
+      it('requires either id or (skill_id + key)', async () => {
+        const result = await tool.execute({})
+        expect(result.success).toBe(false)
+        if (!result.success) {
+          expect(result.error).toContain('id')
+        }
+      })
+
+      it('requires key when using skill_id', async () => {
+        const result = await tool.execute({ skill_id: 'my-skill' })
+        expect(result.success).toBe(false)
+      })
+    })
+
+    describe('API interaction', () => {
+      it('fetches by UUID', async () => {
+        const mockItem = {
+          id: '550e8400-e29b-41d4-a716-446655440000',
+          skill_id: 'my-skill',
+          collection: 'config',
+          key: 'settings',
+          title: 'My Settings',
+          summary: null,
+          content: null,
+          data: { theme: 'dark' },
+          status: 'active',
+          tags: ['config'],
+          pinned: false,
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-01T00:00:00Z',
+        }
+
+        vi.mocked(mockApiClient.get).mockResolvedValue({
+          success: true,
+          data: mockItem,
+        })
+
+        const result = await tool.execute({
+          id: '550e8400-e29b-41d4-a716-446655440000',
+        })
+
+        expect(result.success).toBe(true)
+        expect(mockApiClient.get).toHaveBeenCalledWith(
+          '/api/skill-store/items/550e8400-e29b-41d4-a716-446655440000',
+          { userId: 'agent-1' }
+        )
+      })
+
+      it('fetches by composite key', async () => {
+        vi.mocked(mockApiClient.get).mockResolvedValue({
+          success: true,
+          data: {
+            id: 'some-uuid',
+            skill_id: 'my-skill',
+            collection: 'config',
+            key: 'theme',
+            title: null,
+            summary: null,
+            content: null,
+            data: { color: 'blue' },
+            status: 'active',
+            tags: [],
+            pinned: false,
+            created_at: '2026-01-01T00:00:00Z',
+            updated_at: '2026-01-01T00:00:00Z',
+          },
+        })
+
+        const result = await tool.execute({
+          skill_id: 'my-skill',
+          collection: 'config',
+          key: 'theme',
+        })
+
+        expect(result.success).toBe(true)
+        expect(mockApiClient.get).toHaveBeenCalledWith(
+          expect.stringContaining('/api/skill-store/items/by-key'),
+          { userId: 'agent-1' }
+        )
+      })
+
+      it('returns not found for 404', async () => {
+        vi.mocked(mockApiClient.get).mockResolvedValue({
+          success: false,
+          error: { status: 404, message: 'Not found', code: 'NOT_FOUND' },
+        })
+
+        const result = await tool.execute({
+          id: '550e8400-e29b-41d4-a716-446655440000',
+        })
+
+        expect(result.success).toBe(false)
+        if (!result.success) {
+          expect(result.error).toContain('not found')
+        }
+      })
+    })
+  })
+
+  // ── skill_store_list ─────────────────────────────────────────────────
+
+  describe('skill_store_list', () => {
+    const tool = createSkillStoreListTool(toolOptions)
+
+    describe('tool metadata', () => {
+      it('has correct name', () => {
+        expect(tool.name).toBe('skill_store_list')
+      })
+    })
+
+    describe('parameter validation', () => {
+      it('requires skill_id', async () => {
+        const result = await tool.execute({})
+        expect(result.success).toBe(false)
+        if (!result.success) {
+          expect(result.error).toContain('skill_id')
+        }
+      })
+
+      it('validates limit range', () => {
+        expect(SkillStoreListParamsSchema.safeParse({
+          skill_id: 'test',
+          limit: 0,
+        }).success).toBe(false)
+
+        expect(SkillStoreListParamsSchema.safeParse({
+          skill_id: 'test',
+          limit: 201,
+        }).success).toBe(false)
+
+        expect(SkillStoreListParamsSchema.safeParse({
+          skill_id: 'test',
+          limit: 50,
+        }).success).toBe(true)
+      })
+
+      it('validates status enum', () => {
+        expect(SkillStoreListParamsSchema.safeParse({
+          skill_id: 'test',
+          status: 'invalid',
+        }).success).toBe(false)
+
+        expect(SkillStoreListParamsSchema.safeParse({
+          skill_id: 'test',
+          status: 'active',
+        }).success).toBe(true)
+      })
+    })
+
+    describe('API interaction', () => {
+      it('calls GET /api/skill-store/items with query params', async () => {
+        vi.mocked(mockApiClient.get).mockResolvedValue({
+          success: true,
+          data: {
+            items: [
+              { id: '1', skill_id: 'test', collection: '_default', key: null, title: 'Item 1', status: 'active', tags: [], data: {} },
+              { id: '2', skill_id: 'test', collection: '_default', key: null, title: 'Item 2', status: 'active', tags: [], data: {} },
+            ],
+            total: 2,
+            has_more: false,
+          },
+        })
+
+        const result = await tool.execute({
+          skill_id: 'test',
+          collection: 'notes',
+          limit: 10,
+        })
+
+        expect(result.success).toBe(true)
+        expect(mockApiClient.get).toHaveBeenCalledWith(
+          expect.stringContaining('skill_id=test'),
+          { userId: 'agent-1' }
+        )
+
+        if (result.success) {
+          expect(result.data.content).toContain('2 items')
+          expect(result.data.details.total).toBe(2)
+        }
+      })
+
+      it('handles empty results', async () => {
+        vi.mocked(mockApiClient.get).mockResolvedValue({
+          success: true,
+          data: {
+            items: [],
+            total: 0,
+            has_more: false,
+          },
+        })
+
+        const result = await tool.execute({ skill_id: 'test' })
+
+        expect(result.success).toBe(true)
+        if (result.success) {
+          expect(result.data.content).toContain('No items found')
+        }
+      })
+    })
+  })
+
+  // ── skill_store_delete ───────────────────────────────────────────────
+
+  describe('skill_store_delete', () => {
+    const tool = createSkillStoreDeleteTool(toolOptions)
+
+    describe('tool metadata', () => {
+      it('has correct name', () => {
+        expect(tool.name).toBe('skill_store_delete')
+      })
+    })
+
+    describe('parameter validation', () => {
+      it('requires either id or (skill_id + key)', async () => {
+        const result = await tool.execute({})
+        expect(result.success).toBe(false)
+        if (!result.success) {
+          expect(result.error).toContain('id')
+        }
+      })
+    })
+
+    describe('API interaction', () => {
+      it('deletes by UUID', async () => {
+        vi.mocked(mockApiClient.delete).mockResolvedValue({
+          success: true,
+          data: undefined,
+        })
+
+        const result = await tool.execute({
+          id: '550e8400-e29b-41d4-a716-446655440000',
+        })
+
+        expect(result.success).toBe(true)
+        expect(mockApiClient.delete).toHaveBeenCalledWith(
+          '/api/skill-store/items/550e8400-e29b-41d4-a716-446655440000',
+          { userId: 'agent-1' }
+        )
+      })
+
+      it('deletes by composite key (lookup then delete)', async () => {
+        vi.mocked(mockApiClient.get).mockResolvedValue({
+          success: true,
+          data: { id: 'found-uuid', skill_id: 'test', collection: 'config', key: 'old' },
+        })
+        vi.mocked(mockApiClient.delete).mockResolvedValue({
+          success: true,
+          data: undefined,
+        })
+
+        const result = await tool.execute({
+          skill_id: 'test',
+          collection: 'config',
+          key: 'old',
+        })
+
+        expect(result.success).toBe(true)
+        expect(mockApiClient.get).toHaveBeenCalledWith(
+          expect.stringContaining('/api/skill-store/items/by-key'),
+          { userId: 'agent-1' }
+        )
+        expect(mockApiClient.delete).toHaveBeenCalledWith(
+          '/api/skill-store/items/found-uuid',
+          { userId: 'agent-1' }
+        )
+      })
+
+      it('returns not found for 404', async () => {
+        vi.mocked(mockApiClient.delete).mockResolvedValue({
+          success: false,
+          error: { status: 404, message: 'Not found', code: 'NOT_FOUND' },
+        })
+
+        const result = await tool.execute({
+          id: '550e8400-e29b-41d4-a716-446655440000',
+        })
+
+        expect(result.success).toBe(false)
+        if (!result.success) {
+          expect(result.error).toContain('not found')
+        }
+      })
+    })
+  })
+
+  // ── Zod schema validation ────────────────────────────────────────────
+
+  describe('Schema validation', () => {
+    describe('SkillStorePutParamsSchema', () => {
+      it('validates required skill_id', () => {
+        expect(SkillStorePutParamsSchema.safeParse({}).success).toBe(false)
+        expect(SkillStorePutParamsSchema.safeParse({ skill_id: 'test' }).success).toBe(true)
+      })
+
+      it('validates tags array', () => {
+        expect(SkillStorePutParamsSchema.safeParse({
+          skill_id: 'test',
+          tags: ['valid'],
+        }).success).toBe(true)
+
+        expect(SkillStorePutParamsSchema.safeParse({
+          skill_id: 'test',
+          tags: Array.from({ length: 51 }, () => 'tag'),
+        }).success).toBe(false)
+      })
+    })
+
+    describe('SkillStoreGetParamsSchema', () => {
+      it('accepts id', () => {
+        expect(SkillStoreGetParamsSchema.safeParse({
+          id: '550e8400-e29b-41d4-a716-446655440000',
+        }).success).toBe(true)
+      })
+
+      it('accepts skill_id + key', () => {
+        expect(SkillStoreGetParamsSchema.safeParse({
+          skill_id: 'test',
+          key: 'settings',
+        }).success).toBe(true)
+      })
+
+      it('rejects invalid UUID for id', () => {
+        expect(SkillStoreGetParamsSchema.safeParse({
+          id: 'not-a-uuid',
+        }).success).toBe(false)
+      })
+    })
+
+    describe('SkillStoreListParamsSchema', () => {
+      it('requires skill_id', () => {
+        expect(SkillStoreListParamsSchema.safeParse({}).success).toBe(false)
+      })
+
+      it('validates order_by enum', () => {
+        expect(SkillStoreListParamsSchema.safeParse({
+          skill_id: 'test',
+          order_by: 'created_at',
+        }).success).toBe(true)
+
+        expect(SkillStoreListParamsSchema.safeParse({
+          skill_id: 'test',
+          order_by: 'invalid',
+        }).success).toBe(false)
+      })
+    })
+
+    describe('SkillStoreDeleteParamsSchema', () => {
+      it('accepts id', () => {
+        expect(SkillStoreDeleteParamsSchema.safeParse({
+          id: '550e8400-e29b-41d4-a716-446655440000',
+        }).success).toBe(true)
+      })
+
+      it('accepts skill_id + key', () => {
+        expect(SkillStoreDeleteParamsSchema.safeParse({
+          skill_id: 'test',
+          key: 'to-delete',
+        }).success).toBe(true)
+      })
+    })
+  })
+})


### PR DESCRIPTION
Closes #800

## Summary

- Implements 4 OpenClaw plugin tools for skill-scoped persistent storage:
  - `skill_store_put`: Create/upsert items with Zod validation, credential detection, 1MB data size limit, and text sanitization
  - `skill_store_get`: Retrieve by UUID or composite key (skill_id + collection + key)
  - `skill_store_list`: Filter by collection, status, tags, date range, user_email with pagination
  - `skill_store_delete`: Soft delete by UUID or composite key (lookup-then-delete pattern)
- Registers all 4 tools in `register-openclaw.ts` with JSON Schema definitions and Gateway execute signatures
- 38 unit tests covering parameter validation, credential detection, API interaction, and edge cases
- Full type safety with Zod schemas and TypeScript (no `any`)

## Files Changed

| File | Change |
|------|--------|
| `packages/openclaw-plugin/src/tools/skill-store.ts` | New: 4 tool factory functions with Zod schemas |
| `packages/openclaw-plugin/tests/tools/skill-store.test.ts` | New: 38 unit tests |
| `packages/openclaw-plugin/src/tools/index.ts` | Updated: barrel exports for skill store tools |
| `packages/openclaw-plugin/src/register-openclaw.ts` | Updated: JSON schemas, handlers, tool definitions (20->24 tools) |
| `packages/openclaw-plugin/tests/register-openclaw.test.ts` | Updated: tool count assertions (20->24) |

## Test plan

- [x] All 38 skill store tool tests pass
- [x] Full plugin test suite passes (829 tests, 0 failures)
- [x] TypeScript compilation passes with `--noEmit`
- [x] No `any` types used