### PR TITLE
[#843] Fix missing openclaw.extensions in package.json

### DIFF
--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -66,5 +66,8 @@
   },
   "engines": {
     "node": ">=20.0.0"
+  },
+  "openclaw": {
+    "extensions": ["dist/register-openclaw.js"]
   }
 }

--- a/packages/openclaw-plugin/tests/package-structure.test.ts
+++ b/packages/openclaw-plugin/tests/package-structure.test.ts
@@ -134,6 +134,31 @@ describe('Package Structure', () => {
       const pkg = JSON.parse(readFileSync(packagePath, 'utf-8'))
       expect(pkg.scripts).toHaveProperty('build')
     })
+
+    it('should have openclaw.extensions field for plugin installer discovery', () => {
+      const packagePath = join(packageRoot, 'package.json')
+      const pkg = JSON.parse(readFileSync(packagePath, 'utf-8'))
+      expect(pkg.openclaw).toBeDefined()
+      expect(pkg.openclaw.extensions).toBeDefined()
+      expect(Array.isArray(pkg.openclaw.extensions)).toBe(true)
+      expect(pkg.openclaw.extensions.length).toBeGreaterThan(0)
+    })
+
+    it('should list dist/register-openclaw.js as an openclaw extension entry point', () => {
+      const packagePath = join(packageRoot, 'package.json')
+      const pkg = JSON.parse(readFileSync(packagePath, 'utf-8'))
+      expect(pkg.openclaw.extensions).toContain('dist/register-openclaw.js')
+    })
+
+    it('should have openclaw.extensions entries that match files in the package', () => {
+      const packagePath = join(packageRoot, 'package.json')
+      const pkg = JSON.parse(readFileSync(packagePath, 'utf-8'))
+      // All extension entries should be non-empty strings
+      for (const entry of pkg.openclaw.extensions) {
+        expect(typeof entry).toBe('string')
+        expect(entry.trim().length).toBeGreaterThan(0)
+      }
+    })
   })
 
   describe('.npmignore security', () => {


### PR DESCRIPTION
## Summary

Closes #843

The OpenClaw plugin installer requires `openclaw.extensions` in `package.json` to discover plugin entry points. Without this field, running `openclaw plugins install @troykelly/openclaw-projects` fails with:

```
Error: package.json missing openclaw.extensions
```

### Changes

- **`packages/openclaw-plugin/package.json`**: Added `"openclaw": { "extensions": ["dist/register-openclaw.js"] }` field
- **`packages/openclaw-plugin/tests/package-structure.test.ts`**: Added 3 tests validating:
  - `openclaw.extensions` field exists and is a non-empty array
  - The array contains `dist/register-openclaw.js`
  - All entries are non-empty strings

### Verification

- `pnpm run test` — 894 tests pass (31 test files)
- `pnpm run typecheck` — clean
- `pnpm run build` — clean
- `pnpm pack --dry-run` — confirms `dist/register-openclaw.js` is included in the tarball