### PR TITLE
[#1037] Fix CI E2E test failures — DELETE 400s and relationship response shape

### DIFF
--- a/packages/openclaw-plugin/tests/e2e/plugin-integration.test.ts
+++ b/packages/openclaw-plugin/tests/e2e/plugin-integration.test.ts
@@ -499,12 +499,12 @@ describe.skipIf(!RUN_E2E)('Comprehensive Tool Operations', () => {
       context.createdIds.contacts.push(contact1Response.id, contact2Response.id);
 
       // Set relationship via POST /api/relationships/set (uses display names)
-      const setResponse = await context.apiClient.post<{ id: string }>('/api/relationships/set', {
+      const setResponse = await context.apiClient.post<{ relationship: { id: string }; created: boolean }>('/api/relationships/set', {
         contact_a: `Contact1 ${uniqueId}`,
         contact_b: `Contact2 ${uniqueId}`,
         relationship_type: 'colleague',
       });
-      expect(setResponse.id).toBeDefined();
+      expect(setResponse.relationship.id).toBeDefined();
 
       // Query relationships via GET /api/relationships?contact_id=...
       const queryResponse = await context.apiClient.get<{

--- a/packages/openclaw-plugin/tests/e2e/setup.ts
+++ b/packages/openclaw-plugin/tests/e2e/setup.ts
@@ -100,7 +100,6 @@ export function createTestApiClient(baseUrl: string) {
     async delete(path: string): Promise<void> {
       const response = await fetch(`${baseUrl}${path}`, {
         method: 'DELETE',
-        headers: defaultHeaders,
       });
       if (!response.ok) {
         throw new Error(`DELETE ${path} failed: ${response.status}`);


### PR DESCRIPTION
## Summary

- Remove `Content-Type: application/json` header from DELETE requests in E2E test client (`setup.ts`). Fastify rejects empty bodies when this content type is set (`FST_ERR_CTP_EMPTY_JSON_BODY`), causing `DELETE /api/memories/{id}` and `DELETE /api/skill-store/items/{id}` to return 400.
- Fix relationship test to check `setResponse.relationship.id` instead of `setResponse.id`, matching the actual `RelationshipSetResult` response shape from `POST /api/relationships/set`.

## Test plan

- [ ] CI E2E tests pass (all 21 tests, previously 3 failing)
- [ ] Level 1+3 unit tests still pass (12,529 tests)
- [ ] No regressions

Closes #1037

🤖 Generated with [Claude Code](https://claude.com/claude-code)