### PR TITLE
[#889] Add version to openclaw.plugin.json

### DIFF
--- a/packages/openclaw-plugin/openclaw.plugin.json
+++ b/packages/openclaw-plugin/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "openclaw-projects",
+  "version": "0.0.3",
   "name": "OpenClaw Projects Plugin",
   "description": "Memory provider with projects, todos, and contacts integration",
   "kind": "memory",

--- a/packages/openclaw-plugin/tests/package-structure.test.ts
+++ b/packages/openclaw-plugin/tests/package-structure.test.ts
@@ -81,10 +81,12 @@ describe('Package Structure', () => {
       expect(manifest).toHaveProperty('configSchema')
     })
 
-    it('should not have version field (inherits from package.json)', () => {
+    it('should have version field matching package.json', () => {
       const manifestPath = join(packageRoot, 'openclaw.plugin.json')
       const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8'))
-      expect(manifest).not.toHaveProperty('version')
+      const packagePath = join(packageRoot, 'package.json')
+      const pkg = JSON.parse(readFileSync(packagePath, 'utf-8'))
+      expect(manifest.version).toBe(pkg.version)
     })
 
     it('should not have main field (entry point comes from package.json openclaw.extensions)', () => {


### PR DESCRIPTION
## Summary

Closes #889

- Added `"version": "0.0.3"` to `openclaw.plugin.json` manifest, matching `package.json`
- Updated test from asserting version field is absent to asserting it matches `package.json` version

## Test plan

- [x] Test: manifest version matches package.json version
- [x] All 960 plugin tests pass
- [x] TypeScript strict mode passes

## Local validation

```
pnpm exec vitest run packages/openclaw-plugin/tests/ → 960 passed, 14 skipped
pnpm run --filter @troykelly/openclaw-projects typecheck → clean
```

Generated with [Claude Code](https://claude.com/claude-code)