### PR TITLE
[#858] Fix E2E tests — docker-compose.test.yml Dockerfile reference and service timeout

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -3,7 +3,7 @@
 #
 # Usage:
 #   docker-compose -f docker-compose.test.yml up -d
-#   npm run test:e2e
+#   pnpm run test:e2e
 #   docker-compose -f docker-compose.test.yml down -v
 
 services:
@@ -33,7 +33,7 @@ services:
   backend-test:
     build:
       context: .
-      dockerfile: Dockerfile
+      dockerfile: docker/api/Dockerfile
     container_name: openclaw-backend-test
     environment:
       DATABASE_URL: postgres://openclaw:openclaw_test@postgres-test:5432/openclaw_test

--- a/scripts/wait-for-services.sh
+++ b/scripts/wait-for-services.sh
@@ -5,7 +5,7 @@
 set -e
 
 BACKEND_URL="${E2E_API_URL:-http://localhost:3001}"
-TIMEOUT="${E2E_TIMEOUT:-60}"
+TIMEOUT="${E2E_TIMEOUT:-180}"
 INTERVAL=2
 
 echo "Waiting for backend at $BACKEND_URL..."


### PR DESCRIPTION
## Summary
- Fix `docker-compose.test.yml` backend-test Dockerfile path from nonexistent root `Dockerfile` to `docker/api/Dockerfile`
- Fix comment referencing `npm` → `pnpm`
- Increase `wait-for-services.sh` default timeout from 60s to 180s

Closes #858
Closes #861

## Test plan
- [x] `docker compose -f docker-compose.test.yml config` validates successfully
- [x] `docker/api/Dockerfile` confirmed to exist
- [x] E2E CI workflow should now be able to build and start services

🤖 Generated with [Claude Code](https://claude.com/claude-code)