### PR TITLE
[#884] Lock down plugin config schema

### DIFF
--- a/packages/openclaw-plugin/openclaw.plugin.json
+++ b/packages/openclaw-plugin/openclaw.plugin.json
@@ -106,8 +106,47 @@
         "enum": ["agent", "identity", "session"],
         "default": "agent",
         "description": "How to scope user memories"
+      },
+      "maxRecallMemories": {
+        "type": "integer",
+        "minimum": 1,
+        "maximum": 20,
+        "default": 5,
+        "description": "Maximum memories to inject in auto-recall"
+      },
+      "minRecallScore": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 1,
+        "default": 0.7,
+        "description": "Minimum relevance score for auto-recall (0-1)"
+      },
+      "timeout": {
+        "type": "integer",
+        "minimum": 1000,
+        "maximum": 60000,
+        "default": 30000,
+        "description": "Request timeout in milliseconds"
+      },
+      "maxRetries": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 5,
+        "default": 3,
+        "description": "Maximum retries for failed requests"
+      },
+      "debug": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable debug logging (never logs secrets)"
+      },
+      "baseUrl": {
+        "type": "string",
+        "format": "uri",
+        "description": "Base URL for web app (used for generating note/notebook URLs)"
       }
     },
+    "additionalProperties": false,
     "required": ["apiUrl"],
     "anyOf": [
       { "required": ["apiKey"] },
@@ -222,6 +261,37 @@
       "label": "User Scoping",
       "helpText": "How to isolate memories between users",
       "group": "Memory"
+    },
+    "maxRecallMemories": {
+      "label": "Max Recall Memories",
+      "helpText": "Maximum number of memories to inject during auto-recall",
+      "group": "Memory"
+    },
+    "minRecallScore": {
+      "label": "Min Recall Score",
+      "helpText": "Minimum relevance score (0-1) for auto-recall",
+      "group": "Memory"
+    },
+    "timeout": {
+      "label": "Request Timeout",
+      "helpText": "Timeout in milliseconds for API requests",
+      "group": "Advanced"
+    },
+    "maxRetries": {
+      "label": "Max Retries",
+      "helpText": "Maximum number of retries for failed requests",
+      "group": "Advanced"
+    },
+    "debug": {
+      "label": "Debug Mode",
+      "helpText": "Enable debug logging (never logs secrets)",
+      "group": "Advanced"
+    },
+    "baseUrl": {
+      "label": "Web App URL",
+      "placeholder": "https://app.example.com",
+      "helpText": "Base URL for the web app (used for generating links)",
+      "group": "Advanced"
     }
   }
 }

--- a/packages/openclaw-plugin/src/config.ts
+++ b/packages/openclaw-plugin/src/config.ts
@@ -144,6 +144,7 @@ export const RawPluginConfigSchema = z
     /** Base URL for web app (used for generating note/notebook URLs) */
     baseUrl: z.string().url().optional().describe('Web app base URL'),
   })
+  .strict()
   .refine(
     (data) => data.apiKey || data.apiKeyFile || data.apiKeyCommand,
     {


### PR DESCRIPTION
## Summary

Closes #884

- Added `additionalProperties: false` to the root `configSchema` in `openclaw.plugin.json` so the OpenClaw Gateway rejects typo'd config keys at load time
- Added `.strict()` to the Zod `RawPluginConfigSchema` in `src/config.ts` for consistent runtime validation
- Aligned the JSON manifest with the Zod schema by adding 6 missing property definitions: `maxRecallMemories`, `minRecallScore`, `timeout`, `maxRetries`, `debug`, `baseUrl`
- Added corresponding uiHints for the new properties
- Added tests verifying that unexpected keys are rejected and all valid keys are accepted

## Test plan

- [x] New test: config with unexpected keys is rejected (`RawPluginConfigSchema` strict mode)
- [x] New test: config with typo keys (e.g., `apikey` instead of `apiKey`) is rejected
- [x] New test: config with all valid keys is accepted
- [x] New test: unknown keys rejected even when valid keys present
- [x] All 925 existing plugin tests pass
- [x] TypeScript strict mode passes (`pnpm run --filter @troykelly/openclaw-projects typecheck`)

## Local validation

```
pnpm exec vitest run packages/openclaw-plugin/tests/ → 925 passed, 14 skipped
pnpm run --filter @troykelly/openclaw-projects typecheck → clean
```

Generated with [Claude Code](https://claude.com/claude-code)