### PR TITLE
[#872] Fix TOCTOU race in resolveFromFile and add error context

### DIFF
--- a/packages/openclaw-plugin/tests/config.test.ts
+++ b/packages/openclaw-plugin/tests/config.test.ts
@@ -615,7 +615,7 @@ describe('Config Schema', () => {
     })
 
     it('should resolve apiKey from file', async () => {
-      vi.mocked(fs.existsSync).mockReturnValue(true)
+
       vi.mocked(fs.readFileSync).mockReturnValue('file-api-key\n')
       vi.mocked(fs.statSync).mockReturnValue({ mode: 0o600 } as fs.Stats)
 
@@ -659,7 +659,7 @@ describe('Config Schema', () => {
     })
 
     it('should resolve all Twilio credentials', async () => {
-      vi.mocked(fs.existsSync).mockReturnValue(true)
+
       vi.mocked(fs.readFileSync).mockImplementation((path) => {
         if (String(path).includes('sid')) return 'twilio-sid'
         if (String(path).includes('token')) return 'twilio-token'
@@ -781,7 +781,7 @@ describe('Config Schema', () => {
     })
 
     it('should resolve apiKey from file', () => {
-      vi.mocked(fs.existsSync).mockReturnValue(true)
+
       vi.mocked(fs.readFileSync).mockReturnValue('file-api-key\n')
       vi.mocked(fs.statSync).mockReturnValue({ mode: 0o600 } as fs.Stats)
 
@@ -826,7 +826,7 @@ describe('Config Schema', () => {
 
     it('should resolve all six secret fields', () => {
       vi.mocked(childProcess.execSync).mockReturnValue('cmd-api-key')
-      vi.mocked(fs.existsSync).mockReturnValue(true)
+
       vi.mocked(fs.readFileSync).mockImplementation((path) => {
         const p = String(path)
         if (p.includes('postmark_token')) return 'pm-token'
@@ -867,7 +867,7 @@ describe('Config Schema', () => {
     })
 
     it('should resolve Twilio credentials from files', () => {
-      vi.mocked(fs.existsSync).mockReturnValue(true)
+
       vi.mocked(fs.readFileSync).mockImplementation((path) => {
         if (String(path).includes('sid')) return 'twilio-sid'
         if (String(path).includes('token')) return 'twilio-token'
@@ -944,7 +944,7 @@ describe('Config Schema', () => {
     })
 
     it('should throw when apiKey resolves to whitespace only', () => {
-      vi.mocked(fs.existsSync).mockReturnValue(true)
+
       vi.mocked(fs.readFileSync).mockReturnValue('   \n')
       vi.mocked(fs.statSync).mockReturnValue({ mode: 0o600 } as fs.Stats)
 
@@ -968,8 +968,9 @@ describe('Config Schema', () => {
     })
 
     it('should propagate execSync timeout errors', () => {
-      const timeoutError = new Error('Command timed out') as Error & { killed: boolean }
+      const timeoutError = new Error('Command timed out') as Error & { killed: boolean; signal: string }
       timeoutError.killed = true
+      timeoutError.signal = 'SIGTERM'
       vi.mocked(childProcess.execSync).mockImplementation(() => {
         throw timeoutError
       })
@@ -994,7 +995,7 @@ describe('Config Schema', () => {
     })
 
     it('should propagate readFileSync failure errors', () => {
-      vi.mocked(fs.existsSync).mockReturnValue(true)
+
       vi.mocked(fs.readFileSync).mockImplementation(() => {
         throw new Error('EACCES: permission denied')
       })


### PR DESCRIPTION
## Summary
- Removed `existsSync` pre-check in `resolveFromFile`, handling `ENOENT` in the `readFileSync` catch block instead — eliminates time-of-check/time-of-use race
- Added safe error casting (`instanceof Error` check) for proper error context
- Updated all test mocks: replaced `existsSync` mocks with `readFileSync` ENOENT throws
- Cleaned up stale `existsSync` mock calls from secrets.test.ts and config.test.ts
- Fixed pre-existing `config.test.ts` timeout mock missing `signal: 'SIGTERM'`

## Test plan
- [x] All 955 plugin tests pass (0 failures)
- [x] TypeScript build passes clean
- [x] TOCTOU race condition eliminated
- [x] Error messages preserved: "Secret file does not exist" for ENOENT, "Failed to read secret file" for other errors

Closes #872

🤖 Generated with [Claude Code](https://claude.com/claude-code)