### PR TITLE
[#907] Fix inverted auth troubleshooting guidance

### DIFF
--- a/packages/openclaw-plugin/README.md
+++ b/packages/openclaw-plugin/README.md
@@ -459,7 +459,7 @@ For detailed troubleshooting, see [docs/troubleshooting.md](docs/troubleshooting
 If the status command reports `Auth: invalid`:
 - Verify your `apiKey` matches the `OPENCLAW_PROJECTS_AUTH_SECRET` in the backend `.env`
 - Check the secret retrieval method (file, command) is working
-- Ensure `OPENCLAW_PROJECTS_AUTH_DISABLED` is not set to `false` if using the quickstart compose
+- If using the quickstart compose, auth is disabled by default (`OPENCLAW_PROJECTS_AUTH_DISABLED=true`). If you have overridden this to `false` (enabling auth), ensure your `apiKey` is correctly configured
 
 ### No memories found
 

--- a/packages/openclaw-plugin/docs/troubleshooting.md
+++ b/packages/openclaw-plugin/docs/troubleshooting.md
@@ -115,7 +115,11 @@ If the status is healthy but you still have issues, continue with the specific s
    op read op://Personal/openclaw/api_key
    ```
 
-3. **API key expired or revoked**
+3. **Quickstart compose has auth disabled**
+   - The quickstart compose sets `OPENCLAW_PROJECTS_AUTH_DISABLED=true` by default, so `apiKey` is not needed
+   - If you have overridden this to `false` (enabling auth), ensure your `apiKey` matches `OPENCLAW_PROJECTS_AUTH_SECRET` in the backend `.env`
+
+4. **API key expired or revoked**
    - Generate new key in backend
    - Update configuration
 


### PR DESCRIPTION
## Summary

- Fixed inverted auth troubleshooting text in plugin README line 462: the old text said "Ensure `OPENCLAW_PROJECTS_AUTH_DISABLED` is not set to `false`" which is confusing and logically backwards. Now clarifies that quickstart disables auth by default and explains what to do if you've overridden it.
- Added quickstart auth context to `docs/troubleshooting.md` auth section — noting that quickstart compose has auth disabled by default.

## Test plan

- [x] Plugin tests pass (1008 passed, 3 pre-existing snapshot failures unrelated)
- [x] Verified text is logically correct against `docker-compose.quickstart.yml` (line 141: `OPENCLAW_PROJECTS_AUTH_DISABLED: ${OPENCLAW_PROJECTS_AUTH_DISABLED:-true}`)

Closes #907