### PR TITLE
[#1121] Skip frontend asset tests when build missing

### DIFF
--- a/tests/app_frontend_assets.test.ts
+++ b/tests/app_frontend_assets.test.ts
@@ -3,10 +3,15 @@
  * Part of Issue #779 - Catches stale index.html after rebuild.
  */
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { existsSync, readFileSync } from 'node:fs';
 import { runMigrate } from './helpers/migrate.ts';
 import { buildServer } from '../src/api/server.ts';
 
-describe('Frontend Assets (Issue #779)', () => {
+const frontendIndexPath = new URL('../src/api/static/app/index.html', import.meta.url).pathname;
+const hasFrontendBuild =
+  existsSync(frontendIndexPath) && /index-\w+\.js/.test(readFileSync(frontendIndexPath, 'utf-8'));
+
+describe.skipIf(!hasFrontendBuild)('Frontend Assets (Issue #779)', () => {
   const app = buildServer();
 
   beforeAll(async () => {


### PR DESCRIPTION
## Summary
- Add `describe.skipIf(!hasFrontendBuild)` guard that checks for a built `index.html` with hashed Vite asset references
- Tests still run in CI (where `pnpm app:build` runs first)
- Tests skip gracefully locally when frontend isn't built

## Test plan
- [x] `pnpm exec vitest run tests/app_frontend_assets.test.ts` skips cleanly (2 skipped)
- [x] Tests still pass after `pnpm run app:build` (verified in CI)

Closes #1121

🤖 Generated with [Claude Code](https://claude.com/claude-code)