### PR TITLE
[#801] Add plugin tools: search, collections, aggregate

### DIFF
--- a/packages/openclaw-plugin/src/tools/index.ts
+++ b/packages/openclaw-plugin/src/tools/index.ts
@@ -221,20 +221,29 @@ export {
   type FileShareToolOptions,
 } from './file-share.js'
 
-// Skill Store tools (Issue #800)
+// Skill Store tools (Issue #800, #801)
 export {
   createSkillStorePutTool,
   createSkillStoreGetTool,
   createSkillStoreListTool,
   createSkillStoreDeleteTool,
+  createSkillStoreSearchTool,
+  createSkillStoreCollectionsTool,
+  createSkillStoreAggregateTool,
   SkillStorePutParamsSchema,
   SkillStoreGetParamsSchema,
   SkillStoreListParamsSchema,
   SkillStoreDeleteParamsSchema,
+  SkillStoreSearchParamsSchema,
+  SkillStoreCollectionsParamsSchema,
+  SkillStoreAggregateParamsSchema,
   type SkillStorePutParams,
   type SkillStoreGetParams,
   type SkillStoreListParams,
   type SkillStoreDeleteParams,
+  type SkillStoreSearchParams,
+  type SkillStoreCollectionsParams,
+  type SkillStoreAggregateParams,
   type SkillStoreTool,
   type SkillStoreToolResult,
   type SkillStoreItem,

--- a/packages/openclaw-plugin/tests/tools/skill-store-search.test.ts
+++ b/packages/openclaw-plugin/tests/tools/skill-store-search.test.ts
@@ -1,0 +1,826 @@
+/**
+ * Tests for skill store search, collections, and aggregate tools (Issue #801).
+ *
+ * Covers:
+ * - skill_store_search: parameter validation, full-text search, semantic search, fallback, filtering
+ * - skill_store_collections: parameter validation, API calls, formatting
+ * - skill_store_aggregate: parameter validation, operations (count, count_by_tag, count_by_status, latest, oldest)
+ */
+
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import {
+  createSkillStoreSearchTool,
+  createSkillStoreCollectionsTool,
+  createSkillStoreAggregateTool,
+  SkillStoreSearchParamsSchema,
+  SkillStoreCollectionsParamsSchema,
+  SkillStoreAggregateParamsSchema,
+} from '../../src/tools/skill-store.js'
+import type { ApiClient } from '../../src/api-client.js'
+import type { Logger } from '../../src/logger.js'
+import type { PluginConfig } from '../../src/config.js'
+
+describe('Skill Store Search Tools (Issue #801)', () => {
+  const mockLogger: Logger = {
+    namespace: 'test',
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }
+
+  const mockConfig: PluginConfig = {
+    apiUrl: 'https://api.example.com',
+    apiKey: 'test-key',
+    autoRecall: true,
+    autoCapture: true,
+    userScoping: 'agent',
+    maxRecallMemories: 5,
+    minRecallScore: 0.7,
+    timeout: 30000,
+    maxRetries: 3,
+    debug: false,
+  }
+
+  const mockApiClient = {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    healthCheck: vi.fn(),
+  } as unknown as ApiClient
+
+  const toolOptions = {
+    client: mockApiClient,
+    logger: mockLogger,
+    config: mockConfig,
+    userId: 'agent-1',
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // ── skill_store_search ──────────────────────────────────────────────
+
+  describe('skill_store_search', () => {
+    const tool = createSkillStoreSearchTool(toolOptions)
+
+    describe('tool metadata', () => {
+      it('has correct name', () => {
+        expect(tool.name).toBe('skill_store_search')
+      })
+
+      it('has description mentioning search', () => {
+        expect(tool.description).toBeDefined()
+        expect(tool.description.toLowerCase()).toContain('search')
+      })
+
+      it('has parameter schema', () => {
+        expect(tool.parameters).toBeDefined()
+      })
+    })
+
+    describe('parameter validation', () => {
+      it('requires skill_id', async () => {
+        const result = await tool.execute({ query: 'test' })
+        expect(result.success).toBe(false)
+        if (!result.success) {
+          expect(result.error).toContain('skill_id')
+        }
+      })
+
+      it('requires query', async () => {
+        const result = await tool.execute({ skill_id: 'test' })
+        expect(result.success).toBe(false)
+        if (!result.success) {
+          expect(result.error).toContain('query')
+        }
+      })
+
+      it('rejects empty query', async () => {
+        const result = await tool.execute({ skill_id: 'test', query: '' })
+        expect(result.success).toBe(false)
+      })
+
+      it('validates limit range', () => {
+        expect(SkillStoreSearchParamsSchema.safeParse({
+          skill_id: 'test',
+          query: 'hello',
+          limit: 0,
+        }).success).toBe(false)
+
+        expect(SkillStoreSearchParamsSchema.safeParse({
+          skill_id: 'test',
+          query: 'hello',
+          limit: 201,
+        }).success).toBe(false)
+
+        expect(SkillStoreSearchParamsSchema.safeParse({
+          skill_id: 'test',
+          query: 'hello',
+          limit: 50,
+        }).success).toBe(true)
+      })
+
+      it('accepts optional filters', () => {
+        const result = SkillStoreSearchParamsSchema.safeParse({
+          skill_id: 'test',
+          query: 'hello',
+          collection: 'notes',
+          tags: ['important'],
+          semantic: true,
+          min_similarity: 0.5,
+          limit: 10,
+          user_email: 'user@example.com',
+        })
+        expect(result.success).toBe(true)
+      })
+
+      it('validates min_similarity range', () => {
+        expect(SkillStoreSearchParamsSchema.safeParse({
+          skill_id: 'test',
+          query: 'hello',
+          min_similarity: -0.1,
+        }).success).toBe(false)
+
+        expect(SkillStoreSearchParamsSchema.safeParse({
+          skill_id: 'test',
+          query: 'hello',
+          min_similarity: 1.1,
+        }).success).toBe(false)
+
+        expect(SkillStoreSearchParamsSchema.safeParse({
+          skill_id: 'test',
+          query: 'hello',
+          min_similarity: 0.7,
+        }).success).toBe(true)
+      })
+    })
+
+    describe('full-text search (semantic: false)', () => {
+      it('calls POST /api/skill-store/search', async () => {
+        vi.mocked(mockApiClient.post).mockResolvedValue({
+          success: true,
+          data: {
+            results: [
+              {
+                id: 'item-1',
+                skill_id: 'test',
+                collection: 'notes',
+                key: null,
+                title: 'Meeting Notes',
+                summary: 'Notes from standup',
+                content: 'Discussed the roadmap',
+                data: {},
+                tags: ['meeting'],
+                status: 'active',
+                priority: 0,
+                user_email: null,
+                created_at: '2026-01-01T00:00:00Z',
+                updated_at: '2026-01-01T00:00:00Z',
+                relevance: 0.85,
+              },
+            ],
+            total: 1,
+          },
+        })
+
+        const result = await tool.execute({
+          skill_id: 'test',
+          query: 'roadmap',
+        })
+
+        expect(result.success).toBe(true)
+        expect(mockApiClient.post).toHaveBeenCalledWith(
+          '/api/skill-store/search',
+          expect.objectContaining({
+            skill_id: 'test',
+            query: 'roadmap',
+          }),
+          { userId: 'agent-1' }
+        )
+
+        if (result.success) {
+          expect(result.data.content).toContain('Meeting Notes')
+          expect(result.data.details.results).toHaveLength(1)
+          expect(result.data.details.total).toBe(1)
+        }
+      })
+
+      it('includes filters in request', async () => {
+        vi.mocked(mockApiClient.post).mockResolvedValue({
+          success: true,
+          data: { results: [], total: 0 },
+        })
+
+        await tool.execute({
+          skill_id: 'test',
+          query: 'hello',
+          collection: 'notes',
+          tags: ['important'],
+          limit: 5,
+          user_email: 'user@example.com',
+        })
+
+        expect(mockApiClient.post).toHaveBeenCalledWith(
+          '/api/skill-store/search',
+          expect.objectContaining({
+            skill_id: 'test',
+            query: 'hello',
+            collection: 'notes',
+            tags: ['important'],
+            limit: 5,
+            user_email: 'user@example.com',
+          }),
+          { userId: 'agent-1' }
+        )
+      })
+    })
+
+    describe('semantic search (semantic: true)', () => {
+      it('calls POST /api/skill-store/search/semantic', async () => {
+        vi.mocked(mockApiClient.post).mockResolvedValue({
+          success: true,
+          data: {
+            results: [
+              {
+                id: 'item-2',
+                skill_id: 'test',
+                collection: 'notes',
+                key: null,
+                title: 'Design Doc',
+                summary: 'Architecture overview',
+                content: 'The system uses microservices',
+                data: {},
+                tags: [],
+                status: 'active',
+                priority: 0,
+                user_email: null,
+                created_at: '2026-01-01T00:00:00Z',
+                updated_at: '2026-01-01T00:00:00Z',
+                similarity: 0.92,
+              },
+            ],
+            search_type: 'semantic',
+            query_embedding_provider: 'voyage',
+          },
+        })
+
+        const result = await tool.execute({
+          skill_id: 'test',
+          query: 'system architecture',
+          semantic: true,
+        })
+
+        expect(result.success).toBe(true)
+        expect(mockApiClient.post).toHaveBeenCalledWith(
+          '/api/skill-store/search/semantic',
+          expect.objectContaining({
+            skill_id: 'test',
+            query: 'system architecture',
+          }),
+          { userId: 'agent-1' }
+        )
+
+        if (result.success) {
+          expect(result.data.content).toContain('Design Doc')
+          expect(result.data.details.search_type).toBe('semantic')
+        }
+      })
+
+      it('includes min_similarity in semantic request', async () => {
+        vi.mocked(mockApiClient.post).mockResolvedValue({
+          success: true,
+          data: { results: [], search_type: 'semantic' },
+        })
+
+        await tool.execute({
+          skill_id: 'test',
+          query: 'hello',
+          semantic: true,
+          min_similarity: 0.8,
+        })
+
+        expect(mockApiClient.post).toHaveBeenCalledWith(
+          '/api/skill-store/search/semantic',
+          expect.objectContaining({
+            min_similarity: 0.8,
+          }),
+          { userId: 'agent-1' }
+        )
+      })
+
+      it('reports fallback when semantic falls back to text', async () => {
+        vi.mocked(mockApiClient.post).mockResolvedValue({
+          success: true,
+          data: {
+            results: [
+              {
+                id: 'item-3',
+                skill_id: 'test',
+                collection: '_default',
+                key: null,
+                title: 'Fallback Result',
+                summary: null,
+                content: 'Found via text',
+                data: {},
+                tags: [],
+                status: 'active',
+                priority: 0,
+                user_email: null,
+                created_at: '2026-01-01T00:00:00Z',
+                updated_at: '2026-01-01T00:00:00Z',
+                similarity: 0.5,
+              },
+            ],
+            search_type: 'text',
+          },
+        })
+
+        const result = await tool.execute({
+          skill_id: 'test',
+          query: 'hello',
+          semantic: true,
+        })
+
+        expect(result.success).toBe(true)
+        if (result.success) {
+          expect(result.data.details.search_type).toBe('text')
+        }
+      })
+    })
+
+    describe('empty results', () => {
+      it('returns friendly message when no results found', async () => {
+        vi.mocked(mockApiClient.post).mockResolvedValue({
+          success: true,
+          data: { results: [], total: 0 },
+        })
+
+        const result = await tool.execute({
+          skill_id: 'test',
+          query: 'nonexistent',
+        })
+
+        expect(result.success).toBe(true)
+        if (result.success) {
+          expect(result.data.content).toContain('No items found')
+        }
+      })
+    })
+
+    describe('error handling', () => {
+      it('handles API errors', async () => {
+        vi.mocked(mockApiClient.post).mockResolvedValue({
+          success: false,
+          error: { status: 500, message: 'Server error', code: 'SERVER_ERROR' },
+        })
+
+        const result = await tool.execute({
+          skill_id: 'test',
+          query: 'hello',
+        })
+        expect(result.success).toBe(false)
+      })
+
+      it('handles network exceptions', async () => {
+        vi.mocked(mockApiClient.post).mockRejectedValue(new Error('Network timeout'))
+
+        const result = await tool.execute({
+          skill_id: 'test',
+          query: 'hello',
+        })
+        expect(result.success).toBe(false)
+      })
+    })
+  })
+
+  // ── skill_store_collections ─────────────────────────────────────────
+
+  describe('skill_store_collections', () => {
+    const tool = createSkillStoreCollectionsTool(toolOptions)
+
+    describe('tool metadata', () => {
+      it('has correct name', () => {
+        expect(tool.name).toBe('skill_store_collections')
+      })
+
+      it('has description mentioning collections', () => {
+        expect(tool.description).toBeDefined()
+        expect(tool.description.toLowerCase()).toContain('collection')
+      })
+    })
+
+    describe('parameter validation', () => {
+      it('requires skill_id', async () => {
+        const result = await tool.execute({})
+        expect(result.success).toBe(false)
+        if (!result.success) {
+          expect(result.error).toContain('skill_id')
+        }
+      })
+
+      it('accepts optional user_email', () => {
+        expect(SkillStoreCollectionsParamsSchema.safeParse({
+          skill_id: 'test',
+          user_email: 'user@example.com',
+        }).success).toBe(true)
+      })
+
+      it('validates user_email format', () => {
+        expect(SkillStoreCollectionsParamsSchema.safeParse({
+          skill_id: 'test',
+          user_email: 'not-an-email',
+        }).success).toBe(false)
+      })
+    })
+
+    describe('API interaction', () => {
+      it('calls GET /api/skill-store/collections', async () => {
+        vi.mocked(mockApiClient.get).mockResolvedValue({
+          success: true,
+          data: {
+            collections: [
+              { collection: 'notes', count: 15, latest_at: '2026-01-15T00:00:00Z' },
+              { collection: 'config', count: 3, latest_at: '2026-01-10T00:00:00Z' },
+            ],
+          },
+        })
+
+        const result = await tool.execute({ skill_id: 'my-skill' })
+
+        expect(result.success).toBe(true)
+        expect(mockApiClient.get).toHaveBeenCalledWith(
+          expect.stringContaining('skill_id=my-skill'),
+          { userId: 'agent-1' }
+        )
+
+        if (result.success) {
+          expect(result.data.content).toContain('notes')
+          expect(result.data.content).toContain('15')
+          expect(result.data.content).toContain('config')
+          expect(result.data.content).toContain('3')
+          expect(result.data.details.collections).toHaveLength(2)
+        }
+      })
+
+      it('includes user_email in request', async () => {
+        vi.mocked(mockApiClient.get).mockResolvedValue({
+          success: true,
+          data: { collections: [] },
+        })
+
+        await tool.execute({
+          skill_id: 'test',
+          user_email: 'user@example.com',
+        })
+
+        expect(mockApiClient.get).toHaveBeenCalledWith(
+          expect.stringContaining('user_email=user%40example.com'),
+          { userId: 'agent-1' }
+        )
+      })
+
+      it('handles empty collections', async () => {
+        vi.mocked(mockApiClient.get).mockResolvedValue({
+          success: true,
+          data: { collections: [] },
+        })
+
+        const result = await tool.execute({ skill_id: 'empty-skill' })
+
+        expect(result.success).toBe(true)
+        if (result.success) {
+          expect(result.data.content).toContain('No collections found')
+        }
+      })
+
+      it('handles API errors', async () => {
+        vi.mocked(mockApiClient.get).mockResolvedValue({
+          success: false,
+          error: { status: 500, message: 'Server error', code: 'SERVER_ERROR' },
+        })
+
+        const result = await tool.execute({ skill_id: 'test' })
+        expect(result.success).toBe(false)
+      })
+    })
+  })
+
+  // ── skill_store_aggregate ───────────────────────────────────────────
+
+  describe('skill_store_aggregate', () => {
+    const tool = createSkillStoreAggregateTool(toolOptions)
+
+    describe('tool metadata', () => {
+      it('has correct name', () => {
+        expect(tool.name).toBe('skill_store_aggregate')
+      })
+
+      it('has description mentioning aggregate', () => {
+        expect(tool.description).toBeDefined()
+        expect(tool.description.toLowerCase()).toContain('aggregat')
+      })
+    })
+
+    describe('parameter validation', () => {
+      it('requires skill_id', async () => {
+        const result = await tool.execute({ operation: 'count' })
+        expect(result.success).toBe(false)
+        if (!result.success) {
+          expect(result.error).toContain('skill_id')
+        }
+      })
+
+      it('requires operation', async () => {
+        const result = await tool.execute({ skill_id: 'test' })
+        expect(result.success).toBe(false)
+        if (!result.success) {
+          expect(result.error).toContain('operation')
+        }
+      })
+
+      it('validates operation enum', () => {
+        const validOps = ['count', 'count_by_tag', 'count_by_status', 'latest', 'oldest']
+        for (const op of validOps) {
+          expect(SkillStoreAggregateParamsSchema.safeParse({
+            skill_id: 'test',
+            operation: op,
+          }).success).toBe(true)
+        }
+
+        expect(SkillStoreAggregateParamsSchema.safeParse({
+          skill_id: 'test',
+          operation: 'invalid',
+        }).success).toBe(false)
+      })
+
+      it('accepts optional filters', () => {
+        expect(SkillStoreAggregateParamsSchema.safeParse({
+          skill_id: 'test',
+          operation: 'count',
+          collection: 'notes',
+          since: '2026-01-01T00:00:00Z',
+          until: '2026-02-01T00:00:00Z',
+          user_email: 'user@example.com',
+        }).success).toBe(true)
+      })
+    })
+
+    describe('count operation', () => {
+      it('returns total count', async () => {
+        vi.mocked(mockApiClient.get).mockResolvedValue({
+          success: true,
+          data: { result: { count: 42 } },
+        })
+
+        const result = await tool.execute({
+          skill_id: 'test',
+          operation: 'count',
+        })
+
+        expect(result.success).toBe(true)
+        expect(mockApiClient.get).toHaveBeenCalledWith(
+          expect.stringContaining('skill_id=test'),
+          { userId: 'agent-1' }
+        )
+        expect(mockApiClient.get).toHaveBeenCalledWith(
+          expect.stringContaining('operation=count'),
+          { userId: 'agent-1' }
+        )
+
+        if (result.success) {
+          expect(result.data.content).toContain('42')
+          expect(result.data.details.result).toEqual({ count: 42 })
+        }
+      })
+
+      it('includes collection filter', async () => {
+        vi.mocked(mockApiClient.get).mockResolvedValue({
+          success: true,
+          data: { result: { count: 10 } },
+        })
+
+        await tool.execute({
+          skill_id: 'test',
+          operation: 'count',
+          collection: 'notes',
+        })
+
+        expect(mockApiClient.get).toHaveBeenCalledWith(
+          expect.stringContaining('collection=notes'),
+          { userId: 'agent-1' }
+        )
+      })
+    })
+
+    describe('count_by_tag operation', () => {
+      it('returns tag counts', async () => {
+        vi.mocked(mockApiClient.get).mockResolvedValue({
+          success: true,
+          data: {
+            result: {
+              tags: [
+                { tag: 'important', count: 10 },
+                { tag: 'draft', count: 5 },
+              ],
+            },
+          },
+        })
+
+        const result = await tool.execute({
+          skill_id: 'test',
+          operation: 'count_by_tag',
+        })
+
+        expect(result.success).toBe(true)
+        if (result.success) {
+          expect(result.data.content).toContain('important')
+          expect(result.data.content).toContain('10')
+          expect(result.data.content).toContain('draft')
+          expect(result.data.content).toContain('5')
+        }
+      })
+    })
+
+    describe('count_by_status operation', () => {
+      it('returns status counts', async () => {
+        vi.mocked(mockApiClient.get).mockResolvedValue({
+          success: true,
+          data: {
+            result: {
+              statuses: [
+                { status: 'active', count: 20 },
+                { status: 'archived', count: 8 },
+                { status: 'processing', count: 2 },
+              ],
+            },
+          },
+        })
+
+        const result = await tool.execute({
+          skill_id: 'test',
+          operation: 'count_by_status',
+        })
+
+        expect(result.success).toBe(true)
+        if (result.success) {
+          expect(result.data.content).toContain('active')
+          expect(result.data.content).toContain('20')
+          expect(result.data.content).toContain('archived')
+          expect(result.data.content).toContain('8')
+        }
+      })
+    })
+
+    describe('latest operation', () => {
+      it('returns most recent item', async () => {
+        vi.mocked(mockApiClient.get).mockResolvedValue({
+          success: true,
+          data: {
+            result: {
+              item: {
+                id: 'latest-uuid',
+                skill_id: 'test',
+                collection: 'notes',
+                key: null,
+                title: 'Most Recent Note',
+                status: 'active',
+                created_at: '2026-02-01T12:00:00Z',
+                updated_at: '2026-02-01T12:00:00Z',
+              },
+            },
+          },
+        })
+
+        const result = await tool.execute({
+          skill_id: 'test',
+          operation: 'latest',
+        })
+
+        expect(result.success).toBe(true)
+        if (result.success) {
+          expect(result.data.content).toContain('Most Recent Note')
+          expect(result.data.details.result.item).toBeDefined()
+        }
+      })
+
+      it('handles no items found', async () => {
+        vi.mocked(mockApiClient.get).mockResolvedValue({
+          success: true,
+          data: { result: { item: null } },
+        })
+
+        const result = await tool.execute({
+          skill_id: 'test',
+          operation: 'latest',
+        })
+
+        expect(result.success).toBe(true)
+        if (result.success) {
+          expect(result.data.content).toContain('No items found')
+        }
+      })
+    })
+
+    describe('oldest operation', () => {
+      it('returns oldest item', async () => {
+        vi.mocked(mockApiClient.get).mockResolvedValue({
+          success: true,
+          data: {
+            result: {
+              item: {
+                id: 'oldest-uuid',
+                skill_id: 'test',
+                collection: 'notes',
+                key: null,
+                title: 'First Note',
+                status: 'active',
+                created_at: '2025-01-01T00:00:00Z',
+                updated_at: '2025-01-01T00:00:00Z',
+              },
+            },
+          },
+        })
+
+        const result = await tool.execute({
+          skill_id: 'test',
+          operation: 'oldest',
+        })
+
+        expect(result.success).toBe(true)
+        if (result.success) {
+          expect(result.data.content).toContain('First Note')
+        }
+      })
+    })
+
+    describe('time range filters', () => {
+      it('includes since and until in request', async () => {
+        vi.mocked(mockApiClient.get).mockResolvedValue({
+          success: true,
+          data: { result: { count: 5 } },
+        })
+
+        await tool.execute({
+          skill_id: 'test',
+          operation: 'count',
+          since: '2026-01-01T00:00:00Z',
+          until: '2026-02-01T00:00:00Z',
+        })
+
+        expect(mockApiClient.get).toHaveBeenCalledWith(
+          expect.stringContaining('since='),
+          { userId: 'agent-1' }
+        )
+        expect(mockApiClient.get).toHaveBeenCalledWith(
+          expect.stringContaining('until='),
+          { userId: 'agent-1' }
+        )
+      })
+    })
+
+    describe('error handling', () => {
+      it('handles API errors', async () => {
+        vi.mocked(mockApiClient.get).mockResolvedValue({
+          success: false,
+          error: { status: 500, message: 'Server error', code: 'SERVER_ERROR' },
+        })
+
+        const result = await tool.execute({
+          skill_id: 'test',
+          operation: 'count',
+        })
+        expect(result.success).toBe(false)
+      })
+
+      it('handles network exceptions', async () => {
+        vi.mocked(mockApiClient.get).mockRejectedValue(new Error('Network timeout'))
+
+        const result = await tool.execute({
+          skill_id: 'test',
+          operation: 'count',
+        })
+        expect(result.success).toBe(false)
+      })
+    })
+  })
+
+  // ── Schema exports ──────────────────────────────────────────────────
+
+  describe('Schema exports', () => {
+    it('exports SkillStoreSearchParamsSchema', () => {
+      expect(SkillStoreSearchParamsSchema).toBeDefined()
+    })
+
+    it('exports SkillStoreCollectionsParamsSchema', () => {
+      expect(SkillStoreCollectionsParamsSchema).toBeDefined()
+    })
+
+    it('exports SkillStoreAggregateParamsSchema', () => {
+      expect(SkillStoreAggregateParamsSchema).toBeDefined()
+    })
+  })
+})

--- a/src/api/skill-store/aggregate.ts
+++ b/src/api/skill-store/aggregate.ts
@@ -1,0 +1,151 @@
+/**
+ * Skill Store aggregation service.
+ *
+ * Provides count, count_by_tag, count_by_status, latest, oldest operations
+ * for skill_store_item records.
+ *
+ * Part of Epic #794, Issue #801.
+ */
+
+import type { Pool } from 'pg';
+
+/** Aggregate operation parameters. */
+export interface AggregateParams {
+  skill_id: string;
+  operation: 'count' | 'count_by_tag' | 'count_by_status' | 'latest' | 'oldest';
+  collection?: string;
+  since?: string;
+  until?: string;
+  user_email?: string;
+}
+
+/**
+ * Build WHERE conditions and parameter list for aggregate queries.
+ * Always includes: skill_id filter and soft-delete exclusion.
+ */
+function buildAggregateFilters(
+  params: AggregateParams
+): { conditions: string[]; values: (string | number)[]; paramIndex: number } {
+  const conditions: string[] = [
+    's.skill_id = $1',
+    's.deleted_at IS NULL',
+  ];
+  const values: (string | number)[] = [params.skill_id];
+  let paramIndex = 2;
+
+  if (params.collection) {
+    conditions.push(`s.collection = $${paramIndex}`);
+    values.push(params.collection);
+    paramIndex++;
+  }
+
+  if (params.user_email) {
+    conditions.push(`s.user_email = $${paramIndex}`);
+    values.push(params.user_email);
+    paramIndex++;
+  }
+
+  if (params.since) {
+    conditions.push(`s.created_at >= $${paramIndex}::timestamptz`);
+    values.push(params.since);
+    paramIndex++;
+  }
+
+  if (params.until) {
+    conditions.push(`s.created_at < $${paramIndex}::timestamptz`);
+    values.push(params.until);
+    paramIndex++;
+  }
+
+  return { conditions, values, paramIndex };
+}
+
+/** Item summary returned by latest/oldest. */
+const ITEM_COLUMNS = `
+  s.id::text as id,
+  s.skill_id,
+  s.collection,
+  s.key,
+  s.title,
+  s.status::text as status,
+  s.created_at,
+  s.updated_at
+`;
+
+/**
+ * Run an aggregation on skill store items.
+ */
+export async function aggregateSkillStoreItems(
+  pool: Pool,
+  params: AggregateParams
+): Promise<Record<string, unknown>> {
+  if (!params.skill_id || params.skill_id.trim().length === 0) {
+    throw new Error('skill_id is required');
+  }
+
+  const { conditions, values, paramIndex } = buildAggregateFilters(params);
+  const whereClause = conditions.join(' AND ');
+
+  switch (params.operation) {
+    case 'count': {
+      const result = await pool.query(
+        `SELECT COUNT(*)::int as count
+         FROM skill_store_item s
+         WHERE ${whereClause}`,
+        values
+      );
+      return { count: result.rows[0].count };
+    }
+
+    case 'count_by_tag': {
+      const result = await pool.query(
+        `SELECT tag, COUNT(*)::int as count
+         FROM skill_store_item s, unnest(s.tags) as tag
+         WHERE ${whereClause}
+         GROUP BY tag
+         ORDER BY count DESC, tag`,
+        values
+      );
+      return { tags: result.rows };
+    }
+
+    case 'count_by_status': {
+      const result = await pool.query(
+        `SELECT s.status::text as status, COUNT(*)::int as count
+         FROM skill_store_item s
+         WHERE ${whereClause}
+         GROUP BY s.status
+         ORDER BY count DESC, s.status`,
+        values
+      );
+      return { statuses: result.rows };
+    }
+
+    case 'latest': {
+      const result = await pool.query(
+        `SELECT ${ITEM_COLUMNS}
+         FROM skill_store_item s
+         WHERE ${whereClause}
+         ORDER BY s.created_at DESC
+         LIMIT 1`,
+        values
+      );
+      return { item: result.rows[0] ?? null };
+    }
+
+    case 'oldest': {
+      const result = await pool.query(
+        `SELECT ${ITEM_COLUMNS}
+         FROM skill_store_item s
+         WHERE ${whereClause}
+         ORDER BY s.created_at ASC
+         LIMIT 1`,
+        values
+      );
+      return { item: result.rows[0] ?? null };
+    }
+
+    default:
+      throw new Error(`Unknown operation: ${params.operation}`);
+  }
+}

--- a/tests/skill_store_aggregate.test.ts
+++ b/tests/skill_store_aggregate.test.ts
@@ -1,0 +1,287 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { Pool } from 'pg';
+import { runMigrate } from './helpers/migrate.ts';
+import { createTestPool, truncateAllTables } from './helpers/db.ts';
+
+/**
+ * Tests for Skill Store Aggregate and Collections API (Issue #801).
+ *
+ * Covers:
+ * - GET /api/skill-store/aggregate: count, count_by_tag, count_by_status, latest, oldest
+ * - GET /api/skill-store/collections with user_email filter
+ * - Filter parameters: collection, since, until, user_email
+ * - Soft-deleted items excluded
+ */
+describe('Skill Store Aggregate & Collections (Issue #801)', () => {
+  let pool: Pool;
+
+  beforeAll(async () => {
+    await runMigrate('up');
+    pool = createTestPool();
+  });
+
+  beforeEach(async () => {
+    await truncateAllTables(pool);
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  // Helper to insert an item
+  async function insertItem(overrides: {
+    skill_id?: string;
+    title?: string;
+    summary?: string;
+    content?: string;
+    collection?: string;
+    key?: string;
+    tags?: string[];
+    status?: string;
+    user_email?: string;
+    deleted_at?: string;
+    created_at?: string;
+  } = {}): Promise<string> {
+    const result = await pool.query(
+      `INSERT INTO skill_store_item (skill_id, collection, key, title, summary, content, tags, status, user_email, deleted_at, created_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, COALESCE($8::skill_store_item_status, 'active'), $9, $10::timestamptz, COALESCE($11::timestamptz, now()))
+       RETURNING id::text as id`,
+      [
+        overrides.skill_id ?? 'test-skill',
+        overrides.collection ?? '_default',
+        overrides.key ?? null,
+        overrides.title ?? null,
+        overrides.summary ?? null,
+        overrides.content ?? null,
+        overrides.tags ?? [],
+        overrides.status ?? null,
+        overrides.user_email ?? null,
+        overrides.deleted_at ?? null,
+        overrides.created_at ?? null,
+      ]
+    );
+    return result.rows[0].id;
+  }
+
+  // ── Aggregate: count ────────────────────────────────────────────────
+
+  describe('aggregate count', () => {
+    it('counts all active items for a skill', async () => {
+      const { aggregateSkillStoreItems } = await import(
+        '../src/api/skill-store/aggregate.ts'
+      );
+
+      await insertItem({ skill_id: 'sk1', title: 'Item 1' });
+      await insertItem({ skill_id: 'sk1', title: 'Item 2' });
+      await insertItem({ skill_id: 'sk1', title: 'Deleted', deleted_at: '2026-01-01T00:00:00Z' });
+      await insertItem({ skill_id: 'other', title: 'Other skill' });
+
+      const result = await aggregateSkillStoreItems(pool, {
+        skill_id: 'sk1',
+        operation: 'count',
+      });
+
+      expect(result).toEqual({ count: 2 });
+    });
+
+    it('counts items in a specific collection', async () => {
+      const { aggregateSkillStoreItems } = await import(
+        '../src/api/skill-store/aggregate.ts'
+      );
+
+      await insertItem({ skill_id: 'sk1', collection: 'notes', title: 'Note 1' });
+      await insertItem({ skill_id: 'sk1', collection: 'notes', title: 'Note 2' });
+      await insertItem({ skill_id: 'sk1', collection: 'config', title: 'Config 1' });
+
+      const result = await aggregateSkillStoreItems(pool, {
+        skill_id: 'sk1',
+        operation: 'count',
+        collection: 'notes',
+      });
+
+      expect(result).toEqual({ count: 2 });
+    });
+
+    it('filters by user_email', async () => {
+      const { aggregateSkillStoreItems } = await import(
+        '../src/api/skill-store/aggregate.ts'
+      );
+
+      await insertItem({ skill_id: 'sk1', title: 'User A item', user_email: 'a@test.com' });
+      await insertItem({ skill_id: 'sk1', title: 'User B item', user_email: 'b@test.com' });
+      await insertItem({ skill_id: 'sk1', title: 'No user item' });
+
+      const result = await aggregateSkillStoreItems(pool, {
+        skill_id: 'sk1',
+        operation: 'count',
+        user_email: 'a@test.com',
+      });
+
+      expect(result).toEqual({ count: 1 });
+    });
+
+    it('filters by since/until time range', async () => {
+      const { aggregateSkillStoreItems } = await import(
+        '../src/api/skill-store/aggregate.ts'
+      );
+
+      await insertItem({ skill_id: 'sk1', title: 'Old item', created_at: '2025-01-01T00:00:00Z' });
+      await insertItem({ skill_id: 'sk1', title: 'Recent item', created_at: '2026-01-15T00:00:00Z' });
+      await insertItem({ skill_id: 'sk1', title: 'Future item', created_at: '2026-06-01T00:00:00Z' });
+
+      const result = await aggregateSkillStoreItems(pool, {
+        skill_id: 'sk1',
+        operation: 'count',
+        since: '2026-01-01T00:00:00Z',
+        until: '2026-02-01T00:00:00Z',
+      });
+
+      expect(result).toEqual({ count: 1 });
+    });
+  });
+
+  // ── Aggregate: count_by_tag ─────────────────────────────────────────
+
+  describe('aggregate count_by_tag', () => {
+    it('returns tag counts', async () => {
+      const { aggregateSkillStoreItems } = await import(
+        '../src/api/skill-store/aggregate.ts'
+      );
+
+      await insertItem({ skill_id: 'sk1', tags: ['important', 'draft'] });
+      await insertItem({ skill_id: 'sk1', tags: ['important'] });
+      await insertItem({ skill_id: 'sk1', tags: ['draft', 'review'] });
+      await insertItem({ skill_id: 'sk1', tags: ['important'], deleted_at: '2026-01-01T00:00:00Z' });
+
+      const result = await aggregateSkillStoreItems(pool, {
+        skill_id: 'sk1',
+        operation: 'count_by_tag',
+      });
+
+      expect(result.tags).toBeDefined();
+      const tags = result.tags as Array<{ tag: string; count: number }>;
+      const importantTag = tags.find(t => t.tag === 'important');
+      expect(importantTag?.count).toBe(2);
+      const draftTag = tags.find(t => t.tag === 'draft');
+      expect(draftTag?.count).toBe(2);
+      const reviewTag = tags.find(t => t.tag === 'review');
+      expect(reviewTag?.count).toBe(1);
+    });
+  });
+
+  // ── Aggregate: count_by_status ──────────────────────────────────────
+
+  describe('aggregate count_by_status', () => {
+    it('returns status counts', async () => {
+      const { aggregateSkillStoreItems } = await import(
+        '../src/api/skill-store/aggregate.ts'
+      );
+
+      await insertItem({ skill_id: 'sk1', status: 'active' });
+      await insertItem({ skill_id: 'sk1', status: 'active' });
+      await insertItem({ skill_id: 'sk1', status: 'archived' });
+      await insertItem({ skill_id: 'sk1', status: 'processing' });
+      await insertItem({ skill_id: 'sk1', status: 'active', deleted_at: '2026-01-01T00:00:00Z' });
+
+      const result = await aggregateSkillStoreItems(pool, {
+        skill_id: 'sk1',
+        operation: 'count_by_status',
+      });
+
+      expect(result.statuses).toBeDefined();
+      const statuses = result.statuses as Array<{ status: string; count: number }>;
+      const active = statuses.find(s => s.status === 'active');
+      expect(active?.count).toBe(2);
+      const archived = statuses.find(s => s.status === 'archived');
+      expect(archived?.count).toBe(1);
+      const processing = statuses.find(s => s.status === 'processing');
+      expect(processing?.count).toBe(1);
+    });
+  });
+
+  // ── Aggregate: latest ───────────────────────────────────────────────
+
+  describe('aggregate latest', () => {
+    it('returns the most recently created item', async () => {
+      const { aggregateSkillStoreItems } = await import(
+        '../src/api/skill-store/aggregate.ts'
+      );
+
+      await insertItem({ skill_id: 'sk1', title: 'Old', created_at: '2025-01-01T00:00:00Z' });
+      await insertItem({ skill_id: 'sk1', title: 'New', created_at: '2026-02-01T00:00:00Z' });
+      await insertItem({ skill_id: 'sk1', title: 'Deleted New', created_at: '2026-03-01T00:00:00Z', deleted_at: '2026-03-02T00:00:00Z' });
+
+      const result = await aggregateSkillStoreItems(pool, {
+        skill_id: 'sk1',
+        operation: 'latest',
+      });
+
+      expect(result.item).toBeDefined();
+      expect((result.item as Record<string, unknown>).title).toBe('New');
+    });
+
+    it('returns null when no items exist', async () => {
+      const { aggregateSkillStoreItems } = await import(
+        '../src/api/skill-store/aggregate.ts'
+      );
+
+      const result = await aggregateSkillStoreItems(pool, {
+        skill_id: 'nonexistent',
+        operation: 'latest',
+      });
+
+      expect(result.item).toBeNull();
+    });
+  });
+
+  // ── Aggregate: oldest ───────────────────────────────────────────────
+
+  describe('aggregate oldest', () => {
+    it('returns the oldest created item', async () => {
+      const { aggregateSkillStoreItems } = await import(
+        '../src/api/skill-store/aggregate.ts'
+      );
+
+      await insertItem({ skill_id: 'sk1', title: 'Oldest', created_at: '2025-01-01T00:00:00Z' });
+      await insertItem({ skill_id: 'sk1', title: 'Newer', created_at: '2026-01-01T00:00:00Z' });
+
+      const result = await aggregateSkillStoreItems(pool, {
+        skill_id: 'sk1',
+        operation: 'oldest',
+      });
+
+      expect(result.item).toBeDefined();
+      expect((result.item as Record<string, unknown>).title).toBe('Oldest');
+    });
+  });
+
+  // ── Collections with user_email ─────────────────────────────────────
+
+  describe('collections with user_email', () => {
+    it('filters collections by user_email', async () => {
+      await insertItem({ skill_id: 'sk1', collection: 'notes', user_email: 'a@test.com' });
+      await insertItem({ skill_id: 'sk1', collection: 'notes', user_email: 'a@test.com' });
+      await insertItem({ skill_id: 'sk1', collection: 'notes', user_email: 'b@test.com' });
+      await insertItem({ skill_id: 'sk1', collection: 'config', user_email: 'a@test.com' });
+
+      // Query collections filtered by user a
+      const result = await pool.query(
+        `SELECT collection,
+                COUNT(*) FILTER (WHERE deleted_at IS NULL)::int AS count,
+                MAX(created_at) FILTER (WHERE deleted_at IS NULL) AS latest_at
+         FROM skill_store_item
+         WHERE skill_id = $1 AND user_email = $2
+         GROUP BY collection
+         HAVING COUNT(*) FILTER (WHERE deleted_at IS NULL) > 0
+         ORDER BY collection`,
+        ['sk1', 'a@test.com']
+      );
+
+      expect(result.rows).toHaveLength(2);
+      const notes = result.rows.find((r: { collection: string }) => r.collection === 'notes');
+      expect(notes?.count).toBe(2);
+      const config = result.rows.find((r: { collection: string }) => r.collection === 'config');
+      expect(config?.count).toBe(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds three new OpenClaw plugin tools for skill store search, collection listing, and aggregation
- Adds server-side aggregate API endpoint (`GET /api/skill-store/aggregate`) with `count`, `count_by_tag`, `count_by_status`, `latest`, `oldest` operations
- Updates `GET /api/skill-store/collections` to support `user_email` filtering
- All schemas exported via barrel in `packages/openclaw-plugin/src/tools/index.ts`

### Plugin tools added

| Tool | Description |
|------|-------------|
| `skill_store_search` | Full-text + optional semantic search with graceful fallback. Params: `skill_id`, `query`, `collection`, `tags`, `semantic`, `min_similarity`, `limit`, `user_email` |
| `skill_store_collections` | List collections for a skill with item counts. Params: `skill_id`, `user_email` |
| `skill_store_aggregate` | Simple aggregations. Params: `skill_id`, `collection`, `operation`, `since`, `until`, `user_email` |

## Test plan

- [x] 45 plugin unit tests (vitest, mocked ApiClient) - all passing
- [x] 10 integration tests against real PostgreSQL for aggregate operations - all passing
- [x] 21 existing search integration tests still passing (31 total with new aggregate tests)
- [x] 874 total plugin tests passing (no regressions)
- [x] 234 total integration tests passing (no regressions)

Closes #801

🤖 Generated with [Claude Code](https://claude.com/claude-code)