### PR TITLE
[#866] Harden execSync command execution

### DIFF
--- a/packages/openclaw-plugin/src/secrets.ts
+++ b/packages/openclaw-plugin/src/secrets.ts
@@ -87,11 +87,17 @@ function resolveFromCommand(command: string, timeout: number): string {
     })
     return result.trim()
   } catch (error) {
-    const err = error as Error & { killed?: boolean }
-    if (err.killed) {
+    const err = error as Error & { killed?: boolean; signal?: string }
+    if (err.killed && err.signal === 'SIGTERM') {
       throw new Error(`Secret command timed out after ${timeout}ms`)
     }
-    throw new Error(`Secret command failed: ${err.message}`)
+    if (err.killed) {
+      throw new Error(
+        `Secret command was killed (signal: ${err.signal ?? 'unknown'})`
+      )
+    }
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(`Secret command failed: ${message}`)
   }
 }
 


### PR DESCRIPTION
## Summary

Closes #866

Hardens the `resolveFromCommand` function in `secrets.ts`:

- **Timeout detection**: Changed from checking only `err.killed` (true for ANY kill signal) to checking `err.killed && err.signal === 'SIGTERM'`, which correctly identifies timeout-induced kills
- **Non-timeout kills**: Added distinct error message for processes killed by other signals (e.g., SIGKILL from OOM killer) including signal info
- **Safe error casting**: Replaced unsafe `(error as Error).message` with `error instanceof Error` check, falling back to `String(error)` for non-Error throws

## Test plan

- [x] Test: SIGTERM kill produces "timed out after Xms" message
- [x] Test: SIGKILL kill produces "was killed (signal: SIGKILL)" message  
- [x] Test: Non-Error throw produces useful message (not `undefined`)
- [x] All 49 secrets tests pass
- [x] Build passes (tsc --noEmit)

## Files changed

- `packages/openclaw-plugin/src/secrets.ts` — Fix `resolveFromCommand` error handling
- `packages/openclaw-plugin/tests/secrets.test.ts` — Add tests for new error scenarios