### PR TITLE
[#824] Register missing gateway tools and fix validation bypass

### DIFF
--- a/packages/openclaw-plugin/tests/register-openclaw.test.ts
+++ b/packages/openclaw-plugin/tests/register-openclaw.test.ts
@@ -66,10 +66,10 @@ describe('OpenClaw 2026 API Registration', () => {
   })
 
   describe('registration', () => {
-    it('should register all 24 tools', async () => {
+    it('should register all 27 tools', async () => {
       await registerOpenClaw(mockApi)
 
-      expect(registeredTools).toHaveLength(24)
+      expect(registeredTools).toHaveLength(27)
       const toolNames = registeredTools.map((t) => t.name)
       expect(toolNames).toContain('memory_recall')
       expect(toolNames).toContain('memory_store')
@@ -95,6 +95,9 @@ describe('OpenClaw 2026 API Registration', () => {
       expect(toolNames).toContain('skill_store_get')
       expect(toolNames).toContain('skill_store_list')
       expect(toolNames).toContain('skill_store_delete')
+      expect(toolNames).toContain('skill_store_search')
+      expect(toolNames).toContain('skill_store_collections')
+      expect(toolNames).toContain('skill_store_aggregate')
     })
 
     it('should register before_agent_start hook via api.on() when autoRecall is true', async () => {
@@ -144,7 +147,7 @@ describe('OpenClaw 2026 API Registration', () => {
       expect(mockApi.logger.info).toHaveBeenCalledWith(
         'OpenClaw Projects plugin registered',
         expect.objectContaining({
-          toolCount: 24,
+          toolCount: 27,
         })
       )
     })


### PR DESCRIPTION
## Summary
- Registers all 7 skill store tools in the gateway (was 4; `skill_store_search`, `skill_store_collections`, `skill_store_aggregate` were missing)
- Gateway handlers now delegate to tool module `execute()` methods instead of using raw `params as {...}` type assertions, enabling Zod validation, credential detection, text sanitization, and error sanitization
- Net code reduction: -300 lines of hand-rolled handlers, +184 lines of delegation + schemas

## Test plan
- [x] All 27 tools registered (updated from 24)
- [x] Registration log message reflects 27 tools
- [x] All 874 plugin tests pass
- [x] TypeScript compiles cleanly

Closes #824

🤖 Generated with [Claude Code](https://claude.com/claude-code)