### PR TITLE
[#923] Make apiKey optional for quickstart compatibility

### DIFF
--- a/packages/openclaw-plugin/openclaw.plugin.json
+++ b/packages/openclaw-plugin/openclaw.plugin.json
@@ -148,12 +148,7 @@
       }
     },
     "additionalProperties": false,
-    "required": ["apiUrl"],
-    "anyOf": [
-      { "required": ["apiKey"] },
-      { "required": ["apiKeyFile"] },
-      { "required": ["apiKeyCommand"] }
-    ]
+    "required": ["apiUrl"]
   },
   "uiHints": {
     "apiUrl": {

--- a/packages/openclaw-plugin/src/api-client.ts
+++ b/packages/openclaw-plugin/src/api-client.ts
@@ -94,7 +94,7 @@ function getErrorCode(status: number): string {
  */
 export class ApiClient {
   private readonly baseUrl: string
-  private readonly apiKey: string
+  private readonly apiKey: string | undefined
   private readonly logger: Logger
   private readonly timeout: number
   private readonly maxRetries: number
@@ -193,9 +193,12 @@ export class ApiClient {
 
     try {
       const headers: Record<string, string> = {
-        Authorization: `Bearer ${this.apiKey}`,
         'Content-Type': 'application/json',
         'X-Request-Id': requestId,
+      }
+
+      if (this.apiKey) {
+        headers.Authorization = `Bearer ${this.apiKey}`
       }
 
       if (options?.userId) {

--- a/packages/openclaw-plugin/tests/__snapshots__/schema-snapshots.test.ts.snap
+++ b/packages/openclaw-plugin/tests/__snapshots__/schema-snapshots.test.ts.snap
@@ -45,23 +45,6 @@ exports[`Schema Snapshots > Full tool list > tool names should match snapshot 1`
 exports[`Schema Snapshots > Manifest configSchema > configSchema should match snapshot 1`] = `
 {
   "additionalProperties": false,
-  "anyOf": [
-    {
-      "required": [
-        "apiKey",
-      ],
-    },
-    {
-      "required": [
-        "apiKeyFile",
-      ],
-    },
-    {
-      "required": [
-        "apiKeyCommand",
-      ],
-    },
-  ],
   "properties": {
     "apiKey": {
       "description": "API authentication key (direct value, least secure)",

--- a/packages/openclaw-plugin/tests/package-structure.test.ts
+++ b/packages/openclaw-plugin/tests/package-structure.test.ts
@@ -95,16 +95,15 @@ describe('Package Structure', () => {
       expect(manifest).not.toHaveProperty('main')
     })
 
-    it('should have configSchema with required apiUrl and flexible apiKey', () => {
+    it('should have configSchema with required apiUrl and optional apiKey', () => {
       const manifestPath = join(packageRoot, 'openclaw.plugin.json')
       const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8'))
       expect(manifest.configSchema.required).toContain('apiUrl')
-      // apiKey is now flexible - uses anyOf with apiKey, apiKeyFile, or apiKeyCommand
-      expect(manifest.configSchema.anyOf).toBeDefined()
-      expect(manifest.configSchema.anyOf).toHaveLength(3)
-      expect(manifest.configSchema.anyOf[0].required).toContain('apiKey')
-      expect(manifest.configSchema.anyOf[1].required).toContain('apiKeyFile')
-      expect(manifest.configSchema.anyOf[2].required).toContain('apiKeyCommand')
+      // apiKey is optional to support auth-disabled backends (quickstart)
+      expect(manifest.configSchema).not.toHaveProperty('anyOf')
+      expect(manifest.configSchema.properties).toHaveProperty('apiKey')
+      expect(manifest.configSchema.properties).toHaveProperty('apiKeyFile')
+      expect(manifest.configSchema.properties).toHaveProperty('apiKeyCommand')
     })
   })
 


### PR DESCRIPTION
## Summary

- Remove `anyOf` constraint from manifest configSchema that required one of `apiKey`/`apiKeyFile`/`apiKeyCommand`
- Remove Zod `.refine()` that enforced the same constraint
- Make `apiKey` optional in resolved `PluginConfigSchema`
- API client conditionally includes Authorization header only when apiKey is present
- Updated tests and regenerated snapshots

This fixes the critical onboarding blocker: users following the quickstart (which has auth disabled) could not load the plugin without providing an API key.

Closes #923

## Test plan

- [x] All 1011 plugin tests pass
- [x] TypeScript typecheck clean
- [x] Biome lint clean (0 warnings)
- [x] Snapshot tests regenerated and passing
- [x] Config without apiKey now validates successfully
- [x] Config with apiKey still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)