### PR TITLE
[#970] Add timeouts to all curl commands in postCreate.sh

### DIFF
--- a/.devcontainer/test-curl-timeouts.sh
+++ b/.devcontainer/test-curl-timeouts.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Test script to verify curl timeout configuration
+
+set -euo pipefail
+
+echo "=== Testing Curl Timeout Configuration ==="
+echo ""
+
+# Test 1: Verify timeout flags are present
+test_timeout_flags() {
+  echo "Test 1: Verify all curl commands have timeout flags"
+
+  local postCreate=".devcontainer/postCreate.sh"
+
+  # Find all curl commands (exclude comments and curl availability check)
+  local curl_lines
+  curl_lines=$(grep -n "curl " "$postCreate" | grep -v "^[[:space:]]*#" | grep -v "command -v curl")
+
+  echo "Found curl commands:"
+  echo "$curl_lines"
+  echo ""
+
+  # Check each curl command has timeouts
+  local missing_timeout=false
+  while IFS= read -r line; do
+    if ! echo "$line" | grep -q -- "--max-time"; then
+      echo "FAIL: Missing --max-time on line: $line"
+      missing_timeout=true
+    fi
+    if ! echo "$line" | grep -q -- "--connect-timeout"; then
+      echo "FAIL: Missing --connect-timeout on line: $line"
+      missing_timeout=true
+    fi
+  done <<< "$curl_lines"
+
+  if $missing_timeout; then
+    echo "FAIL: Some curl commands are missing timeout flags"
+    return 1
+  fi
+
+  echo "PASS: All curl commands have timeout flags"
+  echo ""
+}
+
+# Test 2: Verify timeout with slow endpoint (10 second delay)
+test_connect_timeout() {
+  echo "Test 2: Verify connect timeout works (slow connection)"
+
+  # Use httpbin.org delay endpoint
+  local start
+  start=$(date +%s)
+
+  echo "Testing connect timeout with 5s timeout against 10s delay endpoint..."
+
+  # This should timeout in ~5 seconds
+  if curl -fsSL --max-time 5 --connect-timeout 2 https://httpbin.org/delay/10 >/dev/null 2>&1; then
+    echo "WARN: Request succeeded unexpectedly (should have timed out)"
+  else
+    local end
+    end=$(date +%s)
+    local duration=$((end - start))
+
+    echo "Request failed after ${duration}s (expected: ~5s or less)"
+
+    # Verify it failed within reasonable time (should be around 5s, allow up to 10s for variance)
+    if [ "$duration" -le 10 ]; then
+      echo "PASS: Timeout triggered within expected timeframe"
+    else
+      echo "FAIL: Timeout took too long (${duration}s > 10s)"
+      return 1
+    fi
+  fi
+
+  echo ""
+}
+
+# Test 3: Verify valid endpoints still work
+test_normal_operation() {
+  echo "Test 3: Verify curl still works with normal endpoints"
+
+  # Test a quick API call with timeouts
+  echo "Testing GitHub API call with timeouts..."
+
+  if curl -fsSL --max-time 30 --connect-timeout 10 https://api.github.com/zen >/dev/null 2>&1; then
+    echo "PASS: Normal operation works with timeout flags"
+  else
+    echo "FAIL: Valid endpoint failed with timeout flags"
+    return 1
+  fi
+
+  echo ""
+}
+
+# Test 4: Verify timeout values are reasonable
+test_timeout_values() {
+  echo "Test 4: Verify timeout values are reasonable"
+
+  local postCreate=".devcontainer/postCreate.sh"
+
+  # Check max-time values
+  echo "Checking --max-time values..."
+  local max_times
+  max_times=$(grep -oP -- '--max-time \K\d+' "$postCreate" || true)
+
+  echo "Found --max-time values: $(echo "$max_times" | tr '\n' ' ')"
+
+  # All should be between 10 and 300 seconds (5 minutes)
+  while IFS= read -r timeout; do
+    if [ -n "$timeout" ]; then
+      if [ "$timeout" -lt 10 ] || [ "$timeout" -gt 300 ]; then
+        echo "FAIL: --max-time value $timeout is outside reasonable range (10-300s)"
+        return 1
+      fi
+    fi
+  done <<< "$max_times"
+
+  echo "PASS: All --max-time values are reasonable"
+  echo ""
+
+  # Check connect-timeout values
+  echo "Checking --connect-timeout values..."
+  local connect_times
+  connect_times=$(grep -oP -- '--connect-timeout \K\d+' "$postCreate" || true)
+
+  echo "Found --connect-timeout values: $(echo "$connect_times" | tr '\n' ' ')"
+
+  # All should be between 5 and 30 seconds
+  while IFS= read -r timeout; do
+    if [ -n "$timeout" ]; then
+      if [ "$timeout" -lt 5 ] || [ "$timeout" -gt 30 ]; then
+        echo "FAIL: --connect-timeout value $timeout is outside reasonable range (5-30s)"
+        return 1
+      fi
+    fi
+  done <<< "$connect_times"
+
+  echo "PASS: All --connect-timeout values are reasonable"
+  echo ""
+}
+
+# Run all tests
+all_tests_passed=true
+
+test_timeout_flags || all_tests_passed=false
+test_connect_timeout || all_tests_passed=false
+test_normal_operation || all_tests_passed=false
+test_timeout_values || all_tests_passed=false
+
+echo "=== Test Summary ==="
+if $all_tests_passed; then
+  echo "All tests PASSED"
+  exit 0
+else
+  echo "Some tests FAILED"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Prevents devcontainer rebuild from hanging indefinitely on slow or dead network connections.

**Issue**: Closes #970
**Epic**: #967

## Changes

Added timeout configuration to all curl commands in postCreate.sh:
- **--max-time 120s** for downloads (Claude Code installer, Codex binary)
- **--max-time 30s** for API calls (GitHub releases endpoint)
- **--connect-timeout 10s** for all commands (quick failure on dead connections)
- Explicit error messages indicating timeout vs other failures
- Comprehensive test suite to verify timeouts work correctly

## Timeout Values Rationale

| Command | max-time | Reason |
|---------|----------|--------|
| Claude Code installer | 120s | Large script, includes execution time |
| Codex binary download | 120s | Multi-MB tarball |
| GitHub API call | 30s | Small JSON response, should be quick |
| All connect timeouts | 10s | Consistent, reasonable for all cases |

## Security Impact

- Prevents indefinite hangs on dead connections
- Improves devcontainer rebuild reliability
- Better user feedback on network issues
- Prevents resource exhaustion from hung connections

## Test Plan

- [x] All curl commands have timeout flags
- [x] Timeout values are reasonable (10-300s max, 5-30s connect)
- [x] Tested with slow endpoint (httpbin.org delay) - timeout triggers correctly
- [x] Normal operations still work with timeout flags
- [x] Syntax validation passes (bash -n)
- [x] Shellcheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)