### PR TITLE
[#1052] Frontend: OAuth callback handler page

### DIFF
--- a/src/ui/hooks/use-oauth-callback.ts
+++ b/src/ui/hooks/use-oauth-callback.ts
@@ -1,0 +1,117 @@
+/**
+ * Hook that manages the OAuth callback flow.
+ *
+ * Reads code/state/error from the current URL, calls the backend
+ * callback API, and manages loading/success/error state.
+ * On success, auto-redirects to settings after 3 seconds.
+ */
+import { useState, useEffect, useRef } from 'react';
+
+interface OAuthCallbackResult {
+  status: 'loading' | 'success' | 'error';
+  provider?: string;
+  userEmail?: string;
+  errorMessage?: string;
+}
+
+interface CallbackResponse {
+  status: string;
+  provider: string;
+  userEmail: string;
+  connectionId: string;
+  scopes: string[];
+}
+
+interface ErrorResponse {
+  error: string;
+  code?: string;
+  details?: string;
+}
+
+function getErrorMessage(error: string | undefined, code: string | undefined, details: string | undefined): string {
+  if (error === 'access_denied' || details === 'access_denied') {
+    return 'You denied access to your account. You can try again from Connected Accounts settings.';
+  }
+  if (code === 'INVALID_STATE') {
+    return 'The authorization session has expired or was already used. Please start over from Connected Accounts settings.';
+  }
+  if (error) {
+    return error;
+  }
+  return 'An unexpected error occurred while connecting your account.';
+}
+
+export function useOAuthCallback(): OAuthCallbackResult {
+  const [result, setResult] = useState<OAuthCallbackResult>({ status: 'loading' });
+  const calledRef = useRef(false);
+
+  useEffect(() => {
+    if (calledRef.current) return;
+    calledRef.current = true;
+
+    const params = new URLSearchParams(window.location.search);
+    const error = params.get('error');
+    const code = params.get('code');
+    const state = params.get('state');
+
+    // OAuth provider returned an error
+    if (error) {
+      setResult({
+        status: 'error',
+        errorMessage: getErrorMessage(undefined, undefined, error),
+      });
+      return;
+    }
+
+    // Missing required params
+    if (!code || !state) {
+      setResult({
+        status: 'error',
+        errorMessage: 'Missing authorization code or state. Please start over from Connected Accounts settings.',
+      });
+      return;
+    }
+
+    // Call the backend callback API
+    const controller = new AbortController();
+
+    fetch(`/api/oauth/callback?code=${encodeURIComponent(code)}&state=${encodeURIComponent(state)}`, {
+      signal: controller.signal,
+    })
+      .then(async (res) => {
+        if (!res.ok) {
+          const body = (await res.json()) as ErrorResponse;
+          setResult({
+            status: 'error',
+            errorMessage: getErrorMessage(body.error, body.code, body.details),
+          });
+          return;
+        }
+
+        const body = (await res.json()) as CallbackResponse;
+        setResult({
+          status: 'success',
+          provider: body.provider,
+          userEmail: body.userEmail,
+        });
+
+        // Auto-redirect after 3 seconds
+        setTimeout(() => {
+          window.location.href = '/app/settings';
+        }, 3000);
+      })
+      .catch((err: unknown) => {
+        if (err instanceof DOMException && err.name === 'AbortError') return;
+        setResult({
+          status: 'error',
+          errorMessage: 'Network error. Please check your connection and try again.',
+        });
+      });
+
+    return () => {
+      controller.abort();
+    };
+  }, []);
+
+  return result;
+}

--- a/src/ui/pages/OAuthCallbackPage.tsx
+++ b/src/ui/pages/OAuthCallbackPage.tsx
@@ -1,0 +1,110 @@
+/**
+ * OAuth callback page.
+ *
+ * Handles the redirect back from OAuth providers (Microsoft/Google).
+ * Reads code, state, and error from query parameters, calls the
+ * backend callback API, then shows success/error state and redirects
+ * to Connected Accounts settings.
+ */
+import { useOAuthCallback } from '@/ui/hooks/use-oauth-callback';
+
+type CallbackStatus = 'loading' | 'success' | 'error';
+
+function StatusIcon({ status }: { status: CallbackStatus }): React.JSX.Element {
+  if (status === 'loading') {
+    return (
+      <div className="size-12 animate-spin rounded-full border-4 border-primary border-t-transparent" role="status">
+        <span className="sr-only">Connecting account...</span>
+      </div>
+    );
+  }
+
+  if (status === 'success') {
+    return (
+      <div className="flex size-12 items-center justify-center rounded-full bg-green-100 text-green-600 dark:bg-green-900/30 dark:text-green-400">
+        <svg className="size-6" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" />
+        </svg>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex size-12 items-center justify-center rounded-full bg-red-100 text-red-600 dark:bg-red-900/30 dark:text-red-400">
+      <svg className="size-6" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+      </svg>
+    </div>
+  );
+}
+
+function providerLabel(provider: string): string {
+  switch (provider) {
+    case 'microsoft':
+      return 'Microsoft 365';
+    case 'google':
+      return 'Google';
+    default:
+      return provider;
+  }
+}
+
+export function OAuthCallbackPage(): React.JSX.Element {
+  const { status, provider, userEmail, errorMessage } = useOAuthCallback();
+
+  return (
+    <div data-testid="page-oauth-callback" className="flex min-h-[60vh] items-center justify-center p-8">
+      <div className="w-full max-w-md text-center">
+        <div className="mb-6 flex justify-center">
+          <StatusIcon status={status} />
+        </div>
+
+        {status === 'loading' && (
+          <div>
+            <h1 className="text-xl font-semibold text-foreground">Connecting your account...</h1>
+            <p className="mt-2 text-sm text-muted-foreground">
+              Please wait while we complete the authorization.
+            </p>
+          </div>
+        )}
+
+        {status === 'success' && (
+          <div>
+            <h1 className="text-xl font-semibold text-foreground">Account connected</h1>
+            <p className="mt-2 text-sm text-muted-foreground">
+              {provider && (
+                <>
+                  Your {providerLabel(provider)} account
+                  {userEmail && <> ({userEmail})</>} has been connected.
+                </>
+              )}
+            </p>
+            <p className="mt-4 text-xs text-muted-foreground">
+              Redirecting to settings...{' '}
+              <a href="/app/settings" className="text-primary underline hover:no-underline">
+                Go now
+              </a>
+            </p>
+          </div>
+        )}
+
+        {status === 'error' && (
+          <div>
+            <h1 className="text-xl font-semibold text-foreground">Connection failed</h1>
+            <p className="mt-2 text-sm text-muted-foreground">
+              {errorMessage || 'An unexpected error occurred while connecting your account.'}
+            </p>
+            <div className="mt-6">
+              <a
+                href="/app/settings"
+                className="inline-flex items-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+              >
+                Try again
+              </a>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/ui/routes.tsx
+++ b/src/ui/routes.tsx
@@ -31,6 +31,7 @@ const SearchPage = React.lazy(() => import('@/ui/pages/SearchPage.js').then((m) 
 const NotFoundPage = React.lazy(() => import('@/ui/pages/NotFoundPage.js').then((m) => ({ default: m.NotFoundPage })));
 const NotesPage = React.lazy(() => import('@/ui/pages/NotesPage.js').then((m) => ({ default: m.NotesPage })));
 const SkillStorePage = React.lazy(() => import('@/ui/pages/SkillStorePage.js').then((m) => ({ default: m.SkillStorePage })));
+const OAuthCallbackPage = React.lazy(() => import('@/ui/pages/OAuthCallbackPage.js').then((m) => ({ default: m.OAuthCallbackPage })));
 
 /** Loading fallback shown while lazy-loaded pages are being fetched. */
 function PageLoader(): React.JSX.Element {
@@ -67,6 +68,7 @@ function lazy(Component: React.LazyExoticComponent<React.ComponentType>): React.
  *   /contacts -> ContactsPage
  *   /memory -> MemoryPage
  *   /settings -> SettingsPage
+ *   /settings/oauth/callback -> OAuthCallbackPage
  *   /search -> SearchPage
  *   * -> NotFoundPage
  */
@@ -149,6 +151,10 @@ export const routes: RouteObject[] = [
       {
         path: 'settings',
         element: lazy(SettingsPage),
+      },
+      {
+        path: 'settings/oauth/callback',
+        element: lazy(OAuthCallbackPage),
       },
       {
         path: 'search',

--- a/tests/ui/oauth-callback.test.tsx
+++ b/tests/ui/oauth-callback.test.tsx
@@ -1,0 +1,214 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Tests for OAuth callback page.
+ * Part of Issue #1052.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { OAuthCallbackPage } from '../../src/ui/pages/OAuthCallbackPage';
+
+// Save original location
+const originalLocation = window.location;
+
+function mockLocation(search: string): void {
+  Object.defineProperty(window, 'location', {
+    value: { ...originalLocation, search, href: originalLocation.href },
+    writable: true,
+    configurable: true,
+  });
+}
+
+function restoreLocation(): void {
+  Object.defineProperty(window, 'location', {
+    value: originalLocation,
+    writable: true,
+    configurable: true,
+  });
+}
+
+describe('OAuthCallbackPage', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    fetchSpy = vi.spyOn(globalThis, 'fetch');
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    fetchSpy.mockRestore();
+    restoreLocation();
+  });
+
+  it('shows loading state initially during token exchange', () => {
+    mockLocation('?code=test-code&state=test-state');
+    // Keep fetch pending
+    fetchSpy.mockReturnValue(new Promise(() => {}));
+
+    render(<OAuthCallbackPage />);
+
+    expect(screen.getByTestId('page-oauth-callback')).toBeDefined();
+    expect(screen.getByText('Connecting your account...')).toBeDefined();
+    expect(screen.getByRole('status')).toBeDefined();
+  });
+
+  it('shows success state after successful token exchange', async () => {
+    mockLocation('?code=auth-code&state=valid-state');
+    fetchSpy.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          status: 'connected',
+          provider: 'microsoft',
+          userEmail: 'user@example.com',
+          connectionId: 'test-id',
+          scopes: ['contacts'],
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+
+    render(<OAuthCallbackPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Account connected')).toBeDefined();
+    });
+
+    expect(screen.getByText(/Microsoft 365/)).toBeDefined();
+    expect(screen.getByText(/user@example.com/)).toBeDefined();
+    expect(screen.getByText('Go now')).toBeDefined();
+  });
+
+  it('shows error state when provider returns error', () => {
+    mockLocation('?error=access_denied');
+
+    render(<OAuthCallbackPage />);
+
+    expect(screen.getByText('Connection failed')).toBeDefined();
+    expect(screen.getByText(/denied access/)).toBeDefined();
+    expect(screen.getByText('Try again')).toBeDefined();
+  });
+
+  it('shows error when code or state is missing', () => {
+    mockLocation('');
+
+    render(<OAuthCallbackPage />);
+
+    expect(screen.getByText('Connection failed')).toBeDefined();
+    expect(screen.getByText(/Missing authorization code/)).toBeDefined();
+  });
+
+  it('shows error when code is present but state is missing', () => {
+    mockLocation('?code=some-code');
+
+    render(<OAuthCallbackPage />);
+
+    expect(screen.getByText('Connection failed')).toBeDefined();
+    expect(screen.getByText(/Missing authorization code/)).toBeDefined();
+  });
+
+  it('shows error when API returns invalid state', async () => {
+    mockLocation('?code=test-code&state=expired-state');
+    fetchSpy.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          error: 'Invalid or expired OAuth state',
+          code: 'INVALID_STATE',
+        }),
+        { status: 400, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+
+    render(<OAuthCallbackPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Connection failed')).toBeDefined();
+    });
+
+    expect(screen.getByText(/expired or was already used/)).toBeDefined();
+  });
+
+  it('shows error on network failure', async () => {
+    mockLocation('?code=test-code&state=valid-state');
+    fetchSpy.mockRejectedValue(new TypeError('Failed to fetch'));
+
+    render(<OAuthCallbackPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Connection failed')).toBeDefined();
+    });
+
+    expect(screen.getByText(/Network error/)).toBeDefined();
+  });
+
+  it('shows Google provider label correctly', async () => {
+    mockLocation('?code=auth-code&state=valid-state');
+    fetchSpy.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          status: 'connected',
+          provider: 'google',
+          userEmail: 'user@gmail.com',
+          connectionId: 'test-id',
+          scopes: ['contacts'],
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+
+    render(<OAuthCallbackPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Account connected')).toBeDefined();
+    });
+
+    expect(screen.getByText(/Google/)).toBeDefined();
+    expect(screen.getByText(/user@gmail.com/)).toBeDefined();
+  });
+
+  it('calls the correct API endpoint with code and state', async () => {
+    mockLocation('?code=my-code&state=my-state');
+    fetchSpy.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          status: 'connected',
+          provider: 'microsoft',
+          userEmail: 'test@test.com',
+          connectionId: 'id',
+          scopes: [],
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+
+    render(<OAuthCallbackPage />);
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        '/api/oauth/callback?code=my-code&state=my-state',
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
+    });
+  });
+
+  it('shows generic API error message', async () => {
+    mockLocation('?code=test-code&state=valid-state');
+    fetchSpy.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          error: 'Token exchange failed: invalid_grant',
+        }),
+        { status: 400, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+
+    render(<OAuthCallbackPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Connection failed')).toBeDefined();
+    });
+
+    expect(screen.getByText(/Token exchange failed/)).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

- New `OAuthCallbackPage` at `/app/settings/oauth/callback` handles the redirect back from Microsoft/Google OAuth providers
- `useOAuthCallback` hook manages the full callback flow: reads URL params, calls backend API, manages loading/success/error states
- Auto-redirects to Connected Accounts settings after 3 seconds on success
- User-friendly error messages for common scenarios (access denied, expired state, network errors)
- Also fixes pre-existing plugin version mismatch and env var fallback cleanup in OAuth tests

Closes #1052

## Test plan

- [x] 10 unit tests covering all callback scenarios (loading, success, error, network failure, provider labels)
- [x] All 107 related tests pass locally (OAuth + UI + plugin)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)