### PR TITLE
[#1120] Fix rate_limiting test OAuth startup failures

### DIFF
--- a/tests/rate_limiting.test.ts
+++ b/tests/rate_limiting.test.ts
@@ -14,6 +14,16 @@ describe('Rate Limiting', () => {
   beforeEach(() => {
     vi.resetModules();
     process.env = { ...originalEnv };
+    // Clear OAuth credentials to prevent startup validation failure
+    // when NODE_ENV=production (requires OAUTH_TOKEN_ENCRYPTION_KEY)
+    delete process.env.MS365_CLIENT_ID;
+    delete process.env.MS365_CLIENT_SECRET;
+    delete process.env.AZURE_CLIENT_ID;
+    delete process.env.AZURE_CLIENT_SECRET;
+    delete process.env.GOOGLE_CLIENT_ID;
+    delete process.env.GOOGLE_CLIENT_SECRET;
+    delete process.env.GOOGLE_CLOUD_CLIENT_ID;
+    delete process.env.GOOGLE_CLOUD_CLIENT_SECRET;
     process.env.OPENCLAW_PROJECTS_AUTH_DISABLED = 'true';
     // Enable rate limiting for tests
     process.env.NODE_ENV = 'production';


### PR DESCRIPTION
## Summary
- Clear OAuth provider credentials (`MS365_*`, `AZURE_*`, `GOOGLE_*`, `GOOGLE_CLOUD_*`) in `beforeEach`
- Prevents `validateOAuthStartup()` from fatally erroring when `NODE_ENV=production` with OAuth creds from `.env`
- Matches the established pattern used in `tests/oauth/service.test.ts`

## Test plan
- [x] `pnpm exec vitest run tests/rate_limiting.test.ts` passes (all 7 tests)
- [x] No regressions in other tests

Closes #1120

🤖 Generated with [Claude Code](https://claude.com/claude-code)