### PR TITLE
[#1167] Documentation sweep for v0.0.11

### DIFF
--- a/docs/api/messaging.md
+++ b/docs/api/messaging.md
@@ -184,6 +184,120 @@ Webhook endpoint for Postmark delivery status callbacks. Configure in your Postm
 
 ---
 
+## Thread Endpoints
+
+### List Threads
+
+**GET** `/api/threads`
+
+List all conversation threads with optional filtering by channel or contact.
+
+**Query Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `limit` | integer | No | Max threads to return (default 20) |
+| `offset` | integer | No | Pagination offset (default 0) |
+| `channel` | string | No | Filter by channel (e.g., `sms`, `email`) |
+| `contact_id` | string | No | Filter by contact UUID |
+
+**Response (200 OK):**
+```json
+{
+  "threads": [
+    {
+      "id": "019c1234-5678-7890-abcd-ef1234567890",
+      "channel": "sms",
+      "externalThreadKey": "+15551234567",
+      "contact": {
+        "id": "019c1234-5678-7890-abcd-ef1234567891",
+        "displayName": "Jane Doe"
+      },
+      "createdAt": "2026-01-15T12:00:00Z",
+      "updatedAt": "2026-02-14T09:30:00Z",
+      "lastMessage": {
+        "id": "019c1234-5678-7890-abcd-ef1234567892",
+        "direction": "inbound",
+        "body": "Thanks for the reminder!",
+        "receivedAt": "2026-02-14T09:30:00Z"
+      },
+      "messageCount": 12
+    }
+  ],
+  "total": 42,
+  "pagination": {
+    "limit": 20,
+    "offset": 0,
+    "hasMore": true
+  }
+}
+```
+
+**Example:**
+```bash
+# List all threads
+curl https://api.example.com/api/threads \
+  -H "Authorization: Bearer $API_TOKEN"
+
+# Filter by channel
+curl "https://api.example.com/api/threads?channel=sms&limit=10" \
+  -H "Authorization: Bearer $API_TOKEN"
+```
+
+### Get Thread History
+
+**GET** `/api/threads/:id/history`
+
+Get full thread history including messages, related work items, and contact memories.
+
+**Path Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string | Thread UUID |
+
+**Query Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `limit` | integer | No | Max messages to return (default 50, max 200) |
+| `before` | string | No | Messages before this ISO 8601 timestamp |
+| `after` | string | No | Messages after this ISO 8601 timestamp |
+| `includeWorkItems` | boolean | No | Include related work items (default true) |
+| `includeMemories` | boolean | No | Include contact memories (default true) |
+
+**Response (200 OK):**
+```json
+{
+  "thread": {
+    "id": "019c1234-...",
+    "channel": "sms",
+    "externalThreadKey": "+15551234567",
+    "contact": { "id": "...", "displayName": "Jane Doe" },
+    "createdAt": "2026-01-15T12:00:00Z",
+    "updatedAt": "2026-02-14T09:30:00Z"
+  },
+  "messages": [
+    {
+      "id": "...",
+      "direction": "outbound",
+      "body": "Don't forget your appointment tomorrow!",
+      "receivedAt": "2026-02-13T10:00:00Z",
+      "createdAt": "2026-02-13T10:00:00Z"
+    }
+  ],
+  "relatedWorkItems": [],
+  "contactMemories": [],
+  "pagination": {
+    "hasMore": false,
+    "oldestTimestamp": "2026-02-13T10:00:00Z",
+    "newestTimestamp": "2026-02-14T09:30:00Z"
+  }
+}
+```
+
+---
+
 ## Delivery Status Tracking
 
 ### Message Lifecycle

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -318,6 +318,8 @@ Traefik starts immediately without waiting for backend services to become health
 
 During startup, you may briefly see 502/503 errors until the backend services (api, app, modsecurity) pass their health checks. This typically resolves within 15-30 seconds.
 
+Traefik exposes a `--ping=true` endpoint (`/ping`) for external healthchecks (e.g., Docker HEALTHCHECK, load balancer probes). This endpoint responds with `200 OK` when Traefik is ready to accept connections, independent of backend health.
+
 **Startup sequence:**
 1. All services start simultaneously
 2. Traefik acquires TLS certificates via ACME DNS-01
@@ -531,7 +533,8 @@ docker exec openclaw-gateway wget -q -O - http://api:3001/health
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `POSTMARK_TRANSACTIONAL_TOKEN` | (empty) | Postmark API token |
-| `POSTMARK_FROM` | (empty) | From address (verified sender) |
+| `POSTMARK_FROM_EMAIL` | (empty) | From address (verified sender) |
+| `POSTMARK_FROM` | (empty) | Legacy alias for `POSTMARK_FROM_EMAIL` (used as fallback) |
 | `POSTMARK_REPLY_TO` | (empty) | Reply-to address |
 | `POSTMARK_MESSAGE_STREAM` | `outbound` | Message stream name |
 

--- a/docs/development/messaging-setup.md
+++ b/docs/development/messaging-setup.md
@@ -210,9 +210,11 @@ pnpm test:integration
 | `POSTMARK_SERVER_TOKEN` | Yes* | Server API token |
 | `POSTMARK_TRANSACTIONAL_TOKEN` | Yes* | Alternative token name |
 | `POSTMARK_TRANSACTIONAL_TOKEN_FILE` | Yes* | Path to token file |
-| `POSTMARK_FROM_EMAIL` | Yes | Verified sender email |
+| `POSTMARK_FROM_EMAIL` | Yes** | Verified sender email |
+| `POSTMARK_FROM` | No | Legacy alias for `POSTMARK_FROM_EMAIL` (used as fallback) |
 
 *One of the token options is required.
+**Either `POSTMARK_FROM_EMAIL` or legacy `POSTMARK_FROM` must be set.
 
 ### Embeddings (for semantic search)
 

--- a/docs/guides/openclaw-messaging-integration.md
+++ b/docs/guides/openclaw-messaging-integration.md
@@ -203,7 +203,29 @@ if (endpoint.metadata?.bounced) {
 
 ## Threading
 
-Messages are automatically threaded by conversation:
+Messages are automatically threaded by conversation.
+
+### Listing Threads
+
+```typescript
+// List all threads, optionally filtered by channel or contact
+const threads = await fetch('/api/threads?channel=sms&limit=20', {
+  headers: { 'Authorization': `Bearer ${apiToken}` }
+});
+// Returns { threads: [...], total: N, pagination: { limit, offset, hasMore } }
+```
+
+### Thread History
+
+```typescript
+// Get full thread with messages, related work items, and contact memories
+const history = await fetch(`/api/threads/${threadId}/history?limit=50`, {
+  headers: { 'Authorization': `Bearer ${apiToken}` }
+});
+// Returns { thread, messages, relatedWorkItems, contactMemories, pagination }
+```
+
+### Replying to Threads
 
 ```typescript
 // Reply to existing thread

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -29,7 +29,7 @@ Adds to `work_item`:
 
 - `estimate_minutes` (int, nullable)
 - `actual_minutes` (int, nullable)
-- `work_item_kind` (`work_item_kind` enum: `project|initiative|epic|issue`, default `issue`)
+- `work_item_kind` (`work_item_kind` enum: `project|initiative|epic|issue|task`, default `issue`)
 - `parent_work_item_id` (self-referential FK for hierarchy, nullable)
 
 Constraints:

--- a/ops/README.md
+++ b/ops/README.md
@@ -39,7 +39,8 @@ The migrate service runs automatically on startup and exits when complete.
 Health:
 
 ```bash
-curl -fsS http://127.0.0.1:3000/health
+curl -fsS http://[::1]:3000/health
+# or: curl -fsS http://127.0.0.1:3000/health
 ```
 
 ## Services
@@ -54,9 +55,11 @@ curl -fsS http://127.0.0.1:3000/health
 
 ## Traefik wiring
 
-For production with TLS, use `docker-compose.traefik.yml` (coming soon in #529).
+For production with TLS, use `docker-compose.traefik.yml`. See [docs/deployment.md](../docs/deployment.md) for full production deployment instructions including Traefik, ModSecurity WAF, and HTTP/3 support.
 
-The basic compose publishes the API on **127.0.0.1:${API_PORT:-3000}** and frontend on **127.0.0.1:${FRONTEND_PORT:-8080}**.
+The basic compose publishes the API and frontend on dual-stack localhost (`[::1]` and `127.0.0.1`):
+- API: **`[::1]:${API_PORT:-3000}`** / **`127.0.0.1:${API_PORT:-3000}`**
+- Frontend: **`[::1]:${FRONTEND_PORT:-8080}`** / **`127.0.0.1:${FRONTEND_PORT:-8080}`**
 
 ### Option A: Traefik file-provider (current VM pattern)
 

--- a/packages/openclaw-plugin/CHANGELOG.md
+++ b/packages/openclaw-plugin/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.11] - 2026-02-14
+
+### Fixed
+
+#### Plugin Configuration
+- Config validation now uses lenient parsing (`.strip()`) instead of strict mode — unknown properties are silently stripped rather than causing errors (#1137)
+
+#### Memory Tools
+- `memory_forget` now returns full UUIDs in results and auto-deletes when a single match is found (#1138)
+- `memory_recall` correctly maps the `other` category type bidirectionally (#1144)
+- `memory_store` content alias verified and working (#1142)
+
+#### Contact Tools
+- `contact_search` and `contact_get` now correctly map `display_name` and `contact_kind` fields from the API (#1131)
+
+#### Relationship Tools
+- `relationship_query` now sends `contact` query parameter instead of incorrect `contact_id` (#1132)
+
+### Improved
+
+#### Memory Search (API-side, affects plugin results)
+- Memory search responses now include `score` and `embedding_provider` fields (#1145)
+- Content-based deduplication prevents storing duplicate memories (#1143)
+- Keyword boosting improves semantic search relevance (#1146)
+
 ## [1.0.0] - 2024-02-02
 
 ### Added


### PR DESCRIPTION
## Summary

Audit and update documentation to reflect all 17 changes shipped in v0.0.11.

- **docs/schema.md**: Add `task` to `work_item_kind` enum (was missing after #1135)
- **docs/api/messaging.md**: Document new `GET /api/threads` and `GET /api/threads/:id/history` endpoints (#1139)
- **docs/deployment.md**: Add `POSTMARK_FROM_EMAIL` env var (#1133), document Traefik `--ping=true` healthcheck endpoint (#1134)
- **docs/development/messaging-setup.md**: Add `POSTMARK_FROM` legacy fallback note (#1133)
- **docs/guides/openclaw-messaging-integration.md**: Add thread listing and history API examples (#1139)
- **ops/README.md**: Update to dual-stack localhost bindings (#1128), remove stale "coming soon in #529" for Traefik
- **packages/openclaw-plugin/CHANGELOG.md**: Add comprehensive v0.0.11 entry covering all plugin fixes (#1131, #1132, #1137, #1138, #1142, #1143, #1144, #1145, #1146)

Closes #1167

## Test plan

- [ ] Verify all markdown renders correctly on GitHub
- [ ] Spot-check API examples match actual endpoint signatures
- [ ] Confirm env var names match docker-compose files

🤖 Generated with [Claude Code](https://claude.com/claude-code)