### PR TITLE
[#1076] Fix E2E workflow — run docker commands on CI host

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -40,11 +40,27 @@ jobs:
 
       - name: Start E2E test services
         run: |
-          docker compose -f .devcontainer/docker-compose.devcontainer.yml exec -T workspace bash -lc "cd /workspaces/openclaw-projects && docker compose -f docker-compose.test.yml up -d"
+          docker compose -f docker-compose.test.yml up -d
 
       - name: Wait for services
         run: |
-          docker compose -f .devcontainer/docker-compose.devcontainer.yml exec -T workspace bash -lc "cd /workspaces/openclaw-projects && ./scripts/wait-for-services.sh"
+          echo "Waiting for backend-test to be healthy..."
+          timeout 180 bash -c '
+            while true; do
+              status=$(docker compose -f docker-compose.test.yml ps backend-test --format json 2>/dev/null | grep -o "\"Health\":\"[^\"]*\"" | cut -d\" -f4 || echo "")
+              if [ "$status" = "healthy" ]; then
+                echo "Backend is healthy!"
+                break
+              fi
+              echo "Waiting... (status: ${status:-starting})"
+              sleep 2
+            done
+          '
+
+      - name: Connect workspace to test network
+        run: |
+          WORKSPACE_ID=$(docker compose -f .devcontainer/docker-compose.devcontainer.yml ps workspace -q)
+          docker network connect openclaw-test-network "$WORKSPACE_ID"
 
       - name: Run E2E tests
         env:
@@ -57,14 +73,19 @@ jobs:
             -e OPENAI_API_KEY \
             -e GEMINI_API_KEY \
             -e RUN_E2E=true \
+            -e E2E_API_URL=http://openclaw-backend-test:3001 \
             workspace bash -lc "cd /workspaces/openclaw-projects && pnpm test:e2e"
 
       - name: Stop E2E test services
         if: always()
         run: |
-          docker compose -f .devcontainer/docker-compose.devcontainer.yml exec -T workspace bash -lc "cd /workspaces/openclaw-projects && docker compose -f docker-compose.test.yml down -v || true"
+          docker compose -f docker-compose.test.yml down -v || true
 
       - name: Shutdown
         if: always()
         run: |
+          WORKSPACE_ID=$(docker compose -f .devcontainer/docker-compose.devcontainer.yml ps workspace -q 2>/dev/null || echo "")
+          if [ -n "$WORKSPACE_ID" ]; then
+            docker network disconnect openclaw-test-network "$WORKSPACE_ID" 2>/dev/null || true
+          fi
           docker compose -f .devcontainer/docker-compose.devcontainer.yml down -v


### PR DESCRIPTION
## Summary
- Move docker compose commands for test services from inside workspace container to CI host
- Connect workspace container to test network so E2E tests can reach backend-test
- Set E2E_API_URL to use container hostname instead of localhost

The `docker-outside-of-docker` devcontainer feature installs Docker CLI in local dev but isn't available in CI (raw `docker compose up` doesn't apply features). This fix runs Docker operations on the host and uses network bridging — the same approach `scripts/test-full.sh` uses for DooD.

Closes #1076

## Test plan
- [ ] E2E CI workflow passes with the fixed workflow
- [ ] docker compose test services start correctly on CI host
- [ ] workspace container can reach backend-test via openclaw-test-network
- [ ] Tests run with E2E_API_URL=http://openclaw-backend-test:3001

🤖 Generated with [Claude Code](https://claude.com/claude-code)