### PR TITLE
[#960] Expand Level 2 E2E test coverage

### DIFF
--- a/packages/openclaw-plugin/tests/e2e/plugin-integration.test.ts
+++ b/packages/openclaw-plugin/tests/e2e/plugin-integration.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { createE2EContext, areE2EServicesAvailable, testData, type E2ETestContext } from './setup.js';
+import { createE2EContext, areE2EServicesAvailable, testData, cleanupResources, type E2ETestContext } from './setup.js';
 
 // Check if we should skip E2E tests
 const RUN_E2E = process.env.RUN_E2E === 'true';
@@ -131,30 +131,7 @@ describe.skipIf(!RUN_E2E)('Plugin E2E Integration', () => {
   });
 
   afterAll(async () => {
-    // Cleanup all created resources
-    for (const id of context.createdIds.memories) {
-      try {
-        await context.apiClient.delete(`/api/memories/${id}`);
-      } catch {
-        // Ignore cleanup errors
-      }
-    }
-
-    for (const id of context.createdIds.contacts) {
-      try {
-        await context.apiClient.delete(`/api/contacts/${id}`);
-      } catch {
-        // Ignore cleanup errors
-      }
-    }
-
-    for (const id of context.createdIds.workItems) {
-      try {
-        await context.apiClient.delete(`/api/work-items/${id}`);
-      } catch {
-        // Ignore cleanup errors
-      }
-    }
+    await cleanupResources(context);
   });
 });
 
@@ -252,21 +229,320 @@ describe.skipIf(!RUN_E2E)('Plugin Tool Simulation', () => {
   });
 
   afterAll(async () => {
-    // Cleanup
-    for (const id of context.createdIds.memories) {
-      try {
-        await context.apiClient.delete(`/api/memories/${id}`);
-      } catch {}
+    await cleanupResources(context);
+  });
+});
+
+describe.skipIf(!RUN_E2E)('Comprehensive Tool Operations', () => {
+  let context: E2ETestContext;
+
+  beforeAll(async () => {
+    context = createE2EContext();
+
+    const available = await areE2EServicesAvailable(context.config);
+    if (!available) {
+      console.log('E2E services not available - tests will be skipped');
     }
-    for (const id of context.createdIds.contacts) {
-      try {
-        await context.apiClient.delete(`/api/contacts/${id}`);
-      } catch {}
-    }
-    for (const id of context.createdIds.workItems) {
-      try {
-        await context.apiClient.delete(`/api/work-items/${id}`);
-      } catch {}
-    }
+  });
+
+  describe('Memory Lifecycle: Store → Recall → Forget', () => {
+    it('should complete full memory lifecycle', async () => {
+      const uniqueId = `e2e-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+      // Store a memory
+      const memory = {
+        title: `Memory Lifecycle ${uniqueId}`,
+        content: `This is test content for ${uniqueId}`,
+        memoryType: 'fact',
+        importance: 7,
+        confidence: 0.95,
+      };
+
+      const storeResponse = await context.apiClient.post<{ id: string }>('/api/memories', memory);
+      expect(storeResponse.id).toBeDefined();
+      const memoryId = storeResponse.id;
+      context.createdIds.memories.push(memoryId);
+
+      // Recall the memory
+      const recallResponse = await context.apiClient.get<{
+        memories: Array<{ id: string; content: string }>;
+      }>(`/api/memories/search?q=${uniqueId}`);
+
+      expect(recallResponse.memories).toBeDefined();
+      expect(Array.isArray(recallResponse.memories)).toBe(true);
+
+      // Forget the memory
+      await context.apiClient.delete(`/api/memories/${memoryId}`);
+
+      // Verify deletion
+      const verifyResponse = await context.apiClient.get<{
+        memories: Array<{ id: string }>;
+      }>(`/api/memories/search?q=${uniqueId}`);
+
+      // Memory should not appear or list should be empty/not include this ID
+      const found = verifyResponse.memories?.some((m) => m.id === memoryId);
+      expect(found).toBe(false);
+
+      // Remove from cleanup list since already deleted
+      context.createdIds.memories = context.createdIds.memories.filter((id) => id !== memoryId);
+    });
+
+    it('should store memory with tags', async () => {
+      const memory = {
+        title: `Tagged Memory ${Date.now()}`,
+        content: 'Memory with multiple tags',
+        memoryType: 'preference',
+        importance: 8,
+        confidence: 1.0,
+        tags: ['test', 'e2e', 'automated'],
+      };
+
+      const response = await context.apiClient.post<{ id: string; tags?: string[] }>('/api/memories', memory);
+
+      expect(response.id).toBeDefined();
+      context.createdIds.memories.push(response.id);
+    });
+  });
+
+  describe('Project Operations: Create → List → Get', () => {
+    it('should complete project lifecycle', async () => {
+      const uniqueId = `e2e-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+      // Create project
+      const project = {
+        title: `Project ${uniqueId}`,
+        description: `E2E test project ${uniqueId}`,
+        workItemType: 'project',
+        status: 'open',
+      };
+
+      const createResponse = await context.apiClient.post<{ id: string }>('/api/work-items', project);
+      expect(createResponse.id).toBeDefined();
+      const projectId = createResponse.id;
+      context.createdIds.projects.push(projectId);
+
+      // List projects
+      const listResponse = await context.apiClient.get<{
+        workItems: Array<{ id: string; title: string }>;
+      }>('/api/work-items?type=project');
+
+      expect(listResponse.workItems).toBeDefined();
+      expect(Array.isArray(listResponse.workItems)).toBe(true);
+      const found = listResponse.workItems.some((p) => p.id === projectId);
+      expect(found).toBe(true);
+
+      // Get specific project
+      const getResponse = await context.apiClient.get<{
+        id: string;
+        title: string;
+        description: string;
+      }>(`/api/work-items/${projectId}`);
+
+      expect(getResponse.id).toBe(projectId);
+      expect(getResponse.title).toContain(uniqueId);
+    });
+  });
+
+  describe('Todo Operations: Create → List → Complete', () => {
+    it('should complete todo lifecycle', async () => {
+      const uniqueId = `e2e-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+      // Create todo
+      const todo = {
+        title: `Todo ${uniqueId}`,
+        description: `E2E test todo ${uniqueId}`,
+        workItemType: 'task',
+        status: 'open',
+        priority: 'medium',
+      };
+
+      const createResponse = await context.apiClient.post<{ id: string }>('/api/work-items', todo);
+      expect(createResponse.id).toBeDefined();
+      const todoId = createResponse.id;
+      context.createdIds.workItems.push(todoId);
+
+      // List todos
+      const listResponse = await context.apiClient.get<{
+        workItems: Array<{ id: string; title: string; status: string }>;
+      }>('/api/work-items?type=task&status=open');
+
+      expect(listResponse.workItems).toBeDefined();
+      expect(Array.isArray(listResponse.workItems)).toBe(true);
+
+      // Complete todo (update status)
+      const completeResponse = await context.apiClient.post<{ id: string; status: string }>(`/api/work-items/${todoId}`, {
+        status: 'completed',
+      });
+
+      expect(completeResponse.status).toBe('completed');
+    });
+  });
+
+  describe('Contact Operations: Create → Search → Get', () => {
+    it('should complete contact lifecycle', async () => {
+      const uniqueId = `e2e-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+      // Create contact
+      const contact = {
+        name: `Contact ${uniqueId}`,
+        email: testData.uniqueEmail(),
+        phone: testData.uniquePhone(),
+      };
+
+      const createResponse = await context.apiClient.post<{ id: string }>('/api/contacts', contact);
+      expect(createResponse.id).toBeDefined();
+      const contactId = createResponse.id;
+      context.createdIds.contacts.push(contactId);
+
+      // Search contacts
+      const searchResponse = await context.apiClient.get<{
+        contacts: Array<{ id: string; name: string }>;
+      }>(`/api/contacts/search?q=${uniqueId}`);
+
+      expect(searchResponse.contacts).toBeDefined();
+      expect(Array.isArray(searchResponse.contacts)).toBe(true);
+
+      // Get specific contact
+      const getResponse = await context.apiClient.get<{
+        id: string;
+        name: string;
+      }>(`/api/contacts/${contactId}`);
+
+      expect(getResponse.id).toBe(contactId);
+      expect(getResponse.name).toContain(uniqueId);
+    });
+  });
+
+  describe('Skill Store Operations: Put → Get → List → Search → Delete', () => {
+    it('should complete skill store lifecycle', async () => {
+      const uniqueId = `e2e-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+      // Put skill
+      const skill = {
+        collection: 'e2e-test',
+        key: `skill-${uniqueId}`,
+        value: {
+          name: `Test Skill ${uniqueId}`,
+          data: 'test data',
+        },
+        metadata: {
+          tags: ['test', 'e2e'],
+        },
+      };
+
+      const putResponse = await context.apiClient.post<{ id: string; key: string }>('/api/skill-store', skill);
+      expect(putResponse.id).toBeDefined();
+      const skillId = putResponse.id;
+      context.createdIds.skills.push(skillId);
+
+      // Get skill
+      const getResponse = await context.apiClient.get<{
+        id: string;
+        key: string;
+        value: unknown;
+      }>(`/api/skill-store/${skillId}`);
+
+      expect(getResponse.id).toBe(skillId);
+      expect(getResponse.key).toBe(skill.key);
+
+      // List skills
+      const listResponse = await context.apiClient.get<{
+        items: Array<{ id: string; collection: string }>;
+      }>('/api/skill-store?collection=e2e-test');
+
+      expect(listResponse.items).toBeDefined();
+      expect(Array.isArray(listResponse.items)).toBe(true);
+
+      // Search skills
+      const searchResponse = await context.apiClient.get<{
+        items: Array<{ id: string; key: string }>;
+      }>(`/api/skill-store/search?q=${uniqueId}`);
+
+      expect(searchResponse.items).toBeDefined();
+
+      // Delete skill
+      await context.apiClient.delete(`/api/skill-store/${skillId}`);
+
+      // Remove from cleanup list since already deleted
+      context.createdIds.skills = context.createdIds.skills.filter((id) => id !== skillId);
+    });
+  });
+
+  describe('Relationship Operations: Set → Query', () => {
+    it('should set and query relationships', async () => {
+      const uniqueId = `e2e-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+      // Create two contacts
+      const contact1 = {
+        name: `Contact1 ${uniqueId}`,
+        email: testData.uniqueEmail(),
+      };
+
+      const contact2 = {
+        name: `Contact2 ${uniqueId}`,
+        email: testData.uniqueEmail(),
+      };
+
+      const contact1Response = await context.apiClient.post<{ id: string }>('/api/contacts', contact1);
+      const contact2Response = await context.apiClient.post<{ id: string }>('/api/contacts', contact2);
+
+      context.createdIds.contacts.push(contact1Response.id, contact2Response.id);
+
+      // Set relationship
+      const relationship = {
+        contactId1: contact1Response.id,
+        contactId2: contact2Response.id,
+        relationshipType: 'colleague',
+      };
+
+      const setResponse = await context.apiClient.post<{ id: string }>('/api/relationships', relationship);
+      expect(setResponse.id).toBeDefined();
+
+      // Query relationships
+      const queryResponse = await context.apiClient.get<{
+        relationships: Array<{ id: string; relationshipType: string }>;
+      }>(`/api/relationships?contactId=${contact1Response.id}`);
+
+      expect(queryResponse.relationships).toBeDefined();
+      expect(Array.isArray(queryResponse.relationships)).toBe(true);
+    });
+  });
+
+  describe('Thread Operations: List → Get', () => {
+    it('should list and get threads', async () => {
+      // List threads
+      const listResponse = await context.apiClient.get<{
+        threads: Array<{ id: string }>;
+      }>('/api/threads');
+
+      expect(listResponse.threads).toBeDefined();
+      expect(Array.isArray(listResponse.threads)).toBe(true);
+
+      // If threads exist, get one
+      if (listResponse.threads.length > 0) {
+        const threadId = listResponse.threads[0].id;
+
+        const getResponse = await context.apiClient.get<{
+          id: string;
+        }>(`/api/threads/${threadId}`);
+
+        expect(getResponse.id).toBe(threadId);
+      }
+    });
+  });
+
+  describe('Message Search', () => {
+    it('should search messages', async () => {
+      const searchResponse = await context.apiClient.get<{
+        messages: Array<unknown>;
+      }>('/api/messages/search?q=test');
+
+      expect(searchResponse.messages).toBeDefined();
+      expect(Array.isArray(searchResponse.messages)).toBe(true);
+    });
+  });
+
+  afterAll(async () => {
+    await cleanupResources(context);
   });
 });

--- a/packages/openclaw-plugin/tests/e2e/setup.ts
+++ b/packages/openclaw-plugin/tests/e2e/setup.ts
@@ -166,6 +166,7 @@ export interface E2ETestContext {
     projects: string[];
     contacts: string[];
     workItems: string[];
+    skills: string[];
   };
 }
 
@@ -181,6 +182,7 @@ export function createE2EContext(config: E2EConfig = defaultConfig): E2ETestCont
       projects: [],
       contacts: [],
       workItems: [],
+      skills: [],
     },
   };
 }
@@ -200,28 +202,56 @@ export function setupE2ELifecycle(context: E2ETestContext) {
 
   afterAll(async () => {
     // Cleanup all created resources
-    for (const id of context.createdIds.memories) {
-      try {
-        await context.apiClient.delete(`/api/memories/${id}`);
-      } catch {
-        // Ignore cleanup errors
-      }
-    }
-
-    for (const id of context.createdIds.contacts) {
-      try {
-        await context.apiClient.delete(`/api/contacts/${id}`);
-      } catch {
-        // Ignore cleanup errors
-      }
-    }
-
-    for (const id of context.createdIds.workItems) {
-      try {
-        await context.apiClient.delete(`/api/work-items/${id}`);
-      } catch {
-        // Ignore cleanup errors
-      }
-    }
+    await cleanupResources(context);
   });
+}
+
+/**
+ * Cleanup all resources created during tests.
+ */
+export async function cleanupResources(context: E2ETestContext): Promise<void> {
+  // Cleanup memories
+  for (const id of context.createdIds.memories) {
+    try {
+      await context.apiClient.delete(`/api/memories/${id}`);
+    } catch {
+      // Ignore cleanup errors
+    }
+  }
+
+  // Cleanup contacts
+  for (const id of context.createdIds.contacts) {
+    try {
+      await context.apiClient.delete(`/api/contacts/${id}`);
+    } catch {
+      // Ignore cleanup errors
+    }
+  }
+
+  // Cleanup work items
+  for (const id of context.createdIds.workItems) {
+    try {
+      await context.apiClient.delete(`/api/work-items/${id}`);
+    } catch {
+      // Ignore cleanup errors
+    }
+  }
+
+  // Cleanup projects (if not already cleaned via workItems)
+  for (const id of context.createdIds.projects) {
+    try {
+      await context.apiClient.delete(`/api/work-items/${id}`);
+    } catch {
+      // Ignore cleanup errors
+    }
+  }
+
+  // Cleanup skills
+  for (const id of context.createdIds.skills) {
+    try {
+      await context.apiClient.delete(`/api/skill-store/${id}`);
+    } catch {
+      // Ignore cleanup errors
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- Fixes duplicated cleanup logic between setup.ts and test files
- Adds comprehensive E2E test coverage for all major tool operations
- Improves test data isolation with unique timestamps and UUIDs
- Adds skill store cleanup to lifecycle

## Changes

### 1. Centralized Cleanup Logic
- Moved duplicate `afterAll` cleanup blocks to `cleanupResources()` function in setup.ts
- Added skill store cleanup support
- All test suites now use the shared cleanup function

### 2. Comprehensive Tool Operation Tests
Added full lifecycle E2E tests for:
- **Memory**: Store → Recall → Forget cycle, including tag support
- **Projects**: Create → List → Get
- **Todos**: Create → List → Complete
- **Contacts**: Create → Search → Get
- **Skill Store**: Put → Get → List → Search → Delete
- **Relationships**: Set → Query
- **Threads**: List → Get
- **Message Search**: Query messages

### 3. Test Data Isolation
- All tests use unique IDs: `e2e-${Date.now()}-${Math.random().toString(36).slice(2)}`
- Tests clean up after themselves
- No interdependencies between tests

## Test Plan
All tests require `RUN_E2E=true` and running backend:
```bash
pnpm run test:e2e:setup
RUN_E2E=true pnpm run test:e2e
pnpm run test:e2e:teardown
```

## Acceptance Criteria
- [x] E2E tests cover all major tool operations
- [x] Tests use real backend API (require `RUN_E2E=true`)
- [x] All created resources cleaned up after tests
- [x] No test interdependencies
- [x] Duplicated cleanup logic removed
- [x] Skill store cleanup added

Closes #960