### PR TITLE
[#942] Convert remaining JSON docs to YAML and fix config structure

### DIFF
--- a/docs/guides/openclaw-integration.md
+++ b/docs/guides/openclaw-integration.md
@@ -131,12 +131,6 @@ Add the plugin configuration to your OpenClaw config file (`~/.openclaw/config.y
 
 ```yaml
 plugins:
-  # slots assigns plugins to named capability slots that the gateway
-  # routes tool calls to (e.g. "memory", "tasks").  Setting the
-  # "memory" slot here tells OpenClaw to use openclaw-projects for
-  # all memory-related operations (store, recall, search).
-  slots:
-    memory: openclaw-projects
   entries:
     openclaw-projects:
       enabled: true

--- a/packages/openclaw-plugin/docs/README.md
+++ b/packages/openclaw-plugin/docs/README.md
@@ -23,15 +23,14 @@ openclaw plugins install @troykelly/openclaw-projects
 
 Create or edit your OpenClaw configuration to add the plugin:
 
-```json
-{
-  "plugins": {
-    "openclaw-projects": {
-      "apiUrl": "https://api.your-backend.example.com",
-      "apiKeyFile": "~/.secrets/openclaw-api-key"
-    }
-  }
-}
+```yaml
+plugins:
+  entries:
+    openclaw-projects:
+      enabled: true
+      config:
+        apiUrl: "https://api.your-backend.example.com"
+        apiKeyFile: "~/.secrets/openclaw-api-key"
 ```
 
 ### 3. Verify Installation

--- a/packages/openclaw-plugin/docs/security.md
+++ b/packages/openclaw-plugin/docs/security.md
@@ -8,37 +8,53 @@ This document outlines security recommendations for deploying and using the Open
 
 Direct secret values in configuration files are a security risk:
 
-```json
-// BAD - Never do this in production
-{
-  "apiKey": "sk-abc123..."
-}
+```yaml
+# BAD - Never do this in production
+plugins:
+  entries:
+    openclaw-projects:
+      config:
+        apiKey: "sk-abc123..."
 ```
 
 ### Use Secret Managers (Recommended)
 
 Use the `*Command` options to integrate with secret managers:
 
-```json
-// GOOD - 1Password CLI
-{
-  "apiKeyCommand": "op read op://Vault/openclaw/api_key"
-}
+```yaml
+# GOOD - 1Password CLI
+plugins:
+  entries:
+    openclaw-projects:
+      config:
+        apiKeyCommand: "op read op://Vault/openclaw/api_key"
+```
 
-// GOOD - AWS Secrets Manager
-{
-  "apiKeyCommand": "aws secretsmanager get-secret-value --secret-id openclaw/api-key --query SecretString --output text"
-}
+```yaml
+# GOOD - AWS Secrets Manager
+plugins:
+  entries:
+    openclaw-projects:
+      config:
+        apiKeyCommand: "aws secretsmanager get-secret-value --secret-id openclaw/api-key --query SecretString --output text"
+```
 
-// GOOD - HashiCorp Vault
-{
-  "apiKeyCommand": "vault kv get -field=api_key secret/openclaw"
-}
+```yaml
+# GOOD - HashiCorp Vault
+plugins:
+  entries:
+    openclaw-projects:
+      config:
+        apiKeyCommand: "vault kv get -field=api_key secret/openclaw"
+```
 
-// GOOD - macOS Keychain
-{
-  "apiKeyCommand": "security find-generic-password -s 'openclaw-api-key' -w"
-}
+```yaml
+# GOOD - macOS Keychain
+plugins:
+  entries:
+    openclaw-projects:
+      config:
+        apiKeyCommand: "security find-generic-password -s 'openclaw-api-key' -w"
 ```
 
 ### Use File-Based Secrets
@@ -51,10 +67,12 @@ echo "your-api-key" > ~/.secrets/openclaw-api-key
 chmod 600 ~/.secrets/openclaw-api-key
 ```
 
-```json
-{
-  "apiKeyFile": "~/.secrets/openclaw-api-key"
-}
+```yaml
+plugins:
+  entries:
+    openclaw-projects:
+      config:
+        apiKeyFile: "~/.secrets/openclaw-api-key"
 ```
 
 The plugin will warn if secret files have overly permissive permissions.
@@ -74,16 +92,22 @@ Regularly rotate API keys and credentials:
 
 The plugin enforces HTTPS for `apiUrl` in production:
 
-```json
-// Production - HTTPS required
-{
-  "apiUrl": "https://api.example.com"
-}
+```yaml
+# Production - HTTPS required
+plugins:
+  entries:
+    openclaw-projects:
+      config:
+        apiUrl: "https://api.example.com"
+```
 
-// Development only - HTTP allowed
-{
-  "apiUrl": "http://localhost:3000"
-}
+```yaml
+# Development only - HTTP allowed
+plugins:
+  entries:
+    openclaw-projects:
+      config:
+        apiUrl: "http://localhost:3000"
 ```
 
 ### Certificate Validation
@@ -132,10 +156,12 @@ The plugin sanitizes sensitive data in logs:
 
 Enable debug logging only when troubleshooting:
 
-```json
-{
-  "debug": false  // Keep false in production
-}
+```yaml
+plugins:
+  entries:
+    openclaw-projects:
+      config:
+        debug: false  # Keep false in production
 ```
 
 ## Access Control
@@ -144,10 +170,12 @@ Enable debug logging only when troubleshooting:
 
 Configure appropriate user scoping based on your security requirements:
 
-```json
-{
-  "userScoping": "agent"  // Default - memories shared per user
-}
+```yaml
+plugins:
+  entries:
+    openclaw-projects:
+      config:
+        userScoping: agent  # Default - memories shared per user
 ```
 
 Options:


### PR DESCRIPTION
## Summary

- **security.md**: Converted all 7 JSON config blocks to YAML with full `plugins.entries.openclaw-projects.config` path context; removed invalid `//` JSON comments
- **README.md**: Converted JSON block to YAML, fixed flat `plugins.openclaw-projects.apiUrl` structure to correct nested `plugins.entries.openclaw-projects.config.apiUrl`, added `enabled: true`
- **openclaw-integration.md**: Removed undocumented `plugins.slots.memory` section from External Gateway config example

No source code changes — documentation only.

Closes #942

## Test plan
- [x] All 1013 plugin tests pass
- [x] Verified zero remaining `json` fenced code blocks in security.md and README.md
- [x] Verified `plugins.slots` removed from integration guide

🤖 Generated with [Claude Code](https://claude.com/claude-code)