### PR TITLE
[#1046] Database-backed PKCE state storage

### DIFF
--- a/migrations/057_oauth_state.down.sql
+++ b/migrations/057_oauth_state.down.sql
@@ -1,0 +1,4 @@
+-- Migration 057 (down): Remove oauth_state table (issue #1046)
+
+DROP INDEX IF EXISTS oauth_state_expires_at_idx;
+DROP TABLE IF EXISTS oauth_state;

--- a/migrations/057_oauth_state.up.sql
+++ b/migrations/057_oauth_state.up.sql
@@ -1,0 +1,26 @@
+-- Migration 057: Database-backed PKCE state storage (issue #1046)
+--
+-- Replaces the in-memory Map used to store OAuth PKCE state with a
+-- persistent database table.  States are single-use and expire after
+-- 10 minutes by default.
+
+CREATE TABLE IF NOT EXISTS oauth_state (
+  state         text           PRIMARY KEY,
+  provider      oauth_provider NOT NULL,
+  code_verifier text           NOT NULL,
+  scopes        text[]         NOT NULL DEFAULT '{}',
+  user_email    text,
+  redirect_path text,
+  created_at    timestamptz    NOT NULL DEFAULT now(),
+  expires_at    timestamptz    NOT NULL DEFAULT (now() + interval '10 minutes')
+);
+
+CREATE INDEX IF NOT EXISTS oauth_state_expires_at_idx ON oauth_state(expires_at);
+
+COMMENT ON TABLE  oauth_state IS 'Short-lived PKCE state for in-flight OAuth authorization flows';
+COMMENT ON COLUMN oauth_state.state IS 'Cryptographic random token sent as the OAuth state parameter';
+COMMENT ON COLUMN oauth_state.code_verifier IS 'PKCE code verifier; paired with the code_challenge sent to the provider';
+COMMENT ON COLUMN oauth_state.scopes IS 'OAuth scopes requested in this flow';
+COMMENT ON COLUMN oauth_state.user_email IS 'Authenticated user email (if known at flow start)';
+COMMENT ON COLUMN oauth_state.redirect_path IS 'Frontend path to redirect to after callback completes';
+COMMENT ON COLUMN oauth_state.expires_at IS 'Expiry timestamp; states past this time are invalid and can be pruned';

--- a/src/api/oauth/index.ts
+++ b/src/api/oauth/index.ts
@@ -18,6 +18,7 @@ export {
   listConnections,
   isProviderConfigured,
   validateState,
+  cleanExpiredStates,
 } from './service.ts';
 export { syncContacts, getContactSyncCursor } from './contacts.ts';
 export * as microsoft from './microsoft.ts';

--- a/src/api/oauth/types.ts
+++ b/src/api/oauth/types.ts
@@ -47,7 +47,10 @@ export interface OAuthStateData {
   provider: OAuthProvider;
   codeVerifier: string;
   scopes: string[];
+  userEmail?: string;
+  redirectPath?: string;
   createdAt: Date;
+  expiresAt: Date;
 }
 
 export interface OAuthCallbackResult {

--- a/tests/helpers/db.ts
+++ b/tests/helpers/db.ts
@@ -59,6 +59,7 @@ const APPLICATION_TABLES = [
   'work_item_comment',
   'user_presence',
   'calendar_event',
+  'oauth_state',
   'oauth_connection',
   // Note/notebook tables (Epic #337)
   'note_work_item_reference',

--- a/tests/oauth_state.test.ts
+++ b/tests/oauth_state.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Tests for database-backed PKCE state storage (issue #1046).
+ *
+ * Exercises the oauth_state table and the service functions that
+ * replaced the in-memory Map: getAuthorizationUrl (INSERT),
+ * validateState (SELECT+DELETE), and cleanExpiredStates.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { Pool } from 'pg';
+import { createTestPool, truncateAllTables } from './helpers/db.ts';
+import { runMigrate } from './helpers/migrate.ts';
+import { validateState, cleanExpiredStates } from '../src/api/oauth/service.ts';
+import { InvalidStateError } from '../src/api/oauth/types.ts';
+
+describe('oauth_state database storage', () => {
+  let pool: Pool;
+
+  beforeAll(async () => {
+    await runMigrate('up');
+    pool = createTestPool();
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  beforeEach(async () => {
+    await truncateAllTables(pool);
+  });
+
+  // ---------- migration / table existence ----------
+
+  it('oauth_state table exists after migration', async () => {
+    const result = await pool.query(
+      `SELECT tablename FROM pg_tables WHERE schemaname = 'public' AND tablename = 'oauth_state'`,
+    );
+    expect(result.rows).toHaveLength(1);
+  });
+
+  it('oauth_state has an index on expires_at', async () => {
+    const result = await pool.query(
+      `SELECT indexname FROM pg_indexes WHERE tablename = 'oauth_state' AND indexname = 'oauth_state_expires_at_idx'`,
+    );
+    expect(result.rows).toHaveLength(1);
+  });
+
+  // ---------- INSERT (via direct SQL, simulating getAuthorizationUrl) ----------
+
+  it('inserts and retrieves a state row', async () => {
+    await pool.query(
+      `INSERT INTO oauth_state (state, provider, code_verifier, scopes, user_email, redirect_path)
+       VALUES ($1, $2, $3, $4, $5, $6)`,
+      ['test-state-1', 'google', 'verifier-abc', ['scope1', 'scope2'], 'user@example.com', '/settings'],
+    );
+
+    const result = await pool.query('SELECT * FROM oauth_state WHERE state = $1', ['test-state-1']);
+    expect(result.rows).toHaveLength(1);
+
+    const row = result.rows[0];
+    expect(row.provider).toBe('google');
+    expect(row.code_verifier).toBe('verifier-abc');
+    expect(row.scopes).toEqual(['scope1', 'scope2']);
+    expect(row.user_email).toBe('user@example.com');
+    expect(row.redirect_path).toBe('/settings');
+    expect(row.created_at).toBeInstanceOf(Date);
+    expect(row.expires_at).toBeInstanceOf(Date);
+    // expires_at should be ~10 minutes after created_at
+    const diffMs = row.expires_at.getTime() - row.created_at.getTime();
+    expect(diffMs).toBeGreaterThanOrEqual(9 * 60 * 1000);
+    expect(diffMs).toBeLessThanOrEqual(11 * 60 * 1000);
+  });
+
+  it('allows null user_email and redirect_path', async () => {
+    await pool.query(
+      `INSERT INTO oauth_state (state, provider, code_verifier, scopes)
+       VALUES ($1, $2, $3, $4)`,
+      ['test-state-nullable', 'microsoft', 'verifier-xyz', []],
+    );
+
+    const result = await pool.query('SELECT user_email, redirect_path FROM oauth_state WHERE state = $1', [
+      'test-state-nullable',
+    ]);
+    expect(result.rows[0].user_email).toBeNull();
+    expect(result.rows[0].redirect_path).toBeNull();
+  });
+
+  it('rejects duplicate state keys', async () => {
+    await pool.query(
+      `INSERT INTO oauth_state (state, provider, code_verifier) VALUES ($1, $2, $3)`,
+      ['dup-state', 'google', 'v1'],
+    );
+
+    await expect(
+      pool.query(
+        `INSERT INTO oauth_state (state, provider, code_verifier) VALUES ($1, $2, $3)`,
+        ['dup-state', 'microsoft', 'v2'],
+      ),
+    ).rejects.toThrow(/duplicate key/i);
+  });
+
+  // ---------- validateState ----------
+
+  it('validateState returns and deletes valid state', async () => {
+    await pool.query(
+      `INSERT INTO oauth_state (state, provider, code_verifier, scopes, user_email, redirect_path)
+       VALUES ($1, $2, $3, $4, $5, $6)`,
+      ['validate-me', 'microsoft', 'pkce-verifier', ['contacts', 'email'], 'alice@test.com', '/callback'],
+    );
+
+    const data = await validateState(pool, 'validate-me');
+
+    expect(data.provider).toBe('microsoft');
+    expect(data.codeVerifier).toBe('pkce-verifier');
+    expect(data.scopes).toEqual(['contacts', 'email']);
+    expect(data.userEmail).toBe('alice@test.com');
+    expect(data.redirectPath).toBe('/callback');
+    expect(data.createdAt).toBeInstanceOf(Date);
+    expect(data.expiresAt).toBeInstanceOf(Date);
+
+    // State should be deleted (single-use)
+    const remaining = await pool.query('SELECT 1 FROM oauth_state WHERE state = $1', ['validate-me']);
+    expect(remaining.rows).toHaveLength(0);
+  });
+
+  it('validateState throws InvalidStateError for unknown state', async () => {
+    await expect(validateState(pool, 'does-not-exist')).rejects.toThrow(InvalidStateError);
+  });
+
+  it('validateState throws InvalidStateError for expired state', async () => {
+    // Insert a state that already expired
+    await pool.query(
+      `INSERT INTO oauth_state (state, provider, code_verifier, expires_at)
+       VALUES ($1, $2, $3, now() - interval '1 second')`,
+      ['expired-state', 'google', 'verifier'],
+    );
+
+    await expect(validateState(pool, 'expired-state')).rejects.toThrow(InvalidStateError);
+  });
+
+  it('validateState is single-use (second call fails)', async () => {
+    await pool.query(
+      `INSERT INTO oauth_state (state, provider, code_verifier)
+       VALUES ($1, $2, $3)`,
+      ['single-use', 'google', 'v'],
+    );
+
+    await validateState(pool, 'single-use'); // first call succeeds
+    await expect(validateState(pool, 'single-use')).rejects.toThrow(InvalidStateError);
+  });
+
+  // ---------- cleanExpiredStates ----------
+
+  it('cleanExpiredStates removes only expired rows', async () => {
+    // Insert one valid and one expired state
+    await pool.query(
+      `INSERT INTO oauth_state (state, provider, code_verifier)
+       VALUES ($1, $2, $3)`,
+      ['still-valid', 'google', 'v1'],
+    );
+    await pool.query(
+      `INSERT INTO oauth_state (state, provider, code_verifier, expires_at)
+       VALUES ($1, $2, $3, now() - interval '1 second')`,
+      ['already-expired', 'microsoft', 'v2'],
+    );
+
+    const deleted = await cleanExpiredStates(pool);
+    expect(deleted).toBe(1);
+
+    const remaining = await pool.query('SELECT state FROM oauth_state');
+    expect(remaining.rows).toHaveLength(1);
+    expect(remaining.rows[0].state).toBe('still-valid');
+  });
+
+  it('cleanExpiredStates returns 0 when nothing to clean', async () => {
+    const deleted = await cleanExpiredStates(pool);
+    expect(deleted).toBe(0);
+  });
+
+  // ---------- down migration ----------
+
+  it('down migration removes the table and index', async () => {
+    // Apply down then up to verify reversibility
+    await runMigrate('down', 1);
+
+    const result = await pool.query(
+      `SELECT tablename FROM pg_tables WHERE schemaname = 'public' AND tablename = 'oauth_state'`,
+    );
+    expect(result.rows).toHaveLength(0);
+
+    // Re-apply so other tests still work
+    await runMigrate('up');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1046

- **Migration 057**: Creates `oauth_state` table with `state` PK, `oauth_provider` enum, `code_verifier`, `scopes`, optional `user_email`/`redirect_path`, `created_at`, and `expires_at` (defaults to 10 minutes). Includes `expires_at` index for efficient cleanup.
- **Replaced in-memory Map**: Removed the `pendingStates` Map and `setInterval` cleanup from `src/api/oauth/service.ts`. State is now INSERT'd on `getAuthorizationUrl()` and atomically DELETE+RETURNING'd on `validateState()` (single-use guarantee).
- **New `cleanExpiredStates()` function**: Deletes rows past `expires_at`, callable from pgcron or opportunistically.
- **Updated `OAuthStateData` type**: Added `userEmail`, `redirectPath`, and `expiresAt` fields.
- **Updated server.ts call sites**: Both `/api/oauth/authorize/:provider` and `/api/oauth/callback` now pass `pool` to the async state functions.

## Test plan

- [x] 12 integration tests against real Postgres (`tests/oauth_state.test.ts`)
  - Table existence and index verification
  - INSERT with all fields, nullable fields, duplicate key rejection
  - `validateState` success, single-use, expired state, unknown state
  - `cleanExpiredStates` selective cleanup
  - Down migration reversibility
- [x] `pnpm exec vitest run tests/oauth_state.test.ts` — all 12 passing
- [x] No new TypeScript errors in `src/`

## Migration notes

Migration 057 (`oauth_state`) must be applied before the updated service code runs. The migration is idempotent (`IF NOT EXISTS`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)