### PR TITLE
[#871] Fix stub event emitter and document shared secret cache

### DIFF
--- a/packages/openclaw-plugin/src/register-openclaw.ts
+++ b/packages/openclaw-plugin/src/register-openclaw.ts
@@ -2632,12 +2632,17 @@ export const registerOpenClaw: PluginInitializer = (api: OpenClawPluginApi) => {
   // Register background notification service (Issue #325)
   // Create a simple event emitter for notifications
   // In production, this would be provided by the OpenClaw runtime
+  logger.warn('No runtime event emitter available — using stub. Notification events will be logged but not dispatched.')
   const eventEmitter = {
     emit: (event: string, payload: unknown) => {
-      logger.debug('Notification event emitted', { event, payload })
+      logger.debug('Notification event emitted (stub)', { event, payload })
     },
-    on: (_event: string, _handler: (payload: unknown) => void) => {},
-    off: (_event: string, _handler: (payload: unknown) => void) => {},
+    on: (_event: string, _handler: (payload: unknown) => void) => {
+      logger.debug('Event handler registered on stub emitter (will not fire)')
+    },
+    off: (_event: string, _handler: (payload: unknown) => void) => {
+      logger.debug('Event handler removed from stub emitter')
+    },
   }
 
   const notificationService = createNotificationService({

--- a/packages/openclaw-plugin/src/secrets.ts
+++ b/packages/openclaw-plugin/src/secrets.ts
@@ -34,7 +34,12 @@ export interface SecretConfig {
   commandTimeout?: number
 }
 
-/** Cache for resolved secrets */
+/**
+ * Cache for resolved secrets.
+ * Intentionally shared between async (resolveSecret) and sync (resolveSecretSync) paths.
+ * This is safe because resolveSecretSync runs during synchronous plugin registration
+ * (blocking the event loop), and resolveSecret runs afterward in async contexts.
+ */
 const secretCache = new Map<string, string>()
 
 /**

--- a/packages/openclaw-plugin/tests/config.test.ts
+++ b/packages/openclaw-plugin/tests/config.test.ts
@@ -968,8 +968,9 @@ describe('Config Schema', () => {
     })
 
     it('should propagate execSync timeout errors', () => {
-      const timeoutError = new Error('Command timed out') as Error & { killed: boolean }
+      const timeoutError = new Error('Command timed out') as Error & { killed: boolean; signal: string }
       timeoutError.killed = true
+      timeoutError.signal = 'SIGTERM'
       vi.mocked(childProcess.execSync).mockImplementation(() => {
         throw timeoutError
       })


### PR DESCRIPTION
## Summary
- Added `logger.warn()` when no runtime event emitter is available, making it visible that a stub is in use
- Added debug logging to stub emitter `on`/`off` methods for observability
- Documented intentional cache sharing between sync (`resolveSecretSync`) and async (`resolveSecret`) paths with JSDoc explaining safety rationale
- Fixed pre-existing `config.test.ts` timeout mock that was missing `signal: 'SIGTERM'`

## Test plan
- [x] All 955 plugin tests pass
- [x] TypeScript build passes clean
- [x] Pre-existing config.test.ts timeout mock failure now fixed

Closes #871

🤖 Generated with [Claude Code](https://claude.com/claude-code)