### PR TITLE
[#936] Fix BREAKING: read api.pluginConfig instead of api.config

### DIFF
--- a/packages/openclaw-plugin/src/register-openclaw.ts
+++ b/packages/openclaw-plugin/src/register-openclaw.ts
@@ -2170,9 +2170,14 @@ export const registerOpenClaw: PluginInitializer = (api: OpenClawPluginApi) => {
   // synchronously during this call.
   const logger = api.logger ?? createLogger('openclaw-projects')
 
+  // The SDK provides plugin-specific config via api.pluginConfig (from
+  // plugins.entries.<id>.config). Fall back to api.config for older SDKs
+  // or test environments that put plugin config there directly.
+  const pluginCfg = api.pluginConfig ?? api.config
+
   let rawConfig: RawPluginConfig
   try {
-    rawConfig = validateRawConfig(api.config)
+    rawConfig = validateRawConfig(pluginCfg)
   } catch (error: unknown) {
     if (error instanceof ZodError) {
       const issues = error.issues

--- a/packages/openclaw-plugin/src/types/openclaw-api.ts
+++ b/packages/openclaw-plugin/src/types/openclaw-api.ts
@@ -216,8 +216,11 @@ export interface ServiceDefinition {
 
 /** OpenClaw Plugin API provided to plugins */
 export interface OpenClawPluginApi {
-  /** Current plugin configuration (validated against configSchema) */
+  /** Full OpenClaw gateway configuration */
   config: Record<string, unknown>
+
+  /** Plugin-specific configuration from plugins.entries.<id>.config */
+  pluginConfig?: Record<string, unknown>
 
   /** Logger instance */
   logger: Logger


### PR DESCRIPTION
## Summary
- Plugin was reading `api.config` (full gateway config) instead of `api.pluginConfig` (plugin-specific config)
- With `.strict()` Zod validation, this would cause the plugin to silently fail to register when loaded by a real OpenClaw Gateway
- Now prefers `api.pluginConfig` with fallback to `api.config` for backwards compatibility
- Added `pluginConfig` to `OpenClawPluginApi` interface
- Added 2 new tests: pluginConfig preference + fallback path

Closes #936

## Test plan
- [x] All 1013 tests pass (2 new)
- [x] Build clean
- [x] Typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)