### PR TITLE
[#848] Fix plugin version to 0.0.3

### DIFF
--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@troykelly/openclaw-projects",
-  "version": "1.0.0",
+  "version": "0.0.3",
   "description": "OpenClaw memory plugin with projects, todos, and contacts integration",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/openclaw-plugin/tests/package-structure.test.ts
+++ b/packages/openclaw-plugin/tests/package-structure.test.ts
@@ -119,11 +119,11 @@ describe('Package Structure', () => {
       expect(pkg.name).toBe('@troykelly/openclaw-projects')
     })
 
-    it('should have a production-ready version (>= 1.0.0)', () => {
+    it('should have a valid semver version', () => {
       const packagePath = join(packageRoot, 'package.json')
       const pkg = JSON.parse(readFileSync(packagePath, 'utf-8'))
-      const [major] = pkg.version.split('.').map(Number)
-      expect(major).toBeGreaterThanOrEqual(1)
+      expect(pkg.version).toMatch(/^\d+\.\d+\.\d+$/)
+      expect(pkg.version).toBe('0.0.3')
     })
 
     it('should have zod as dependency', () => {


### PR DESCRIPTION
## Summary

Closes #848

Follow-up to PR #856 — corrects the version from `1.0.0` to `0.0.3` per user clarification.

- Change `packages/openclaw-plugin/package.json` version from `1.0.0` to `0.0.3`
- Update version test to assert exact version `0.0.3`
- `openclaw.plugin.json` still has no `version` field (inherits from package.json, set in PR #856)

## Test Plan

- [x] TDD: updated test to expect `0.0.3`, confirmed it fails with `1.0.0`
- [x] Changed version, confirmed tests pass
- [x] All 921 plugin tests pass
- [x] Build passes

## Local Commands Run

```bash
pnpm exec vitest run packages/openclaw-plugin/tests/ # 921 passed, 0 failed
pnpm run build # success
```