### PR TITLE
[#1036] Fix E2E tests in DooD devcontainer — join test network

### DIFF
--- a/scripts/test-full.sh
+++ b/scripts/test-full.sh
@@ -11,11 +11,23 @@
 set -e
 
 TEARDOWN_DONE=0
+E2E_NETWORK_JOINED=0
+
+# Detect Docker-outside-of-Docker: if /.dockerenv exists and docker is available,
+# we're inside a devcontainer that shares the host Docker socket. E2E sibling
+# containers won't be reachable via localhost — we need to join their network
+# and use the container hostname.
+is_dood() {
+  [ -f /.dockerenv ] && command -v docker >/dev/null 2>&1
+}
 
 cleanup() {
   if [ $TEARDOWN_DONE -eq 0 ]; then
     echo ""
     echo "=== Tearing down test services ==="
+    if [ $E2E_NETWORK_JOINED -eq 1 ]; then
+      docker network disconnect openclaw-test-network "$(hostname)" 2>/dev/null || true
+    fi
     pnpm run test:e2e:teardown 2>/dev/null || true
     TEARDOWN_DONE=1
   fi
@@ -38,6 +50,16 @@ pnpm test
 echo ""
 echo "=== Level 2: E2E Tests ==="
 pnpm run test:e2e:setup
+
+# In DooD, connect this container to the test network so we can reach the
+# backend-test container by name instead of localhost.
+if is_dood; then
+  echo "DooD detected — joining openclaw-test-network..."
+  docker network connect openclaw-test-network "$(hostname)" 2>/dev/null || true
+  E2E_NETWORK_JOINED=1
+  export E2E_API_URL="http://openclaw-backend-test:3001"
+fi
+
 pnpm run test:e2e
 
 echo ""


### PR DESCRIPTION
## Summary

- Detect Docker-outside-of-Docker (DooD) in `test-full.sh` and connect the devcontainer to the `openclaw-test-network` so E2E tests can reach the backend-test container
- Set `E2E_API_URL=http://openclaw-backend-test:3001` to use container hostname instead of unreachable `localhost:3001`
- Clean up network connection on teardown
- Mirrors the CI approach in `.github/workflows/ci.yml` lines 96-107

## Root Cause

In DooD setups, sibling containers (started via `docker-compose.test.yml`) run on the host, not inside the devcontainer. Port mappings like `3001:3001` bind to the host's localhost, not the devcontainer's localhost. The devcontainer needs to join the same Docker network and use container names for service discovery.

## Test plan

- [ ] `pnpm run test:full` passes all 3 levels inside the devcontainer (Level 2 E2E tests no longer get ECONNREFUSED)
- [ ] CI still passes (non-DooD environments unaffected — `is_dood` returns false)
- [ ] Cleanup disconnects from network on teardown/interrupt

Closes #1036

🤖 Generated with [Claude Code](https://claude.com/claude-code)