### PR TITLE
[#808] Add skill store activity feed integration

### DIFF
--- a/migrations/052_skill_store_activity.down.sql
+++ b/migrations/052_skill_store_activity.down.sql
@@ -1,0 +1,4 @@
+-- Migration 052 down: Remove Skill Store Activity tracking (issue #808)
+
+DROP TABLE IF EXISTS skill_store_activity;
+DROP TYPE IF EXISTS skill_store_activity_type;

--- a/migrations/052_skill_store_activity.up.sql
+++ b/migrations/052_skill_store_activity.up.sql
@@ -1,0 +1,40 @@
+-- Migration 052: Skill Store Activity tracking (issue #808)
+-- Extends the activity feed to cover skill store operations.
+
+-- Activity types for skill store operations
+DO $$ BEGIN
+  CREATE TYPE skill_store_activity_type AS ENUM (
+    'item_created',
+    'item_updated',
+    'item_deleted',
+    'item_archived',
+    'items_bulk_created',
+    'items_bulk_deleted',
+    'schedule_triggered',
+    'schedule_paused',
+    'schedule_resumed',
+    'collection_deleted'
+  );
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+-- Skill store activity log table
+CREATE TABLE IF NOT EXISTS skill_store_activity (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  activity_type skill_store_activity_type NOT NULL,
+  skill_id text NOT NULL,
+  collection text,
+  description text NOT NULL,
+  metadata jsonb NOT NULL DEFAULT '{}',
+  read_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Indexes for efficient queries
+CREATE INDEX IF NOT EXISTS idx_skill_store_activity_skill_id ON skill_store_activity(skill_id);
+CREATE INDEX IF NOT EXISTS idx_skill_store_activity_created_at ON skill_store_activity(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_skill_store_activity_type ON skill_store_activity(activity_type);
+CREATE INDEX IF NOT EXISTS idx_skill_store_activity_read_at ON skill_store_activity(read_at);
+
+COMMENT ON TABLE skill_store_activity IS 'Tracks activity/changes on skill store items and schedules for activity feed (issue #808)';

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -1630,7 +1630,74 @@ export function buildServer(options: ProjectsApiOptions = {}): FastifyInstance {
 
     const pool = createPool();
 
-    // Build dynamic WHERE clause
+    // Issue #808: If entityType is 'skill_store', query only skill_store_activity.
+    // If no entityType filter, UNION both tables. Otherwise query work_item_activity only.
+    const isSkillStoreOnly = query.entityType === 'skill_store';
+    const includeSkillStore = !query.entityType || isSkillStoreOnly;
+
+    if (isSkillStoreOnly) {
+      // Skill store activity only (Issue #808)
+      const conditions: string[] = [];
+      const params: (string | number)[] = [];
+      let paramIndex = 1;
+
+      if (query.actionType) {
+        conditions.push(`sa.activity_type::text = $${paramIndex}`);
+        params.push(query.actionType);
+        paramIndex++;
+      }
+
+      if (query.since) {
+        conditions.push(`sa.created_at > $${paramIndex}`);
+        params.push(query.since);
+        paramIndex++;
+      }
+
+      const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+
+      const countResult = await pool.query(
+        `SELECT COUNT(*) as count FROM skill_store_activity sa ${whereClause}`,
+        params
+      );
+      const total = parseInt((countResult.rows[0] as { count: string }).count, 10);
+
+      params.push(limit);
+      params.push(offset);
+
+      const result = await pool.query(
+        `SELECT sa.id::text as id,
+                sa.activity_type::text as type,
+                NULL as work_item_id,
+                sa.description as work_item_title,
+                'skill_store' as entity_type,
+                NULL as actor_email,
+                sa.description,
+                sa.created_at,
+                sa.read_at,
+                sa.skill_id,
+                sa.collection,
+                sa.metadata
+           FROM skill_store_activity sa
+           ${whereClause}
+          ORDER BY sa.created_at DESC
+          LIMIT $${paramIndex} OFFSET $${paramIndex + 1}`,
+        params
+      );
+      await pool.end();
+
+      const response: {
+        items: unknown[];
+        pagination?: { page: number; limit: number; total: number; hasMore: boolean };
+      } = { items: result.rows };
+
+      if (page !== null) {
+        response.pagination = { page, limit, total, hasMore: offset + result.rows.length < total };
+      }
+
+      return reply.send(response);
+    }
+
+    // Build dynamic WHERE clause for work_item_activity
     const conditions: string[] = [];
     const params: (string | number)[] = [];
     let paramIndex = 1;
@@ -1671,13 +1738,35 @@ export function buildServer(options: ProjectsApiOptions = {}): FastifyInstance {
 
     const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
 
+    // Issue #808: When no entityType filter, UNION skill_store_activity into the feed
+    const skillStoreUnion = includeSkillStore
+      ? `UNION ALL
+         SELECT sa.id::text as id,
+                sa.activity_type::text as type,
+                NULL::text as work_item_id,
+                sa.description as work_item_title,
+                'skill_store' as entity_type,
+                NULL::text as actor_email,
+                sa.description,
+                sa.created_at,
+                sa.read_at
+           FROM skill_store_activity sa`
+      : '';
+
+    const skillStoreCountUnion = includeSkillStore
+      ? `UNION ALL SELECT sa.id FROM skill_store_activity sa`
+      : '';
+
     // Get total count for pagination
     const countResult = await pool.query(
       `${projectIdCTE}
-       SELECT COUNT(*) as count
-         FROM work_item_activity a
-         JOIN work_item w ON w.id = a.work_item_id
-         ${whereClause}`,
+       SELECT COUNT(*) as count FROM (
+         SELECT a.id
+           FROM work_item_activity a
+           JOIN work_item w ON w.id = a.work_item_id
+           ${whereClause}
+         ${skillStoreCountUnion}
+       ) combined`,
       params
     );
     const total = parseInt((countResult.rows[0] as { count: string }).count, 10);
@@ -1688,19 +1777,22 @@ export function buildServer(options: ProjectsApiOptions = {}): FastifyInstance {
 
     const result = await pool.query(
       `${projectIdCTE}
-       SELECT a.id::text as id,
-              a.activity_type::text as type,
-              a.work_item_id::text as work_item_id,
-              w.title as work_item_title,
-              w.work_item_kind::text as entity_type,
-              a.actor_email,
-              a.description,
-              a.created_at,
-              a.read_at
-         FROM work_item_activity a
-         JOIN work_item w ON w.id = a.work_item_id
-         ${whereClause}
-        ORDER BY a.created_at DESC
+       SELECT * FROM (
+         SELECT a.id::text as id,
+                a.activity_type::text as type,
+                a.work_item_id::text as work_item_id,
+                w.title as work_item_title,
+                w.work_item_kind::text as entity_type,
+                a.actor_email,
+                a.description,
+                a.created_at,
+                a.read_at
+           FROM work_item_activity a
+           JOIN work_item w ON w.id = a.work_item_id
+           ${whereClause}
+         ${skillStoreUnion}
+       ) combined
+        ORDER BY created_at DESC
         LIMIT $${paramIndex} OFFSET $${paramIndex + 1}`,
       params
     );
@@ -13085,6 +13177,19 @@ export function buildServer(options: ProjectsApiOptions = {}): FastifyInstance {
         const row = upsertResult.rows[0];
         const wasInsert = row._was_insert;
         delete row._was_insert;
+
+        // Emit activity event (Issue #808)
+        await pool.query(
+          `INSERT INTO skill_store_activity (activity_type, skill_id, collection, description, metadata)
+           VALUES ($1::skill_store_activity_type, $2, $3, $4, $5::jsonb)`,
+          [
+            wasInsert ? 'item_created' : 'item_updated',
+            skillId, collection,
+            wasInsert ? `Created item: ${title || key || row.id}` : `Updated item: ${title || key || row.id}`,
+            JSON.stringify({ item_id: row.id, key, title }),
+          ]
+        );
+
         return reply.code(wasInsert ? 201 : 200).send(row);
       }
 
@@ -13099,6 +13204,15 @@ export function buildServer(options: ProjectsApiOptions = {}): FastifyInstance {
         [skillId, collection, key, title, summary, content, data, tags,
          priority, mediaUrl, mediaType, sourceUrl, userEmail, expiresAt, pinned]
       );
+
+      // Emit activity event (Issue #808)
+      const insertedRow = insertResult.rows[0] as { id: string };
+      await pool.query(
+        `INSERT INTO skill_store_activity (activity_type, skill_id, collection, description, metadata)
+         VALUES ('item_created'::skill_store_activity_type, $1, $2, $3, $4::jsonb)`,
+        [skillId, collection, `Created item: ${title || insertedRow.id}`, JSON.stringify({ item_id: insertedRow.id, key, title })]
+      );
+
       return reply.code(201).send(insertResult.rows[0]);
     } finally {
       await pool.end();
@@ -13237,6 +13351,18 @@ export function buildServer(options: ProjectsApiOptions = {}): FastifyInstance {
         throw err;
       }
 
+      // Emit single summary activity event for bulk operation (Issue #808)
+      if (results.length > 0) {
+        const firstItem = items[0] as Record<string, unknown>;
+        const bulkSkillId = firstItem.skill_id as string;
+        const bulkCollection = (firstItem.collection as string) || '_default';
+        await pool.query(
+          `INSERT INTO skill_store_activity (activity_type, skill_id, collection, description, metadata)
+           VALUES ('items_bulk_created'::skill_store_activity_type, $1, $2, $3, $4::jsonb)`,
+          [bulkSkillId, bulkCollection, `Bulk created ${results.length} items`, JSON.stringify({ count: results.length, collection: bulkCollection })]
+        );
+      }
+
       return reply.send({ items: results, created: results.length });
     } finally {
       await pool.end();
@@ -13293,7 +13419,18 @@ export function buildServer(options: ProjectsApiOptions = {}): FastifyInstance {
          WHERE ${conditions.join(' AND ')}`,
         params
       );
-      return reply.send({ deleted: result.rowCount ?? 0 });
+
+      // Emit summary activity event for bulk delete (Issue #808)
+      const deletedCount = result.rowCount ?? 0;
+      if (deletedCount > 0) {
+        await pool.query(
+          `INSERT INTO skill_store_activity (activity_type, skill_id, collection, description, metadata)
+           VALUES ('items_bulk_deleted'::skill_store_activity_type, $1, $2, $3, $4::jsonb)`,
+          [skillId, collection || null, `Bulk deleted ${deletedCount} items`, JSON.stringify({ count: deletedCount, collection })]
+        );
+      }
+
+      return reply.send({ deleted: deletedCount });
     } finally {
       await pool.end();
     }
@@ -13513,6 +13650,15 @@ export function buildServer(options: ProjectsApiOptions = {}): FastifyInstance {
       if (result.rows.length === 0) {
         return reply.code(404).send({ error: 'not found' });
       }
+
+      // Emit activity event (Issue #808)
+      const updatedItem = result.rows[0] as { id: string; skill_id: string; collection: string; title: string | null };
+      await pool.query(
+        `INSERT INTO skill_store_activity (activity_type, skill_id, collection, description, metadata)
+         VALUES ('item_updated'::skill_store_activity_type, $1, $2, $3, $4::jsonb)`,
+        [updatedItem.skill_id, updatedItem.collection, `Updated item: ${updatedItem.title || updatedItem.id}`, JSON.stringify({ item_id: updatedItem.id })]
+      );
+
       return reply.send(result.rows[0]);
     } finally {
       await pool.end();
@@ -13531,6 +13677,12 @@ export function buildServer(options: ProjectsApiOptions = {}): FastifyInstance {
     const permanent = query.permanent === 'true';
     const pool = createPool();
     try {
+      // Fetch item info for activity event before deletion (Issue #808)
+      const itemInfo = await pool.query(
+        `SELECT skill_id, collection, title FROM skill_store_item WHERE id = $1`,
+        [params.id]
+      );
+
       let result;
       if (permanent) {
         result = await pool.query(
@@ -13549,6 +13701,17 @@ export function buildServer(options: ProjectsApiOptions = {}): FastifyInstance {
       if ((result.rowCount ?? 0) === 0) {
         return reply.code(404).send({ error: 'not found' });
       }
+
+      // Emit activity event (Issue #808)
+      if (itemInfo.rows.length > 0) {
+        const item = itemInfo.rows[0] as { skill_id: string; collection: string; title: string | null };
+        await pool.query(
+          `INSERT INTO skill_store_activity (activity_type, skill_id, collection, description, metadata)
+           VALUES ('item_deleted'::skill_store_activity_type, $1, $2, $3, $4::jsonb)`,
+          [item.skill_id, item.collection, `Deleted item: ${item.title || params.id}`, JSON.stringify({ item_id: params.id, permanent })]
+        );
+      }
+
       return reply.code(204).send();
     } finally {
       await pool.end();
@@ -14073,6 +14236,13 @@ export function buildServer(options: ProjectsApiOptions = {}): FastifyInstance {
         ]
       );
 
+      // Emit activity event (Issue #808)
+      await pool.query(
+        `INSERT INTO skill_store_activity (activity_type, skill_id, collection, description, metadata)
+         VALUES ('schedule_triggered'::skill_store_activity_type, $1, $2, $3, $4::jsonb)`,
+        [schedule.skill_id, schedule.collection, `Manually triggered schedule`, JSON.stringify({ schedule_id: schedule.id })]
+      );
+
       return reply.code(202).send({
         job_id: (jobResult.rows[0] as { id: string }).id,
         message: 'Schedule triggered, job enqueued for processing',
@@ -14109,6 +14279,15 @@ export function buildServer(options: ProjectsApiOptions = {}): FastifyInstance {
         return reply.code(404).send({ error: 'Schedule not found' });
       }
 
+      const schedule = result.rows[0] as { id: string; skill_id: string; collection: string | null };
+
+      // Emit activity event (Issue #808)
+      await pool.query(
+        `INSERT INTO skill_store_activity (activity_type, skill_id, collection, description, metadata)
+         VALUES ('schedule_paused'::skill_store_activity_type, $1, $2, $3, $4::jsonb)`,
+        [schedule.skill_id, schedule.collection, `Paused schedule`, JSON.stringify({ schedule_id: schedule.id })]
+      );
+
       return reply.send(result.rows[0]);
     } finally {
       await pool.end();
@@ -14141,6 +14320,15 @@ export function buildServer(options: ProjectsApiOptions = {}): FastifyInstance {
       if (result.rows.length === 0) {
         return reply.code(404).send({ error: 'Schedule not found' });
       }
+
+      const schedule = result.rows[0] as { id: string; skill_id: string; collection: string | null };
+
+      // Emit activity event (Issue #808)
+      await pool.query(
+        `INSERT INTO skill_store_activity (activity_type, skill_id, collection, description, metadata)
+         VALUES ('schedule_resumed'::skill_store_activity_type, $1, $2, $3, $4::jsonb)`,
+        [schedule.skill_id, schedule.collection, `Resumed schedule`, JSON.stringify({ schedule_id: schedule.id })]
+      );
 
       return reply.send(result.rows[0]);
     } finally {

--- a/tests/helpers/db.ts
+++ b/tests/helpers/db.ts
@@ -69,6 +69,7 @@ const APPLICATION_TABLES = [
   'note',
   'notebook',
   // Skill Store (Epic #794)
+  'skill_store_activity',
   'skill_store_schedule',
   'skill_store_item',
   // Async/queue tables (no FKs today, but still want consistent cleanup)

--- a/tests/skill_store_activity.test.ts
+++ b/tests/skill_store_activity.test.ts
@@ -1,0 +1,364 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { Pool } from 'pg';
+import { buildServer } from '../src/api/server.ts';
+import { runMigrate } from './helpers/migrate.ts';
+import { createTestPool, truncateAllTables } from './helpers/db.ts';
+
+/**
+ * Integration tests for Skill Store Activity Feed (Issue #808).
+ *
+ * Covers:
+ * - Activity events on item create/update/delete
+ * - Activity events on schedule trigger
+ * - Activity events on bulk operations (summary events)
+ * - Events appear in /api/activity endpoint
+ * - Events include skill_id, collection, operation type
+ */
+describe('Skill Store Activity Feed (Issue #808)', () => {
+  const app = buildServer();
+  let pool: Pool;
+
+  beforeAll(async () => {
+    await runMigrate('up');
+    pool = createTestPool();
+    await app.ready();
+  });
+
+  beforeEach(async () => {
+    await truncateAllTables(pool);
+  });
+
+  afterAll(async () => {
+    await app.close();
+    await pool.end();
+  });
+
+  describe('Migration', () => {
+    it('creates skill_store_activity table', async () => {
+      const result = await pool.query(
+        `SELECT tablename FROM pg_tables
+         WHERE schemaname = 'public' AND tablename = 'skill_store_activity'`
+      );
+      expect(result.rows).toHaveLength(1);
+    });
+
+    it('has all required columns', async () => {
+      const result = await pool.query(
+        `SELECT column_name FROM information_schema.columns
+         WHERE table_name = 'skill_store_activity'
+         ORDER BY ordinal_position`
+      );
+      const columns = result.rows.map((r) => r.column_name);
+      expect(columns).toContain('id');
+      expect(columns).toContain('activity_type');
+      expect(columns).toContain('skill_id');
+      expect(columns).toContain('collection');
+      expect(columns).toContain('description');
+      expect(columns).toContain('metadata');
+      expect(columns).toContain('read_at');
+      expect(columns).toContain('created_at');
+    });
+
+    it('has required indexes', async () => {
+      const result = await pool.query(
+        `SELECT indexname FROM pg_indexes
+         WHERE tablename = 'skill_store_activity'
+         ORDER BY indexname`
+      );
+      const indexNames = result.rows.map((r) => r.indexname);
+      expect(indexNames).toContain('idx_skill_store_activity_skill_id');
+      expect(indexNames).toContain('idx_skill_store_activity_created_at');
+      expect(indexNames).toContain('idx_skill_store_activity_type');
+    });
+  });
+
+  describe('Item create activity', () => {
+    it('emits activity event when item is created', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/skill-store/items',
+        payload: {
+          skill_id: 'test-skill',
+          collection: 'articles',
+          title: 'Test Article',
+          content: 'Some content',
+        },
+      });
+      expect(res.statusCode).toBe(201);
+
+      const activity = await pool.query(
+        `SELECT activity_type::text, skill_id, collection, description, metadata
+         FROM skill_store_activity
+         WHERE activity_type = 'item_created'`
+      );
+      expect(activity.rows).toHaveLength(1);
+      expect(activity.rows[0].skill_id).toBe('test-skill');
+      expect(activity.rows[0].collection).toBe('articles');
+      expect(activity.rows[0].description).toContain('Test Article');
+    });
+  });
+
+  describe('Item update activity', () => {
+    it('emits activity event when item is updated', async () => {
+      // Create item
+      const createRes = await app.inject({
+        method: 'POST',
+        url: '/api/skill-store/items',
+        payload: {
+          skill_id: 'test-skill',
+          collection: 'articles',
+          title: 'Original Title',
+        },
+      });
+      const itemId = createRes.json().id;
+
+      // Update item
+      const updateRes = await app.inject({
+        method: 'PATCH',
+        url: `/api/skill-store/items/${itemId}`,
+        payload: { title: 'Updated Title' },
+      });
+      expect(updateRes.statusCode).toBe(200);
+
+      const activity = await pool.query(
+        `SELECT activity_type::text, skill_id, description
+         FROM skill_store_activity
+         WHERE activity_type = 'item_updated'`
+      );
+      expect(activity.rows).toHaveLength(1);
+      expect(activity.rows[0].skill_id).toBe('test-skill');
+    });
+  });
+
+  describe('Item delete activity', () => {
+    it('emits activity event when item is deleted', async () => {
+      // Create item
+      const createRes = await app.inject({
+        method: 'POST',
+        url: '/api/skill-store/items',
+        payload: {
+          skill_id: 'test-skill',
+          collection: 'articles',
+          title: 'To Delete',
+        },
+      });
+      const itemId = createRes.json().id;
+
+      // Delete item
+      const deleteRes = await app.inject({
+        method: 'DELETE',
+        url: `/api/skill-store/items/${itemId}`,
+      });
+      expect(deleteRes.statusCode).toBe(204);
+
+      const activity = await pool.query(
+        `SELECT activity_type::text, skill_id, description
+         FROM skill_store_activity
+         WHERE activity_type = 'item_deleted'`
+      );
+      expect(activity.rows).toHaveLength(1);
+      expect(activity.rows[0].skill_id).toBe('test-skill');
+    });
+  });
+
+  describe('Bulk operations activity', () => {
+    it('emits summary event for bulk create (not N individual events)', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/skill-store/items/bulk',
+        payload: {
+          items: [
+            { skill_id: 'test-skill', collection: 'articles', title: 'Item 1' },
+            { skill_id: 'test-skill', collection: 'articles', title: 'Item 2' },
+            { skill_id: 'test-skill', collection: 'articles', title: 'Item 3' },
+          ],
+        },
+      });
+      expect(res.statusCode).toBe(200);
+
+      const activity = await pool.query(
+        `SELECT activity_type::text, skill_id, description, metadata
+         FROM skill_store_activity
+         WHERE activity_type = 'items_bulk_created'`
+      );
+      // Should be 1 summary event, not 3 individual events
+      expect(activity.rows).toHaveLength(1);
+      expect(activity.rows[0].skill_id).toBe('test-skill');
+      expect(activity.rows[0].metadata.count).toBe(3);
+    });
+
+    it('emits summary event for bulk delete', async () => {
+      // Create items first
+      await app.inject({
+        method: 'POST',
+        url: '/api/skill-store/items/bulk',
+        payload: {
+          items: [
+            { skill_id: 'test-skill', collection: 'articles', title: 'Item 1' },
+            { skill_id: 'test-skill', collection: 'articles', title: 'Item 2' },
+          ],
+        },
+      });
+
+      // Clear activity from create
+      await pool.query(`DELETE FROM skill_store_activity`);
+
+      const res = await app.inject({
+        method: 'DELETE',
+        url: '/api/skill-store/items/bulk',
+        payload: {
+          skill_id: 'test-skill',
+          collection: 'articles',
+        },
+      });
+      expect(res.statusCode).toBe(200);
+
+      const activity = await pool.query(
+        `SELECT activity_type::text, skill_id, description, metadata
+         FROM skill_store_activity
+         WHERE activity_type = 'items_bulk_deleted'`
+      );
+      expect(activity.rows).toHaveLength(1);
+      expect(activity.rows[0].skill_id).toBe('test-skill');
+    });
+  });
+
+  describe('Schedule trigger activity', () => {
+    it('emits activity event when schedule is manually triggered', async () => {
+      // Create a schedule
+      const createRes = await app.inject({
+        method: 'POST',
+        url: '/api/skill-store/schedules',
+        payload: {
+          skill_id: 'test-skill',
+          collection: 'articles',
+          cron_expression: '0 9 * * *',
+          webhook_url: 'https://example.com/hook',
+        },
+      });
+      const scheduleId = createRes.json().id;
+
+      // Trigger it
+      const triggerRes = await app.inject({
+        method: 'POST',
+        url: `/api/skill-store/schedules/${scheduleId}/trigger`,
+      });
+      expect(triggerRes.statusCode).toBe(202);
+
+      const activity = await pool.query(
+        `SELECT activity_type::text, skill_id, collection, description
+         FROM skill_store_activity
+         WHERE activity_type = 'schedule_triggered'`
+      );
+      expect(activity.rows).toHaveLength(1);
+      expect(activity.rows[0].skill_id).toBe('test-skill');
+      expect(activity.rows[0].collection).toBe('articles');
+    });
+  });
+
+  describe('Activity feed API includes skill store events', () => {
+    it('includes skill store events in /api/activity', async () => {
+      // Create a skill store item to generate activity
+      await app.inject({
+        method: 'POST',
+        url: '/api/skill-store/items',
+        payload: {
+          skill_id: 'test-skill',
+          collection: 'articles',
+          title: 'Activity Test Item',
+        },
+      });
+
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/activity',
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      // Should include at least the skill store item_created event
+      const skillStoreEvents = body.items.filter(
+        (item: Record<string, unknown>) => item.entity_type === 'skill_store'
+      );
+      expect(skillStoreEvents.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('supports filtering by entity type for skill store events', async () => {
+      // Create activity
+      await app.inject({
+        method: 'POST',
+        url: '/api/skill-store/items',
+        payload: {
+          skill_id: 'test-skill',
+          collection: 'articles',
+          title: 'Filter Test',
+        },
+      });
+
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/activity?entityType=skill_store',
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.items.length).toBeGreaterThanOrEqual(1);
+      for (const item of body.items) {
+        expect(item.entity_type).toBe('skill_store');
+      }
+    });
+  });
+
+  describe('Pause/Resume activity', () => {
+    it('emits activity on pause', async () => {
+      const createRes = await app.inject({
+        method: 'POST',
+        url: '/api/skill-store/schedules',
+        payload: {
+          skill_id: 'test-skill',
+          cron_expression: '0 9 * * *',
+          webhook_url: 'https://example.com/hook',
+        },
+      });
+      const scheduleId = createRes.json().id;
+
+      await app.inject({
+        method: 'POST',
+        url: `/api/skill-store/schedules/${scheduleId}/pause`,
+      });
+
+      const activity = await pool.query(
+        `SELECT activity_type::text, skill_id
+         FROM skill_store_activity
+         WHERE activity_type = 'schedule_paused'`
+      );
+      expect(activity.rows).toHaveLength(1);
+    });
+
+    it('emits activity on resume', async () => {
+      const createRes = await app.inject({
+        method: 'POST',
+        url: '/api/skill-store/schedules',
+        payload: {
+          skill_id: 'test-skill',
+          cron_expression: '0 9 * * *',
+          webhook_url: 'https://example.com/hook',
+          enabled: false,
+        },
+      });
+      const scheduleId = createRes.json().id;
+
+      await app.inject({
+        method: 'POST',
+        url: `/api/skill-store/schedules/${scheduleId}/resume`,
+      });
+
+      const activity = await pool.query(
+        `SELECT activity_type::text, skill_id
+         FROM skill_store_activity
+         WHERE activity_type = 'schedule_resumed'`
+      );
+      expect(activity.rows).toHaveLength(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #808

- Add `skill_store_activity` table (migration 052) with enum type for tracking skill store operations
- Emit activity events on item create/update/delete, bulk create/delete (summary events), and schedule trigger/pause/resume
- Extend `GET /api/activity` endpoint to include skill store events via UNION query
- Support `entityType=skill_store` filtering for the activity feed
- Add 13 integration tests covering migration, all activity emission types, and the activity feed API

## Test plan

- [x] Migration creates `skill_store_activity` table with all required columns and indexes
- [x] Item create/update/delete emit individual activity events with correct skill_id and collection
- [x] Bulk create/delete emit single summary events (not N individual events) with count in metadata
- [x] Schedule trigger/pause/resume emit activity events
- [x] `GET /api/activity` includes skill store events alongside work item events
- [x] `GET /api/activity?entityType=skill_store` returns only skill store events
- [x] All 13 tests passing locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)