### PR TITLE
[#944] Add 429 retry, initial poll, batch deletion, and clarify since param

### DIFF
--- a/packages/openclaw-plugin/src/services/notification-service.ts
+++ b/packages/openclaw-plugin/src/services/notification-service.ts
@@ -121,6 +121,8 @@ export function createNotificationService(
       const queryParams = new URLSearchParams()
       queryParams.set('limit', '20')
       if (lastSeenId) {
+        // "since" is a notification ID (not a timestamp) — the backend returns
+        // only notifications created after this ID, providing cursor-based pagination.
         queryParams.set('since', lastSeenId)
       }
 
@@ -183,7 +185,8 @@ export function createNotificationService(
         pollIntervalMs: config.pollIntervalMs,
       })
 
-      // Start polling
+      // Poll immediately on start, then at the configured interval
+      poll()
       pollingInterval = setInterval(() => {
         poll()
       }, config.pollIntervalMs)


### PR DESCRIPTION
Closes #944

## Summary
- **429 Retry**: Added HTTP 429 to retryable statuses in `isRetryableStatus()` and use the `Retry-After` header value (already parsed) as the retry delay instead of exponential backoff
- **Initial Poll**: Notification service now calls `poll()` immediately on `start()` instead of waiting for the first interval tick
- **Batch Deletion**: Changed sequential `for` loop in `deleteByQuery` to parallel `Promise.all` with batches of 10
- **Since Param**: Added clarifying comment that the `since` query parameter is a notification ID (cursor-based pagination), not a timestamp

## Test plan
- [x] All 1017 plugin tests pass
- [x] New test: 429 retry behavior (retries and uses Retry-After delay)
- [x] New test: immediate poll on service start
- [x] New test: batched parallel deletion of 15 memories
- [x] Updated existing test: last poll timestamp now set after initial poll