### PR TITLE
[#962] CI workflow — add E2E and Gateway test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,26 @@ jobs:
             -e GEMINI_API_KEY \
             workspace bash -lc "cd /workspaces/openclaw-projects && pnpm -s test"
 
+      - name: Start E2E services
+        run: |
+          docker compose -f docker-compose.test.yml up -d --build
+
+      - name: Wait for E2E services
+        run: |
+          docker compose -f .devcontainer/docker-compose.devcontainer.yml exec -T \
+            workspace bash -lc "cd /workspaces/openclaw-projects && bash scripts/wait-for-services.sh"
+
+      - name: Run E2E tests
+        run: |
+          docker compose -f .devcontainer/docker-compose.devcontainer.yml exec -T \
+            -e RUN_E2E=true \
+            workspace bash -lc "cd /workspaces/openclaw-projects && pnpm run test:e2e"
+
+      - name: Teardown E2E services
+        if: always()
+        run: |
+          docker compose -f docker-compose.test.yml down -v
+
       - name: Shutdown
         if: always()
         run: |


### PR DESCRIPTION
## Summary
Adds E2E test execution to the CI workflow to complement existing unit and Gateway tests.

- Starts E2E services using `docker-compose.test.yml`
- Waits for services to be ready using `wait-for-services.sh`
- Runs E2E tests with `RUN_E2E=true` environment variable
- Teardown E2E services with `if: always()` to ensure cleanup
- Gateway tests already covered by existing `pnpm test` step (no separate job needed)
- Plugin build already happens in Typecheck step (`pnpm build`)

## Test Plan
- [ ] Verify CI runs all test steps successfully
- [ ] Verify E2E services start and teardown correctly
- [ ] Verify E2E tests execute in CI environment
- [ ] Verify cleanup happens even if tests fail

Closes #962

Generated with [Claude Code](https://claude.com/claude-code)