### PR TITLE
[#1166] Fix root URL and auth flow

### DIFF
--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -404,8 +404,8 @@ export function buildServer(options: ProjectsApiOptions = {}): FastifyInstance {
       return;
     }
 
-    // Skip auth for /app/* routes (these use session cookies via requireDashboardSession)
-    if (url.startsWith('/app/')) {
+    // Skip auth for root redirect and /app/* routes (these use session cookies via requireDashboardSession)
+    if (url === '/' || url === '/app' || url.startsWith('/app/')) {
       return;
     }
 
@@ -1225,6 +1225,11 @@ export function buildServer(options: ProjectsApiOptions = {}): FastifyInstance {
       },
     },
   }));
+
+  // Root URL redirect (issue #1166): GET / → /app so browsers don't get an empty response.
+  app.get('/', async (_req, reply) => {
+    return reply.redirect('/app');
+  });
 
   // New frontend (issue #52). These routes are protected by the existing dashboard session cookie.
 

--- a/src/ui/components/settings/settings-page.tsx
+++ b/src/ui/components/settings/settings-page.tsx
@@ -5,21 +5,22 @@
  * Keyboard Shortcuts, and About. On mobile, the sidebar collapses into a
  * vertical list. Changes save immediately with visual confirmation.
  */
+
+import { Bell, CheckCircle, Clock, Eye, Info, Keyboard, Layout, Link2, Monitor, Moon, Smartphone, Sun, User } from 'lucide-react';
 import * as React from 'react';
-import { useState, useCallback, useRef, useEffect } from 'react';
-import { Sun, Moon, Monitor, Bell, Layout, Clock, Eye, User, Keyboard, Info, CheckCircle, Smartphone, Link2 } from 'lucide-react';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/ui/components/ui/card';
-import { Switch } from '@/ui/components/ui/switch';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Skeleton } from '@/ui/components/feedback';
 import { Badge } from '@/ui/components/ui/badge';
 import { Button } from '@/ui/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/ui/components/ui/card';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/ui/components/ui/select';
-import { Skeleton } from '@/ui/components/feedback';
 import { Separator } from '@/ui/components/ui/separator';
+import { Switch } from '@/ui/components/ui/switch';
 import { cn } from '@/ui/lib/utils';
-import { useSettings } from './use-settings';
-import { EmbeddingSettingsSection } from './embedding-settings-section';
 import { ConnectedAccountsSection } from './connected-accounts-section';
-import type { Theme, DefaultView, EmailDigestFrequency } from './types';
+import { EmbeddingSettingsSection } from './embedding-settings-section';
+import type { DefaultView, EmailDigestFrequency, Theme } from './types';
+import { useSettings } from './use-settings';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -545,7 +546,7 @@ export function SettingsPage() {
 
   const handleItemsPerPageChange = useCallback(
     (value: string) => {
-      handleUpdate({ items_per_page: parseInt(value, 10) });
+      handleUpdate({ items_per_page: Number.parseInt(value, 10) });
     },
     [handleUpdate],
   );
@@ -604,7 +605,7 @@ export function SettingsPage() {
           <h2 className="text-lg font-semibold text-destructive">Error</h2>
           <p className="mt-2 text-muted-foreground">{state.message}</p>
           {state.status === 401 && (
-            <a href="/app/auth" className="mt-4 inline-block text-primary hover:underline">
+            <a href="/app" className="mt-4 inline-block text-primary hover:underline">
               Sign in
             </a>
           )}

--- a/tests/app_frontend.test.ts
+++ b/tests/app_frontend.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
-import { Pool } from 'pg';
-import { runMigrate } from './helpers/migrate.ts';
-import { createTestPool, truncateAllTables } from './helpers/db.ts';
+import type { Pool } from 'pg';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { buildServer } from '../src/api/server.ts';
+import { createTestPool, truncateAllTables } from './helpers/db.ts';
+import { runMigrate } from './helpers/migrate.ts';
 
 /**
  * New frontend entrypoints.
@@ -47,6 +47,13 @@ describe('/app frontend', () => {
     const cookieHeader = Array.isArray(setCookie) ? setCookie[0] : setCookie;
     return cookieHeader.split(';')[0];
   }
+
+  // Issue #1166: GET / should redirect to /app
+  it('redirects GET / to /app', async () => {
+    const res = await app.inject({ method: 'GET', url: '/' });
+    expect(res.statusCode).toBe(302);
+    expect(res.headers.location).toBe('/app');
+  });
 
   it('requires auth (shows login UI) when not authenticated', async () => {
     const res = await app.inject({ method: 'GET', url: '/app/work-items' });

--- a/tests/ui/auth-guard.test.tsx
+++ b/tests/ui/auth-guard.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Tests for the SPA auth guard in AppLayout (issue #1166).
+ * Verifies that unauthenticated users see a sign-in prompt instead
+ * of the broken dashboard, and authenticated users see normal content.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import type * as React from 'react';
+import { createMemoryRouter, RouterProvider } from 'react-router';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { routes } from '@/ui/routes.js';
+
+// Pre-resolve lazy-loaded components
+beforeAll(async () => {
+  await Promise.all([
+    import('@/ui/layouts/app-layout.js'),
+    import('@/ui/pages/DashboardPage.js'),
+    import('@/ui/pages/ActivityPage.js'),
+    import('@/ui/pages/ProjectListPage.js'),
+    import('@/ui/pages/WorkItemDetailPage.js'),
+    import('@/ui/pages/ItemTimelinePage.js'),
+    import('@/ui/pages/DependencyGraphPage.js'),
+    import('@/ui/pages/KanbanPage.js'),
+    import('@/ui/pages/GlobalTimelinePage.js'),
+    import('@/ui/pages/ContactsPage.js'),
+    import('@/ui/pages/SettingsPage.js'),
+    import('@/ui/pages/SearchPage.js'),
+    import('@/ui/pages/NotFoundPage.js'),
+  ]);
+});
+
+// Mock command palette to avoid cmdk jsdom rendering issues
+vi.mock('@/ui/components/command-palette', () => ({
+  CommandPalette: () => null,
+}));
+
+// Mock api-client
+vi.mock('@/ui/lib/api-client', () => ({
+  apiClient: {
+    get: vi.fn().mockRejectedValue(new Error('Not implemented in test')),
+    post: vi.fn().mockRejectedValue(new Error('Not implemented in test')),
+    patch: vi.fn().mockRejectedValue(new Error('Not implemented in test')),
+    delete: vi.fn().mockRejectedValue(new Error('Not implemented in test')),
+  },
+}));
+
+// Controllable user state mock
+const mockUserState = {
+  email: null as string | null,
+  isLoading: false,
+  isAuthenticated: false,
+};
+
+vi.mock('@/ui/contexts/user-context', () => ({
+  useUser: () => mockUserState,
+  useUserEmail: () => mockUserState.email,
+  UserProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+const WAIT_OPTS = { timeout: 5_000 };
+
+function renderWithRouter(initialPath = '/') {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+  const router = createMemoryRouter(routes, {
+    initialEntries: [initialPath],
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  );
+}
+
+describe('Auth guard (issue #1166)', () => {
+  beforeEach(() => {
+    // Reset to unauthenticated state
+    mockUserState.email = null;
+    mockUserState.isLoading = false;
+    mockUserState.isAuthenticated = false;
+  });
+
+  it('shows loading spinner while auth state is being determined', async () => {
+    mockUserState.isLoading = true;
+    renderWithRouter('/dashboard');
+    await waitFor(() => {
+      expect(screen.getByTestId('auth-loading')).toBeInTheDocument();
+    }, WAIT_OPTS);
+  });
+
+  it('shows sign-in prompt when user is not authenticated', async () => {
+    renderWithRouter('/dashboard');
+    await waitFor(() => {
+      expect(screen.getByTestId('auth-required')).toBeInTheDocument();
+    }, WAIT_OPTS);
+    expect(screen.getByText(/you need to sign in/i)).toBeInTheDocument();
+    // The sign-in link should point to /app (server-rendered login page)
+    const signInLink = screen.getByRole('link', { name: /sign in/i });
+    expect(signInLink).toHaveAttribute('href', '/app');
+  });
+
+  it('renders page content when user is authenticated', async () => {
+    mockUserState.email = 'test@example.com';
+    mockUserState.isAuthenticated = true;
+    renderWithRouter('/dashboard');
+    await waitFor(() => {
+      expect(screen.getByTestId('page-dashboard')).toBeInTheDocument();
+    }, WAIT_OPTS);
+  });
+
+  it('blocks /settings route when unauthenticated', async () => {
+    renderWithRouter('/settings');
+    await waitFor(() => {
+      expect(screen.getByTestId('auth-required')).toBeInTheDocument();
+    }, WAIT_OPTS);
+    expect(screen.queryByTestId('page-settings')).not.toBeInTheDocument();
+  });
+
+  it('blocks /work-items route when unauthenticated', async () => {
+    renderWithRouter('/work-items');
+    await waitFor(() => {
+      expect(screen.getByTestId('auth-required')).toBeInTheDocument();
+    }, WAIT_OPTS);
+    expect(screen.queryByTestId('page-project-list')).not.toBeInTheDocument();
+  });
+});

--- a/tests/ui/routing.test.tsx
+++ b/tests/ui/routing.test.tsx
@@ -1,11 +1,12 @@
 /**
  * @vitest-environment jsdom
  */
-import * as React from 'react';
-import { describe, it, expect, vi, beforeAll } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { createMemoryRouter, RouterProvider } from 'react-router';
+
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type * as React from 'react';
+import { createMemoryRouter, RouterProvider } from 'react-router';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
 import { routes } from '@/ui/routes.js';
 
 // Pre-resolve all lazy-loaded components so React.lazy resolves synchronously
@@ -38,6 +39,14 @@ vi.mock('@/ui/lib/api-client', () => ({
     patch: vi.fn().mockRejectedValue(new Error('Not implemented in test')),
     delete: vi.fn().mockRejectedValue(new Error('Not implemented in test')),
   },
+}));
+
+// Mock user context to simulate an authenticated user (issue #1166).
+// Without this, the auth guard in AppLayout blocks all route rendering.
+vi.mock('@/ui/contexts/user-context', () => ({
+  useUser: () => ({ email: 'test@example.com', isLoading: false, isAuthenticated: true }),
+  useUserEmail: () => 'test@example.com',
+  UserProvider: ({ children }: { children: React.ReactNode }) => children,
 }));
 
 // Mock command palette to avoid cmdk jsdom rendering issues in route tests


### PR DESCRIPTION
## Summary

- Add `GET /` route that redirects to `/app`
- Add auth guard in `AppLayout` — shows login prompt when unauthenticated instead of broken dashboard
- Fix settings page auth link from `/app/auth` to correct path
- Add tests for root redirect and auth guard behavior

Closes #1166

## Test plan

- [ ] `GET /` redirects to `/app`
- [ ] Unauthenticated users see login prompt, not broken dashboard
- [ ] Settings page auth link works correctly
- [ ] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)