### PR TITLE
[#975] Add shellcheck validation to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,21 @@ on:
       - main
 
 jobs:
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run shellcheck
+        uses: ludeeus/action-shellcheck@master
+        with:
+          scandir: '.devcontainer'
+          severity: warning
+          format: tty
+
   test:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## Summary

Adds automated shellcheck validation to prevent shell script regressions.

Closes #975

## Changes

- Added shellcheck job to `.github/workflows/ci.yml`
- Runs in parallel with main test suite for fast feedback
- Scans all `.sh` files in `.devcontainer/`
- Set to `warning` severity level
- Fails PR if issues are found

## Testing

- Verified shellcheck passes on current `postCreate.sh`
- Tested locally: `shellcheck -S warning .devcontainer/*.sh`

## Related

Part of Epic #967 (devcontainer security improvements)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>