### PR TITLE
[#1119] Fix UI test failures from gateway setup in jsdom

### DIFF
--- a/tests/setup-gateway.ts
+++ b/tests/setup-gateway.ts
@@ -1,0 +1,5 @@
+// Only load gateway setup in Node (not jsdom) — gateway imports use
+// relative paths that fail under Vite's /@fs/ resolver in jsdom.
+if (typeof window === 'undefined') {
+  await import('../.local/openclaw-gateway/test/setup.ts');
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -62,7 +62,7 @@ export default defineConfig({
     setupFiles: [
       './tests/setup-api.ts',
       './tests/setup-ui.ts',
-      ...(hasGateway ? ['./.local/openclaw-gateway/test/setup.ts'] : []),
+      ...(hasGateway ? ['./tests/setup-gateway.ts'] : []),
     ],
   },
   resolve: {


### PR DESCRIPTION
## Summary
- Add `tests/setup-gateway.ts` wrapper that checks `typeof window === 'undefined'` before importing gateway setup
- Update `vitest.config.ts` to reference the wrapper instead of the gateway setup file directly
- Gateway setup uses relative imports (`../src/...`) that fail under jsdom's `/@fs/` virtual FS resolver

## Test plan
- [x] `pnpm exec vitest run tests/ui/stores.test.ts` passes (38 tests)
- [x] Gateway tests still pass (10 files, 38 tests) after plugin build
- [x] Gateway setup only loads in Node environment, not jsdom

Closes #1119

🤖 Generated with [Claude Code](https://claude.com/claude-code)