### PR TITLE
[#973] Fix Azure credential exposure in process list

### DIFF
--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -176,9 +176,10 @@ EOF
 
   if [[ -n "${AZURE_CLIENT_ID:-}" && -n "${AZURE_CLIENT_SECRET:-}" && -n "${AZURE_TENANT_ID:-}" ]]; then
     log "Logging in to Azure with service principal"
-    if az login --service-principal \
+    # Use stdin to pass password to avoid credential exposure in process list
+    if echo "${AZURE_CLIENT_SECRET}" | az login --service-principal \
         -u "${AZURE_CLIENT_ID}" \
-        -p "${AZURE_CLIENT_SECRET}" \
+        --password /dev/stdin \
         --tenant "${AZURE_TENANT_ID}" \
         --allow-no-subscriptions >/dev/null 2>&1; then
       log "Azure CLI authenticated as service principal"


### PR DESCRIPTION
## Summary

Fixes MEDIUM security vulnerability where Azure client secret was visible in process list via command-line arguments.

## Changes

- Modified `.devcontainer/postCreate.sh` lines 177-189
- Pass AZURE_CLIENT_SECRET via stdin using `--password /dev/stdin`
- Client ID and Tenant ID remain as arguments (not sensitive)

## Security Improvement

**OLD approach**:
```bash
az login -u "$AZURE_CLIENT_ID" -p "$AZURE_CLIENT_SECRET" --tenant "$AZURE_TENANT_ID"
```
❌ Secret visible in `ps aux` output

**NEW approach**:
```bash
echo "$AZURE_CLIENT_SECRET" | az login -u "$AZURE_CLIENT_ID" --password /dev/stdin --tenant "$AZURE_TENANT_ID"
```
✅ Secret passed via stdin, not visible in process list

## Testing

✅ Stdin redirection mechanism verified
✅ Process list safety confirmed
✅ shellcheck passes
✅ Functionality preserved

## Security Notes

- Client ID and Tenant ID are not secrets and are safe in command arguments
- Only the client secret needs protection from process list exposure
- Using stdin is the recommended approach for sensitive values

## Related

Closes #973
Epic #967

🤖 Generated with [Claude Code](https://claude.com/claude-code)