### PR TITLE
[#909] Standardize config format across all documentation

### DIFF
--- a/docs/guides/openclaw-integration.md
+++ b/docs/guides/openclaw-integration.md
@@ -140,33 +140,25 @@ The plugin is automatically configured via environment variables:
 
 ### External Gateway
 
-Add the plugin configuration to your OpenClaw config file:
+Add the plugin configuration to your OpenClaw config file (`~/.openclaw/config.yaml`):
 
-```jsonc
-// ~/.openclaw/config.json
-{
-  "plugins": {
-    "slots": {
-      // Set openclaw-projects as the memory provider
-      "memory": "openclaw-projects"
-    },
-    "entries": {
-      "openclaw-projects": {
-        "enabled": true,
-        "config": {
-          // Your deployed API URL
-          "apiUrl": "https://api.your-domain.com",
-          // Authentication (choose one method)
-          "apiKey": "your-shared-auth-secret",
-          // Or load from file (for Docker secrets)
-          // "apiKeyFile": "~/.secrets/openclaw-projects-api-key",
-          // Or load from command (for 1Password, etc.)
-          // "apiKeyCommand": "op read 'op://vault/openclaw-projects/api-key'"
-        }
-      }
-    }
-  }
-}
+```yaml
+plugins:
+  slots:
+    # Set openclaw-projects as the memory provider
+    memory: openclaw-projects
+  entries:
+    openclaw-projects:
+      enabled: true
+      config:
+        # Your deployed API URL
+        apiUrl: https://api.your-domain.com
+        # Authentication (choose one method)
+        apiKey: your-shared-auth-secret
+        # Or load from file (for Docker secrets)
+        # apiKeyFile: ~/.secrets/openclaw-projects-api-key
+        # Or load from command (for 1Password, etc.)
+        # apiKeyCommand: "op read 'op://vault/openclaw-projects/api-key'"
 ```
 
 Restart your gateway:

--- a/packages/openclaw-plugin/docs/configuration.md
+++ b/packages/openclaw-plugin/docs/configuration.md
@@ -4,17 +4,18 @@ This document describes all configuration options for the OpenClaw Projects Plug
 
 ## Configuration File
 
-The plugin is configured through your OpenClaw configuration file:
+The plugin is configured through your OpenClaw configuration file (`~/.openclaw/config.yaml`):
 
-```json
-{
-  "plugins": {
-    "openclaw-projects": {
-      // Configuration options here
-    }
-  }
-}
+```yaml
+plugins:
+  entries:
+    openclaw-projects:
+      enabled: true
+      config:
+        # Configuration options here
 ```
+
+All options listed below go under the `plugins.entries.openclaw-projects.config` key.
 
 ## API Connection
 
@@ -203,52 +204,49 @@ Enable debug logging.
 
 ### Development (Simple)
 
-```json
-{
-  "plugins": {
-    "openclaw-projects": {
-      "apiUrl": "http://localhost:3000",
-      "apiKey": "dev-key-123"
-    }
-  }
-}
+```yaml
+plugins:
+  entries:
+    openclaw-projects:
+      enabled: true
+      config:
+        apiUrl: http://localhost:3000
+        apiKey: dev-key-123
 ```
 
 ### Production (Secure)
 
-```json
-{
-  "plugins": {
-    "openclaw-projects": {
-      "apiUrl": "https://api.openclaw-projects.example.com",
-      "apiKeyCommand": "op read op://Production/openclaw/api_key",
-      "twilioAccountSidCommand": "op read op://Production/twilio/account_sid",
-      "twilioAuthTokenCommand": "op read op://Production/twilio/auth_token",
-      "twilioPhoneNumberCommand": "op read op://Production/twilio/phone_number",
-      "postmarkTokenCommand": "op read op://Production/postmark/server_token",
-      "postmarkFromEmail": "noreply@example.com",
-      "autoRecall": true,
-      "autoCapture": true,
-      "userScoping": "agent"
-    }
-  }
-}
+```yaml
+plugins:
+  entries:
+    openclaw-projects:
+      enabled: true
+      config:
+        apiUrl: https://api.openclaw-projects.example.com
+        apiKeyCommand: op read op://Production/openclaw/api_key
+        twilioAccountSidCommand: op read op://Production/twilio/account_sid
+        twilioAuthTokenCommand: op read op://Production/twilio/auth_token
+        twilioPhoneNumberCommand: op read op://Production/twilio/phone_number
+        postmarkTokenCommand: op read op://Production/postmark/server_token
+        postmarkFromEmail: noreply@example.com
+        autoRecall: true
+        autoCapture: true
+        userScoping: agent
 ```
 
 ### File-Based Secrets
 
-```json
-{
-  "plugins": {
-    "openclaw-projects": {
-      "apiUrl": "https://api.openclaw-projects.example.com",
-      "apiKeyFile": "~/.secrets/openclaw/api-key",
-      "twilioAccountSidFile": "~/.secrets/twilio/account-sid",
-      "twilioAuthTokenFile": "~/.secrets/twilio/auth-token",
-      "twilioPhoneNumberFile": "~/.secrets/twilio/phone-number"
-    }
-  }
-}
+```yaml
+plugins:
+  entries:
+    openclaw-projects:
+      enabled: true
+      config:
+        apiUrl: https://api.openclaw-projects.example.com
+        apiKeyFile: ~/.secrets/openclaw/api-key
+        twilioAccountSidFile: ~/.secrets/twilio/account-sid
+        twilioAuthTokenFile: ~/.secrets/twilio/auth-token
+        twilioPhoneNumberFile: ~/.secrets/twilio/phone-number
 ```
 
 ## Environment Variables

--- a/packages/openclaw-plugin/docs/installation.md
+++ b/packages/openclaw-plugin/docs/installation.md
@@ -69,17 +69,16 @@ You should see `openclaw-projects` in the list.
 
 Create or update your OpenClaw configuration. See [Configuration Reference](./configuration.md) for all options.
 
-Minimum required configuration:
+Minimum required configuration (`~/.openclaw/config.yaml`):
 
-```json
-{
-  "plugins": {
-    "openclaw-projects": {
-      "apiUrl": "https://api.your-backend.example.com",
-      "apiKey": "your-api-key"
-    }
-  }
-}
+```yaml
+plugins:
+  entries:
+    openclaw-projects:
+      enabled: true
+      config:
+        apiUrl: https://api.your-backend.example.com
+        apiKey: your-api-key
 ```
 
 ### 3. Test the Connection


### PR DESCRIPTION
## Summary

- Convert all config examples from JSON/JSONC to YAML (matching OpenClaw convention)
- Standardize nesting to `plugins.entries.openclaw-projects.config.*` across all docs
- Files updated:
  - `packages/openclaw-plugin/docs/configuration.md` -- intro block + 3 example configs
  - `packages/openclaw-plugin/docs/installation.md` -- minimum config example
  - `docs/guides/openclaw-integration.md` -- external gateway config example

The canonical config structure is now consistent with the plugin README.

## Test plan

- [x] Plugin tests pass (1008 passed, 3 pre-existing snapshot failures from #906)
- [x] All YAML examples use consistent `plugins.entries.openclaw-projects.config` nesting
- [x] Cross-referenced with plugin README examples

Closes #909