### PR TITLE
[#1034] Fix flaky loading state test in project-views

### DIFF
--- a/tests/ui/project-views.test.tsx
+++ b/tests/ui/project-views.test.tsx
@@ -255,9 +255,11 @@ describe('ProjectListPage', () => {
 
       renderPage('/work-items');
 
+      // Increased timeout: React.lazy module loading can exceed the default
+      // 1000ms waitFor timeout when running under full test-suite load.
       await waitFor(() => {
         expect(screen.getByTestId('page-project-list')).toBeInTheDocument();
-      });
+      }, { timeout: 5000 });
     });
   });
 
@@ -354,9 +356,11 @@ describe('ProjectDetailPage', () => {
 
       renderPage('/projects/proj-1');
 
+      // Increased timeout: React.lazy module loading can exceed the default
+      // 1000ms waitFor timeout when running under full test-suite load.
       await waitFor(() => {
         expect(screen.getByTestId('page-project-detail')).toBeInTheDocument();
-      });
+      }, { timeout: 5000 });
     });
   });
 


### PR DESCRIPTION
## Summary

- Increases `waitFor` timeout from default 1000ms to 5000ms for both loading state tests in `tests/ui/project-views.test.tsx`
- The tests use `React.lazy()` for component imports which introduces async module loading. Under full test-suite load, lazy imports can take >1000ms, exceeding the default `waitFor` timeout and causing flaky failures
- Both `ProjectListPage` and `ProjectDetailPage` loading state assertions are updated

## Test plan

- [x] All 24 tests in `project-views.test.tsx` pass in isolation
- [ ] Full `pnpm run test:full` passes with this fix

Closes #1034

🤖 Generated with [Claude Code](https://claude.com/claude-code)