### PR TITLE
[#890] Remove dead registerAsync export

### DIFF
--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -4,9 +4,9 @@
  * This plugin provides memory management, projects, todos, and contacts
  * integration for OpenClaw agents.
  *
- * Supports two registration patterns:
- * 1. OpenClaw 2026 API: `export default (api) => { ... }` (recommended)
- * 2. Legacy API: `register(ctx)` returns plugin instance (deprecated)
+ * Registration pattern:
+ * - OpenClaw 2026 API: `export default (api) => { ... }` (recommended)
+ * - Legacy API: `register(ctx)` returns plugin instance
  */
 
 // Re-export the OpenClaw 2026 API default export
@@ -279,12 +279,10 @@ function createPluginInstance(
 }
 
 /**
- * Registers the plugin with OpenClaw (synchronous version).
+ * Registers the plugin with OpenClaw.
  *
- * This function supports configurations with direct secret values only.
- * For file or command-based secrets, use registerAsync instead.
- *
- * @deprecated Use registerAsync for flexible secret handling
+ * Validates the raw configuration and resolves direct secret values
+ * to produce a fully initialized plugin instance.
  */
 export function register(ctx: RegistrationContext): PluginInstance {
   const logger = ctx.logger ?? createLogger('openclaw-projects')
@@ -312,28 +310,6 @@ export function register(ctx: RegistrationContext): PluginInstance {
     maxRetries: rawConfig.maxRetries,
     debug: rawConfig.debug,
   })
-
-  return createPluginInstance(config, logger, ctx.runtime)
-}
-
-/**
- * Registers the plugin with OpenClaw (asynchronous version).
- *
- * This function supports all secret loading methods:
- * - Direct values (apiKey: "sk-xxx")
- * - File references (apiKeyFile: "~/.secrets/api_key")
- * - Command references (apiKeyCommand: "op read op://...")
- *
- * Preferred over register() for flexible secret handling.
- */
-export async function registerAsync(ctx: RegistrationContext): Promise<PluginInstance> {
-  const logger = ctx.logger ?? createLogger('openclaw-projects')
-
-  // Validate raw configuration
-  const rawConfig = validateRawConfig(ctx.config)
-
-  // Resolve all secrets
-  const config = await resolveConfigSecrets(rawConfig)
 
   return createPluginInstance(config, logger, ctx.runtime)
 }

--- a/packages/openclaw-plugin/tests/index.test.ts
+++ b/packages/openclaw-plugin/tests/index.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import * as pluginExports from '../src/index.js'
 import {
   register,
   plugin,
@@ -48,6 +49,10 @@ describe('Plugin Entry Point', () => {
     it('should export plugin object', () => {
       expect(plugin).toBeDefined()
       expect(typeof plugin).toBe('object')
+    })
+
+    it('should not export registerAsync (removed dead export)', () => {
+      expect('registerAsync' in pluginExports).toBe(false)
     })
   })
 


### PR DESCRIPTION
## Summary

Closes #890

- Removed `registerAsync` function from `src/index.ts` (dead export - OpenClaw Gateway loader is synchronous)
- Updated `register()` JSDoc to remove references to `registerAsync` and the `@deprecated` tag
- Updated module-level doc comment to remove mention of async registration
- Added test verifying `registerAsync` is no longer exported

## Test plan

- [x] Test: `registerAsync` is not in plugin exports
- [x] `register()` still works correctly (all existing register tests pass)
- [x] All 961 plugin tests pass
- [x] TypeScript strict mode passes

## Local validation

```
pnpm exec vitest run packages/openclaw-plugin/tests/ → 961 passed, 14 skipped
pnpm run --filter @troykelly/openclaw-projects typecheck → clean
```

Generated with [Claude Code](https://claude.com/claude-code)