### PR TITLE
[#1115] Fix Vite base path for Docker deployment

### DIFF
--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -21,8 +21,9 @@ COPY src/ ./src/
 COPY vite.config.ts tsconfig.json tsconfig.build.json ./
 COPY components.json ./
 
-# Build the frontend app
-RUN pnpm run app:build
+# Build the frontend app with base=/ for nginx root-relative asset paths.
+# Default Vite base is /static/app/ (for Fastify); Docker/nginx serves from root.
+RUN VITE_BASE=/ pnpm run app:build
 
 # Pre-compress assets with gzip and brotli for optimal delivery
 # Install brotli tool for compression

--- a/docker/app/nginx.conf.template
+++ b/docker/app/nginx.conf.template
@@ -66,27 +66,8 @@ server {
         proxy_buffering off;
     }
 
-    # ==========================================================================
-    # Vite base path handling
-    # ==========================================================================
-    # Vite builds with base: '/static/app/' so index.html references assets at
-    # /static/app/assets/... but the Docker build copies files to the nginx root
-    # (/usr/share/nginx/html/), placing them at /assets/... on disk.
-
-    # Rewrite only asset requests to strip the Vite base prefix.
-    # Scoped to /assets/ to avoid rewriting /static/app/api/... into /api/.
-    location /static/app/assets/ {
-        rewrite ^/static/app/(.*)$ /$1 last;
-    }
-
-    # SPA fallback for /static/app/* client-side routes (deep links).
-    # Serves index.html directly without rewriting into other location blocks.
-    location /static/app/ {
-        try_files $uri /index.html;
-    }
-
     # Hashed assets (immutable cache) - Vite generates files with content hashes
-    # Match files in /assets/ directory with hash patterns like index-abc123.js
+    # Docker build uses VITE_BASE=/ so assets are at /assets/ matching nginx root.
     location /assets/ {
         add_header Cache-Control "public, max-age=31536000, immutable" always;
         try_files $uri =404;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,7 +8,7 @@ import path from 'node:path';
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   root: path.join(__dirname, 'src', 'ui', 'app'),
-  base: '/static/app/',
+  base: process.env.VITE_BASE || '/static/app/',
   server: {
     host: '::',
   },


### PR DESCRIPTION
## Summary
- Make Vite `base` configurable via `VITE_BASE` env var (default `/static/app/` for Fastify)
- Set `VITE_BASE=/` in Docker build so assets reference `/assets/...` matching nginx root
- Remove broken nginx rewrite hack from PR #1100 — assets now served directly

Closes #1115

## Changes

| File | Change |
|------|--------|
| `vite.config.ts` | `base: process.env.VITE_BASE \|\| '/static/app/'` |
| `docker/app/Dockerfile` | `RUN VITE_BASE=/ pnpm run app:build` |
| `docker/app/nginx.conf.template` | Remove rewrite block and `/static/app/` locations |
| `tests/docker/app-dockerfile.test.ts` | Updated tests for new approach |

## Verification

Built Docker image locally and tested all paths:

| Request | Content-Type | Status |
|---------|-------------|--------|
| `/` | text/html | Root page |
| `/assets/index-*.css` | text/css | Correct |
| `/assets/index-*.js` | application/javascript | Correct |
| `/app/dashboard` | text/html | SPA fallback |
| `/assets/nonexistent.js` | — | 404 |

## Test plan
- [x] `pnpm test` — no new failures (pre-existing failures in contacts_api, todos_api, skill_store_quotas unrelated)
- [x] `pnpm run lint` — 0 errors, 1590 warnings (all pre-existing)
- [x] Docker image builds successfully
- [x] CSS served as `text/css` (not `text/html`)
- [x] JS served as `application/javascript` (not `text/html`)
- [x] SPA deep links return `index.html`
- [x] Missing assets return 404
- [x] Fastify deployment unaffected (default base unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)