### PR TITLE
[#1081][#1082] Fix Traefik ACME chmod and ModSecurity read-only filesystem

### DIFF
--- a/docker-compose.full.yml
+++ b/docker-compose.full.yml
@@ -124,6 +124,12 @@ services:
       - ALL
     cap_add:
       - NET_BIND_SERVICE
+      # CHOWN + FOWNER: required for ACME storage initialisation.
+      # The host bind-mount (/etc/traefik/acme) is created as root, but Traefik
+      # 3.x runs as non-root (UID 65532). The entrypoint needs to chown/chmod
+      # acme.json so Traefik can read/write certificates.
+      - CHOWN
+      - FOWNER
     deploy:
       resources:
         limits:
@@ -179,6 +185,9 @@ services:
       - /var/log/apache2:mode=1777,size=32M
       - /var/run/apache2:mode=1777,size=8M
       - /var/lock/apache2:mode=1777,size=8M
+      # OWASP CRS startup writes: sed edits modsecurity configs, generates self-signed TLS cert
+      - /etc/modsecurity.d:mode=1777,size=8M
+      - /usr/local/apache2/conf:mode=1777,size=1M
     security_opt:
       - no-new-privileges:true
     cap_drop:

--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -122,6 +122,12 @@ services:
       - ALL
     cap_add:
       - NET_BIND_SERVICE
+      # CHOWN + FOWNER: required for ACME storage initialisation.
+      # The host bind-mount (/etc/traefik/acme) is created as root, but Traefik
+      # 3.x runs as non-root (UID 65532). The entrypoint needs to chown/chmod
+      # acme.json so Traefik can read/write certificates.
+      - CHOWN
+      - FOWNER
     deploy:
       resources:
         limits:
@@ -200,6 +206,9 @@ services:
       - /var/log/apache2:mode=1777,size=32M
       - /var/run/apache2:mode=1777,size=8M
       - /var/lock/apache2:mode=1777,size=8M
+      # OWASP CRS startup writes: sed edits modsecurity configs, generates self-signed TLS cert
+      - /etc/modsecurity.d:mode=1777,size=8M
+      - /usr/local/apache2/conf:mode=1777,size=1M
     security_opt:
       - no-new-privileges:true
     cap_drop:


### PR DESCRIPTION
## Summary

- **Traefik crash-loop** (#1081): `chmod: /etc/traefik/acme/acme.json: Operation not permitted` — Traefik 3.x runs as non-root (UID 65532) but the host bind-mount is root-owned. Added `CHOWN` + `FOWNER` capabilities and updated the entrypoint to `chown` the ACME directory to the running user before `chmod`.
- **ModSecurity read-only** (#1082): OWASP CRS startup writes to `/etc/modsecurity.d` (sed config edits) and `/usr/local/apache2/conf` (self-signed cert generation), both blocked by `read_only: true`. Added tmpfs mounts for these paths.

Both fixes applied to `docker-compose.traefik.yml` and `docker-compose.full.yml`.

## Test plan

- [ ] `pnpm test` passes (compose validation + entrypoint tests)
- [ ] Traefik container starts without crash-loop on production host
- [ ] ModSecurity container starts without read-only errors
- [ ] ACME certificates are issued and stored correctly
- [ ] `docker logs openclaw-traefik` shows "ACME storage ready: /etc/traefik/acme/acme.json (mode 600)"

Closes #1081
Closes #1082

🤖 Generated with [Claude Code](https://claude.com/claude-code)