### PR TITLE
[#940] Fix apiKey-required claims across docs

### DIFF
--- a/packages/openclaw-plugin/README.md
+++ b/packages/openclaw-plugin/README.md
@@ -238,9 +238,10 @@ Configure the plugin in your OpenClaw config file or pass config programmaticall
 | Option | Type | Description |
 |--------|------|-------------|
 | `apiUrl` | string | Backend API URL (must be HTTPS in production) |
-| `apiKey` | string | API authentication key (direct value) |
 
-You must provide the API key via one of three methods:
+### Authentication (Optional)
+
+When your backend has authentication enabled, provide the API key via one of three methods. If your backend has auth disabled (e.g., the quickstart compose), no API key is needed.
 
 | Method | Config Key | Description |
 |--------|-----------|-------------|

--- a/packages/openclaw-plugin/docs/configuration.md
+++ b/packages/openclaw-plugin/docs/configuration.md
@@ -31,9 +31,9 @@ The base URL of your openclaw-projects backend API.
 
 **Security Note**: Must be HTTPS in production environments.
 
-### API Key Options
+### API Key Options (Optional)
 
-You must provide the API key using one of these three methods:
+When your backend has authentication enabled, provide the API key using one of these three methods. If your backend has auth disabled (e.g., the quickstart compose), no API key is needed.
 
 #### apiKey
 
@@ -42,7 +42,7 @@ Direct API key value. **Least secure** - only use for development.
 | Property | Value |
 |----------|-------|
 | Type | string |
-| Required | One of apiKey/apiKeyFile/apiKeyCommand |
+| Required | No (required only when backend auth is enabled) |
 | Example | `"sk-abc123..."` |
 
 #### apiKeyFile
@@ -52,7 +52,7 @@ Path to a file containing the API key. File should have restricted permissions (
 | Property | Value |
 |----------|-------|
 | Type | string |
-| Required | One of apiKey/apiKeyFile/apiKeyCommand |
+| Required | No (required only when backend auth is enabled) |
 | Example | `"~/.secrets/openclaw-api-key"` |
 
 #### apiKeyCommand
@@ -62,7 +62,7 @@ Shell command to execute to retrieve the API key. **Most secure** - integrates w
 | Property | Value |
 |----------|-------|
 | Type | string |
-| Required | One of apiKey/apiKeyFile/apiKeyCommand |
+| Required | No (required only when backend auth is enabled) |
 | Example | `"op read op://Personal/openclaw/api_key"` |
 
 ## Twilio Configuration (SMS)
@@ -296,6 +296,5 @@ The plugin respects standard environment variables when applicable:
 The plugin validates configuration at startup. Invalid configuration will prevent the plugin from loading. Common validation errors:
 
 - Missing required `apiUrl`
-- No API key method specified
 - Invalid email format for `postmarkFromEmail`
 - Invalid phone format (must be E.164)

--- a/packages/openclaw-plugin/docs/troubleshooting.md
+++ b/packages/openclaw-plugin/docs/troubleshooting.md
@@ -277,7 +277,7 @@ If the status is healthy but you still have issues, continue with the specific s
        openclaw-projects:
          config:
            apiUrl: "https://api.example.com"       # Required
-           apiKey: "..."  # One of apiKey/apiKeyFile/apiKeyCommand required
+           # apiKey is optional — only needed when backend auth is enabled
    ```
 
 2. **Invalid field type**


### PR DESCRIPTION
## Summary

- Updated `packages/openclaw-plugin/README.md`: moved apiKey out of "Required Settings" table into a new "Authentication (Optional)" section
- Updated `packages/openclaw-plugin/docs/configuration.md`: changed "You must provide the API key" to conditional language, updated Required fields to "No (required only when backend auth is enabled)", removed "No API key method specified" from validation errors
- Updated `packages/openclaw-plugin/docs/troubleshooting.md`: removed apiKey-required claim from config validation example

Closes #940