### PR TITLE
[#1170] Fix Traefik ping port conflict with ModSecurity

### DIFF
--- a/docker-compose.full.yml
+++ b/docker-compose.full.yml
@@ -83,7 +83,10 @@ services:
     command:
       - --api.dashboard=false
       - --api.insecure=false
+      # Ping endpoint for healthchecks (bound to dedicated entrypoint to avoid
+      # conflicting with ModSecurity on the default port 8080)
       - --ping=true
+      - --ping.entryPoint=ping
       - --providers.docker=true
       - --providers.docker.exposedByDefault=false
       # Note: --providers.docker.network is omitted because Traefik uses host networking
@@ -91,6 +94,7 @@ services:
       - --providers.file.directory=/etc/traefik/dynamic
       - --providers.file.watch=true
       # Entrypoints (Traefik binds directly to host ports via network_mode: host)
+      - --entrypoints.ping.address=:8082
       - --entrypoints.web.address=:${HTTP_PORT:-80}
       - --entrypoints.web.http.redirections.entryPoint.to=websecure
       - --entrypoints.web.http.redirections.entryPoint.scheme=https
@@ -118,7 +122,7 @@ services:
       - /etc/traefik/acme:/etc/traefik/acme
     entrypoint: ["/entrypoint.sh"]
     healthcheck:
-      test: ["CMD", "traefik", "healthcheck"]
+      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:8082/ping"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -73,8 +73,10 @@ services:
       # API and Dashboard
       - --api.dashboard=false
       - --api.insecure=false
-      # Ping endpoint for healthchecks
+      # Ping endpoint for healthchecks (bound to dedicated entrypoint to avoid
+      # conflicting with ModSecurity on the default port 8080)
       - --ping=true
+      - --ping.entryPoint=ping
       # Providers
       - --providers.docker=true
       - --providers.docker.exposedByDefault=false
@@ -83,6 +85,7 @@ services:
       - --providers.file.directory=/etc/traefik/dynamic
       - --providers.file.watch=true
       # Entrypoints (Traefik binds directly to host ports via network_mode: host)
+      - --entrypoints.ping.address=:8082
       - --entrypoints.web.address=:${HTTP_PORT:-80}
       - --entrypoints.web.http.redirections.entryPoint.to=websecure
       - --entrypoints.web.http.redirections.entryPoint.scheme=https
@@ -114,7 +117,7 @@ services:
       - /etc/traefik/acme:/etc/traefik/acme
     entrypoint: ["/entrypoint.sh"]
     healthcheck:
-      test: ["CMD", "traefik", "healthcheck"]
+      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:8082/ping"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -318,7 +318,7 @@ Traefik starts immediately without waiting for backend services to become health
 
 During startup, you may briefly see 502/503 errors until the backend services (api, app, modsecurity) pass their health checks. This typically resolves within 15-30 seconds.
 
-Traefik exposes a `--ping=true` endpoint (`/ping`) for external healthchecks (e.g., Docker HEALTHCHECK, load balancer probes). This endpoint responds with `200 OK` when Traefik is ready to accept connections, independent of backend health.
+Traefik exposes a `/ping` healthcheck endpoint bound to a dedicated `ping` entrypoint on port **8082**. This avoids a conflict with ModSecurity, which uses the default Traefik ping port (8080). The Docker HEALTHCHECK uses `http://127.0.0.1:8082/ping` to verify Traefik is ready, independent of backend health.
 
 **Startup sequence:**
 1. All services start simultaneously


### PR DESCRIPTION
## Summary

Closes #1170

PR #1155 added `--ping=true` to Traefik, but with host networking the default ping entrypoint binds to port 8080, which conflicts with ModSecurity (also on 8080).

This fix:
- Adds a dedicated `ping` entrypoint on port **8082** (`--ping.entryPoint=ping`, `--entrypoints.ping.address=:8082`)
- Updates the Docker HEALTHCHECK to use `wget -q --spider http://127.0.0.1:8082/ping` instead of `traefik healthcheck`
- Updates `docs/deployment.md` to document the ping endpoint on port 8082

Changes applied to both `docker-compose.traefik.yml` and `docker-compose.full.yml`.

## Test plan

- [ ] Verify `docker compose -f docker-compose.traefik.yml config` parses without errors
- [ ] Verify `docker compose -f docker-compose.full.yml config` parses without errors
- [ ] Deploy and confirm Traefik healthcheck passes on port 8082
- [ ] Confirm ModSecurity still binds to port 8080 without conflict