### PR TITLE
[#1023] Build openclaw-plugin package before tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,10 @@ jobs:
         run: |
           docker compose -f .devcontainer/docker-compose.devcontainer.yml exec -T workspace bash -lc "cd /workspaces/openclaw-projects && pnpm app:build && pnpm css:build"
 
+      - name: Build plugin package
+        run: |
+          docker compose -f .devcontainer/docker-compose.devcontainer.yml exec -T workspace bash -lc "cd /workspaces/openclaw-projects && pnpm --filter @troykelly/openclaw-projects run build"
+
       - name: Run tests
         env:
           VOYAGERAI_API_KEY: ${{ secrets.VOYAGERAI_API_KEY }}


### PR DESCRIPTION
## Summary

- Adds a \`Build plugin package\` step to CI workflow between frontend build and test run
- Runs \`pnpm --filter @troykelly/openclaw-projects run build\` to compile TypeScript to \`dist/\`
- Fixes the \`Cannot find module '../../dist/index.js'\` error in \`plugin-exports.test.ts\`

Closes #1023

## Test plan

- [ ] CI \`test\` job passes with plugin-exports test finding \`dist/index.js\`
- [ ] No increase in CI run time (plugin build is fast TypeScript compilation)
- [ ] No regressions in other test files

🤖 Generated with [Claude Code](https://claude.ai/code)