### PR TITLE
[#1008] Pin SeaweedFS Docker image to 4.09

### DIFF
--- a/.devcontainer/docker-compose.devcontainer.yml
+++ b/.devcontainer/docker-compose.devcontainer.yml
@@ -78,7 +78,7 @@ services:
       retries: 10
 
   seaweedfs:
-    image: chrislusf/seaweedfs:latest
+    image: chrislusf/seaweedfs:4.09
     command: "server -s3 -s3.port=8333 -master.volumeSizeLimitMB=100 -volume.max=10"
     environment:
       # SeaweedFS S3 credentials (used by the filer/s3 gateway)

--- a/docker-compose.full.yml
+++ b/docker-compose.full.yml
@@ -224,7 +224,7 @@ services:
   # SeaweedFS (unchanged from Traefik compose)
   # =============================================================================
   seaweedfs:
-    image: chrislusf/seaweedfs:latest
+    image: chrislusf/seaweedfs:4.09
     container_name: openclaw-seaweedfs
     restart: unless-stopped
     entrypoint: ["/docker-entrypoint-s3.sh"]

--- a/docker-compose.quickstart.yml
+++ b/docker-compose.quickstart.yml
@@ -65,7 +65,7 @@ services:
   # SeaweedFS (S3-compatible object storage)
   # ---------------------------------------------------------------------------
   seaweedfs:
-    image: chrislusf/seaweedfs:latest
+    image: chrislusf/seaweedfs:4.09
     container_name: openclaw-qs-seaweedfs
     restart: unless-stopped
     entrypoint: ["/docker-entrypoint-s3.sh"]

--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -258,7 +258,7 @@ services:
   # SeaweedFS (S3-compatible object storage)
   # =============================================================================
   seaweedfs:
-    image: chrislusf/seaweedfs:latest
+    image: chrislusf/seaweedfs:4.09
     container_name: openclaw-seaweedfs
     restart: unless-stopped
     entrypoint: ["/docker-entrypoint-s3.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,7 @@ services:
   # SeaweedFS (S3-compatible object storage)
   # =============================================================================
   seaweedfs:
-    image: chrislusf/seaweedfs:latest
+    image: chrislusf/seaweedfs:4.09
     container_name: openclaw-seaweedfs
     restart: unless-stopped
     entrypoint: ["/docker-entrypoint-s3.sh"]


### PR DESCRIPTION
## Summary

- Pin `chrislusf/seaweedfs` Docker image from `latest` to `4.09` across all 5 compose files
- The `latest` tag no longer exists on Docker Hub, breaking CI and all docker compose workflows

Closes #1008

## Files changed

- `docker-compose.yml`
- `docker-compose.full.yml`
- `docker-compose.traefik.yml`
- `docker-compose.quickstart.yml`
- `.devcontainer/docker-compose.devcontainer.yml`

## Test plan

- [ ] CI test job should pass the "Build + start devcontainer services" step
- [ ] `docker compose -f .devcontainer/docker-compose.devcontainer.yml pull seaweedfs` succeeds
- [ ] SeaweedFS healthcheck passes after startup

🤖 Generated with [Claude Code](https://claude.ai/code)