### PR TITLE
[#943] Fix undefined baseUrl URL generation in notes and notebooks

### DIFF
--- a/packages/openclaw-plugin/src/tools/notebooks.ts
+++ b/packages/openclaw-plugin/src/tools/notebooks.ts
@@ -84,7 +84,7 @@ export interface NotebookListSuccess {
       description: string | null
       isArchived: boolean
       noteCount: number
-      url: string
+      url?: string
     }>
     total: number
     limit: number
@@ -178,7 +178,7 @@ export function createNotebookListTool(options: NotebookToolOptions): NotebookLi
               description: nb.description,
               isArchived: nb.isArchived,
               noteCount: nb.noteCount ?? 0,
-              url: `${config.baseUrl}/notebooks/${nb.id}`,
+              ...(config.baseUrl ? { url: `${config.baseUrl}/notebooks/${nb.id}` } : {}),
             })),
             total: result.total,
             limit: result.limit,
@@ -219,7 +219,7 @@ export interface NotebookCreateSuccess {
     name: string
     description: string | null
     createdAt: string
-    url: string
+    url?: string
   }
 }
 
@@ -304,7 +304,7 @@ export function createNotebookCreateTool(options: NotebookToolOptions): Notebook
             name: notebook.name,
             description: notebook.description,
             createdAt: notebook.createdAt,
-            url: `${config.baseUrl}/notebooks/${notebook.id}`,
+            ...(config.baseUrl ? { url: `${config.baseUrl}/notebooks/${notebook.id}` } : {}),
           },
         }
       } catch (error) {
@@ -348,12 +348,12 @@ export interface NotebookGetSuccess {
     noteCount: number
     createdAt: string
     updatedAt: string
-    url: string
+    url?: string
     notes?: Array<{
       id: string
       title: string
       visibility: string
-      url: string
+      url?: string
     }>
   }
 }
@@ -441,7 +441,7 @@ export function createNotebookGetTool(options: NotebookToolOptions): NotebookGet
             noteCount: notebook.noteCount ?? 0,
             createdAt: notebook.createdAt,
             updatedAt: notebook.updatedAt,
-            url: `${config.baseUrl}/notebooks/${notebook.id}`,
+            ...(config.baseUrl ? { url: `${config.baseUrl}/notebooks/${notebook.id}` } : {}),
           },
         }
 
@@ -450,7 +450,7 @@ export function createNotebookGetTool(options: NotebookToolOptions): NotebookGet
             id: n.id,
             title: n.title,
             visibility: n.visibility,
-            url: `${config.baseUrl}/notes/${n.id}`,
+            ...(config.baseUrl ? { url: `${config.baseUrl}/notes/${n.id}` } : {}),
           }))
         }
 

--- a/packages/openclaw-plugin/src/tools/notes.ts
+++ b/packages/openclaw-plugin/src/tools/notes.ts
@@ -112,7 +112,7 @@ export interface NoteCreateSuccess {
     notebookId: string | null
     visibility: string
     createdAt: string
-    url: string
+    url?: string
   }
 }
 
@@ -210,7 +210,7 @@ export function createNoteCreateTool(options: NoteToolOptions): NoteCreateTool {
             notebookId: note.notebookId,
             visibility: note.visibility,
             createdAt: note.createdAt,
-            url: `${config.baseUrl}/notes/${note.id}`,
+            ...(config.baseUrl ? { url: `${config.baseUrl}/notes/${note.id}` } : {}),
           },
         }
       } catch (error) {
@@ -250,7 +250,7 @@ export interface NoteGetSuccess {
     isPinned: boolean
     createdAt: string
     updatedAt: string
-    url: string
+    url?: string
     versionCount?: number
   }
 }
@@ -342,7 +342,7 @@ export function createNoteGetTool(options: NoteToolOptions): NoteGetTool {
             isPinned: note.isPinned,
             createdAt: note.createdAt,
             updatedAt: note.updatedAt,
-            url: `${config.baseUrl}/notes/${note.id}`,
+            ...(config.baseUrl ? { url: `${config.baseUrl}/notes/${note.id}` } : {}),
             versionCount: (note as Note & { versionCount?: number }).versionCount,
           },
         }
@@ -384,7 +384,7 @@ export interface NoteUpdateSuccess {
     title: string
     visibility: string
     updatedAt: string
-    url: string
+    url?: string
     changes: string[]
   }
 }
@@ -518,7 +518,7 @@ export function createNoteUpdateTool(options: NoteToolOptions): NoteUpdateTool {
             title: note.title,
             visibility: note.visibility,
             updatedAt: note.updatedAt,
-            url: `${config.baseUrl}/notes/${note.id}`,
+            ...(config.baseUrl ? { url: `${config.baseUrl}/notes/${note.id}` } : {}),
             changes,
           },
         }
@@ -682,7 +682,7 @@ export interface NoteSearchSuccess {
       score: number
       tags: string[]
       visibility: string
-      url: string
+      url?: string
     }>
     total: number
     limit: number
@@ -786,7 +786,7 @@ export function createNoteSearchTool(options: NoteToolOptions): NoteSearchTool {
               score: r.score,
               tags: r.tags,
               visibility: r.visibility,
-              url: `${config.baseUrl}/notes/${r.id}`,
+              ...(config.baseUrl ? { url: `${config.baseUrl}/notes/${r.id}` } : {}),
             })),
             total: searchResult.total,
             limit: searchResult.limit,

--- a/packages/openclaw-plugin/tests/tools/notebooks.test.ts
+++ b/packages/openclaw-plugin/tests/tools/notebooks.test.ts
@@ -51,6 +51,147 @@ describe('notebook tools', () => {
     vi.clearAllMocks()
   })
 
+  describe('undefined baseUrl handling', () => {
+    const noBaseUrlConfig: PluginConfig = {
+      ...mockConfig,
+      baseUrl: undefined,
+    }
+
+    it('notebook_list should omit url when baseUrl is undefined', async () => {
+      ;(mockApiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+        success: true,
+        data: {
+          notebooks: [
+            {
+              id: '123e4567-e89b-12d3-a456-426614174000',
+              name: 'Work Notes',
+              description: 'Notes for work',
+              isArchived: false,
+              noteCount: 5,
+              createdAt: '2024-01-01T00:00:00Z',
+              updatedAt: '2024-01-01T00:00:00Z',
+            },
+          ],
+          total: 1,
+          limit: 50,
+          offset: 0,
+        },
+      })
+
+      const tool = createNotebookListTool({
+        client: mockApiClient,
+        logger: mockLogger,
+        config: noBaseUrlConfig,
+        userId: 'user@example.com',
+      })
+
+      const result = await tool.execute({})
+
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.notebooks[0].url).toBeUndefined()
+        expect(JSON.stringify(result.data)).not.toContain('undefined')
+      }
+    })
+
+    it('notebook_create should omit url when baseUrl is undefined', async () => {
+      ;(mockApiClient.post as ReturnType<typeof vi.fn>).mockResolvedValue({
+        success: true,
+        data: {
+          id: '123e4567-e89b-12d3-a456-426614174000',
+          name: 'New Notebook',
+          description: null,
+          createdAt: '2024-01-01T00:00:00Z',
+        },
+      })
+
+      const tool = createNotebookCreateTool({
+        client: mockApiClient,
+        logger: mockLogger,
+        config: noBaseUrlConfig,
+        userId: 'user@example.com',
+      })
+
+      const result = await tool.execute({ name: 'New Notebook' })
+
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.url).toBeUndefined()
+        expect(JSON.stringify(result.data)).not.toContain('undefined')
+      }
+    })
+
+    it('notebook_get should omit url when baseUrl is undefined', async () => {
+      ;(mockApiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+        success: true,
+        data: {
+          id: '123e4567-e89b-12d3-a456-426614174000',
+          name: 'Work Notes',
+          description: null,
+          isArchived: false,
+          noteCount: 2,
+          createdAt: '2024-01-01T00:00:00Z',
+          updatedAt: '2024-01-01T00:00:00Z',
+        },
+      })
+
+      const tool = createNotebookGetTool({
+        client: mockApiClient,
+        logger: mockLogger,
+        config: noBaseUrlConfig,
+        userId: 'user@example.com',
+      })
+
+      const result = await tool.execute({
+        notebookId: '123e4567-e89b-12d3-a456-426614174000',
+      })
+
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.url).toBeUndefined()
+        expect(JSON.stringify(result.data)).not.toContain('undefined')
+      }
+    })
+
+    it('notebook_get should omit url from notes when baseUrl is undefined', async () => {
+      ;(mockApiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+        success: true,
+        data: {
+          id: '123e4567-e89b-12d3-a456-426614174000',
+          name: 'Work Notes',
+          description: null,
+          isArchived: false,
+          noteCount: 1,
+          createdAt: '2024-01-01T00:00:00Z',
+          updatedAt: '2024-01-01T00:00:00Z',
+          notes: [
+            { id: 'note-1', title: 'Note 1', visibility: 'private', updatedAt: '2024-01-01' },
+          ],
+        },
+      })
+
+      const tool = createNotebookGetTool({
+        client: mockApiClient,
+        logger: mockLogger,
+        config: noBaseUrlConfig,
+        userId: 'user@example.com',
+      })
+
+      const result = await tool.execute({
+        notebookId: '123e4567-e89b-12d3-a456-426614174000',
+        includeNotes: true,
+      })
+
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.url).toBeUndefined()
+        expect(result.data.notes).toBeDefined()
+        expect(result.data.notes?.[0].url).toBeUndefined()
+        expect(JSON.stringify(result.data)).not.toContain('undefined')
+      }
+    })
+  })
+
   describe('notebook_list tool', () => {
     describe('tool metadata', () => {
       it('should have correct name', () => {

--- a/packages/openclaw-plugin/tests/tools/notes.test.ts
+++ b/packages/openclaw-plugin/tests/tools/notes.test.ts
@@ -489,6 +489,149 @@ describe('note tools', () => {
     })
   })
 
+  describe('undefined baseUrl handling', () => {
+    const noBaseUrlConfig: PluginConfig = {
+      ...mockConfig,
+      baseUrl: undefined,
+    }
+
+    it('note_create should omit url when baseUrl is undefined', async () => {
+      ;(mockApiClient.post as ReturnType<typeof vi.fn>).mockResolvedValue({
+        success: true,
+        data: {
+          id: '123e4567-e89b-12d3-a456-426614174000',
+          title: 'Test Note',
+          content: 'Test content',
+          notebookId: null,
+          visibility: 'private',
+          createdAt: '2024-01-01T00:00:00Z',
+        },
+      })
+
+      const tool = createNoteCreateTool({
+        client: mockApiClient,
+        logger: mockLogger,
+        config: noBaseUrlConfig,
+        userId: 'user@example.com',
+      })
+
+      const result = await tool.execute({
+        title: 'Test Note',
+        content: 'Test content',
+      })
+
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.url).toBeUndefined()
+        expect(JSON.stringify(result.data)).not.toContain('undefined')
+      }
+    })
+
+    it('note_get should omit url when baseUrl is undefined', async () => {
+      ;(mockApiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+        success: true,
+        data: {
+          id: '123e4567-e89b-12d3-a456-426614174000',
+          title: 'Test Note',
+          content: 'Test content',
+          notebookId: null,
+          tags: [],
+          visibility: 'private',
+          summary: null,
+          isPinned: false,
+          createdAt: '2024-01-01T00:00:00Z',
+          updatedAt: '2024-01-01T00:00:00Z',
+        },
+      })
+
+      const tool = createNoteGetTool({
+        client: mockApiClient,
+        logger: mockLogger,
+        config: noBaseUrlConfig,
+        userId: 'user@example.com',
+      })
+
+      const result = await tool.execute({
+        noteId: '123e4567-e89b-12d3-a456-426614174000',
+      })
+
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.url).toBeUndefined()
+        expect(JSON.stringify(result.data)).not.toContain('undefined')
+      }
+    })
+
+    it('note_update should omit url when baseUrl is undefined', async () => {
+      ;(mockApiClient.put as ReturnType<typeof vi.fn>).mockResolvedValue({
+        success: true,
+        data: {
+          id: '123e4567-e89b-12d3-a456-426614174000',
+          title: 'Updated Title',
+          visibility: 'private',
+          updatedAt: '2024-01-01T00:00:00Z',
+        },
+      })
+
+      const tool = createNoteUpdateTool({
+        client: mockApiClient,
+        logger: mockLogger,
+        config: noBaseUrlConfig,
+        userId: 'user@example.com',
+      })
+
+      const result = await tool.execute({
+        noteId: '123e4567-e89b-12d3-a456-426614174000',
+        title: 'Updated Title',
+      })
+
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.url).toBeUndefined()
+        expect(JSON.stringify(result.data)).not.toContain('undefined')
+      }
+    })
+
+    it('note_search should omit url from results when baseUrl is undefined', async () => {
+      ;(mockApiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+        success: true,
+        data: {
+          query: 'test',
+          searchType: 'hybrid',
+          results: [
+            {
+              id: '123e4567-e89b-12d3-a456-426614174000',
+              title: 'Test Note',
+              snippet: 'Test content...',
+              score: 0.95,
+              tags: ['test'],
+              visibility: 'private',
+              updatedAt: '2024-01-01T00:00:00Z',
+            },
+          ],
+          total: 1,
+          limit: 20,
+          offset: 0,
+        },
+      })
+
+      const tool = createNoteSearchTool({
+        client: mockApiClient,
+        logger: mockLogger,
+        config: noBaseUrlConfig,
+        userId: 'user@example.com',
+      })
+
+      const result = await tool.execute({ query: 'test' })
+
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.results[0].url).toBeUndefined()
+        expect(JSON.stringify(result.data)).not.toContain('undefined')
+      }
+    })
+  })
+
   describe('note_search tool', () => {
     describe('tool metadata', () => {
       it('should have correct name', () => {


### PR DESCRIPTION
## Summary

- When `baseUrl` config is undefined, template literals produced `"undefined/notes/123..."` strings in URL fields
- Fixed all 8 locations in `notes.ts` and `notebooks.ts` to conditionally spread the `url` field only when `baseUrl` is defined
- Made `url` optional in all related TypeScript interfaces
- Added 8 new tests verifying `url` is omitted and no `"undefined"` appears in JSON output when `baseUrl` is undefined

Closes #943

## Test plan

- [x] All 8 new `baseUrl: undefined` tests pass
- [x] Full plugin test suite passes (1021 passed, 14 skipped)
- [x] Existing tests with `baseUrl` defined still pass (url field still present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)