### PR TITLE
[#1126] Expose SeaweedFS via Traefik for presigned URL access

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -317,6 +317,16 @@ SEAWEEDFS_VOLUME_SIZE_LIMIT_MB=1000
 # OpenClaw Gateway host port (docker-compose.full.yml only, container listens on 18789)
 # GATEWAY_HOST_PORT=18789
 
+# SeaweedFS S3 host port (container listens on 8333)
+# Published to localhost for Traefik to route s3.DOMAIN presigned URLs
+# SEAWEEDFS_HOST_PORT=8333
+
+# External S3 endpoint for presigned URL rewriting
+# When set, the API rewrites internal S3 presigned URLs to use this public address.
+# Default in Traefik compose: https://s3.${DOMAIN}
+# Requires a DNS record for s3.DOMAIN pointing to the Traefik host.
+# S3_EXTERNAL_ENDPOINT=https://s3.example.com
+
 # =============================================================================
 # DNS Provider Configuration
 # =============================================================================

--- a/docker-compose.full.yml
+++ b/docker-compose.full.yml
@@ -13,6 +13,7 @@
 #      |
 #      +-- DOMAIN/          --> 127.0.0.1:APP_HOST_PORT   (app frontend)
 #      +-- api.DOMAIN/      --> 127.0.0.1:MODSEC_HOST_PORT (modsecurity --> api)
+#      +-- s3.DOMAIN/       --> 127.0.0.1:SEAWEEDFS_HOST_PORT (seaweedfs S3)
 #      +-- DOMAIN/openclaw/ --> 127.0.0.1:GATEWAY_HOST_PORT (openclaw-gateway)
 #      +-- ws.DOMAIN/       --> 127.0.0.1:GATEWAY_HOST_PORT (openclaw-gateway)
 #      +-- hooks.DOMAIN/    --> 127.0.0.1:GATEWAY_HOST_PORT (openclaw-gateway)
@@ -65,6 +66,7 @@ services:
       API_HOST_PORT: ${API_HOST_PORT:-3001}
       APP_HOST_PORT: ${APP_HOST_PORT:-8081}
       GATEWAY_HOST_PORT: ${GATEWAY_HOST_PORT:-18789}
+      SEAWEEDFS_HOST_PORT: ${SEAWEEDFS_HOST_PORT:-8333}
       # DNS provider credentials (passed through to ACME/lego)
       # Note: lego checks CF_DNS_API_TOKEN first — if set (even empty),
       # it ignores CF_API_KEY + CF_API_EMAIL.  The entrypoint unsets
@@ -270,6 +272,11 @@ services:
       S3_SECRET_KEY: ${S3_SECRET_KEY:?S3_SECRET_KEY is required}
       SEAWEEDFS_VOLUME_SIZE_LIMIT_MB: ${SEAWEEDFS_VOLUME_SIZE_LIMIT_MB:-30000}
       SEAWEEDFS_VOLUME_MAX: ${SEAWEEDFS_VOLUME_MAX:-100}
+    # Publish S3 port to localhost for Traefik (host networking mode)
+    # Enables presigned URL access via s3.DOMAIN Traefik route
+    ports:
+      - "127.0.0.1:${SEAWEEDFS_HOST_PORT:-8333}:8333"
+      - "[::1]:${SEAWEEDFS_HOST_PORT:-8333}:8333"
     volumes:
       - seaweedfs_data:/data
       - ./docker/seaweedfs/s3.json.template:/etc/seaweedfs/s3.json.template:ro
@@ -352,6 +359,10 @@ services:
       S3_ACCESS_KEY: ${S3_ACCESS_KEY:-openclaw}
       S3_SECRET_KEY: ${S3_SECRET_KEY:?S3_SECRET_KEY is required}
       S3_FORCE_PATH_STYLE: "true"
+      # External S3 endpoint for presigned URL rewriting
+      # When set, presigned URLs use this public address instead of the internal
+      # Docker endpoint. Requires s3.DOMAIN DNS + Traefik route (automatic).
+      S3_EXTERNAL_ENDPOINT: ${S3_EXTERNAL_ENDPOINT:-https://s3.${DOMAIN}}
       POSTMARK_FROM: ${POSTMARK_FROM:-}
       POSTMARK_REPLY_TO: ${POSTMARK_REPLY_TO:-}
       POSTMARK_MESSAGE_STREAM: ${POSTMARK_MESSAGE_STREAM:-outbound}

--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -54,6 +54,7 @@ services:
       MODSEC_HOST_PORT: ${MODSEC_HOST_PORT:-8080}
       API_HOST_PORT: ${API_HOST_PORT:-3001}
       APP_HOST_PORT: ${APP_HOST_PORT:-8081}
+      SEAWEEDFS_HOST_PORT: ${SEAWEEDFS_HOST_PORT:-8333}
       # DNS provider credentials (passed through to ACME/lego)
       # Note: lego checks CF_DNS_API_TOKEN first — if set (even empty),
       # it ignores CF_API_KEY + CF_API_EMAIL.  The entrypoint unsets
@@ -298,6 +299,11 @@ services:
       # Volume configuration (production defaults)
       SEAWEEDFS_VOLUME_SIZE_LIMIT_MB: ${SEAWEEDFS_VOLUME_SIZE_LIMIT_MB:-30000}
       SEAWEEDFS_VOLUME_MAX: ${SEAWEEDFS_VOLUME_MAX:-100}
+    # Publish S3 port to localhost for Traefik (host networking mode)
+    # Enables presigned URL access via s3.DOMAIN Traefik route
+    ports:
+      - "127.0.0.1:${SEAWEEDFS_HOST_PORT:-8333}:8333"
+      - "[::1]:${SEAWEEDFS_HOST_PORT:-8333}:8333"
     volumes:
       - seaweedfs_data:/data
       - ./docker/seaweedfs/s3.json.template:/etc/seaweedfs/s3.json.template:ro
@@ -388,6 +394,10 @@ services:
       S3_ACCESS_KEY: ${S3_ACCESS_KEY:-openclaw}
       S3_SECRET_KEY: ${S3_SECRET_KEY:?S3_SECRET_KEY is required}
       S3_FORCE_PATH_STYLE: "true"
+      # External S3 endpoint for presigned URL rewriting
+      # When set, presigned URLs use this public address instead of the internal
+      # Docker endpoint. Requires s3.DOMAIN DNS + Traefik route (automatic).
+      S3_EXTERNAL_ENDPOINT: ${S3_EXTERNAL_ENDPOINT:-https://s3.${DOMAIN}}
       # Optional: Postmark email (magic links)
       POSTMARK_FROM: ${POSTMARK_FROM:-}
       POSTMARK_REPLY_TO: ${POSTMARK_REPLY_TO:-}

--- a/docker/traefik/dynamic-config.yml.template
+++ b/docker/traefik/dynamic-config.yml.template
@@ -8,6 +8,7 @@
 # Architecture:
 #   Client -> Traefik (host network) -> 127.0.0.1:MODSEC_HOST_PORT (ModSecurity WAF) -> API
 #   Client -> Traefik (host network) -> 127.0.0.1:APP_HOST_PORT (App/frontend)
+#   Client -> Traefik (host network) -> 127.0.0.1:SEAWEEDFS_HOST_PORT (SeaweedFS S3)
 #   Client -> Traefik (host network) -> 127.0.0.1:GATEWAY_HOST_PORT (OpenClaw Gateway)
 
 # TLS Options
@@ -121,6 +122,21 @@ http:
         certResolver: letsencrypt
         options: default
 
+    # SeaweedFS S3 - Presigned URL access at s3.DOMAIN
+    # Allows clients to download shared files via presigned S3 URLs
+    # The API rewrites internal S3 URLs to https://s3.DOMAIN when
+    # S3_EXTERNAL_ENDPOINT is set (see src/api/file-storage/sharing.ts)
+    s3-router:
+      rule: "Host(`s3.${DOMAIN}`)"
+      service: seaweedfs-service
+      entryPoints:
+        - websecure
+      middlewares:
+        - security-headers
+      tls:
+        certResolver: letsencrypt
+        options: default
+
   # Services
   # All services point to localhost because Traefik uses host networking.
   # Backend containers publish their ports to localhost for Traefik to reach.
@@ -166,3 +182,10 @@ http:
           path: /health
           interval: 10s
           timeout: 3s
+
+    # SeaweedFS S3 service
+    # Serves presigned URL downloads directly from object storage
+    seaweedfs-service:
+      loadBalancer:
+        servers:
+          - url: "http://${SERVICE_HOST}:${SEAWEEDFS_HOST_PORT}"

--- a/docker/traefik/entrypoint.sh
+++ b/docker/traefik/entrypoint.sh
@@ -187,6 +187,7 @@ generate_config() {
     export API_HOST_PORT="${API_HOST_PORT:-3001}"
     export APP_HOST_PORT="${APP_HOST_PORT:-8081}"
     export GATEWAY_HOST_PORT="${GATEWAY_HOST_PORT:-18789}"
+    export SEAWEEDFS_HOST_PORT="${SEAWEEDFS_HOST_PORT:-8333}"
     
     # Generate TRUSTED_IPS_YAML for template
     export TRUSTED_IPS_YAML
@@ -213,6 +214,7 @@ generate_config() {
         -e "s|\${API_HOST_PORT}|$(escape_sed "${API_HOST_PORT}")|g" \
         -e "s|\${APP_HOST_PORT}|$(escape_sed "${APP_HOST_PORT}")|g" \
         -e "s|\${GATEWAY_HOST_PORT}|$(escape_sed "${GATEWAY_HOST_PORT}")|g" \
+        -e "s|\${SEAWEEDFS_HOST_PORT}|$(escape_sed "${SEAWEEDFS_HOST_PORT}")|g" \
         < "${TEMPLATE_FILE}" \
         > "${OUTPUT_FILE}"
 


### PR DESCRIPTION
## Summary

- Adds `s3.DOMAIN` Traefik route and `seaweedfs-service` to the dynamic config template so presigned S3 URLs are externally reachable through TLS
- Publishes SeaweedFS S3 port (8333) to localhost in both `docker-compose.traefik.yml` and `docker-compose.full.yml`
- Wires `SEAWEEDFS_HOST_PORT` through the Traefik entrypoint's sed substitution
- Sets `S3_EXTERNAL_ENDPOINT=https://s3.${DOMAIN}` in the API environment so `sharing.ts` rewrites internal presigned URLs to the public endpoint
- Documents `SEAWEEDFS_HOST_PORT` and `S3_EXTERNAL_ENDPOINT` in `.env.example`

## Deployment notes

Operators need to add a DNS record for `s3.DOMAIN` pointing to the Traefik host. Traefik's ACME DNS-01 challenge will automatically provision the TLS certificate.

Closes #1126

## Test plan

- [ ] Verify `docker compose -f docker-compose.traefik.yml config` resolves `S3_EXTERNAL_ENDPOINT` correctly
- [ ] Verify `docker compose -f docker-compose.full.yml config` resolves `S3_EXTERNAL_ENDPOINT` correctly
- [ ] Deploy and confirm `s3.DOMAIN` routes to SeaweedFS through Traefik
- [ ] Upload a file via API, request a presigned share URL, confirm it uses `https://s3.DOMAIN/...`
- [ ] Download the file via the presigned URL through Traefik

🤖 Generated with [Claude Code](https://claude.com/claude-code)