### PR TITLE
[#859] Add typecheck step to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,14 +24,24 @@ jobs:
           # The bind mount ends up non-writable for vscode, causing EACCES when tools create temp files in the repo.
           docker compose -f .devcontainer/docker-compose.devcontainer.yml exec -T -u root workspace bash -lc "chown -R vscode:vscode /workspaces/openclaw-projects"
 
-      - name: Install deps + build + run tests
+      - name: Install dependencies
+        run: |
+          docker compose -f .devcontainer/docker-compose.devcontainer.yml exec -T workspace bash -lc "cd /workspaces/openclaw-projects && pnpm install --frozen-lockfile"
+
+      - name: Typecheck
+        run: |
+          docker compose -f .devcontainer/docker-compose.devcontainer.yml exec -T workspace bash -lc "cd /workspaces/openclaw-projects && pnpm build"
+
+      - name: Build frontend
+        run: |
+          docker compose -f .devcontainer/docker-compose.devcontainer.yml exec -T workspace bash -lc "cd /workspaces/openclaw-projects && pnpm app:build && pnpm css:build"
+
+      - name: Run tests
         env:
           VOYAGERAI_API_KEY: ${{ secrets.VOYAGERAI_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
         run: |
-          docker compose -f .devcontainer/docker-compose.devcontainer.yml exec -T workspace bash -lc "cd /workspaces/openclaw-projects && pnpm install --frozen-lockfile"
-          docker compose -f .devcontainer/docker-compose.devcontainer.yml exec -T workspace bash -lc "cd /workspaces/openclaw-projects && pnpm app:build && pnpm css:build"
           docker compose -f .devcontainer/docker-compose.devcontainer.yml exec -T \
             -e VOYAGERAI_API_KEY \
             -e OPENAI_API_KEY \


### PR DESCRIPTION
Closes #859

## Summary

Split the monolithic "Install deps + build + run tests" CI step into four separate named steps:

1. **Install dependencies** — `pnpm install --frozen-lockfile`
2. **Typecheck** — `pnpm build` (runs `tsc -p tsconfig.build.json --noEmit`)
3. **Build frontend** — `pnpm app:build && pnpm css:build`
4. **Run tests** — `pnpm -s test` (with API key env vars)

The typecheck step runs before both the frontend build and tests, so type errors will fail CI early.

## Acceptance Criteria

- [x] CI runs `pnpm build` (tsc --noEmit) as a named step
- [x] Typecheck runs before tests
- [x] Type errors cause CI to fail
- [x] Existing CI still passes (verified `pnpm build` passes locally)

## Local Verification

```bash
pnpm build  # passes with no errors
```