### PR TITLE
[#926] Fix root README install command and plugin README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This is **not** part of OpenClaw itself — it's an independent project that Ope
 OpenClaw agents connect to this backend via the plugin:
 
 ```bash
-pnpm add @troykelly/openclaw-projects
+openclaw plugins install @troykelly/openclaw-projects
 ```
 
 The plugin provides tools for memory, projects, todos, and contacts that agents can use during conversations. See [packages/openclaw-plugin/README.md](packages/openclaw-plugin/README.md) for details.

--- a/packages/openclaw-plugin/README.md
+++ b/packages/openclaw-plugin/README.md
@@ -98,7 +98,7 @@ If the status shows unhealthy, see [Troubleshooting](#troubleshooting) below.
 - See [Configuration](#configuration) for optional settings (embedding providers, SMS, email)
 - See [Tools](#tools) for the 27 available agent tools
 - See [Which compose file?](#which-compose-file) to choose the right deployment for your needs
-- For the full deployment guide, see [docs/installation.md](docs/installation.md)
+- For the detailed installation guide, see [docs/installation.md](docs/installation.md)
 
 ### Which compose file?
 


### PR DESCRIPTION
## Summary
- Changed root `README.md` install command from `pnpm add @troykelly/openclaw-projects` to `openclaw plugins install @troykelly/openclaw-projects` — this is the recommended install method for most users.
- Changed `packages/openclaw-plugin/README.md` link text from "full deployment guide" to "detailed installation guide" to accurately describe what `docs/installation.md` contains.

Closes #926