### PR TITLE
[#937] Fix stateful regex security bug in hooks.ts

### DIFF
--- a/packages/openclaw-plugin/src/hooks.ts
+++ b/packages/openclaw-plugin/src/hooks.ts
@@ -15,10 +15,10 @@ const DEFAULT_CAPTURE_TIMEOUT_MS = 10000
 
 /** Patterns that indicate sensitive content to filter */
 const SENSITIVE_PATTERNS = [
-  /\b(?:password|passwd|pwd)\s*[:=]\s*\S+/gi,
-  /\b(?:api[_-]?key|apikey)\s*[:=]\s*\S+/gi,
-  /\bsk-[a-zA-Z0-9]{10,}/g, // API keys (10+ chars after sk-)
-  /\b(?:secret|token)\s*[:=]\s*\S+/gi,
+  /\b(?:password|passwd|pwd)\s*[:=]\s*\S+/i,
+  /\b(?:api[_-]?key|apikey)\s*[:=]\s*\S+/i,
+  /\bsk-[a-zA-Z0-9]{10,}/, // API keys (10+ chars after sk-)
+  /\b(?:secret|token)\s*[:=]\s*\S+/i,
   /\b\d{4}[\s-]?\d{4}[\s-]?\d{4}[\s-]?\d{4}\b/, // Credit card numbers
   /\b\d{3}-\d{2}-\d{4}\b/, // SSN
 ]
@@ -93,7 +93,8 @@ function containsSensitiveContent(content: string): boolean {
 function filterSensitiveContent(content: string): string {
   let filtered = content
   for (const pattern of SENSITIVE_PATTERNS) {
-    filtered = filtered.replace(pattern, '[REDACTED]')
+    const globalPattern = new RegExp(pattern.source, pattern.flags.includes('g') ? pattern.flags : `${pattern.flags}g`)
+    filtered = filtered.replace(globalPattern, '[REDACTED]')
   }
   return filtered
 }


### PR DESCRIPTION
## Summary

- Removed `/g` flag from `SENSITIVE_PATTERNS` in `hooks.ts` to prevent `RegExp.lastIndex` state causing intermittent false negatives in `containsSensitiveContent()`
- `filterSensitiveContent()` now creates fresh `RegExp` objects with `/g` for each replacement, avoiding shared mutable state
- Added tests verifying consistent detection across 5 consecutive calls with the same sensitive content (password patterns and API key patterns)

Closes #937

## Test plan

- [x] All 1015 plugin tests pass (22 hooks tests, including 2 new regression tests)
- [x] New test: consecutive calls with `password=hunter2` always detected
- [x] New test: consecutive calls with `sk-abcdef1234567890` always detected