### PR TITLE
[#938] Fix uiHints helpText → help to match SDK type

### DIFF
--- a/packages/openclaw-plugin/openclaw.plugin.json
+++ b/packages/openclaw-plugin/openclaw.plugin.json
@@ -154,23 +154,23 @@
     "apiUrl": {
       "label": "Backend URL",
       "placeholder": "https://api.openclaw-projects.example.com",
-      "helpText": "The URL of your OpenClaw Projects backend API"
+      "help": "The URL of your OpenClaw Projects backend API"
     },
     "apiKey": {
       "label": "API Key",
       "sensitive": true,
       "placeholder": "sk-...",
-      "helpText": "Direct API key value (least secure, for development)"
+      "help": "Direct API key value (least secure, for development)"
     },
     "apiKeyFile": {
       "label": "API Key File",
       "placeholder": "~/.secrets/openclaw-api-key",
-      "helpText": "Path to a file containing your API key"
+      "help": "Path to a file containing your API key"
     },
     "apiKeyCommand": {
       "label": "API Key Command",
       "placeholder": "op read op://Personal/openclaw/api_key",
-      "helpText": "Command to retrieve API key (e.g., 1Password CLI)"
+      "help": "Command to retrieve API key (e.g., 1Password CLI)"
     },
     "twilioAccountSid": {
       "label": "Twilio Account SID",
@@ -240,53 +240,53 @@
     },
     "secretCommandTimeout": {
       "label": "Secret Command Timeout",
-      "helpText": "Timeout in milliseconds for secret retrieval commands",
+      "help": "Timeout in milliseconds for secret retrieval commands",
       "group": "Advanced"
     },
     "autoRecall": {
       "label": "Auto-Recall",
-      "helpText": "Automatically inject relevant memories at conversation start",
+      "help": "Automatically inject relevant memories at conversation start",
       "group": "Memory"
     },
     "autoCapture": {
       "label": "Auto-Capture",
-      "helpText": "Automatically store important information as memories",
+      "help": "Automatically store important information as memories",
       "group": "Memory"
     },
     "userScoping": {
       "label": "User Scoping",
-      "helpText": "How to isolate memories between users",
+      "help": "How to isolate memories between users",
       "group": "Memory"
     },
     "maxRecallMemories": {
       "label": "Max Recall Memories",
-      "helpText": "Maximum number of memories to inject during auto-recall",
+      "help": "Maximum number of memories to inject during auto-recall",
       "group": "Memory"
     },
     "minRecallScore": {
       "label": "Min Recall Score",
-      "helpText": "Minimum relevance score (0-1) for auto-recall",
+      "help": "Minimum relevance score (0-1) for auto-recall",
       "group": "Memory"
     },
     "timeout": {
       "label": "Request Timeout",
-      "helpText": "Timeout in milliseconds for API requests",
+      "help": "Timeout in milliseconds for API requests",
       "group": "Advanced"
     },
     "maxRetries": {
       "label": "Max Retries",
-      "helpText": "Maximum number of retries for failed requests",
+      "help": "Maximum number of retries for failed requests",
       "group": "Advanced"
     },
     "debug": {
       "label": "Debug Mode",
-      "helpText": "Enable debug logging (never logs secrets)",
+      "help": "Enable debug logging (never logs secrets)",
       "group": "Advanced"
     },
     "baseUrl": {
       "label": "Web App URL",
       "placeholder": "https://app.example.com",
-      "helpText": "Base URL for the web app (used for generating links)",
+      "help": "Base URL for the web app (used for generating links)",
       "group": "Advanced"
     }
   }

--- a/packages/openclaw-plugin/tests/__snapshots__/schema-snapshots.test.ts.snap
+++ b/packages/openclaw-plugin/tests/__snapshots__/schema-snapshots.test.ts.snap
@@ -212,60 +212,60 @@ exports[`Schema Snapshots > Manifest configSchema > full manifest structure (exc
 exports[`Schema Snapshots > Manifest configSchema > manifest uiHints should match snapshot 1`] = `
 {
   "apiKey": {
-    "helpText": "Direct API key value (least secure, for development)",
+    "help": "Direct API key value (least secure, for development)",
     "label": "API Key",
     "placeholder": "sk-...",
     "sensitive": true,
   },
   "apiKeyCommand": {
-    "helpText": "Command to retrieve API key (e.g., 1Password CLI)",
+    "help": "Command to retrieve API key (e.g., 1Password CLI)",
     "label": "API Key Command",
     "placeholder": "op read op://Personal/openclaw/api_key",
   },
   "apiKeyFile": {
-    "helpText": "Path to a file containing your API key",
+    "help": "Path to a file containing your API key",
     "label": "API Key File",
     "placeholder": "~/.secrets/openclaw-api-key",
   },
   "apiUrl": {
-    "helpText": "The URL of your OpenClaw Projects backend API",
+    "help": "The URL of your OpenClaw Projects backend API",
     "label": "Backend URL",
     "placeholder": "https://api.openclaw-projects.example.com",
   },
   "autoCapture": {
     "group": "Memory",
-    "helpText": "Automatically store important information as memories",
+    "help": "Automatically store important information as memories",
     "label": "Auto-Capture",
   },
   "autoRecall": {
     "group": "Memory",
-    "helpText": "Automatically inject relevant memories at conversation start",
+    "help": "Automatically inject relevant memories at conversation start",
     "label": "Auto-Recall",
   },
   "baseUrl": {
     "group": "Advanced",
-    "helpText": "Base URL for the web app (used for generating links)",
+    "help": "Base URL for the web app (used for generating links)",
     "label": "Web App URL",
     "placeholder": "https://app.example.com",
   },
   "debug": {
     "group": "Advanced",
-    "helpText": "Enable debug logging (never logs secrets)",
+    "help": "Enable debug logging (never logs secrets)",
     "label": "Debug Mode",
   },
   "maxRecallMemories": {
     "group": "Memory",
-    "helpText": "Maximum number of memories to inject during auto-recall",
+    "help": "Maximum number of memories to inject during auto-recall",
     "label": "Max Recall Memories",
   },
   "maxRetries": {
     "group": "Advanced",
-    "helpText": "Maximum number of retries for failed requests",
+    "help": "Maximum number of retries for failed requests",
     "label": "Max Retries",
   },
   "minRecallScore": {
     "group": "Memory",
-    "helpText": "Minimum relevance score (0-1) for auto-recall",
+    "help": "Minimum relevance score (0-1) for auto-recall",
     "label": "Min Recall Score",
   },
   "postmarkFromEmail": {
@@ -296,12 +296,12 @@ exports[`Schema Snapshots > Manifest configSchema > manifest uiHints should matc
   },
   "secretCommandTimeout": {
     "group": "Advanced",
-    "helpText": "Timeout in milliseconds for secret retrieval commands",
+    "help": "Timeout in milliseconds for secret retrieval commands",
     "label": "Secret Command Timeout",
   },
   "timeout": {
     "group": "Advanced",
-    "helpText": "Timeout in milliseconds for API requests",
+    "help": "Timeout in milliseconds for API requests",
     "label": "Request Timeout",
   },
   "twilioAccountSid": {
@@ -346,7 +346,7 @@ exports[`Schema Snapshots > Manifest configSchema > manifest uiHints should matc
   },
   "userScoping": {
     "group": "Memory",
-    "helpText": "How to isolate memories between users",
+    "help": "How to isolate memories between users",
     "label": "User Scoping",
   },
 }


### PR DESCRIPTION
Closes #938

## Summary
- Renamed all 13 occurrences of `helpText` to `help` in `openclaw.plugin.json` uiHints section
- Updated schema snapshot to match

## Problem
The SDK's `PluginConfigUiHint` type uses `help` but the manifest used `helpText`, causing help text to be silently dropped by the Gateway UI.

## Test plan
- [x] All 1013 plugin tests pass
- [x] Schema snapshot updated and verified