### PR TITLE
Bump version to 0.0.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@troykelly/openclaw-projects-server",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "private": true,
   "description": "Postgres-backed project + task management system",
   "type": "module",

--- a/packages/openclaw-plugin/openclaw.plugin.json
+++ b/packages/openclaw-plugin/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "openclaw-projects",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "name": "OpenClaw Projects Plugin",
   "description": "Memory provider with projects, todos, and contacts integration",
   "kind": "memory",

--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@troykelly/openclaw-projects",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "OpenClaw memory plugin with projects, todos, and contacts integration",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/openclaw-plugin/tests/__snapshots__/schema-snapshots.test.ts.snap
+++ b/packages/openclaw-plugin/tests/__snapshots__/schema-snapshots.test.ts.snap
@@ -205,7 +205,7 @@ exports[`Schema Snapshots > Manifest configSchema > full manifest structure (exc
   "skills": [
     "skills",
   ],
-  "version": "0.0.6",
+  "version": "0.0.7",
 }
 `;
 


### PR DESCRIPTION
## Summary

- Bumps version from 0.0.6 to 0.0.7 across root package, plugin package, plugin manifest, and schema snapshot

## Files changed

- `package.json` (root)
- `packages/openclaw-plugin/package.json`
- `packages/openclaw-plugin/openclaw.plugin.json`
- `packages/openclaw-plugin/tests/__snapshots__/schema-snapshots.test.ts.snap`

## Test plan

- [ ] CI passes all checks (version-only change, no behavior change)
- [ ] Schema snapshot test passes with updated version

🤖 Generated with [Claude Code](https://claude.com/claude-code)