### PR TITLE
Bump version to 0.0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@troykelly/openclaw-projects-server",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "private": true,
   "description": "Postgres-backed project + task management system",
   "type": "module",

--- a/packages/openclaw-plugin/openclaw.plugin.json
+++ b/packages/openclaw-plugin/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "openclaw-projects",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "name": "OpenClaw Projects Plugin",
   "description": "Memory provider with projects, todos, and contacts integration",
   "kind": "memory",

--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@troykelly/openclaw-projects",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "OpenClaw memory plugin with projects, todos, and contacts integration",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/openclaw-plugin/tests/__snapshots__/schema-snapshots.test.ts.snap
+++ b/packages/openclaw-plugin/tests/__snapshots__/schema-snapshots.test.ts.snap
@@ -205,7 +205,7 @@ exports[`Schema Snapshots > Manifest configSchema > full manifest structure (exc
   "skills": [
     "skills",
   ],
-  "version": "0.0.7",
+  "version": "0.0.8",
 }
 `;
 


### PR DESCRIPTION
## Summary

- Bump version from 0.0.7 to 0.0.8 across root package, plugin package, plugin manifest, and schema snapshot

## Changes since 0.0.7

- #1090: Fix ModSecurity CRS plugin activation failure (setup.conf not found)
- #1092: Fix ModSecurity CRS rule configuration and Apache PID under read_only
- #1089: Replace envsubst with sed in Traefik entrypoint

## Test plan

- [ ] CI passes (schema snapshot test validates version consistency)
- [ ] Container images build successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)