### PR TITLE
[#845] Fix skills discovery — change skillsDir to skills array in manifest

### DIFF
--- a/packages/openclaw-plugin/openclaw.plugin.json
+++ b/packages/openclaw-plugin/openclaw.plugin.json
@@ -5,7 +5,7 @@
   "version": "2.1.0",
   "kind": "memory",
   "main": "dist/index.js",
-  "skillsDir": "skills",
+  "skills": ["skills"],
   "configSchema": {
     "type": "object",
     "properties": {

--- a/packages/openclaw-plugin/tests/package-structure.test.ts
+++ b/packages/openclaw-plugin/tests/package-structure.test.ts
@@ -178,10 +178,17 @@ describe('Package Structure', () => {
   })
 
   describe('Skills Directory', () => {
-    it('should have skillsDir declared in manifest', () => {
+    it('should have skills field as an array in manifest', () => {
       const manifestPath = join(packageRoot, 'openclaw.plugin.json')
       const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8'))
-      expect(manifest.skillsDir).toBe('skills')
+      expect(Array.isArray(manifest.skills)).toBe(true)
+      expect(manifest.skills).toContain('skills')
+    })
+
+    it('should not have the deprecated skillsDir field', () => {
+      const manifestPath = join(packageRoot, 'openclaw.plugin.json')
+      const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8'))
+      expect(manifest).not.toHaveProperty('skillsDir')
     })
 
     it('should have skills directory', () => {


### PR DESCRIPTION
## Summary

Closes #845

- Replace deprecated `skillsDir` string field with `skills` array field in `openclaw.plugin.json`
- OpenClaw's manifest loader uses `normalizeStringList(raw.skills)` which expects an array, not `skillsDir`
- All 4 bundled skills (contact-lookup, daily-summary, project-status, send-reminder) are now discoverable

## Changes

- `packages/openclaw-plugin/openclaw.plugin.json`: `"skillsDir": "skills"` -> `"skills": ["skills"]`
- `packages/openclaw-plugin/tests/package-structure.test.ts`: Updated test to assert `skills` is an array containing `"skills"`, and added test asserting `skillsDir` is absent

## Test Plan

- [x] TDD: wrote failing tests first, confirmed they fail
- [x] Implemented fix, confirmed tests pass
- [x] All 892 plugin tests pass (`pnpm exec vitest run packages/openclaw-plugin/tests/`)
- [x] Build passes (`pnpm run build`)
- [x] Verified all 4 SKILL.md files exist in skills directories

## Local Commands Run

```bash
pnpm exec vitest run packages/openclaw-plugin/tests/ --reporter=verbose  # 892 passed, 0 failed
pnpm run build  # success
```