### PR TITLE
[#887] Configure Biome linter

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -30,7 +30,7 @@
       "suspicious": {
         "noExplicitAny": "warn",
         "noArrayIndexKey": "warn",
-        "noControlCharactersInRegex": "warn",
+        "noControlCharactersInRegex": "off",
         "noGlobalIsNan": "warn",
         "noImplicitAnyLet": "warn",
         "noConfusingVoidType": "warn",
@@ -100,5 +100,26 @@
         "organizeImports": "on"
       }
     }
-  }
+  },
+  "overrides": [
+    {
+      "includes": ["**/tests/**", "**/*.test.ts"],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noExplicitAny": "off"
+          },
+          "style": {
+            "noNonNullAssertion": "off"
+          },
+          "complexity": {
+            "noBannedTypes": "off"
+          },
+          "correctness": {
+            "noUnusedVariables": "off"
+          }
+        }
+      }
+    }
+  ]
 }

--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -27,7 +27,7 @@
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
     "lint": "biome lint .",
-    "prepublishOnly": "pnpm run clean && pnpm run build && pnpm run test && pnpm run typecheck"
+    "prepublishOnly": "pnpm run clean && pnpm run build && pnpm run test && pnpm run typecheck && pnpm run lint"
   },
   "repository": {
     "type": "git",

--- a/packages/openclaw-plugin/src/api-client.ts
+++ b/packages/openclaw-plugin/src/api-client.ts
@@ -63,7 +63,7 @@ function generateRequestId(): string {
  */
 function calculateRetryDelay(attempt: number, baseDelay = 1000, maxDelay = 10000): number {
   // Exponential backoff: 1s, 2s, 4s, 8s...
-  const exponentialDelay = baseDelay * Math.pow(2, attempt)
+  const exponentialDelay = baseDelay * 2 ** attempt
   // Add jitter (±25%) to prevent thundering herd
   const jitter = exponentialDelay * (0.75 + Math.random() * 0.5)
   return Math.min(jitter, maxDelay)
@@ -163,7 +163,6 @@ export class ApiClient {
 
         // Network errors are retryable
         if (attempt < this.maxRetries) {
-          continue
         }
       }
     }

--- a/packages/openclaw-plugin/src/gateway/rpc-methods.ts
+++ b/packages/openclaw-plugin/src/gateway/rpc-methods.ts
@@ -40,10 +40,8 @@ export interface SubscribeResult {
   subscribed: NotificationEvent[]
 }
 
-/** Unsubscribe method parameters */
-export interface UnsubscribeParams {
-  /** Empty - unsubscribes from all events */
-}
+/** Unsubscribe method parameters — empty: unsubscribes from all events */
+export type UnsubscribeParams = Record<string, never>
 
 /** Unsubscribe method result */
 export interface UnsubscribeResult {

--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -34,14 +34,13 @@ export type {
   ServiceDefinition,
 } from './types/openclaw-api.js'
 
-import type { PluginConfig, RawPluginConfig } from './config.js'
+import type { PluginConfig, } from './config.js'
 import {
   validateConfig,
   validateRawConfig,
   resolveConfigSecrets,
   redactConfig,
 } from './config.js'
-import { clearSecretCache } from './secrets.js'
 import { createLogger, type Logger } from './logger.js'
 import { createApiClient, type ApiClient } from './api-client.js'
 import { extractContext, getUserScopeKey, type PluginContext } from './context.js'
@@ -57,8 +56,6 @@ import {
 import {
   createCliCommands,
   type CliCommands,
-  type CliContext,
-  type CommandResult,
 } from './cli.js'
 import {
   createMemoryRecallTool,

--- a/packages/openclaw-plugin/src/register-openclaw.ts
+++ b/packages/openclaw-plugin/src/register-openclaw.ts
@@ -25,34 +25,7 @@ import { validateRawConfig, resolveConfigSecretsSync, redactConfig, type PluginC
 import { createLogger, type Logger } from './logger.js'
 import { createApiClient, type ApiClient } from './api-client.js'
 import { extractContext, getUserScopeKey } from './context.js'
-import { zodToJsonSchema } from './utils/zod-to-json-schema.js'
 import {
-  MemoryRecallParamsSchema,
-  MemoryStoreParamsSchema,
-  MemoryForgetParamsSchema,
-  ProjectListParamsSchema,
-  ProjectGetParamsSchema,
-  ProjectCreateParamsSchema,
-  TodoListParamsSchema,
-  TodoCreateParamsSchema,
-  TodoCompleteParamsSchema,
-  ContactSearchParamsSchema,
-  ContactGetParamsSchema,
-  ContactCreateParamsSchema,
-  SmsSendParamsSchema,
-  EmailSendParamsSchema,
-  MessageSearchParamsSchema,
-  ThreadListParamsSchema,
-  ThreadGetParamsSchema,
-  RelationshipSetParamsSchema,
-  RelationshipQueryParamsSchema,
-  SkillStorePutParamsSchema,
-  SkillStoreGetParamsSchema,
-  SkillStoreListParamsSchema,
-  SkillStoreDeleteParamsSchema,
-  SkillStoreSearchParamsSchema,
-  SkillStoreCollectionsParamsSchema,
-  SkillStoreAggregateParamsSchema,
   createSkillStorePutTool,
   createSkillStoreGetTool,
   createSkillStoreListTool,
@@ -60,18 +33,12 @@ import {
   createSkillStoreSearchTool,
   createSkillStoreCollectionsTool,
   createSkillStoreAggregateTool,
-  MemoryCategory,
-  ProjectStatus,
 } from './tools/index.js'
 import { createGatewayMethods, registerGatewayRpcMethods } from './gateway/rpc-methods.js'
 import { createNotificationService } from './services/notification-service.js'
 import {
-  createAutoRecallHook,
   createAutoCaptureHook,
   createGraphAwareRecallHook,
-  type AutoRecallHookOptions,
-  type AutoCaptureHookOptions,
-  type GraphAwareRecallHookOptions,
 } from './hooks.js'
 
 /** Plugin state stored during registration */
@@ -2526,7 +2493,7 @@ export const registerOpenClaw: PluginInitializer = (api: OpenClawPluginApi) => {
     const beforeAgentStartHandler = async (
       event: PluginHookBeforeAgentStartEvent,
       _ctx: PluginHookAgentContext
-    ): Promise<PluginHookBeforeAgentStartResult | void> => {
+    ): Promise<PluginHookBeforeAgentStartResult | undefined> => {
       logger.debug('Auto-recall hook triggered', {
         promptLength: event.prompt?.length ?? 0,
       })
@@ -2536,7 +2503,7 @@ export const registerOpenClaw: PluginInitializer = (api: OpenClawPluginApi) => {
         // uses the user's actual prompt for semantic search
         const result = await autoRecallHook({ prompt: event.prompt })
 
-        if (result && result.prependContext) {
+        if (result?.prependContext) {
           return { prependContext: result.prependContext }
         }
       } catch (error) {

--- a/packages/openclaw-plugin/src/secrets.ts
+++ b/packages/openclaw-plugin/src/secrets.ts
@@ -152,12 +152,12 @@ export async function resolveSecret(
   let resolved: string | undefined
 
   // Priority 1: Command
-  if (config.command && config.command.trim()) {
+  if (config.command?.trim()) {
     const timeout = config.commandTimeout ?? DEFAULT_COMMAND_TIMEOUT
     resolved = resolveFromCommand(config.command, timeout)
   }
   // Priority 2: File
-  else if (config.file && config.file.trim()) {
+  else if (config.file?.trim()) {
     resolved = resolveFromFile(config.file)
   }
   // Priority 3: Direct
@@ -197,12 +197,12 @@ export function resolveSecretSync(
   let resolved: string | undefined
 
   // Priority 1: Command
-  if (config.command && config.command.trim()) {
+  if (config.command?.trim()) {
     const timeout = config.commandTimeout ?? DEFAULT_COMMAND_TIMEOUT
     resolved = resolveFromCommand(config.command, timeout)
   }
   // Priority 2: File
-  else if (config.file && config.file.trim()) {
+  else if (config.file?.trim()) {
     resolved = resolveFromFile(config.file)
   }
   // Priority 3: Direct

--- a/packages/openclaw-plugin/src/tools/index.ts
+++ b/packages/openclaw-plugin/src/tools/index.ts
@@ -251,6 +251,4 @@ export {
 } from './skill-store.js'
 
 /** Tool factory types */
-export interface ToolFactoryOptions {
-  // Common options for tool factories
-}
+export type ToolFactoryOptions = Record<string, never>

--- a/packages/openclaw-plugin/src/tools/memory-store.ts
+++ b/packages/openclaw-plugin/src/tools/memory-store.ts
@@ -113,7 +113,7 @@ function truncateForPreview(text: string, maxLength = 100): string {
   if (text.length <= maxLength) {
     return text
   }
-  return text.substring(0, maxLength) + '...'
+  return `${text.substring(0, maxLength)}...`
 }
 
 /**
@@ -139,7 +139,7 @@ function sanitizeErrorMessage(error: unknown): string {
  * Creates the memory_store tool.
  */
 export function createMemoryStoreTool(options: MemoryStoreToolOptions): MemoryStoreTool {
-  const { client, logger, config, userId } = options
+  const { client, logger, userId } = options
 
   return {
     name: 'memory_store',

--- a/packages/openclaw-plugin/src/tools/message-search.ts
+++ b/packages/openclaw-plugin/src/tools/message-search.ts
@@ -10,7 +10,6 @@ import type { PluginConfig } from '../config.js'
 
 /** Channel type enum */
 const ChannelType = z.enum(['sms', 'email', 'all'])
-type ChannelType = z.infer<typeof ChannelType>
 
 /** Maximum results limit */
 const MAX_LIMIT = 100

--- a/packages/openclaw-plugin/src/tools/notes.ts
+++ b/packages/openclaw-plugin/src/tools/notes.ts
@@ -81,7 +81,7 @@ function truncateForPreview(text: string, maxLength = 100): string {
   if (text.length <= maxLength) {
     return text
   }
-  return text.substring(0, maxLength) + '...'
+  return `${text.substring(0, maxLength)}...`
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/packages/openclaw-plugin/src/tools/projects.ts
+++ b/packages/openclaw-plugin/src/tools/projects.ts
@@ -109,7 +109,7 @@ function stripHtml(text: string): string {
  */
 function truncate(text: string, maxLength = 100): string {
   if (text.length <= maxLength) return text
-  return text.substring(0, maxLength) + '...'
+  return `${text.substring(0, maxLength)}...`
 }
 
 /**

--- a/packages/openclaw-plugin/src/tools/skill-store.ts
+++ b/packages/openclaw-plugin/src/tools/skill-store.ts
@@ -9,7 +9,7 @@
  */
 
 import { z } from 'zod'
-import type { ApiClient } from '../api-client.js'
+import type { ApiClient, ApiResponse } from '../api-client.js'
 import type { Logger } from '../logger.js'
 import type { PluginConfig } from '../config.js'
 
@@ -197,7 +197,7 @@ function sanitizeErrorMessage(error: unknown): string {
  */
 function truncateForPreview(text: string, maxLength = 100): string {
   if (text.length <= maxLength) return text
-  return text.substring(0, maxLength) + '...'
+  return `${text.substring(0, maxLength)}...`
 }
 
 /**
@@ -365,7 +365,7 @@ export function createSkillStoreGetTool(options: SkillStoreToolOptions): SkillSt
       })
 
       try {
-        let response
+        let response: ApiResponse<SkillStoreItem>
 
         if (validated.id) {
           response = await client.get<SkillStoreItem>(

--- a/packages/openclaw-plugin/src/tools/threads.ts
+++ b/packages/openclaw-plugin/src/tools/threads.ts
@@ -10,7 +10,6 @@ import type { PluginConfig } from '../config.js'
 
 /** Channel type enum */
 const ChannelType = z.enum(['sms', 'email'])
-type ChannelType = z.infer<typeof ChannelType>
 
 /** Default and max limits */
 const DEFAULT_LIST_LIMIT = 20

--- a/packages/openclaw-plugin/src/tools/todos.ts
+++ b/packages/openclaw-plugin/src/tools/todos.ts
@@ -120,7 +120,7 @@ function isValidIsoDate(date: string): boolean {
   }
   // Also validate it's a real date
   const parsed = new Date(date)
-  return !isNaN(parsed.getTime())
+  return !Number.isNaN(parsed.getTime())
 }
 
 /**

--- a/packages/openclaw-plugin/src/types/openclaw-api.ts
+++ b/packages/openclaw-plugin/src/types/openclaw-api.ts
@@ -162,7 +162,7 @@ export type HookEvent =
   | 'messageSent'
 
 /** Legacy hook handler function */
-export type HookHandler<T = unknown> = (event: T) => Promise<T | null | void>
+export type HookHandler<T = unknown> = (event: T) => Promise<T | null | undefined>
 
 /** CLI registration callback */
 export interface CliRegistrationContext {

--- a/packages/openclaw-plugin/tests/cli.test.ts
+++ b/packages/openclaw-plugin/tests/cli.test.ts
@@ -12,7 +12,6 @@ import {
   createExportCommand,
   createCliCommands,
   type CliContext,
-  type CommandResult,
 } from '../src/cli.js'
 import type { ApiClient } from '../src/api-client.js'
 import type { Logger } from '../src/logger.js'

--- a/packages/openclaw-plugin/tests/e2e/plugin-integration.test.ts
+++ b/packages/openclaw-plugin/tests/e2e/plugin-integration.test.ts
@@ -8,12 +8,10 @@
  * Run with: npm run test:e2e
  */
 
-import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest'
+import { describe, it, expect, beforeAll, afterAll, } from 'vitest'
 import {
-  defaultConfig,
   createE2EContext,
   areE2EServicesAvailable,
-  waitForService,
   testData,
   type E2ETestContext,
 } from './setup.js'

--- a/packages/openclaw-plugin/tests/gateway-rpc.test.ts
+++ b/packages/openclaw-plugin/tests/gateway-rpc.test.ts
@@ -7,11 +7,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import {
   createGatewayMethods,
   type SubscribeParams,
-  type SubscribeResult,
-  type UnsubscribeParams,
-  type UnsubscribeResult,
   type GetNotificationsParams,
-  type GetNotificationsResult,
   type NotificationEvent,
 } from '../src/gateway/rpc-methods.js'
 import type { ApiClient } from '../src/api-client.js'

--- a/packages/openclaw-plugin/tests/graph-aware-integration.test.ts
+++ b/packages/openclaw-plugin/tests/graph-aware-integration.test.ts
@@ -6,18 +6,16 @@
  * Part of Epic #486, Issue #497.
  */
 
-import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { describe, expect, it, vi, beforeEach, } from 'vitest'
 import { registerOpenClaw, schemas } from '../src/register-openclaw.js'
 import type {
   OpenClawPluginAPI,
-  ToolDefinition,
   PluginHookBeforeAgentStartEvent,
   PluginHookAgentContext,
   PluginHookBeforeAgentStartResult,
 } from '../src/types/openclaw-api.js'
 import {
   createGraphAwareRecallHook,
-  type GraphAwareRecallHookOptions,
 } from '../src/hooks.js'
 import type { ApiClient } from '../src/api-client.js'
 import type { Logger } from '../src/logger.js'
@@ -259,7 +257,7 @@ describe('Graph-Aware Integration', () => {
       }) as unknown as typeof fetch
 
       try {
-        let registeredOnHooks = new Map<string, Function>()
+        const registeredOnHooks = new Map<string, Function>()
 
         const mockApi: OpenClawPluginAPI = {
           config: {
@@ -292,7 +290,7 @@ describe('Graph-Aware Integration', () => {
         const beforeAgentStartHook = registeredOnHooks.get('before_agent_start') as (
           event: PluginHookBeforeAgentStartEvent,
           ctx: PluginHookAgentContext
-        ) => Promise<PluginHookBeforeAgentStartResult | void>
+        ) => Promise<PluginHookBeforeAgentStartResult | undefined>
 
         expect(beforeAgentStartHook).toBeDefined()
 
@@ -383,7 +381,7 @@ describe('Graph-Aware Integration', () => {
       }) as unknown as typeof fetch
 
       try {
-        let registeredOnHooks = new Map<string, Function>()
+        const registeredOnHooks = new Map<string, Function>()
 
         const mockApi: OpenClawPluginAPI = {
           config: {
@@ -416,7 +414,7 @@ describe('Graph-Aware Integration', () => {
         const hook = registeredOnHooks.get('before_agent_start') as (
           event: PluginHookBeforeAgentStartEvent,
           ctx: PluginHookAgentContext
-        ) => Promise<PluginHookBeforeAgentStartResult | void>
+        ) => Promise<PluginHookBeforeAgentStartResult | undefined>
 
         const result = await hook(
           { prompt: 'When is my anniversary and what food should I get?' },

--- a/packages/openclaw-plugin/tests/hooks.test.ts
+++ b/packages/openclaw-plugin/tests/hooks.test.ts
@@ -8,8 +8,6 @@ import {
   createAutoRecallHook,
   createAutoCaptureHook,
   createHealthCheck,
-  AutoRecallHookOptions,
-  AutoCaptureHookOptions,
 } from '../src/hooks.js'
 import type { ApiClient } from '../src/api-client.js'
 import type { Logger } from '../src/logger.js'

--- a/packages/openclaw-plugin/tests/integration.test.ts
+++ b/packages/openclaw-plugin/tests/integration.test.ts
@@ -3,7 +3,7 @@
  * Tests full plugin lifecycle and multi-user scenarios.
  */
 
-import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { describe, expect, it, vi, } from 'vitest'
 import { register, type RegistrationContext } from '../src/index.js'
 import type { Logger } from '../src/logger.js'
 
@@ -222,7 +222,7 @@ describe('Integration Tests', () => {
           logger: mockLogger,
         }
 
-        const instance = register(ctx)
+        const _instance = register(ctx)
 
         // The plugin should register and log with some userId
         expect(mockLogger.info).toHaveBeenCalledWith(
@@ -246,7 +246,7 @@ describe('Integration Tests', () => {
           logger: mockLogger,
         }
 
-        const instance = register(ctx)
+        const _instance = register(ctx)
 
         // With session scoping, userId should include session info
         expect(mockLogger.info).toHaveBeenCalledWith(
@@ -270,7 +270,7 @@ describe('Integration Tests', () => {
           logger: mockLogger,
         }
 
-        const instance = register(ctx)
+        const _instance = register(ctx)
 
         expect(mockLogger.info).toHaveBeenCalledWith(
           'Plugin registered',

--- a/packages/openclaw-plugin/tests/package-structure.test.ts
+++ b/packages/openclaw-plugin/tests/package-structure.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
-import { existsSync, readFileSync } from 'fs'
-import { join, dirname } from 'path'
-import { fileURLToPath } from 'url'
+import { existsSync, readFileSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const packageRoot = join(__dirname, '..')

--- a/packages/openclaw-plugin/tests/register-openclaw.test.ts
+++ b/packages/openclaw-plugin/tests/register-openclaw.test.ts
@@ -9,7 +9,6 @@ import type {
   PluginHookAgentContext,
   PluginHookBeforeAgentStartResult,
   PluginHookAgentEndEvent,
-  AgentToolResult,
 } from '../src/types/openclaw-api.js'
 
 // Mock fs and child_process for secret resolution
@@ -190,7 +189,7 @@ describe('OpenClaw 2026 API Registration', () => {
         const hook = registeredOnHooks.get('before_agent_start') as (
           event: PluginHookBeforeAgentStartEvent,
           ctx: PluginHookAgentContext
-        ) => Promise<PluginHookBeforeAgentStartResult | void>
+        ) => Promise<PluginHookBeforeAgentStartResult | undefined>
 
         expect(hook).toBeDefined()
 
@@ -234,7 +233,7 @@ describe('OpenClaw 2026 API Registration', () => {
         const hook = registeredOnHooks.get('before_agent_start') as (
           event: PluginHookBeforeAgentStartEvent,
           ctx: PluginHookAgentContext
-        ) => Promise<PluginHookBeforeAgentStartResult | void>
+        ) => Promise<PluginHookBeforeAgentStartResult | undefined>
 
         const result = await hook(
           { prompt: 'Tell me about my preferences' },
@@ -270,7 +269,7 @@ describe('OpenClaw 2026 API Registration', () => {
         const hook = registeredOnHooks.get('before_agent_start') as (
           event: PluginHookBeforeAgentStartEvent,
           ctx: PluginHookAgentContext
-        ) => Promise<PluginHookBeforeAgentStartResult | void>
+        ) => Promise<PluginHookBeforeAgentStartResult | undefined>
 
         await hook(
           { prompt: 'What are my food preferences?' },
@@ -302,7 +301,7 @@ describe('OpenClaw 2026 API Registration', () => {
         const hook = registeredOnHooks.get('before_agent_start') as (
           event: PluginHookBeforeAgentStartEvent,
           ctx: PluginHookAgentContext
-        ) => Promise<PluginHookBeforeAgentStartResult | void>
+        ) => Promise<PluginHookBeforeAgentStartResult | undefined>
 
         // The hook has a 5s internal timeout. The slow fetch will trigger it.
         const result = await hook(
@@ -327,7 +326,7 @@ describe('OpenClaw 2026 API Registration', () => {
         const hook = registeredOnHooks.get('before_agent_start') as (
           event: PluginHookBeforeAgentStartEvent,
           ctx: PluginHookAgentContext
-        ) => Promise<PluginHookBeforeAgentStartResult | void>
+        ) => Promise<PluginHookBeforeAgentStartResult | undefined>
 
         // Should not throw even when network fails
         const result = await hook(

--- a/packages/openclaw-plugin/tests/security.test.ts
+++ b/packages/openclaw-plugin/tests/security.test.ts
@@ -12,7 +12,6 @@ import {
   createProjectListTool,
   createProjectGetTool,
   createProjectCreateTool,
-  createTodoListTool,
   createTodoCreateTool,
   createTodoCompleteTool,
   createContactSearchTool,

--- a/packages/openclaw-plugin/tests/tools/contacts.test.ts
+++ b/packages/openclaw-plugin/tests/tools/contacts.test.ts
@@ -8,9 +8,9 @@ import {
   createContactSearchTool,
   createContactGetTool,
   createContactCreateTool,
-  ContactSearchParams,
-  ContactGetParams,
-  ContactCreateParams,
+  type ContactSearchParams,
+  type ContactGetParams,
+  type ContactCreateParams,
 } from '../../src/tools/contacts.js'
 import type { ApiClient } from '../../src/api-client.js'
 import type { Logger } from '../../src/logger.js'

--- a/packages/openclaw-plugin/tests/tools/memory-forget.test.ts
+++ b/packages/openclaw-plugin/tests/tools/memory-forget.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { describe, expect, it, vi, beforeEach } from 'vitest'
-import { createMemoryForgetTool, MemoryForgetParams } from '../../src/tools/memory-forget.js'
+import { createMemoryForgetTool, type MemoryForgetParams } from '../../src/tools/memory-forget.js'
 import type { ApiClient } from '../../src/api-client.js'
 import type { Logger } from '../../src/logger.js'
 import type { PluginConfig } from '../../src/config.js'

--- a/packages/openclaw-plugin/tests/tools/memory-recall.test.ts
+++ b/packages/openclaw-plugin/tests/tools/memory-recall.test.ts
@@ -4,8 +4,8 @@
  */
 
 import { describe, expect, it, vi, beforeEach } from 'vitest'
-import { createMemoryRecallTool, MemoryRecallParams } from '../../src/tools/memory-recall.js'
-import type { ApiClient, ApiResponse } from '../../src/api-client.js'
+import { createMemoryRecallTool, type MemoryRecallParams } from '../../src/tools/memory-recall.js'
+import type { ApiClient, } from '../../src/api-client.js'
 import type { Logger } from '../../src/logger.js'
 import type { PluginConfig } from '../../src/config.js'
 

--- a/packages/openclaw-plugin/tests/tools/memory-store.test.ts
+++ b/packages/openclaw-plugin/tests/tools/memory-store.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { describe, expect, it, vi, beforeEach } from 'vitest'
-import { createMemoryStoreTool, MemoryStoreParams } from '../../src/tools/memory-store.js'
+import { createMemoryStoreTool, type MemoryStoreParams } from '../../src/tools/memory-store.js'
 import type { ApiClient } from '../../src/api-client.js'
 import type { Logger } from '../../src/logger.js'
 import type { PluginConfig } from '../../src/config.js'

--- a/packages/openclaw-plugin/tests/tools/notebooks.test.ts
+++ b/packages/openclaw-plugin/tests/tools/notebooks.test.ts
@@ -8,7 +8,6 @@ import {
   createNotebookListTool,
   createNotebookCreateTool,
   createNotebookGetTool,
-  type NotebookListParams,
   type NotebookCreateParams,
   type NotebookGetParams,
 } from '../../src/tools/notebooks.js'

--- a/packages/openclaw-plugin/tests/tools/notes.test.ts
+++ b/packages/openclaw-plugin/tests/tools/notes.test.ts
@@ -13,7 +13,6 @@ import {
   type NoteCreateParams,
   type NoteGetParams,
   type NoteUpdateParams,
-  type NoteDeleteParams,
   type NoteSearchParams,
 } from '../../src/tools/notes.js'
 import type { ApiClient } from '../../src/api-client.js'

--- a/packages/openclaw-plugin/tests/tools/projects.test.ts
+++ b/packages/openclaw-plugin/tests/tools/projects.test.ts
@@ -8,9 +8,9 @@ import {
   createProjectListTool,
   createProjectGetTool,
   createProjectCreateTool,
-  ProjectListParams,
-  ProjectGetParams,
-  ProjectCreateParams,
+  type ProjectListParams,
+  type ProjectGetParams,
+  type ProjectCreateParams,
 } from '../../src/tools/projects.js'
 import type { ApiClient } from '../../src/api-client.js'
 import type { Logger } from '../../src/logger.js'

--- a/packages/openclaw-plugin/tests/tools/todos.test.ts
+++ b/packages/openclaw-plugin/tests/tools/todos.test.ts
@@ -8,9 +8,8 @@ import {
   createTodoListTool,
   createTodoCreateTool,
   createTodoCompleteTool,
-  TodoListParams,
-  TodoCreateParams,
-  TodoCompleteParams,
+  type TodoCreateParams,
+  type TodoCompleteParams,
 } from '../../src/tools/todos.js'
 import type { ApiClient } from '../../src/api-client.js'
 import type { Logger } from '../../src/logger.js'


### PR DESCRIPTION
Closes #887

## Summary

- Install `@biomejs/biome` v2.3.14 as a root dev dependency
- Create `biome.json` at repository root with recommended rules + project-specific overrides
- Update plugin `package.json` lint script from placeholder `echo` to `biome lint src/`
- Add root `package.json` lint script (`biome lint`)
- Add lint step to CI workflow (`.github/workflows/ci.yml`)
- Add lint to plugin `prepublishOnly` chain
- Fix all lint errors in plugin source and test files
- Disable `noControlCharactersInRegex` (false positives on intentional sanitization regex)
- Relax rules for test files (noExplicitAny, noNonNullAssertion, noBannedTypes, noUnusedVariables)

## Rules Configuration

| Rule | Level | Rationale |
|------|-------|-----------|
| recommended | on | Biome defaults |
| noForEach | off | Used intentionally in codebase |
| noStaticOnlyClass | off | Plugin patterns use static classes |
| noNonNullAssertion | warn | Flagged but not blocking |
| useConst | error | Enforce const over let |
| noParameterAssign | off | Used in codebase |
| noExplicitAny | warn (off in tests) | Flagged, not blocking |
| noControlCharactersInRegex | off | Sanitization regex is intentional |
| noUnusedImports | error | Catch dead imports |
| noUnusedVariables | warn (off in tests) | Catch unused code |

## Lint errors fixed

- Removed unused imports (index.ts, register-openclaw.ts)
- Removed unused type aliases (message-search.ts, threads.ts)
- Replaced `{}` types with `Record<string, never>` (rpc-methods.ts, tools/index.ts)
- Applied optional chaining (secrets.ts, register-openclaw.ts)
- Replaced `Math.pow` with `**` operator (api-client.ts)
- Removed useless `continue` (api-client.ts)
- Replaced `void` in unions with `undefined` (register-openclaw.ts, openclaw-api.ts)
- Added type annotation to untyped `let` (skill-store.ts)
- Replaced `isNaN()` with `Number.isNaN()` (todos.ts)
- Removed unused destructured variable (memory-store.ts)
- Auto-fixed unused imports and `let` -> `const` in test files

## Local validation

```
pnpm run lint                           # 0 errors, 4 warnings
pnpm exec vitest run packages/openclaw-plugin/tests/  # 921 passed, 14 skipped
pnpm run --filter @troykelly/openclaw-projects typecheck  # clean
```