### PR TITLE
[#1027] Use dedicated vitest config for E2E tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "tsc -p tsconfig.build.json --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:e2e": "RUN_E2E=true vitest run packages/openclaw-plugin/tests/e2e",
+    "test:e2e": "RUN_E2E=true vitest run --config vitest.config.e2e.ts",
     "test:gateway": "vitest run packages/openclaw-plugin/tests/gateway",
     "test:playwright": "pnpm run css:build && pnpm run app:build && playwright test",
     "test:full": "bash scripts/test-full.sh",

--- a/vitest.config.e2e.ts
+++ b/vitest.config.e2e.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from 'vitest/config';
+import path from 'node:path';
+
+/**
+ * Vitest config for Level 2 E2E tests only.
+ *
+ * The root vitest.config.ts excludes packages/openclaw-plugin/tests/e2e/**
+ * to prevent E2E tests from running during `pnpm test` (Level 1).
+ * This dedicated config includes only the E2E tests and skips the
+ * unit-test setup files that aren't needed for E2E.
+ */
+export default defineConfig({
+  test: {
+    globals: true,
+    testTimeout: 60000,
+    include: ['packages/openclaw-plugin/tests/e2e/**/*.test.ts'],
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+});


### PR DESCRIPTION
## Summary

- Add `vitest.config.e2e.ts` with only E2E test includes and a 60s timeout
- Update `test:e2e` script to use `--config vitest.config.e2e.ts` instead of inheriting root config
- Root vitest config still excludes E2E tests from `pnpm test` (Level 1)

Closes #1027

## Root Cause

The `test:e2e` script ran `vitest run packages/openclaw-plugin/tests/e2e` using the root vitest config, which excludes that exact path at line 32. The exclude takes precedence over the path filter, resulting in "No test files found".

## Test plan

- [x] `RUN_E2E=true pnpm exec vitest run --config vitest.config.e2e.ts` finds and runs E2E test file
- [x] Default `pnpm test` still excludes E2E tests (root config unchanged)