### PR TITLE
[#957] Migrate to Docker-outside-of-Docker devcontainer feature

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -22,20 +22,8 @@ RUN set -eux; \
   apt-get install -y --no-install-recommends nodejs; \
   rm -rf /var/lib/apt/lists/*
 
-# Docker CLI (outside-of-docker / docker-sock) support.
-# Install ONLY the client bits (no daemon) from Docker's official apt repo:
-# - docker-ce-cli provides `docker`
-# - docker-compose-plugin provides `docker compose`
-# - docker-buildx-plugin is commonly expected by modern compose builds
-RUN set -eux; \
-  install -m 0755 -d /etc/apt/keyrings; \
-  curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc; \
-  chmod a+r /etc/apt/keyrings/docker.asc; \
-  echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo \"$VERSION_CODENAME\") stable" \
-    > /etc/apt/sources.list.d/docker.list; \
-  apt-get update; \
-  apt-get install -y --no-install-recommends docker-ce-cli docker-compose-plugin docker-buildx-plugin; \
-  rm -rf /var/lib/apt/lists/*
+# Docker CLI is now provided by the docker-outside-of-docker devcontainer feature.
+# See devcontainer.json: ghcr.io/devcontainers/features/docker-outside-of-docker:1
 
 # Ensure pnpm exists even when host mounts are not present.
 RUN npm install -g pnpm

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,6 +22,7 @@
       "userUid": "automatic",
       "userGid": "automatic"
     },
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
     "ghcr.io/devcontainers/features/git:1": {},
     "ghcr.io/devcontainers/features/node:1": {
       "version": "25"

--- a/.devcontainer/docker-compose.devcontainer.yml
+++ b/.devcontainer/docker-compose.devcontainer.yml
@@ -18,7 +18,14 @@ services:
       CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: "1"
     volumes:
       - ..:/workspaces/openclaw-projects:cached
-      - /var/run/docker.sock:/var/run/docker.sock
+      # Docker-outside-of-Docker: mount host socket to docker-host.sock.
+      # The DooD feature's socat proxy creates /var/run/docker.sock with
+      # proper group permissions (docker group, mode 660) for non-root users.
+      # See: https://github.com/devcontainers/features/issues/444
+      - /var/run/docker.sock:/var/run/docker-host.sock
+    # Required: DooD feature entrypoint is NOT auto-merged with Docker Compose.
+    # This starts the socat proxy before exec'ing into `command`.
+    entrypoint: /usr/local/share/docker-init.sh
     command: sleep infinity
     depends_on:
       postgres:


### PR DESCRIPTION
## Summary
- Replace manual Docker CLI apt install in Dockerfile with official `ghcr.io/devcontainers/features/docker-outside-of-docker:1` feature
- Change socket mount from `docker.sock` to `docker-host.sock` (feature's socat proxy expects this)
- Add `entrypoint: /usr/local/share/docker-init.sh` (required — feature entrypoints don't auto-merge with Docker Compose per [devcontainers/features#444](https://github.com/devcontainers/features/issues/444))

## What changed
| File | Change |
|------|--------|
| `.devcontainer/devcontainer.json` | Added `docker-outside-of-docker:1` feature |
| `.devcontainer/Dockerfile` | Removed lines 25-38 (manual docker-ce-cli/compose-plugin/buildx-plugin install) |
| `.devcontainer/docker-compose.devcontainer.yml` | Socket mount → `docker-host.sock`, added entrypoint |

## Why
The manual Docker install worked but lacked proper socket permission handling for non-root users. The official feature handles:
- Docker group creation and user membership
- `socat` proxy with proper permissions (mode 660, group=docker)
- Compose v2, buildx, and Compose Switch included by default

## Test plan
- [ ] Rebuild devcontainer
- [ ] `docker ps` works as `vscode` user
- [ ] `docker compose version` shows v2
- [ ] CI passes (entrypoint runs harmlessly — starts socat, then execs `sleep infinity`)

Closes #957

🤖 Generated with [Claude Code](https://claude.com/claude-code)