### PR TITLE
[#911] Clarify quickstart auth story and add compose decision tree

### DIFF
--- a/packages/openclaw-plugin/README.md
+++ b/packages/openclaw-plugin/README.md
@@ -71,10 +71,9 @@ plugins:
       enabled: true
       config:
         apiUrl: http://localhost:3000
-        apiKey: <AUTH_SECRET from your .env file>
 ```
 
-Copy the `OPENCLAW_PROJECTS_AUTH_SECRET` value from the `.env` file generated in step 1.
+The quickstart compose disables authentication by default, so no `apiKey` is needed. When you later switch to a production compose file with auth enabled, add `apiKey` with the `OPENCLAW_PROJECTS_AUTH_SECRET` value from your `.env` file. See [Configuration](#configuration) for details.
 
 ### 6. Verify the connection
 
@@ -98,8 +97,20 @@ If the status shows unhealthy, see [Troubleshooting](#troubleshooting) below.
 
 - See [Configuration](#configuration) for optional settings (embedding providers, SMS, email)
 - See [Tools](#tools) for the 27 available agent tools
-- For production deployment, use `docker-compose.yml` (basic) or `docker-compose.traefik.yml` (with TLS)
+- See [Which compose file?](#which-compose-file) to choose the right deployment for your needs
 - For the full deployment guide, see [docs/installation.md](docs/installation.md)
+
+### Which compose file?
+
+| File | Auth | Use case |
+|------|------|----------|
+| `docker-compose.quickstart.yml` | Disabled | Local development and testing (recommended for getting started) |
+| `docker-compose.yml` | Enabled | Basic production deployment without TLS |
+| `docker-compose.traefik.yml` | Enabled | Production with automatic TLS, HTTP/3, and WAF |
+| `docker-compose.full.yml` | Enabled | All services including frontend and optional integrations |
+| `docker-compose.test.yml` | Disabled | CI and automated testing |
+
+Start with `docker-compose.quickstart.yml`. When you are ready for production, switch to `docker-compose.yml` or `docker-compose.traefik.yml` and configure your `apiKey` in the plugin config.
 
 ## Features
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -618,8 +618,9 @@ printf "    Embedding:         %s\n" "${ENV_VALUES[EMBEDDING_PROVIDER]:-not conf
 
 printf "\n  ${BOLD}Next steps:${RESET}\n"
 printf "    1. Review the generated .env file\n"
-printf "    2. Start services:\n"
-printf "       docker compose up -d\n"
-printf "    3. Or use the quickstart compose file:\n"
+printf "    2. Start services with the quickstart compose (recommended):\n"
 printf "       docker compose -f docker-compose.quickstart.yml up -d\n"
+printf "    3. Verify the API is running:\n"
+printf "       curl http://localhost:3000/health\n"
+printf "\n  For production, use docker-compose.yml or docker-compose.traefik.yml instead.\n"
 printf "\n"


### PR DESCRIPTION
## Summary

- **Plugin quickstart step 5**: Removed `apiKey` from the quickstart config example since auth is disabled by default in the quickstart compose. Added note explaining when to add `apiKey` (when switching to production compose with auth enabled).
- **Compose decision matrix**: Added a "Which compose file?" section with a table showing all 5 compose files, their auth status, and use cases.
- **Setup.sh output**: Changed "Next steps" to recommend quickstart compose by default instead of ambiguous "or" between `docker compose up -d` and quickstart. Added health check verification step.

## Test plan

- [x] Plugin tests pass (1008 passed, 3 pre-existing snapshot failures unrelated)
- [x] Verified compose file table matches actual files and their auth settings
- [x] Verified setup.sh output formatting looks correct

Closes #911