### PR TITLE
[#830] Fix embedding silent success causing infinite backfill

### DIFF
--- a/migrations/054_embedding_skipped_status.down.sql
+++ b/migrations/054_embedding_skipped_status.down.sql
@@ -1,0 +1,13 @@
+-- Migration 054: Remove 'skipped' from skill_store_item embedding_status (Rollback)
+-- Part of Epic #794, Issue #830
+
+-- Revert any skipped items back to pending before restoring the constraint
+UPDATE skill_store_item SET embedding_status = 'pending' WHERE embedding_status = 'skipped';
+
+-- Restore original CHECK constraint
+ALTER TABLE skill_store_item
+  DROP CONSTRAINT IF EXISTS skill_store_item_embedding_status_check;
+
+ALTER TABLE skill_store_item
+  ADD CONSTRAINT skill_store_item_embedding_status_check
+  CHECK (embedding_status IN ('complete', 'pending', 'failed'));

--- a/migrations/054_embedding_skipped_status.up.sql
+++ b/migrations/054_embedding_skipped_status.up.sql
@@ -1,0 +1,16 @@
+-- Migration 054: Add 'skipped' to skill_store_item embedding_status
+-- Part of Epic #794, Issue #830
+--
+-- Fixes: Items with no embeddable content (no title/summary/content) get
+-- embedding_status='skipped' to prevent infinite backfill re-enqueue.
+
+-- Drop old CHECK constraint and add new one including 'skipped'
+ALTER TABLE skill_store_item
+  DROP CONSTRAINT IF EXISTS skill_store_item_embedding_status_check;
+
+ALTER TABLE skill_store_item
+  ADD CONSTRAINT skill_store_item_embedding_status_check
+  CHECK (embedding_status IN ('complete', 'pending', 'failed', 'skipped'));
+
+COMMENT ON COLUMN skill_store_item.embedding_status
+  IS 'Embedding status: complete, pending, failed, or skipped (no embeddable content)';


### PR DESCRIPTION
## Summary
- Items with no embeddable content (no title/summary/content) now get `embedding_status='skipped'` instead of staying `'pending'`, preventing the backfill function from re-enqueueing jobs infinitely
- Migration 054 adds `'skipped'` to the `skill_store_item` embedding_status CHECK constraint
- Both `handleSkillStoreEmbedJob` and `backfillSkillStoreEmbeddings` now set the terminal `'skipped'` status

## Test plan
- [x] Test: item with no text gets `embedding_status='skipped'` after embed job
- [x] Test: backfill does not re-enqueue items already marked `'skipped'`
- [x] All 110 relevant tests pass (15 job handler + 47 SSRF + 48 schedule API)

Closes #830

🤖 Generated with [Claude Code](https://claude.com/claude-code)