### PR TITLE
[#1174] Remove redundant Postmark pre-flight check from email_send

### DIFF
--- a/packages/openclaw-plugin/src/register-openclaw.ts
+++ b/packages/openclaw-plugin/src/register-openclaw.ts
@@ -1501,14 +1501,6 @@ function createToolHandlers(state: PluginState) {
         idempotencyKey?: string;
       };
 
-      // Check Postmark configuration
-      if (!config.postmarkToken || !config.postmarkFromEmail) {
-        return {
-          success: false,
-          error: 'Postmark is not configured. Please configure Postmark credentials.',
-        };
-      }
-
       // Validate email format
       const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
       if (!emailRegex.test(to)) {

--- a/packages/openclaw-plugin/src/tools/email-send.ts
+++ b/packages/openclaw-plugin/src/tools/email-send.ts
@@ -84,17 +84,10 @@ function sanitizeErrorMessage(error: unknown): string {
 }
 
 /**
- * Check if Postmark is configured.
- */
-function isPostmarkConfigured(config: PluginConfig): boolean {
-  return !!(config.postmarkToken && config.postmarkFromEmail);
-}
-
-/**
  * Creates the email_send tool.
  */
 export function createEmailSendTool(options: EmailSendToolOptions): EmailSendTool {
-  const { client, logger, config, userId } = options;
+  const { client, logger, userId } = options;
 
   return {
     name: 'email_send',
@@ -110,14 +103,6 @@ export function createEmailSendTool(options: EmailSendToolOptions): EmailSendToo
       }
 
       const { to, subject, body, htmlBody, threadId, idempotencyKey } = parseResult.data;
-
-      // Check Postmark configuration
-      if (!isPostmarkConfigured(config)) {
-        return {
-          success: false,
-          error: 'Postmark is not configured. Please configure Postmark credentials.',
-        };
-      }
 
       // Log invocation (without email address for privacy)
       logger.info('email_send invoked', {


### PR DESCRIPTION
## Summary

- Removes the pre-flight check for `postmarkToken` and `postmarkFromEmail` in the plugin's `email_send` handler
- The API server already has Postmark credentials via its own environment variables — the plugin doesn't need to duplicate them
- Updated tests to verify email_send works without Postmark config in the plugin

## Changes

- `packages/openclaw-plugin/src/register-openclaw.ts`: Removed inline pre-flight check (~line 1505)
- `packages/openclaw-plugin/src/tools/email-send.ts`: Removed `isPostmarkConfigured()` function and its usage
- `packages/openclaw-plugin/tests/tools/email-send.test.ts`: Updated existing test + added 2 new test cases

## Test plan

- [x] Existing email_send tests updated and passing
- [x] New tests verify email_send proceeds without Postmark plugin config
- [x] Tests cover both partial and fully missing Postmark config scenarios

Closes #1174

🤖 Generated with [Claude Code](https://claude.com/claude-code)