### PR TITLE
[#1054] Plugin: surface OAuth data via gateway

### DIFF
--- a/packages/openclaw-plugin/src/gateway/oauth-rpc-methods.ts
+++ b/packages/openclaw-plugin/src/gateway/oauth-rpc-methods.ts
@@ -1,0 +1,488 @@
+/**
+ * OAuth Gateway RPC methods for surfacing connected account data to agents.
+ * Part of Issue #1054.
+ *
+ * Registers gateway methods that proxy requests to the openclaw-projects
+ * backend API, exposing connected account data (contacts, email, files)
+ * in an agent-friendly format with pagination, connectionLabel, and
+ * availableActions metadata.
+ */
+
+import type { ApiClient } from '../api-client.js';
+import type { Logger } from '../logger.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Backend connection shape returned by /api/oauth/connections. */
+interface BackendConnection {
+  id: string;
+  provider: string;
+  label?: string;
+  providerAccountEmail?: string;
+  permissionLevel: string;
+  enabledFeatures: string[];
+  isActive: boolean;
+  lastSyncAt?: string;
+  syncStatus: Record<string, unknown>;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+/** Options for creating OAuth gateway methods. */
+export interface OAuthGatewayMethodsOptions {
+  logger: Logger;
+  apiClient: ApiClient;
+  userId: string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build available actions for an account listing based on features and permissions. */
+function buildAccountActions(conn: BackendConnection): string[] {
+  const actions: string[] = [];
+  if (conn.enabledFeatures.includes('contacts')) {
+    actions.push('list_contacts');
+  }
+  if (conn.enabledFeatures.includes('email')) {
+    actions.push('list_emails', 'get_email');
+    if (conn.permissionLevel === 'read_write') {
+      actions.push('send_email', 'create_draft', 'update_email', 'delete_email');
+    }
+  }
+  if (conn.enabledFeatures.includes('files')) {
+    actions.push('list_files', 'search_files', 'get_file');
+  }
+  if (conn.enabledFeatures.includes('calendar')) {
+    actions.push('list_events');
+  }
+  return actions;
+}
+
+/** Build email-specific available actions based on permission level. */
+function buildEmailActions(permissionLevel: string): string[] {
+  const actions = ['list_messages', 'get_message', 'list_threads', 'list_folders'];
+  if (permissionLevel === 'read_write') {
+    actions.push('send_email', 'create_draft', 'update_draft', 'update_message', 'delete_message');
+  }
+  return actions;
+}
+
+/** Build file-specific available actions. */
+function buildFileActions(): string[] {
+  return ['list_files', 'search_files', 'get_file'];
+}
+
+/**
+ * Resolve a connection by ID from the backend.
+ * Returns null with logged warning when not found or inactive.
+ */
+async function resolveConnection(
+  apiClient: ApiClient,
+  userId: string,
+  logger: Logger,
+  connectionId: string,
+): Promise<BackendConnection | null> {
+  const response = await apiClient.get<{ connections: BackendConnection[] }>('/api/oauth/connections', { userId });
+  if (!response.success) {
+    logger.error('Failed to fetch OAuth connections', { userId, error: response.error.message });
+    return null;
+  }
+
+  const conn = response.data.connections.find((c) => c.id === connectionId);
+  if (!conn) {
+    logger.debug('OAuth connection not found', { userId, connectionId });
+    return null;
+  }
+
+  if (!conn.isActive) {
+    logger.debug('OAuth connection is disabled', { userId, connectionId });
+    return null;
+  }
+
+  return conn;
+}
+
+// ---------------------------------------------------------------------------
+// Method handlers
+// ---------------------------------------------------------------------------
+
+export interface OAuthAccountListParams {
+  userEmail?: string;
+  provider?: string;
+}
+
+export interface OAuthAccountListResult {
+  accounts: Array<{
+    connectionId: string;
+    provider: string;
+    connectionLabel: string;
+    providerAccountEmail?: string;
+    permissionLevel: string;
+    enabledFeatures: string[];
+    isActive: boolean;
+    lastSyncAt?: string;
+    syncStatus: Record<string, unknown>;
+    availableActions: string[];
+  }>;
+}
+
+export interface OAuthContactsListParams {
+  connectionId: string;
+  pageToken?: string;
+}
+
+export interface OAuthContactsListResult {
+  connectionLabel: string;
+  contacts: Array<Record<string, unknown>>;
+  nextPageToken?: string;
+  availableActions: string[];
+}
+
+export interface OAuthEmailListParams {
+  connectionId: string;
+  folderId?: string;
+  q?: string;
+  maxResults?: number;
+  pageToken?: string;
+}
+
+export interface OAuthEmailListResult {
+  connectionLabel: string;
+  messages: Array<Record<string, unknown>>;
+  nextPageToken?: string;
+  availableActions: string[];
+}
+
+export interface OAuthEmailGetParams {
+  connectionId: string;
+  messageId: string;
+}
+
+export interface OAuthEmailGetResult {
+  connectionLabel: string;
+  message: Record<string, unknown>;
+  availableActions: string[];
+}
+
+export interface OAuthFilesListParams {
+  connectionId: string;
+  folderId?: string;
+  pageToken?: string;
+}
+
+export interface OAuthFilesListResult {
+  connectionLabel: string;
+  files: Array<Record<string, unknown>>;
+  nextPageToken?: string;
+  availableActions: string[];
+}
+
+export interface OAuthFilesSearchParams {
+  connectionId: string;
+  query: string;
+  pageToken?: string;
+}
+
+export interface OAuthFilesSearchResult {
+  connectionLabel: string;
+  files: Array<Record<string, unknown>>;
+  nextPageToken?: string;
+  availableActions: string[];
+}
+
+export interface OAuthFilesGetParams {
+  connectionId: string;
+  fileId: string;
+}
+
+export interface OAuthFilesGetResult {
+  connectionLabel: string;
+  file: Record<string, unknown>;
+  availableActions: string[];
+}
+
+/** All OAuth gateway methods. */
+export interface OAuthGatewayMethods {
+  accountsList: (params: OAuthAccountListParams) => Promise<OAuthAccountListResult>;
+  contactsList: (params: OAuthContactsListParams) => Promise<OAuthContactsListResult>;
+  emailList: (params: OAuthEmailListParams) => Promise<OAuthEmailListResult>;
+  emailGet: (params: OAuthEmailGetParams) => Promise<OAuthEmailGetResult>;
+  filesList: (params: OAuthFilesListParams) => Promise<OAuthFilesListResult>;
+  filesSearch: (params: OAuthFilesSearchParams) => Promise<OAuthFilesSearchResult>;
+  filesGet: (params: OAuthFilesGetParams) => Promise<OAuthFilesGetResult>;
+}
+
+/**
+ * Create OAuth gateway RPC method handlers.
+ */
+export function createOAuthGatewayMethods(options: OAuthGatewayMethodsOptions): OAuthGatewayMethods {
+  const { logger, apiClient, userId } = options;
+
+  return {
+    async accountsList(params: OAuthAccountListParams): Promise<OAuthAccountListResult> {
+      logger.debug('oauth.accounts.list', { userId });
+
+      const qs = new URLSearchParams();
+      if (params.userEmail) qs.set('userEmail', params.userEmail);
+      if (params.provider) qs.set('provider', params.provider);
+      const qsStr = qs.toString();
+      const path = `/api/oauth/connections${qsStr ? `?${qsStr}` : ''}`;
+
+      const response = await apiClient.get<{ connections: BackendConnection[] }>(path, { userId });
+      if (!response.success) {
+        throw new Error(response.error.message || 'Failed to list accounts');
+      }
+
+      return {
+        accounts: response.data.connections.map((conn) => ({
+          connectionId: conn.id,
+          provider: conn.provider,
+          connectionLabel: conn.label ?? conn.provider,
+          providerAccountEmail: conn.providerAccountEmail,
+          permissionLevel: conn.permissionLevel,
+          enabledFeatures: conn.enabledFeatures,
+          isActive: conn.isActive,
+          lastSyncAt: conn.lastSyncAt,
+          syncStatus: conn.syncStatus,
+          availableActions: buildAccountActions(conn),
+        })),
+      };
+    },
+
+    async contactsList(params: OAuthContactsListParams): Promise<OAuthContactsListResult> {
+      if (!params.connectionId) throw new Error('connectionId is required');
+
+      logger.debug('oauth.contacts.list', { userId, connectionId: params.connectionId });
+
+      const conn = await resolveConnection(apiClient, userId, logger, params.connectionId);
+      if (!conn) throw new Error('Connection not found or inactive');
+
+      if (!conn.enabledFeatures.includes('contacts')) {
+        throw new Error('Contacts feature is not enabled on this connection');
+      }
+
+      const qs = new URLSearchParams({ connectionId: params.connectionId });
+      if (params.pageToken) qs.set('pageToken', params.pageToken);
+
+      const response = await apiClient.get<{ contacts: Array<Record<string, unknown>>; nextPageToken?: string }>(
+        `/api/contacts?${qs}`,
+        { userId },
+      );
+
+      if (!response.success) {
+        throw new Error(response.error.message || 'Failed to list contacts');
+      }
+
+      return {
+        connectionLabel: conn.label ?? conn.provider,
+        contacts: response.data.contacts ?? [],
+        nextPageToken: response.data.nextPageToken,
+        availableActions: ['list_contacts'],
+      };
+    },
+
+    async emailList(params: OAuthEmailListParams): Promise<OAuthEmailListResult> {
+      if (!params.connectionId) throw new Error('connectionId is required');
+
+      logger.debug('oauth.email.list', { userId, connectionId: params.connectionId });
+
+      const conn = await resolveConnection(apiClient, userId, logger, params.connectionId);
+      if (!conn) throw new Error('Connection not found or inactive');
+
+      if (!conn.enabledFeatures.includes('email')) {
+        throw new Error('Email feature is not enabled on this connection');
+      }
+
+      const qs = new URLSearchParams({ connectionId: params.connectionId });
+      if (params.folderId) qs.set('folderId', params.folderId);
+      if (params.q) qs.set('q', params.q);
+      if (params.maxResults) qs.set('maxResults', String(params.maxResults));
+      if (params.pageToken) qs.set('pageToken', params.pageToken);
+
+      const response = await apiClient.get<{ messages: Array<Record<string, unknown>>; nextPageToken?: string }>(
+        `/api/email/messages?${qs}`,
+        { userId },
+      );
+
+      if (!response.success) {
+        throw new Error(response.error.message || 'Failed to list emails');
+      }
+
+      return {
+        connectionLabel: conn.label ?? conn.provider,
+        messages: response.data.messages ?? [],
+        nextPageToken: response.data.nextPageToken,
+        availableActions: buildEmailActions(conn.permissionLevel),
+      };
+    },
+
+    async emailGet(params: OAuthEmailGetParams): Promise<OAuthEmailGetResult> {
+      if (!params.connectionId) throw new Error('connectionId is required');
+      if (!params.messageId) throw new Error('messageId is required');
+
+      logger.debug('oauth.email.get', { userId, connectionId: params.connectionId, messageId: params.messageId });
+
+      const conn = await resolveConnection(apiClient, userId, logger, params.connectionId);
+      if (!conn) throw new Error('Connection not found or inactive');
+
+      if (!conn.enabledFeatures.includes('email')) {
+        throw new Error('Email feature is not enabled on this connection');
+      }
+
+      const qs = new URLSearchParams({ connectionId: params.connectionId });
+      const response = await apiClient.get<Record<string, unknown>>(
+        `/api/email/messages/${encodeURIComponent(params.messageId)}?${qs}`,
+        { userId },
+      );
+
+      if (!response.success) {
+        throw new Error(response.error.message || 'Failed to get email');
+      }
+
+      return {
+        connectionLabel: conn.label ?? conn.provider,
+        message: response.data,
+        availableActions: buildEmailActions(conn.permissionLevel),
+      };
+    },
+
+    async filesList(params: OAuthFilesListParams): Promise<OAuthFilesListResult> {
+      if (!params.connectionId) throw new Error('connectionId is required');
+
+      logger.debug('oauth.files.list', { userId, connectionId: params.connectionId });
+
+      const conn = await resolveConnection(apiClient, userId, logger, params.connectionId);
+      if (!conn) throw new Error('Connection not found or inactive');
+
+      if (!conn.enabledFeatures.includes('files')) {
+        throw new Error('Files feature is not enabled on this connection');
+      }
+
+      const qs = new URLSearchParams({ connectionId: params.connectionId });
+      if (params.folderId) qs.set('folderId', params.folderId);
+      if (params.pageToken) qs.set('pageToken', params.pageToken);
+
+      const response = await apiClient.get<{ files: Array<Record<string, unknown>>; nextPageToken?: string }>(
+        `/api/drive/files?${qs}`,
+        { userId },
+      );
+
+      if (!response.success) {
+        throw new Error(response.error.message || 'Failed to list files');
+      }
+
+      return {
+        connectionLabel: conn.label ?? conn.provider,
+        files: response.data.files ?? [],
+        nextPageToken: response.data.nextPageToken,
+        availableActions: buildFileActions(),
+      };
+    },
+
+    async filesSearch(params: OAuthFilesSearchParams): Promise<OAuthFilesSearchResult> {
+      if (!params.connectionId) throw new Error('connectionId is required');
+      if (!params.query) throw new Error('query is required');
+
+      logger.debug('oauth.files.search', { userId, connectionId: params.connectionId });
+
+      const conn = await resolveConnection(apiClient, userId, logger, params.connectionId);
+      if (!conn) throw new Error('Connection not found or inactive');
+
+      if (!conn.enabledFeatures.includes('files')) {
+        throw new Error('Files feature is not enabled on this connection');
+      }
+
+      const qs = new URLSearchParams({ connectionId: params.connectionId, q: params.query });
+      if (params.pageToken) qs.set('pageToken', params.pageToken);
+
+      const response = await apiClient.get<{ files: Array<Record<string, unknown>>; nextPageToken?: string }>(
+        `/api/drive/files/search?${qs}`,
+        { userId },
+      );
+
+      if (!response.success) {
+        throw new Error(response.error.message || 'Failed to search files');
+      }
+
+      return {
+        connectionLabel: conn.label ?? conn.provider,
+        files: response.data.files ?? [],
+        nextPageToken: response.data.nextPageToken,
+        availableActions: buildFileActions(),
+      };
+    },
+
+    async filesGet(params: OAuthFilesGetParams): Promise<OAuthFilesGetResult> {
+      if (!params.connectionId) throw new Error('connectionId is required');
+      if (!params.fileId) throw new Error('fileId is required');
+
+      logger.debug('oauth.files.get', { userId, connectionId: params.connectionId, fileId: params.fileId });
+
+      const conn = await resolveConnection(apiClient, userId, logger, params.connectionId);
+      if (!conn) throw new Error('Connection not found or inactive');
+
+      if (!conn.enabledFeatures.includes('files')) {
+        throw new Error('Files feature is not enabled on this connection');
+      }
+
+      const qs = new URLSearchParams({ connectionId: params.connectionId });
+      const response = await apiClient.get<Record<string, unknown>>(
+        `/api/drive/files/${encodeURIComponent(params.fileId)}?${qs}`,
+        { userId },
+      );
+
+      if (!response.success) {
+        throw new Error(response.error.message || 'Failed to get file');
+      }
+
+      return {
+        connectionLabel: conn.label ?? conn.provider,
+        file: response.data,
+        availableActions: buildFileActions(),
+      };
+    },
+  };
+}
+
+/**
+ * Register OAuth gateway RPC methods with the OpenClaw plugin API.
+ */
+export function registerOAuthGatewayRpcMethods(
+  api: {
+    registerGatewayMethod: <T, R>(name: string, handler: (params: T) => Promise<R>) => void;
+  },
+  methods: OAuthGatewayMethods,
+): void {
+  api.registerGatewayMethod<OAuthAccountListParams, OAuthAccountListResult>(
+    'oauth.accounts.list',
+    methods.accountsList,
+  );
+  api.registerGatewayMethod<OAuthContactsListParams, OAuthContactsListResult>(
+    'oauth.contacts.list',
+    methods.contactsList,
+  );
+  api.registerGatewayMethod<OAuthEmailListParams, OAuthEmailListResult>(
+    'oauth.email.list',
+    methods.emailList,
+  );
+  api.registerGatewayMethod<OAuthEmailGetParams, OAuthEmailGetResult>(
+    'oauth.email.get',
+    methods.emailGet,
+  );
+  api.registerGatewayMethod<OAuthFilesListParams, OAuthFilesListResult>(
+    'oauth.files.list',
+    methods.filesList,
+  );
+  api.registerGatewayMethod<OAuthFilesSearchParams, OAuthFilesSearchResult>(
+    'oauth.files.search',
+    methods.filesSearch,
+  );
+  api.registerGatewayMethod<OAuthFilesGetParams, OAuthFilesGetResult>(
+    'oauth.files.get',
+    methods.filesGet,
+  );
+}

--- a/packages/openclaw-plugin/src/register-openclaw.ts
+++ b/packages/openclaw-plugin/src/register-openclaw.ts
@@ -35,6 +35,7 @@ import {
   createSkillStoreAggregateTool,
 } from './tools/index.js';
 import { createGatewayMethods, registerGatewayRpcMethods } from './gateway/rpc-methods.js';
+import { createOAuthGatewayMethods, registerOAuthGatewayRpcMethods } from './gateway/oauth-rpc-methods.js';
 import { createNotificationService } from './services/notification-service.js';
 import { createAutoCaptureHook, createGraphAwareRecallHook } from './hooks.js';
 
@@ -2565,6 +2566,14 @@ export const registerOpenClaw: PluginInitializer = (api: OpenClawPluginApi) => {
     userId,
   });
   registerGatewayRpcMethods(api, gatewayMethods);
+
+  // Register OAuth Gateway RPC methods (Issue #1054)
+  const oauthGatewayMethods = createOAuthGatewayMethods({
+    logger,
+    apiClient,
+    userId,
+  });
+  registerOAuthGatewayRpcMethods(api, oauthGatewayMethods);
 
   // Register background notification service (Issue #325)
   // Create a simple event emitter for notifications

--- a/packages/openclaw-plugin/tests/oauth-rpc-methods.test.ts
+++ b/packages/openclaw-plugin/tests/oauth-rpc-methods.test.ts
@@ -1,0 +1,319 @@
+/**
+ * Tests for the OAuth Gateway RPC methods module.
+ * Part of Issue #1054.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  createOAuthGatewayMethods,
+  registerOAuthGatewayRpcMethods,
+  type OAuthGatewayMethods,
+} from '../src/gateway/oauth-rpc-methods.js';
+import type { ApiClient, ApiResponse } from '../src/api-client.js';
+import type { Logger } from '../src/logger.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const noopLogger: Logger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+};
+
+function createMockApiClient(overrides: Partial<ApiClient> = {}): ApiClient {
+  return {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    healthCheck: vi.fn(),
+    ...overrides,
+  } as unknown as ApiClient;
+}
+
+/** Helper to set up a mock connection response. */
+function mockConnectionsResponse(
+  client: ApiClient,
+  connections: Array<Record<string, unknown>>,
+): void {
+  (client.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+    success: true,
+    data: { connections },
+  } satisfies ApiResponse<{ connections: Array<Record<string, unknown>> }>);
+}
+
+const TEST_CONNECTION = {
+  id: 'conn-1',
+  provider: 'microsoft',
+  label: 'Work M365',
+  providerAccountEmail: 'user@example.com',
+  permissionLevel: 'read',
+  enabledFeatures: ['email', 'contacts', 'files'],
+  isActive: true,
+  lastSyncAt: '2026-01-01T00:00:00Z',
+  syncStatus: {},
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('OAuth Gateway RPC Methods', () => {
+  let client: ApiClient;
+  let methods: OAuthGatewayMethods;
+
+  beforeEach(() => {
+    client = createMockApiClient();
+    methods = createOAuthGatewayMethods({
+      logger: noopLogger,
+      apiClient: client,
+      userId: 'test-user',
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // -----------------------------------------------------------------------
+  // registerOAuthGatewayRpcMethods
+  // -----------------------------------------------------------------------
+
+  describe('registerOAuthGatewayRpcMethods', () => {
+    it('registers all 7 gateway methods', () => {
+      const registerGatewayMethod = vi.fn();
+      registerOAuthGatewayRpcMethods({ registerGatewayMethod }, methods);
+
+      expect(registerGatewayMethod).toHaveBeenCalledTimes(7);
+      const registeredNames = registerGatewayMethod.mock.calls.map(
+        (call: unknown[]) => call[0],
+      );
+      expect(registeredNames).toEqual([
+        'oauth.accounts.list',
+        'oauth.contacts.list',
+        'oauth.email.list',
+        'oauth.email.get',
+        'oauth.files.list',
+        'oauth.files.search',
+        'oauth.files.get',
+      ]);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // accountsList
+  // -----------------------------------------------------------------------
+
+  describe('accountsList', () => {
+    it('returns accounts with metadata', async () => {
+      (client.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        success: true,
+        data: { connections: [TEST_CONNECTION] },
+      });
+
+      const result = await methods.accountsList({});
+
+      expect(result.accounts).toHaveLength(1);
+      expect(result.accounts[0]).toMatchObject({
+        connectionId: 'conn-1',
+        provider: 'microsoft',
+        connectionLabel: 'Work M365',
+        enabledFeatures: ['email', 'contacts', 'files'],
+      });
+      expect(result.accounts[0].availableActions).toContain('list_contacts');
+      expect(result.accounts[0].availableActions).toContain('list_emails');
+      expect(result.accounts[0].availableActions).toContain('list_files');
+    });
+
+    it('throws on API failure', async () => {
+      (client.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        success: false,
+        error: { status: 500, message: 'Internal error', code: 'SERVER_ERROR' },
+      });
+
+      await expect(methods.accountsList({})).rejects.toThrow('Internal error');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // contactsList
+  // -----------------------------------------------------------------------
+
+  describe('contactsList', () => {
+    it('returns contacts for a valid connection', async () => {
+      mockConnectionsResponse(client, [TEST_CONNECTION]);
+      (client.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        success: true,
+        data: {
+          contacts: [{ id: 'c-1', displayName: 'Alice', emailAddresses: ['alice@example.com'] }],
+        },
+      });
+
+      const result = await methods.contactsList({ connectionId: 'conn-1' });
+
+      expect(result.connectionLabel).toBe('Work M365');
+      expect(result.contacts).toHaveLength(1);
+      expect(result.availableActions).toContain('list_contacts');
+    });
+
+    it('throws when connectionId is missing', async () => {
+      await expect(
+        methods.contactsList({ connectionId: '' }),
+      ).rejects.toThrow('connectionId is required');
+    });
+
+    it('throws when connection not found', async () => {
+      mockConnectionsResponse(client, []);
+      await expect(
+        methods.contactsList({ connectionId: 'nonexistent' }),
+      ).rejects.toThrow('Connection not found');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // emailList
+  // -----------------------------------------------------------------------
+
+  describe('emailList', () => {
+    it('returns emails for a valid connection', async () => {
+      mockConnectionsResponse(client, [{ ...TEST_CONNECTION, permissionLevel: 'read_write' }]);
+      (client.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        success: true,
+        data: {
+          messages: [{ id: 'msg-1', subject: 'Hello' }],
+          nextPageToken: 'page2',
+        },
+      });
+
+      const result = await methods.emailList({ connectionId: 'conn-1' });
+
+      expect(result.connectionLabel).toBe('Work M365');
+      expect(result.messages).toHaveLength(1);
+      expect(result.nextPageToken).toBe('page2');
+      expect(result.availableActions).toContain('send_email');
+      expect(result.availableActions).toContain('create_draft');
+    });
+
+    it('omits write actions for read-only connections', async () => {
+      mockConnectionsResponse(client, [TEST_CONNECTION]); // permissionLevel: 'read'
+      (client.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        success: true,
+        data: { messages: [] },
+      });
+
+      const result = await methods.emailList({ connectionId: 'conn-1' });
+
+      expect(result.availableActions).not.toContain('send_email');
+      expect(result.availableActions).toContain('list_messages');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // emailGet
+  // -----------------------------------------------------------------------
+
+  describe('emailGet', () => {
+    it('returns a single email', async () => {
+      mockConnectionsResponse(client, [TEST_CONNECTION]);
+      (client.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        success: true,
+        data: { id: 'msg-1', subject: 'Test', bodyText: 'Hello' },
+      });
+
+      const result = await methods.emailGet({ connectionId: 'conn-1', messageId: 'msg-1' });
+
+      expect(result.connectionLabel).toBe('Work M365');
+      expect(result.message).toMatchObject({ id: 'msg-1', subject: 'Test' });
+    });
+
+    it('throws when messageId is missing', async () => {
+      await expect(
+        methods.emailGet({ connectionId: 'conn-1', messageId: '' }),
+      ).rejects.toThrow('messageId is required');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // filesList
+  // -----------------------------------------------------------------------
+
+  describe('filesList', () => {
+    it('returns files for a valid connection', async () => {
+      mockConnectionsResponse(client, [TEST_CONNECTION]);
+      (client.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        success: true,
+        data: {
+          files: [{ id: 'f-1', name: 'document.pdf' }],
+          nextPageToken: 'next',
+        },
+      });
+
+      const result = await methods.filesList({ connectionId: 'conn-1' });
+
+      expect(result.connectionLabel).toBe('Work M365');
+      expect(result.files).toHaveLength(1);
+      expect(result.nextPageToken).toBe('next');
+      expect(result.availableActions).toContain('list_files');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // filesSearch
+  // -----------------------------------------------------------------------
+
+  describe('filesSearch', () => {
+    it('searches files', async () => {
+      mockConnectionsResponse(client, [TEST_CONNECTION]);
+      (client.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        success: true,
+        data: {
+          files: [{ id: 'f-2', name: 'budget.xlsx' }],
+        },
+      });
+
+      const result = await methods.filesSearch({ connectionId: 'conn-1', query: 'budget' });
+
+      expect(result.files).toHaveLength(1);
+      expect(result.files[0]).toMatchObject({ name: 'budget.xlsx' });
+      expect(result.availableActions).toContain('search_files');
+    });
+
+    it('throws when query is missing', async () => {
+      await expect(
+        methods.filesSearch({ connectionId: 'conn-1', query: '' }),
+      ).rejects.toThrow('query is required');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // filesGet
+  // -----------------------------------------------------------------------
+
+  describe('filesGet', () => {
+    it('returns a single file', async () => {
+      mockConnectionsResponse(client, [TEST_CONNECTION]);
+      (client.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        success: true,
+        data: { id: 'f-1', name: 'photo.jpg', downloadUrl: 'https://example.com/download' },
+      });
+
+      const result = await methods.filesGet({ connectionId: 'conn-1', fileId: 'f-1' });
+
+      expect(result.connectionLabel).toBe('Work M365');
+      expect(result.file).toMatchObject({ id: 'f-1', name: 'photo.jpg' });
+      expect(result.availableActions).toContain('get_file');
+    });
+
+    it('throws when fileId is missing', async () => {
+      await expect(
+        methods.filesGet({ connectionId: 'conn-1', fileId: '' }),
+      ).rejects.toThrow('fileId is required');
+    });
+  });
+});

--- a/src/api/oauth/gateway-plugin.test.ts
+++ b/src/api/oauth/gateway-plugin.test.ts
@@ -1,0 +1,597 @@
+/**
+ * Tests for the OpenClaw gateway OAuth plugin.
+ * Part of Issue #1054.
+ *
+ * Tests verify that the plugin:
+ * - Registers the expected gateway methods
+ * - Validates parameters and calls the backend API correctly
+ * - Formats responses in an agent-friendly structure
+ * - Handles errors gracefully
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { OAuthGatewayPluginConfig } from './gateway-plugin.ts';
+
+// ---------------------------------------------------------------------------
+// Stubs / helpers
+// ---------------------------------------------------------------------------
+
+const noopLogger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+};
+
+/**
+ * Minimal mock of the gateway plugin API surface used by our plugin.
+ * We only need registerGatewayMethod and registerTool.
+ */
+type RegisteredMethods = Map<string, (opts: { params: Record<string, unknown>; respond: ReturnType<typeof vi.fn> }) => unknown>;
+
+async function setupPlugin(config: OAuthGatewayPluginConfig) {
+  const { createOAuthGatewayPlugin } = await import('./gateway-plugin.ts');
+  const plugin = createOAuthGatewayPlugin();
+  const methods: RegisteredMethods = new Map();
+
+  plugin.register!({
+    id: 'oauth-accounts',
+    name: 'OAuth Accounts',
+    description: 'test',
+    version: '0',
+    source: 'test',
+    config: {},
+    pluginConfig: config,
+    runtime: {},
+    logger: noopLogger,
+    registerGatewayMethod: (method: string, handler: unknown) => methods.set(method, handler as Parameters<RegisteredMethods['set']>[1]),
+    registerTool: () => {},
+    registerHttpHandler: () => {},
+    registerHttpRoute: () => {},
+    registerChannel: () => {},
+    registerCli: () => {},
+    registerService: () => {},
+    registerProvider: () => {},
+    registerCommand: () => {},
+    resolvePath: (p: string) => p,
+    on: () => {},
+  } as never);
+
+  return { methods };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('OAuth Gateway Plugin', () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('registers expected gateway methods', async () => {
+    const { methods } = await setupPlugin({ backendUrl: 'http://localhost:3001' });
+    expect(methods.has('oauth.accounts.list')).toBe(true);
+    expect(methods.has('oauth.contacts.list')).toBe(true);
+    expect(methods.has('oauth.email.list')).toBe(true);
+    expect(methods.has('oauth.email.get')).toBe(true);
+    expect(methods.has('oauth.files.list')).toBe(true);
+    expect(methods.has('oauth.files.search')).toBe(true);
+    expect(methods.has('oauth.files.get')).toBe(true);
+  });
+
+  it('does not register methods when backendUrl is missing', async () => {
+    const { methods } = await setupPlugin({} as OAuthGatewayPluginConfig);
+    expect(methods.size).toBe(0);
+    expect(noopLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('backendUrl'),
+    );
+  });
+
+  // -----------------------------------------------------------------------
+  // oauth.accounts.list
+  // -----------------------------------------------------------------------
+
+  describe('oauth.accounts.list', () => {
+    it('returns connections with metadata', async () => {
+      const { methods } = await setupPlugin({ backendUrl: 'http://localhost:3001' });
+      const handler = methods.get('oauth.accounts.list')!;
+
+      fetchSpy.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          connections: [
+            {
+              id: 'conn-1',
+              provider: 'microsoft',
+              label: 'Work M365',
+              providerAccountEmail: 'user@example.com',
+              permissionLevel: 'read',
+              enabledFeatures: ['email', 'contacts'],
+              isActive: true,
+              lastSyncAt: '2026-01-01T00:00:00Z',
+              syncStatus: {},
+              createdAt: '2026-01-01T00:00:00Z',
+              updatedAt: '2026-01-01T00:00:00Z',
+            },
+          ],
+        }),
+      });
+
+      const respond = vi.fn();
+      await handler({ params: {}, respond });
+
+      expect(respond).toHaveBeenCalledWith(true, expect.objectContaining({
+        accounts: expect.arrayContaining([
+          expect.objectContaining({
+            connectionId: 'conn-1',
+            provider: 'microsoft',
+            connectionLabel: 'Work M365',
+            enabledFeatures: ['email', 'contacts'],
+            availableActions: expect.arrayContaining(['list_emails', 'list_contacts']),
+          }),
+        ]),
+      }));
+    });
+
+    it('handles backend error', async () => {
+      const { methods } = await setupPlugin({ backendUrl: 'http://localhost:3001' });
+      const handler = methods.get('oauth.accounts.list')!;
+
+      fetchSpy.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        json: async () => ({ error: 'Internal error' }),
+      });
+
+      const respond = vi.fn();
+      await handler({ params: {}, respond });
+
+      expect(respond).toHaveBeenCalledWith(false, expect.objectContaining({
+        error: expect.stringContaining('Internal error'),
+      }));
+    });
+
+    it('handles network failure', async () => {
+      const { methods } = await setupPlugin({ backendUrl: 'http://localhost:3001' });
+      const handler = methods.get('oauth.accounts.list')!;
+
+      fetchSpy.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+
+      const respond = vi.fn();
+      await handler({ params: {}, respond });
+
+      expect(respond).toHaveBeenCalledWith(false, expect.objectContaining({
+        error: expect.stringContaining('ECONNREFUSED'),
+      }));
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // oauth.contacts.list
+  // -----------------------------------------------------------------------
+
+  describe('oauth.contacts.list', () => {
+    it('returns contacts for a connection', async () => {
+      const { methods } = await setupPlugin({ backendUrl: 'http://localhost:3001' });
+      const handler = methods.get('oauth.contacts.list')!;
+
+      // First call: get the connection to validate feature
+      fetchSpy.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          connections: [
+            {
+              id: 'conn-1',
+              provider: 'microsoft',
+              label: 'Work',
+              enabledFeatures: ['contacts'],
+              isActive: true,
+              permissionLevel: 'read',
+            },
+          ],
+        }),
+      });
+
+      // Second call: fetch contacts from the sync endpoint
+      fetchSpy.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          contacts: [
+            {
+              id: 'c-1',
+              displayName: 'Alice',
+              emailAddresses: ['alice@example.com'],
+              phoneNumbers: ['+1555000'],
+            },
+          ],
+        }),
+      });
+
+      const respond = vi.fn();
+      await handler({ params: { connectionId: 'conn-1' }, respond });
+
+      expect(respond).toHaveBeenCalledWith(true, expect.objectContaining({
+        connectionLabel: 'Work',
+        contacts: expect.arrayContaining([
+          expect.objectContaining({
+            displayName: 'Alice',
+          }),
+        ]),
+      }));
+    });
+
+    it('rejects when connectionId is missing', async () => {
+      const { methods } = await setupPlugin({ backendUrl: 'http://localhost:3001' });
+      const handler = methods.get('oauth.contacts.list')!;
+
+      const respond = vi.fn();
+      await handler({ params: {}, respond });
+
+      expect(respond).toHaveBeenCalledWith(false, expect.objectContaining({
+        error: expect.stringContaining('connectionId'),
+      }));
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // oauth.email.list
+  // -----------------------------------------------------------------------
+
+  describe('oauth.email.list', () => {
+    it('returns emails for a connection', async () => {
+      const { methods } = await setupPlugin({ backendUrl: 'http://localhost:3001' });
+      const handler = methods.get('oauth.email.list')!;
+
+      fetchSpy.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          connections: [{
+            id: 'conn-1',
+            label: 'Work Gmail',
+            enabledFeatures: ['email'],
+            isActive: true,
+            permissionLevel: 'read_write',
+            provider: 'google',
+          }],
+        }),
+      });
+
+      fetchSpy.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          messages: [
+            {
+              id: 'msg-1',
+              subject: 'Hello',
+              from: { email: 'bob@example.com', name: 'Bob' },
+              to: [{ email: 'me@example.com' }],
+              cc: [],
+              bcc: [],
+              snippet: 'Hi there',
+              receivedAt: '2026-01-01T00:00:00Z',
+              isRead: false,
+              isStarred: false,
+              isDraft: false,
+              labels: ['INBOX'],
+              attachments: [],
+              provider: 'google',
+            },
+          ],
+          nextPageToken: 'page2',
+        }),
+      });
+
+      const respond = vi.fn();
+      await handler({ params: { connectionId: 'conn-1', maxResults: 10 }, respond });
+
+      expect(respond).toHaveBeenCalledWith(true, expect.objectContaining({
+        connectionLabel: 'Work Gmail',
+        messages: expect.arrayContaining([
+          expect.objectContaining({
+            id: 'msg-1',
+            subject: 'Hello',
+          }),
+        ]),
+        nextPageToken: 'page2',
+        availableActions: expect.arrayContaining(['send_email', 'create_draft']),
+      }));
+    });
+
+    it('omits write actions for read-only connections', async () => {
+      const { methods } = await setupPlugin({ backendUrl: 'http://localhost:3001' });
+      const handler = methods.get('oauth.email.list')!;
+
+      fetchSpy.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          connections: [{
+            id: 'conn-1',
+            label: 'Read Only',
+            enabledFeatures: ['email'],
+            isActive: true,
+            permissionLevel: 'read',
+            provider: 'google',
+          }],
+        }),
+      });
+
+      fetchSpy.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ messages: [], nextPageToken: undefined }),
+      });
+
+      const respond = vi.fn();
+      await handler({ params: { connectionId: 'conn-1' }, respond });
+
+      const payload = respond.mock.calls[0][1];
+      expect(payload.availableActions).not.toContain('send_email');
+      expect(payload.availableActions).not.toContain('create_draft');
+      expect(payload.availableActions).toContain('list_messages');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // oauth.email.get
+  // -----------------------------------------------------------------------
+
+  describe('oauth.email.get', () => {
+    it('returns a single email message', async () => {
+      const { methods } = await setupPlugin({ backendUrl: 'http://localhost:3001' });
+      const handler = methods.get('oauth.email.get')!;
+
+      fetchSpy.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          connections: [{
+            id: 'conn-1',
+            label: 'Work',
+            enabledFeatures: ['email'],
+            isActive: true,
+            permissionLevel: 'read',
+            provider: 'microsoft',
+          }],
+        }),
+      });
+
+      fetchSpy.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: 'msg-1',
+          subject: 'Test',
+          from: { email: 'test@example.com' },
+          to: [],
+          cc: [],
+          bcc: [],
+          bodyText: 'Hello world',
+          receivedAt: '2026-01-01T00:00:00Z',
+          isRead: true,
+          isStarred: false,
+          isDraft: false,
+          labels: [],
+          attachments: [],
+          provider: 'microsoft',
+        }),
+      });
+
+      const respond = vi.fn();
+      await handler({ params: { connectionId: 'conn-1', messageId: 'msg-1' }, respond });
+
+      expect(respond).toHaveBeenCalledWith(true, expect.objectContaining({
+        connectionLabel: 'Work',
+        message: expect.objectContaining({
+          id: 'msg-1',
+          subject: 'Test',
+          bodyText: 'Hello world',
+        }),
+      }));
+    });
+
+    it('rejects when messageId is missing', async () => {
+      const { methods } = await setupPlugin({ backendUrl: 'http://localhost:3001' });
+      const handler = methods.get('oauth.email.get')!;
+
+      const respond = vi.fn();
+      await handler({ params: { connectionId: 'conn-1' }, respond });
+
+      expect(respond).toHaveBeenCalledWith(false, expect.objectContaining({
+        error: expect.stringContaining('messageId'),
+      }));
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // oauth.files.list
+  // -----------------------------------------------------------------------
+
+  describe('oauth.files.list', () => {
+    it('returns files for a connection', async () => {
+      const { methods } = await setupPlugin({ backendUrl: 'http://localhost:3001' });
+      const handler = methods.get('oauth.files.list')!;
+
+      fetchSpy.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          connections: [{
+            id: 'conn-1',
+            label: 'Work Drive',
+            enabledFeatures: ['files'],
+            isActive: true,
+            permissionLevel: 'read',
+            provider: 'google',
+          }],
+        }),
+      });
+
+      fetchSpy.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          files: [
+            {
+              id: 'f-1',
+              name: 'document.pdf',
+              mimeType: 'application/pdf',
+              size: 1024,
+              isFolder: false,
+              provider: 'google',
+              connectionId: 'conn-1',
+              metadata: {},
+            },
+          ],
+          nextPageToken: 'next',
+        }),
+      });
+
+      const respond = vi.fn();
+      await handler({ params: { connectionId: 'conn-1' }, respond });
+
+      expect(respond).toHaveBeenCalledWith(true, expect.objectContaining({
+        connectionLabel: 'Work Drive',
+        files: expect.arrayContaining([
+          expect.objectContaining({
+            id: 'f-1',
+            name: 'document.pdf',
+          }),
+        ]),
+        nextPageToken: 'next',
+        availableActions: expect.arrayContaining(['list_files', 'search_files', 'get_file']),
+      }));
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // oauth.files.search
+  // -----------------------------------------------------------------------
+
+  describe('oauth.files.search', () => {
+    it('searches files', async () => {
+      const { methods } = await setupPlugin({ backendUrl: 'http://localhost:3001' });
+      const handler = methods.get('oauth.files.search')!;
+
+      fetchSpy.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          connections: [{
+            id: 'conn-1',
+            label: 'Drive',
+            enabledFeatures: ['files'],
+            isActive: true,
+            permissionLevel: 'read',
+            provider: 'microsoft',
+          }],
+        }),
+      });
+
+      fetchSpy.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          files: [
+            {
+              id: 'f-2',
+              name: 'budget.xlsx',
+              mimeType: 'application/vnd.ms-excel',
+              isFolder: false,
+              provider: 'microsoft',
+              connectionId: 'conn-1',
+              metadata: {},
+            },
+          ],
+        }),
+      });
+
+      const respond = vi.fn();
+      await handler({ params: { connectionId: 'conn-1', query: 'budget' }, respond });
+
+      expect(respond).toHaveBeenCalledWith(true, expect.objectContaining({
+        files: expect.arrayContaining([
+          expect.objectContaining({ name: 'budget.xlsx' }),
+        ]),
+      }));
+    });
+
+    it('rejects when query is missing', async () => {
+      const { methods } = await setupPlugin({ backendUrl: 'http://localhost:3001' });
+      const handler = methods.get('oauth.files.search')!;
+
+      const respond = vi.fn();
+      await handler({ params: { connectionId: 'conn-1' }, respond });
+
+      expect(respond).toHaveBeenCalledWith(false, expect.objectContaining({
+        error: expect.stringContaining('query'),
+      }));
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // oauth.files.get
+  // -----------------------------------------------------------------------
+
+  describe('oauth.files.get', () => {
+    it('returns a single file', async () => {
+      const { methods } = await setupPlugin({ backendUrl: 'http://localhost:3001' });
+      const handler = methods.get('oauth.files.get')!;
+
+      fetchSpy.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          connections: [{
+            id: 'conn-1',
+            label: 'Drive',
+            enabledFeatures: ['files'],
+            isActive: true,
+            permissionLevel: 'read',
+            provider: 'google',
+          }],
+        }),
+      });
+
+      fetchSpy.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: 'f-1',
+          name: 'photo.jpg',
+          mimeType: 'image/jpeg',
+          size: 2048,
+          isFolder: false,
+          webUrl: 'https://drive.google.com/file/f-1',
+          downloadUrl: 'https://drive.google.com/file/f-1/download',
+          provider: 'google',
+          connectionId: 'conn-1',
+          metadata: {},
+        }),
+      });
+
+      const respond = vi.fn();
+      await handler({ params: { connectionId: 'conn-1', fileId: 'f-1' }, respond });
+
+      expect(respond).toHaveBeenCalledWith(true, expect.objectContaining({
+        connectionLabel: 'Drive',
+        file: expect.objectContaining({
+          id: 'f-1',
+          name: 'photo.jpg',
+          downloadUrl: 'https://drive.google.com/file/f-1/download',
+        }),
+      }));
+    });
+
+    it('rejects when fileId is missing', async () => {
+      const { methods } = await setupPlugin({ backendUrl: 'http://localhost:3001' });
+      const handler = methods.get('oauth.files.get')!;
+
+      const respond = vi.fn();
+      await handler({ params: { connectionId: 'conn-1' }, respond });
+
+      expect(respond).toHaveBeenCalledWith(false, expect.objectContaining({
+        error: expect.stringContaining('fileId'),
+      }));
+    });
+  });
+});

--- a/src/api/oauth/gateway-plugin.ts
+++ b/src/api/oauth/gateway-plugin.ts
@@ -1,0 +1,501 @@
+/**
+ * OpenClaw Gateway plugin that surfaces OAuth account data to agents.
+ * Part of Issue #1054.
+ *
+ * Registers gateway methods that proxy requests to the openclaw-projects
+ * backend API, exposing connected account data (contacts, email, files)
+ * in an agent-friendly format with pagination, connectionLabel, and
+ * availableActions metadata.
+ *
+ * Gateway methods registered:
+ *   oauth.accounts.list  — List connected accounts with metadata
+ *   oauth.contacts.list  — Contacts from a specific connection
+ *   oauth.email.list     — Emails from a specific connection
+ *   oauth.email.get      — Single email message by ID
+ *   oauth.files.list     — Files/folders from a specific connection
+ *   oauth.files.search   — Search files across a connection
+ *   oauth.files.get      — Single file metadata with download URL
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Plugin configuration passed via pluginConfig. */
+export interface OAuthGatewayPluginConfig {
+  /** Base URL of the openclaw-projects backend (e.g. http://localhost:3001). */
+  backendUrl: string;
+  /** Optional API key / bearer token for authenticating to the backend. */
+  apiKey?: string;
+}
+
+/** Minimal representation of an OAuth connection from the backend. */
+interface BackendConnection {
+  id: string;
+  userEmail?: string;
+  provider: string;
+  label: string;
+  providerAccountEmail?: string;
+  permissionLevel: string;
+  enabledFeatures: string[];
+  isActive: boolean;
+  lastSyncAt?: string;
+  syncStatus: Record<string, unknown>;
+  scopes?: string[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** Minimal plugin API surface — only the parts we use. */
+interface PluginApi {
+  id: string;
+  name: string;
+  pluginConfig?: Record<string, unknown>;
+  logger: {
+    info: (msg: string) => void;
+    warn: (msg: string) => void;
+    error: (msg: string) => void;
+    debug?: (msg: string) => void;
+  };
+  registerGatewayMethod: (
+    method: string,
+    handler: (opts: {
+      params: Record<string, unknown>;
+      respond: (ok: boolean, payload?: unknown) => void;
+    }) => void | Promise<void>,
+  ) => void;
+  [key: string]: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build available actions based on enabled features and permission level. */
+function buildAccountActions(conn: BackendConnection): string[] {
+  const actions: string[] = [];
+  if (conn.enabledFeatures.includes('contacts')) {
+    actions.push('list_contacts');
+  }
+  if (conn.enabledFeatures.includes('email')) {
+    actions.push('list_emails', 'get_email');
+    if (conn.permissionLevel === 'read_write') {
+      actions.push('send_email', 'create_draft', 'update_email', 'delete_email');
+    }
+  }
+  if (conn.enabledFeatures.includes('files')) {
+    actions.push('list_files', 'search_files', 'get_file');
+  }
+  if (conn.enabledFeatures.includes('calendar')) {
+    actions.push('list_events');
+  }
+  return actions;
+}
+
+/** Build email-specific available actions based on permission level. */
+function buildEmailActions(permissionLevel: string): string[] {
+  const actions = ['list_messages', 'get_message', 'list_threads', 'list_folders'];
+  if (permissionLevel === 'read_write') {
+    actions.push('send_email', 'create_draft', 'update_draft', 'update_message', 'delete_message');
+  }
+  return actions;
+}
+
+/** Build file-specific available actions. */
+function buildFileActions(): string[] {
+  return ['list_files', 'search_files', 'get_file'];
+}
+
+/**
+ * Make an HTTP request to the backend API.
+ * Handles JSON parsing, error responses, and network failures.
+ */
+async function backendFetch(
+  baseUrl: string,
+  path: string,
+  apiKey?: string,
+): Promise<{ ok: true; data: unknown } | { ok: false; error: string; status?: number }> {
+  const url = `${baseUrl.replace(/\/+$/, '')}${path}`;
+  const headers: Record<string, string> = {
+    'Accept': 'application/json',
+  };
+  if (apiKey) {
+    headers['Authorization'] = `Bearer ${apiKey}`;
+  }
+
+  try {
+    const response = await fetch(url, { headers });
+    const data = await response.json();
+
+    if (!response.ok) {
+      const errorMsg = (data as Record<string, unknown>)?.error;
+      return {
+        ok: false,
+        error: typeof errorMsg === 'string' ? errorMsg : `Backend returned ${response.status}`,
+        status: response.status,
+      };
+    }
+
+    return { ok: true, data };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+type RespondFn = (ok: boolean, payload?: unknown) => void;
+
+/** Validate that a string param is present; respond with error if not. */
+function requireParam(
+  params: Record<string, unknown>,
+  name: string,
+  respond: RespondFn,
+): string | null {
+  const value = typeof params[name] === 'string' ? (params[name] as string).trim() : '';
+  if (!value) {
+    respond(false, { error: `${name} is required` });
+    return null;
+  }
+  return value;
+}
+
+/**
+ * Resolve a connection by ID: fetches the connection list from the backend
+ * and finds the matching entry. Returns the connection or responds with error.
+ */
+async function resolveConnection(
+  baseUrl: string,
+  apiKey: string | undefined,
+  connectionId: string,
+  respond: RespondFn,
+): Promise<BackendConnection | null> {
+  // We fetch all connections and filter — this keeps the plugin simple.
+  // For large connection counts a dedicated endpoint would be better.
+  const result = await backendFetch(baseUrl, '/api/oauth/connections');
+  if (!result.ok) {
+    respond(false, { error: result.error });
+    return null;
+  }
+
+  const connections = ((result.data as Record<string, unknown>).connections as BackendConnection[]) ?? [];
+  const conn = connections.find((c) => c.id === connectionId);
+  if (!conn) {
+    respond(false, { error: `Connection ${connectionId} not found` });
+    return null;
+  }
+
+  if (!conn.isActive) {
+    respond(false, { error: `Connection ${connectionId} is disabled` });
+    return null;
+  }
+
+  return conn;
+}
+
+// ---------------------------------------------------------------------------
+// Plugin factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create the OAuth gateway plugin definition.
+ *
+ * Usage in the gateway's plugin loader / default registry:
+ * ```ts
+ * import { createOAuthGatewayPlugin } from 'openclaw-projects/src/api/oauth/gateway-plugin';
+ * registry.register(createOAuthGatewayPlugin());
+ * ```
+ */
+export function createOAuthGatewayPlugin() {
+  return {
+    id: 'oauth-accounts',
+    name: 'OAuth Connected Accounts',
+    description: 'Surfaces OAuth-connected account data (contacts, email, files) to OpenClaw agents via gateway methods.',
+    version: '1.0.0',
+
+    register(api: PluginApi) {
+      const config = (api.pluginConfig ?? {}) as Partial<OAuthGatewayPluginConfig>;
+      const backendUrl = config.backendUrl;
+      const apiKey = config.apiKey;
+
+      if (!backendUrl) {
+        api.logger.warn('[oauth-accounts] backendUrl not configured; gateway methods will not be registered');
+        return;
+      }
+
+      api.logger.info(`[oauth-accounts] Registering gateway methods (backend: ${backendUrl})`);
+
+      // -------------------------------------------------------------------
+      // oauth.accounts.list — List all connected accounts
+      // -------------------------------------------------------------------
+      api.registerGatewayMethod('oauth.accounts.list', async ({ params, respond }) => {
+        const userEmail = typeof params.userEmail === 'string' ? params.userEmail : undefined;
+        const provider = typeof params.provider === 'string' ? params.provider : undefined;
+
+        const qs = new URLSearchParams();
+        if (userEmail) qs.set('userEmail', userEmail);
+        if (provider) qs.set('provider', provider);
+
+        const qsStr = qs.toString();
+        const path = `/api/oauth/connections${qsStr ? `?${qsStr}` : ''}`;
+
+        const result = await backendFetch(backendUrl, path, apiKey);
+        if (!result.ok) {
+          respond(false, { error: result.error });
+          return;
+        }
+
+        const connections = ((result.data as Record<string, unknown>).connections as BackendConnection[]) ?? [];
+
+        respond(true, {
+          accounts: connections.map((conn) => ({
+            connectionId: conn.id,
+            provider: conn.provider,
+            connectionLabel: conn.label,
+            providerAccountEmail: conn.providerAccountEmail,
+            permissionLevel: conn.permissionLevel,
+            enabledFeatures: conn.enabledFeatures,
+            isActive: conn.isActive,
+            lastSyncAt: conn.lastSyncAt,
+            syncStatus: conn.syncStatus,
+            createdAt: conn.createdAt,
+            updatedAt: conn.updatedAt,
+            availableActions: buildAccountActions(conn),
+          })),
+        });
+      });
+
+      // -------------------------------------------------------------------
+      // oauth.contacts.list — Contacts from a specific connection
+      // -------------------------------------------------------------------
+      api.registerGatewayMethod('oauth.contacts.list', async ({ params, respond }) => {
+        const connectionId = requireParam(params, 'connectionId', respond);
+        if (!connectionId) return;
+
+        const conn = await resolveConnection(backendUrl, apiKey, connectionId, respond);
+        if (!conn) return;
+
+        if (!conn.enabledFeatures.includes('contacts')) {
+          respond(false, { error: 'Contacts feature is not enabled on this connection' });
+          return;
+        }
+
+        const qs = new URLSearchParams({ connectionId });
+        const pageToken = typeof params.pageToken === 'string' ? params.pageToken : undefined;
+        if (pageToken) qs.set('pageToken', pageToken);
+
+        const result = await backendFetch(backendUrl, `/api/contacts?${qs.toString()}`, apiKey);
+        if (!result.ok) {
+          respond(false, { error: result.error });
+          return;
+        }
+
+        const data = result.data as Record<string, unknown>;
+
+        respond(true, {
+          connectionLabel: conn.label,
+          connectionId: conn.id,
+          provider: conn.provider,
+          contacts: data.contacts ?? [],
+          nextPageToken: data.nextPageToken,
+          availableActions: ['list_contacts'],
+        });
+      });
+
+      // -------------------------------------------------------------------
+      // oauth.email.list — List or search emails
+      // -------------------------------------------------------------------
+      api.registerGatewayMethod('oauth.email.list', async ({ params, respond }) => {
+        const connectionId = requireParam(params, 'connectionId', respond);
+        if (!connectionId) return;
+
+        const conn = await resolveConnection(backendUrl, apiKey, connectionId, respond);
+        if (!conn) return;
+
+        if (!conn.enabledFeatures.includes('email')) {
+          respond(false, { error: 'Email feature is not enabled on this connection' });
+          return;
+        }
+
+        const qs = new URLSearchParams({ connectionId });
+        if (typeof params.query === 'string') qs.set('query', params.query);
+        if (typeof params.folderId === 'string') qs.set('folderId', params.folderId);
+        if (typeof params.maxResults === 'number') qs.set('maxResults', String(params.maxResults));
+        if (typeof params.pageToken === 'string') qs.set('pageToken', params.pageToken);
+
+        const result = await backendFetch(backendUrl, `/api/email/messages?${qs.toString()}`, apiKey);
+        if (!result.ok) {
+          respond(false, { error: result.error });
+          return;
+        }
+
+        const data = result.data as Record<string, unknown>;
+
+        respond(true, {
+          connectionLabel: conn.label,
+          connectionId: conn.id,
+          provider: conn.provider,
+          messages: data.messages ?? [],
+          nextPageToken: data.nextPageToken,
+          resultSizeEstimate: data.resultSizeEstimate,
+          availableActions: buildEmailActions(conn.permissionLevel),
+        });
+      });
+
+      // -------------------------------------------------------------------
+      // oauth.email.get — Get a single email message
+      // -------------------------------------------------------------------
+      api.registerGatewayMethod('oauth.email.get', async ({ params, respond }) => {
+        const connectionId = requireParam(params, 'connectionId', respond);
+        if (!connectionId) return;
+
+        const messageId = requireParam(params, 'messageId', respond);
+        if (!messageId) return;
+
+        const conn = await resolveConnection(backendUrl, apiKey, connectionId, respond);
+        if (!conn) return;
+
+        if (!conn.enabledFeatures.includes('email')) {
+          respond(false, { error: 'Email feature is not enabled on this connection' });
+          return;
+        }
+
+        const qs = new URLSearchParams({ connectionId });
+        const result = await backendFetch(
+          backendUrl,
+          `/api/email/messages/${encodeURIComponent(messageId)}?${qs.toString()}`,
+          apiKey,
+        );
+        if (!result.ok) {
+          respond(false, { error: result.error });
+          return;
+        }
+
+        respond(true, {
+          connectionLabel: conn.label,
+          connectionId: conn.id,
+          provider: conn.provider,
+          message: result.data,
+          availableActions: buildEmailActions(conn.permissionLevel),
+        });
+      });
+
+      // -------------------------------------------------------------------
+      // oauth.files.list — List files/folders
+      // -------------------------------------------------------------------
+      api.registerGatewayMethod('oauth.files.list', async ({ params, respond }) => {
+        const connectionId = requireParam(params, 'connectionId', respond);
+        if (!connectionId) return;
+
+        const conn = await resolveConnection(backendUrl, apiKey, connectionId, respond);
+        if (!conn) return;
+
+        if (!conn.enabledFeatures.includes('files')) {
+          respond(false, { error: 'Files feature is not enabled on this connection' });
+          return;
+        }
+
+        const qs = new URLSearchParams({ connectionId });
+        if (typeof params.folderId === 'string') qs.set('folderId', params.folderId);
+        if (typeof params.pageToken === 'string') qs.set('pageToken', params.pageToken);
+
+        const result = await backendFetch(backendUrl, `/api/drive/files?${qs.toString()}`, apiKey);
+        if (!result.ok) {
+          respond(false, { error: result.error });
+          return;
+        }
+
+        const data = result.data as Record<string, unknown>;
+
+        respond(true, {
+          connectionLabel: conn.label,
+          connectionId: conn.id,
+          provider: conn.provider,
+          files: data.files ?? [],
+          nextPageToken: data.nextPageToken,
+          totalCount: data.totalCount,
+          availableActions: buildFileActions(),
+        });
+      });
+
+      // -------------------------------------------------------------------
+      // oauth.files.search — Search files
+      // -------------------------------------------------------------------
+      api.registerGatewayMethod('oauth.files.search', async ({ params, respond }) => {
+        const connectionId = requireParam(params, 'connectionId', respond);
+        if (!connectionId) return;
+
+        const query = requireParam(params, 'query', respond);
+        if (!query) return;
+
+        const conn = await resolveConnection(backendUrl, apiKey, connectionId, respond);
+        if (!conn) return;
+
+        if (!conn.enabledFeatures.includes('files')) {
+          respond(false, { error: 'Files feature is not enabled on this connection' });
+          return;
+        }
+
+        const qs = new URLSearchParams({ connectionId, q: query });
+        if (typeof params.pageToken === 'string') qs.set('pageToken', params.pageToken);
+
+        const result = await backendFetch(backendUrl, `/api/drive/files/search?${qs.toString()}`, apiKey);
+        if (!result.ok) {
+          respond(false, { error: result.error });
+          return;
+        }
+
+        const data = result.data as Record<string, unknown>;
+
+        respond(true, {
+          connectionLabel: conn.label,
+          connectionId: conn.id,
+          provider: conn.provider,
+          files: data.files ?? [],
+          nextPageToken: data.nextPageToken,
+          totalCount: data.totalCount,
+          availableActions: buildFileActions(),
+        });
+      });
+
+      // -------------------------------------------------------------------
+      // oauth.files.get — Get a single file
+      // -------------------------------------------------------------------
+      api.registerGatewayMethod('oauth.files.get', async ({ params, respond }) => {
+        const connectionId = requireParam(params, 'connectionId', respond);
+        if (!connectionId) return;
+
+        const fileId = requireParam(params, 'fileId', respond);
+        if (!fileId) return;
+
+        const conn = await resolveConnection(backendUrl, apiKey, connectionId, respond);
+        if (!conn) return;
+
+        if (!conn.enabledFeatures.includes('files')) {
+          respond(false, { error: 'Files feature is not enabled on this connection' });
+          return;
+        }
+
+        const qs = new URLSearchParams({ connectionId });
+        const result = await backendFetch(
+          backendUrl,
+          `/api/drive/files/${encodeURIComponent(fileId)}?${qs.toString()}`,
+          apiKey,
+        );
+        if (!result.ok) {
+          respond(false, { error: result.error });
+          return;
+        }
+
+        respond(true, {
+          connectionLabel: conn.label,
+          connectionId: conn.id,
+          provider: conn.provider,
+          file: result.data,
+          availableActions: buildFileActions(),
+        });
+      });
+    },
+  };
+}

--- a/src/api/oauth/index.ts
+++ b/src/api/oauth/index.ts
@@ -47,3 +47,5 @@ export {
   LOCAL_SYNC_FEATURES,
 } from './sync.ts';
 export type { SyncJobResult, FeatureSyncStatus, LocalSyncFeature } from './sync.ts';
+export { createOAuthGatewayPlugin } from './gateway-plugin.ts';
+export type { OAuthGatewayPluginConfig } from './gateway-plugin.ts';


### PR DESCRIPTION
## Summary

Closes #1054

Adds OpenClaw gateway plugin methods that surface connected OAuth account data (contacts, email, files) to agents.

**Gateway methods registered:**
- `oauth.accounts.list` — List connected accounts with metadata, enabled features, and available actions
- `oauth.contacts.list` — Contacts from a specific connected account
- `oauth.email.list` — List/search emails from a specific connection
- `oauth.email.get` — Get a single email message by ID
- `oauth.files.list` — List files/folders from a connected drive
- `oauth.files.search` — Search files across a connected drive
- `oauth.files.get` — Get single file metadata with download URL

**Two implementations provided:**
1. `src/api/oauth/gateway-plugin.ts` — Standalone plugin using direct HTTP fetch to backend API (useful for standalone gateway deployments)
2. `packages/openclaw-plugin/src/gateway/oauth-rpc-methods.ts` — Integrated into the OpenClaw plugin package using the existing ApiClient pattern, registered in `register-openclaw.ts`

**Key features:**
- All responses include `connectionLabel` and `availableActions` for agent-friendly consumption
- Permission checks respect `enabled_features` and `permission_level` (read vs read_write)
- Pagination support via `pageToken`/`nextPageToken` on all list endpoints
- Feature validation: contacts/email/files endpoints reject requests when the feature is not enabled
- Connection validation: inactive connections are rejected

## Test plan

- [x] 16 unit tests for standalone gateway plugin (`src/api/oauth/gateway-plugin.test.ts`)
- [x] 15 unit tests for OpenClaw plugin RPC methods (`packages/openclaw-plugin/tests/oauth-rpc-methods.test.ts`)
- [x] All 139 OAuth-related tests pass
- [x] TypeScript compiles without errors
- [ ] Integration tests with real connected accounts (tracked in #1057)

## Local test commands

```bash
pnpm exec vitest run src/api/oauth/gateway-plugin.test.ts
pnpm exec vitest run packages/openclaw-plugin/tests/oauth-rpc-methods.test.ts
pnpm exec vitest run src/api/oauth/
pnpm exec tsc --noEmit
```