### PR TITLE
[#912] Complete configuration reference and fix naming inconsistencies

### DIFF
--- a/packages/openclaw-plugin/docs/configuration.md
+++ b/packages/openclaw-plugin/docs/configuration.md
@@ -159,6 +159,28 @@ How to isolate memories between users.
 - `"identity"` - Memories scoped to specific identity/account
 - `"session"` - Memories isolated to single session
 
+### maxRecallMemories
+
+Maximum number of memories to inject during auto-recall.
+
+| Property | Value |
+|----------|-------|
+| Type | integer |
+| Default | `5` |
+| Minimum | `1` |
+| Maximum | `20` |
+
+### minRecallScore
+
+Minimum similarity score for memories to be included in auto-recall. Higher values return fewer but more relevant memories.
+
+| Property | Value |
+|----------|-------|
+| Type | number |
+| Default | `0.7` |
+| Minimum | `0` |
+| Maximum | `1` |
+
 ## Advanced Options
 
 ### secretCommandTimeout
@@ -180,6 +202,8 @@ HTTP request timeout in milliseconds.
 |----------|-------|
 | Type | integer |
 | Default | `30000` |
+| Minimum | `1000` |
+| Maximum | `60000` |
 
 ### maxRetries
 
@@ -189,15 +213,27 @@ Maximum number of retry attempts for failed requests.
 |----------|-------|
 | Type | integer |
 | Default | `3` |
+| Minimum | `0` |
+| Maximum | `5` |
 
 ### debug
 
-Enable debug logging.
+Enable debug logging. Secrets are never included in debug output.
 
 | Property | Value |
 |----------|-------|
 | Type | boolean |
 | Default | `false` |
+
+### baseUrl
+
+Base URL for the web application. Used for generating links to notes and notebooks in tool responses.
+
+| Property | Value |
+|----------|-------|
+| Type | string (URL) |
+| Required | No |
+| Example | `"https://app.your-domain.com"` |
 
 ## Example Configurations
 

--- a/packages/openclaw-plugin/docs/troubleshooting.md
+++ b/packages/openclaw-plugin/docs/troubleshooting.md
@@ -153,10 +153,10 @@ If the status is healthy but you still have issues, continue with the specific s
 
 **Solutions:**
 
-1. **Check minScore setting**
+1. **Check minRecallScore setting**
    ```json
    {
-     "minScore": 0.5  // Lower threshold
+     "minRecallScore": 0.5  // Lower threshold
    }
    ```
 


### PR DESCRIPTION
## Summary

- Add 3 missing configuration options to `configuration.md`: `maxRecallMemories`, `minRecallScore`, `baseUrl`
- Add min/max constraints to `timeout` and `maxRetries` to match the Zod schema
- Clarify `debug` description re: secret safety
- Fix `minScore` -> `minRecallScore` naming in `troubleshooting.md`

All config options in the Zod schema (`packages/openclaw-plugin/src/config.ts`) are now documented.

## Test plan

- [x] Plugin tests pass (1008 passed, 3 pre-existing snapshot failures from #906)
- [x] Cross-referenced all options against `RawPluginConfigSchema` in `src/config.ts`

Closes #912