### PR TITLE
[#965] Graceful port conflict detection in E2E setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test:e2e": "RUN_E2E=true vitest run packages/openclaw-plugin/tests/e2e",
     "test:gateway": "vitest run packages/openclaw-plugin/tests/gateway",
     "test:playwright": "pnpm run css:build && pnpm run app:build && playwright test",
-    "test:e2e:setup": "docker compose -f docker-compose.test.yml up -d && ./scripts/wait-for-services.sh",
+    "test:e2e:setup": "./scripts/check-e2e-ports.sh && docker compose -f docker-compose.test.yml up -d && ./scripts/wait-for-services.sh",
     "test:e2e:teardown": "docker compose -f docker-compose.test.yml down -v",
     "db:up": "docker compose -f .devcontainer/docker-compose.devcontainer.yml up -d postgres seaweedfs",
     "db:down": "docker compose -f .devcontainer/docker-compose.devcontainer.yml down",

--- a/scripts/check-e2e-ports.sh
+++ b/scripts/check-e2e-ports.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Check E2E test ports are available before starting containers
+# Part of Epic #956, Issue #965
+#
+# Usage: ./scripts/check-e2e-ports.sh
+# Returns: 0 if ports available, 1 if conflict detected
+
+set -e
+
+# Allow port configuration via env vars (optional enhancement)
+E2E_POSTGRES_PORT="${E2E_POSTGRES_PORT:-5433}"
+E2E_BACKEND_PORT="${E2E_BACKEND_PORT:-3001}"
+
+check_port() {
+  local port=$1
+  local service=$2
+
+  # Use ss to check if port is in LISTEN state
+  # -t = TCP, -l = listening, -n = numeric ports
+  if ss -tlnp 2>/dev/null | grep -q ":${port} "; then
+    echo "ERROR: Port ${port} (${service}) is already in use."
+    echo "Stop the conflicting service first, or set E2E_${service^^}_PORT to a different port."
+    return 1
+  fi
+  return 0
+}
+
+echo "Checking E2E test port availability..."
+
+# Track if any port is in use
+conflict=0
+
+# Check postgres port
+if ! check_port "$E2E_POSTGRES_PORT" "postgres"; then
+  conflict=1
+fi
+
+# Check backend port
+if ! check_port "$E2E_BACKEND_PORT" "backend"; then
+  conflict=1
+fi
+
+if [ $conflict -eq 1 ]; then
+  echo ""
+  echo "Port conflict detected. Cannot start E2E test containers."
+  exit 1
+fi
+
+echo "All E2E test ports are available."
+exit 0


### PR DESCRIPTION
## Summary
- Added `check-e2e-ports.sh` script to detect port conflicts before starting E2E test containers
- Integrated port check into `test:e2e:setup` command before `docker compose up`
- Script provides clear error messages naming the conflicting port (5433 for postgres, 3001 for backend)
- Supports optional `E2E_POSTGRES_PORT` and `E2E_BACKEND_PORT` env vars for custom port configuration
- Setup exits non-zero on port conflict, preventing containers from starting

## Test Plan
- [x] Verified script passes when ports are available
- [x] Verified script fails with clear message when port 5433 is occupied
- [x] Verified script fails with clear message when port 3001 is occupied
- [x] Verified custom port configuration via env vars works correctly
- [x] Verified `test:e2e:setup` command integration
- [x] Build and lint pass locally

## Related
Closes #965
Part of Epic #956

🤖 Generated with Claude Code