### PR TITLE
[#846] Remove unused main field from plugin manifest

### DIFF
--- a/packages/openclaw-plugin/openclaw.plugin.json
+++ b/packages/openclaw-plugin/openclaw.plugin.json
@@ -4,7 +4,6 @@
   "description": "Memory provider with projects, todos, and contacts integration",
   "version": "2.1.0",
   "kind": "memory",
-  "main": "dist/index.js",
   "skills": ["skills"],
   "configSchema": {
     "type": "object",

--- a/packages/openclaw-plugin/tests/package-structure.test.ts
+++ b/packages/openclaw-plugin/tests/package-structure.test.ts
@@ -79,8 +79,13 @@ describe('Package Structure', () => {
       expect(manifest).toHaveProperty('name')
       expect(manifest).toHaveProperty('description')
       expect(manifest).toHaveProperty('version')
-      expect(manifest).toHaveProperty('main')
       expect(manifest).toHaveProperty('configSchema')
+    })
+
+    it('should not have main field (entry point comes from package.json)', () => {
+      const manifestPath = join(packageRoot, 'openclaw.plugin.json')
+      const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8'))
+      expect(manifest).not.toHaveProperty('main')
     })
 
     it('should have configSchema with required apiUrl and flexible apiKey', () => {


### PR DESCRIPTION
## Summary

Closes #846

- Remove `"main": "dist/index.js"` from `openclaw.plugin.json` — OpenClaw's manifest loader does not read this field
- Entry point discovery uses `package.json`'s `openclaw.extensions` (fixed in #843), not the manifest's `main`
- `package.json` retains its `main` field for Node.js module resolution

## Changes

- `packages/openclaw-plugin/openclaw.plugin.json`: Removed `"main": "dist/index.js"`
- `packages/openclaw-plugin/tests/package-structure.test.ts`: Removed `main` from required fields assertion, added test asserting `main` is absent from manifest

## Test Plan

- [x] TDD: wrote failing test first, confirmed it fails
- [x] Implemented fix, confirmed tests pass
- [x] All 918 plugin tests pass
- [x] Build passes
- [x] Verified `package.json` still has `main` for Node.js resolution

## Local Commands Run

```bash
pnpm exec vitest run packages/openclaw-plugin/tests/ # 918 passed, 0 failed
pnpm run build # success
```