### PR TITLE
[#989] Fix CI: restore docker-outside-of-docker feature

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,6 +22,7 @@
       "userUid": "automatic",
       "userGid": "automatic"
     },
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
     "ghcr.io/devcontainers/features/git:1": {},
     "ghcr.io/devcontainers/features/node:1": {
       "version": "25"

--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -84,7 +84,7 @@ install_codex_binary() {
 
   local tmp
   tmp=$(mktemp -d)
-  trap 'rm -rf "$tmp"' RETURN
+  trap 'rm -rf "${tmp:-}"' RETURN
 
   log "Downloading: $asset_url"
   curl -fsSL "$asset_url" -o "$tmp/codex.tar.gz"


### PR DESCRIPTION
## Problem

Closes #989

CI test job failing on ALL PRs with:
```
Error: failed to create task for container: 
exec: "/usr/local/share/docker-init.sh": no such file or directory
```

## Root Cause

The `docker-outside-of-docker` devcontainer feature was removed from devcontainer.json, but docker-init.sh is still required by the container runtime.

## Fix

Restore the `ghcr.io/devcontainers/features/docker-outside-of-docker:1` feature to devcontainer.json.

## Testing

- CI should pass with this change
- All Epic #967 PRs will inherit this fix after rebase

## Related

- Blocks all Epic #967 security PRs from merging