### PR TITLE
Bump version to 0.0.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@troykelly/openclaw-projects-server",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "private": true,
   "description": "Postgres-backed project + task management system",
   "type": "module",

--- a/packages/openclaw-plugin/openclaw.plugin.json
+++ b/packages/openclaw-plugin/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "openclaw-projects",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "name": "OpenClaw Projects Plugin",
   "description": "Memory provider with projects, todos, and contacts integration",
   "kind": "memory",

--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@troykelly/openclaw-projects",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "OpenClaw memory plugin with projects, todos, and contacts integration",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/openclaw-plugin/tests/__snapshots__/schema-snapshots.test.ts.snap
+++ b/packages/openclaw-plugin/tests/__snapshots__/schema-snapshots.test.ts.snap
@@ -205,7 +205,7 @@ exports[`Schema Snapshots > Manifest configSchema > full manifest structure (exc
   "skills": [
     "skills",
   ],
-  "version": "0.0.8",
+  "version": "0.0.9",
 }
 `;
 


### PR DESCRIPTION
## Summary
- Bumps version from 0.0.8 to 0.0.9 across root package.json, plugin package.json, plugin manifest, and schema snapshot

## Files changed
- `package.json` — root server version
- `packages/openclaw-plugin/package.json` — plugin npm version
- `packages/openclaw-plugin/openclaw.plugin.json` — plugin manifest version
- `packages/openclaw-plugin/tests/__snapshots__/schema-snapshots.test.ts.snap` — snapshot update

## Test plan
- [x] Full test suite passes (12854 passed, 4 pre-existing rate_limiting failures unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)