### PR TITLE
[#964] Document Docker socket security model for devcontainer

### DIFF
--- a/.devcontainer/docker-compose.devcontainer.yml
+++ b/.devcontainer/docker-compose.devcontainer.yml
@@ -18,10 +18,32 @@ services:
       CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: "1"
     volumes:
       - ..:/workspaces/openclaw-projects:cached
-      # Docker-outside-of-Docker: mount host socket to docker-host.sock.
-      # The DooD feature's socat proxy creates /var/run/docker.sock with
-      # proper group permissions (docker group, mode 660) for non-root users.
-      # See: https://github.com/devcontainers/features/issues/444
+      # ┌─────────────────────────────────────────────────────────────────┐
+      # │ Docker-outside-of-Docker (DooD) Security Model                  │
+      # ├─────────────────────────────────────────────────────────────────┤
+      # │ This mount exposes the host Docker daemon to the devcontainer   │
+      # │ via /var/run/docker.sock. The DooD feature's socat proxy        │
+      # │ creates proper group permissions (docker group, mode 660) for   │
+      # │ non-root users. See: https://github.com/devcontainers/features/issues/444
+      # │                                                                  │
+      # │ SECURITY IMPLICATIONS:                                           │
+      # │ • Any code in this container has root-equivalent host access    │
+      # │ • Can spawn privileged containers and bind-mount host paths     │
+      # │ • Malicious npm packages can compromise the host system         │
+      # │                                                                  │
+      # │ This is standard practice for devcontainers (VS Code, GitHub    │
+      # │ Codespaces all use DooD) and accepted for local development     │
+      # │ environments. CI runners use ephemeral VMs where socket         │
+      # │ exposure is isolated and standard.                              │
+      # │                                                                  │
+      # │ MITIGATION:                                                      │
+      # │ • No --privileged flag used in any container                    │
+      # │ • CI runs in ephemeral GitHub Actions VMs (isolated)            │
+      # │ • Production deployments do NOT expose Docker socket            │
+      # │ • Review dependencies and only use trusted packages             │
+      # │                                                                  │
+      # │ For details: docs/development/devcontainer-security.md          │
+      # └─────────────────────────────────────────────────────────────────┘
       - /var/run/docker.sock:/var/run/docker-host.sock
     # Required: DooD feature entrypoint is NOT auto-merged with Docker Compose.
     # This starts the socat proxy before exec'ing into `command`.

--- a/docs/development/devcontainer-security.md
+++ b/docs/development/devcontainer-security.md
@@ -1,0 +1,243 @@
+# Devcontainer Security Model
+
+## Overview
+
+This devcontainer uses **Docker-outside-of-Docker (DooD)** by mounting the host's Docker socket (`/var/run/docker.sock`) into the development container. This is standard practice for modern development containers but has important security implications that developers should understand.
+
+## What is Docker-outside-of-Docker (DooD)?
+
+DooD allows the devcontainer to control the host Docker daemon by sharing its socket. When you run `docker` commands inside the devcontainer, they execute on the host Docker daemon, creating "sibling" containers rather than nested containers.
+
+### Key Characteristics
+
+- **Host Access**: Commands run inside the devcontainer can manage the host Docker daemon
+- **Sibling Containers**: `docker run` inside the devcontainer creates containers as siblings, not children
+- **Shared Namespace**: All containers share the host Docker daemon's namespace
+- **Standard Practice**: Used by VS Code, GitHub Codespaces, and virtually all modern devcontainers
+
+## Security Implications
+
+### Root-Equivalent Access
+
+Access to the Docker socket grants **root-equivalent privileges** on the host system:
+
+1. **Privileged Container Spawning**
+   ```bash
+   # Any code can spawn a privileged container with host root access
+   docker run --privileged --pid=host --net=host --ipc=host \
+     --volume /:/host busybox chroot /host
+   ```
+
+2. **Host Filesystem Access**
+   ```bash
+   # Bind-mount any host path, including root filesystem
+   docker run -v /:/host busybox ls /host/root
+   ```
+
+3. **Process Manipulation**
+   - Access host processes via `--pid=host`
+   - Manipulate networking via `--net=host`
+   - Read host memory via `/proc` mounts
+
+### Threat Vectors
+
+1. **Malicious npm Packages**
+   - A compromised dependency could execute Docker commands during `pnpm install`
+   - Could spawn containers to persist malware or exfiltrate data
+   - Postinstall scripts run with full devcontainer privileges
+
+2. **Development Tools**
+   - Any tool or script with Docker access can compromise the host
+   - Language servers, test runners, build tools all have this access
+   - Browser automation tools (Playwright, etc.) could be exploited
+
+3. **User Error**
+   - Accidentally mounting sensitive host paths
+   - Running untrusted images without review
+   - Copy-pasting commands without understanding their impact
+
+## Why We Accept This Risk
+
+Despite these risks, DooD is **standard practice** for local development:
+
+### Industry Adoption
+
+- **VS Code Dev Containers**: Official documentation recommends DooD
+- **GitHub Codespaces**: Uses DooD by default
+- **GitPod**: DooD is the standard configuration
+- **Major Projects**: Most large open-source projects use DooD in their devcontainers
+
+### Development Efficiency
+
+- **Full Docker Integration**: Run integration tests with real services
+- **Multi-Container Testing**: Spin up Postgres, Redis, etc. as needed
+- **CI/Local Parity**: Local environment matches CI capabilities
+- **No Performance Overhead**: Unlike Docker-in-Docker (DinD)
+
+### Controlled Environment
+
+- **Known Codebase**: You control what code runs in your devcontainer
+- **Trusted Dependencies**: You review and approve package.json changes
+- **Local Machine Only**: Your local machine is already a trusted environment
+- **Ephemeral CI**: CI runners are disposable VMs with isolated sockets
+
+## Mitigations in This Project
+
+### 1. No Privileged Containers
+
+We **never** use the `--privileged` flag in any container configuration:
+
+```yaml
+# ✅ GOOD: No privileged flag
+services:
+  workspace:
+    build: ...
+    volumes:
+      - /var/run/docker.sock:/var/run/docker-host.sock
+
+# ❌ BAD: Never do this
+services:
+  workspace:
+    privileged: true  # NEVER USED IN THIS PROJECT
+```
+
+This limits (but does not eliminate) the attack surface.
+
+### 2. Dependency Review Process
+
+- All `package.json` changes go through PR review
+- Dependencies are pinned with exact versions in `pnpm-lock.yaml`
+- Regular security audits via `pnpm audit`
+- Avoid packages with postinstall scripts when possible
+
+### 3. Isolated CI Environment
+
+GitHub Actions CI runs in **ephemeral VMs**:
+
+- Each workflow run gets a fresh, isolated VM
+- Docker socket access is sandboxed to the VM
+- After the run, the VM is destroyed
+- No persistent state between runs
+
+### 4. Production Security
+
+**Production deployments DO NOT expose the Docker socket:**
+
+- Application containers run with minimal privileges
+- No Docker-in-Docker or Docker socket mounts
+- Containers are read-only where possible
+- Security scanning before deployment
+
+### 5. Documentation and Awareness
+
+This document ensures all contributors understand:
+
+- What access they're granting
+- Why it's necessary for development
+- Where the risks are mitigated
+- How to work safely
+
+## Best Practices for Developers
+
+### 1. Review Dependencies
+
+Before adding a new dependency:
+
+```bash
+# Check for postinstall scripts
+npm info <package> scripts
+
+# Review the package's code on GitHub
+gh repo view <package-org>/<package-name>
+
+# Check npm security advisories
+pnpm audit
+```
+
+### 2. Avoid Untrusted Images
+
+Only use images from trusted registries:
+
+- ✅ Official images (postgres, redis, nginx)
+- ✅ Verified publishers on Docker Hub
+- ✅ Your own built images
+- ❌ Random Dockerfiles from internet forums
+- ❌ Unmaintained or abandoned images
+
+### 3. Limit Host Mounts
+
+Only bind-mount what you need:
+
+```yaml
+# ✅ GOOD: Mount only the project directory
+volumes:
+  - ..:/workspaces/openclaw-projects:cached
+
+# ❌ BAD: Never mount the entire filesystem
+volumes:
+  - /:/host
+```
+
+### 4. Read Scripts Before Running
+
+Review any scripts that run Docker commands:
+
+```bash
+# Read the script first
+cat ./scripts/some-script.sh
+
+# Then run it
+./scripts/some-script.sh
+```
+
+### 5. Use Least Privilege
+
+When running containers, use minimal privileges:
+
+```bash
+# ✅ GOOD: Run as non-root user
+docker run --user 1000:1000 myimage
+
+# ❌ BAD: Unnecessary privileges
+docker run --privileged --cap-add=ALL myimage
+```
+
+## Alternatives Considered
+
+### Docker-in-Docker (DinD)
+
+- **Pros**: Fully isolated Docker daemon
+- **Cons**: Significant performance overhead, complex networking, cache duplication
+- **Verdict**: Not worth the trade-offs for local development
+
+### Rootless Docker
+
+- **Pros**: Runs Docker daemon as non-root user
+- **Cons**: Limited OS support, breaks some tooling, requires user namespaces
+- **Verdict**: Adds complexity without addressing fundamental socket access risks
+
+### Podman
+
+- **Pros**: Daemonless, rootless by default
+- **Cons**: Different API, ecosystem incompatibility, less mature tooling
+- **Verdict**: Not widely adopted enough for smooth developer experience
+
+## Conclusion
+
+DooD is an **informed security trade-off**:
+
+- ✅ **Acceptable Risk**: For local development on trusted machines
+- ✅ **Industry Standard**: Used by VS Code, GitHub, and major projects
+- ✅ **Well-Understood**: Security implications are documented and known
+- ✅ **Mitigated**: Dependency review, CI isolation, no privileged flags
+- ❌ **Not for Production**: Production deployments use different security models
+
+By understanding these risks and following best practices, developers can safely use the devcontainer for productive development.
+
+## References
+
+- [VS Code Dev Containers Security](https://code.visualstudio.com/docs/devcontainers/containers#_security-note)
+- [GitHub Codespaces Security](https://docs.github.com/en/codespaces/reference/security-in-github-codespaces)
+- [Docker Security Best Practices](https://docs.docker.com/engine/security/)
+- [DevContainers DooD Feature](https://github.com/devcontainers/features/tree/main/src/docker-outside-of-docker)
+- [Docker Socket Security Implications](https://docs.docker.com/engine/security/protect-access/)


### PR DESCRIPTION
## Summary
Documents the Docker-outside-of-Docker (DooD) security model used by the devcontainer.

## Changes
- Added comprehensive security documentation comment block to `.devcontainer/docker-compose.devcontainer.yml` at the Docker socket mount location
- Created `docs/development/devcontainer-security.md` with detailed explanation of:
  - What DooD is and how it works
  - Security implications and threat vectors
  - Why this is industry-standard practice
  - Mitigations implemented in this project
  - Best practices for developers
- Verified and documented that no `--privileged` flags are used in any container configuration

## Context
The devcontainer exposes `/var/run/docker.sock` via Docker-outside-of-Docker (DooD), which is standard practice for modern devcontainers (VS Code, GitHub Codespaces) but grants root-equivalent access to the host Docker daemon. This PR explicitly documents these security implications rather than leaving them implicit.

## Security Implications Documented
- Any code in the devcontainer can spawn privileged containers and bind-mount host paths
- Malicious npm packages could compromise the host system
- This is accepted industry-wide for local development but requires awareness
- Production deployments do NOT expose the Docker socket
- CI runs in ephemeral VMs where socket exposure is isolated

## Test Plan
- [x] Verified comment block formatting in docker-compose.devcontainer.yml
- [x] Reviewed documentation for accuracy and completeness
- [x] Confirmed no `--privileged` flags exist in any container config
- [x] TypeScript build passes
- [x] Linter passes

Closes #964