### PR TITLE
[#1192] Add backfill migration for user_email scoping

### DIFF
--- a/migrations/061_backfill_user_email.down.sql
+++ b/migrations/061_backfill_user_email.down.sql
@@ -1,0 +1,9 @@
+-- Rollback migration 061: Revert backfilled user_email to NULL
+-- Only touches rows that were set to the sentinel default by the up migration.
+
+UPDATE work_item SET user_email = NULL WHERE user_email = 'default@openclaw.local';
+UPDATE contact SET user_email = NULL WHERE user_email = 'default@openclaw.local';
+UPDATE contact_endpoint SET user_email = NULL WHERE user_email = 'default@openclaw.local';
+UPDATE relationship SET user_email = NULL WHERE user_email = 'default@openclaw.local';
+UPDATE external_thread SET user_email = NULL WHERE user_email = 'default@openclaw.local';
+UPDATE external_message SET user_email = NULL WHERE user_email = 'default@openclaw.local';

--- a/migrations/061_backfill_user_email.up.sql
+++ b/migrations/061_backfill_user_email.up.sql
@@ -1,0 +1,34 @@
+-- Migration 061: Backfill user_email for existing rows
+-- Issue #1192 (part of #1172): Assign a default scope to all pre-existing data
+-- that was created before user_email scoping was introduced in migration 060.
+--
+-- We use the sentinel value 'default@openclaw.local' so that:
+--   1. Existing single-agent deployments continue to work — all data belongs
+--      to one logical owner.
+--   2. The value is clearly distinguishable from real email addresses, making
+--      it easy for operators to reassign data to actual users later.
+--   3. The down migration can reliably reverse just the rows it touched.
+
+-- work_item
+UPDATE work_item SET user_email = 'default@openclaw.local' WHERE user_email IS NULL;
+
+-- contact
+UPDATE contact SET user_email = 'default@openclaw.local' WHERE user_email IS NULL;
+
+-- contact_endpoint
+UPDATE contact_endpoint SET user_email = 'default@openclaw.local' WHERE user_email IS NULL;
+
+-- relationship
+UPDATE relationship SET user_email = 'default@openclaw.local' WHERE user_email IS NULL;
+
+-- external_thread
+UPDATE external_thread SET user_email = 'default@openclaw.local' WHERE user_email IS NULL;
+
+-- external_message
+UPDATE external_message SET user_email = 'default@openclaw.local' WHERE user_email IS NULL;
+
+-- NOTE: Adding NOT NULL constraint is deferred intentionally.
+-- Once all API routes enforce user_email on insert/update (Phases 2-12),
+-- a future migration should add:
+--   ALTER TABLE <table> ALTER COLUMN user_email SET NOT NULL;
+-- for each table above.


### PR DESCRIPTION
## Summary

- Backfills existing rows with `user_email = 'default@openclaw.local'` sentinel value
- Covers all 6 tables from migration 060: work_item, contact, contact_endpoint, relationship, external_thread, external_message
- NOT NULL constraint intentionally deferred until all API routes enforce user_email on write

## Test plan

- [x] Up migration sets user_email for all NULL rows
- [x] Down migration reverts only sentinel values to NULL
- [ ] CI validation

Closes #1192

🤖 Generated with [Claude Code](https://claude.com/claude-code)