### PR TITLE
[#1088] Fix ModSecurity CRS plugin activation failure

### DIFF
--- a/docker-compose.full.yml
+++ b/docker-compose.full.yml
@@ -541,6 +541,9 @@ volumes:
   # ModSecurity named volumes — auto-populated from the CRS image on first run.
   # Required because the CRS entrypoint modifies files that ship inside the image
   # (setup.conf, crs-setup.conf, TLS certs). A tmpfs mount hides those files.
+  # NOTE: On CRS image upgrades, remove these volumes to pick up new defaults:
+  #   docker compose -f docker-compose.full.yml down
+  #   docker volume rm openclaw-projects_modsec_conf openclaw-projects_modsec_apache_conf
   modsec_conf:
   modsec_apache_conf:
   openclaw_data:

--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -513,6 +513,9 @@ volumes:
   # ModSecurity named volumes — auto-populated from the CRS image on first run.
   # Required because the CRS entrypoint modifies files that ship inside the image
   # (setup.conf, crs-setup.conf, TLS certs). A tmpfs mount hides those files.
+  # NOTE: On CRS image upgrades, remove these volumes to pick up new defaults:
+  #   docker compose -f docker-compose.traefik.yml down
+  #   docker volume rm openclaw-projects_modsec_conf openclaw-projects_modsec_apache_conf
   modsec_conf:
   modsec_apache_conf:
 


### PR DESCRIPTION
## Summary

- Replace tmpfs mounts for `/etc/modsecurity.d` and `/usr/local/apache2/conf` with named Docker volumes (`modsec_conf`, `modsec_apache_conf`) in the modsecurity service
- Named volumes auto-populate from image content on first creation, preserving `setup.conf` and other CRS config files that the entrypoint needs to modify
- Both `docker-compose.traefik.yml` and `docker-compose.full.yml` updated identically
- `read_only: true` container hardening preserved

## Root Cause

The `owasp/modsecurity-crs:apache-alpine` image ships config files in `/etc/modsecurity.d/` (including `setup.conf`). The CRS entrypoint runs:
- `activate-plugins.sh` — uses `sed` to toggle plugin includes in `setup.conf`
- `configure-rules.sh` — uses `ed` to modify `crs-setup.conf`

Mounting tmpfs over `/etc/modsecurity.d` hides these files, causing the entrypoint to fail with "setup.conf not found".

## Fix

Named Docker volumes (unlike tmpfs) auto-populate from the image's directory content on first creation. This preserves the original files while still allowing the entrypoint to write to them. The same approach is applied to `/usr/local/apache2/conf` where the entrypoint generates a self-signed TLS certificate.

## Test plan

- [ ] `docker compose -f docker-compose.traefik.yml config` validates without errors
- [ ] `docker compose -f docker-compose.full.yml config` validates without errors
- [ ] ModSecurity container starts successfully with `docker compose -f docker-compose.traefik.yml up modsecurity`
- [ ] Container logs show CRS rules loading without "setup.conf not found" errors
- [ ] Container still runs with `read_only: true` (verify via `docker inspect`)

Closes #1088

🤖 Generated with [Claude Code](https://claude.com/claude-code)