### PR TITLE
[#1179] Remove unsupported format validators from plugin schema

### DIFF
--- a/packages/openclaw-plugin/openclaw.plugin.json
+++ b/packages/openclaw-plugin/openclaw.plugin.json
@@ -74,7 +74,7 @@
       },
       "postmarkFromEmail": {
         "type": "string",
-        "format": "email",
+        "pattern": "^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$",
         "description": "Postmark From Email address (direct value)"
       },
       "postmarkFromEmailFile": {
@@ -143,7 +143,7 @@
       },
       "baseUrl": {
         "type": "string",
-        "format": "uri",
+        "pattern": "^https?://",
         "description": "Base URL for web app (used for generating note/notebook URLs)"
       }
     },

--- a/packages/openclaw-plugin/tests/__snapshots__/schema-snapshots.test.ts.snap
+++ b/packages/openclaw-plugin/tests/__snapshots__/schema-snapshots.test.ts.snap
@@ -74,7 +74,7 @@ exports[`Schema Snapshots > Manifest configSchema > configSchema should match sn
     },
     "baseUrl": {
       "description": "Base URL for web app (used for generating note/notebook URLs)",
-      "format": "uri",
+      "pattern": "^https?://",
       "type": "string",
     },
     "debug": {
@@ -105,7 +105,7 @@ exports[`Schema Snapshots > Manifest configSchema > configSchema should match sn
     },
     "postmarkFromEmail": {
       "description": "Postmark From Email address (direct value)",
-      "format": "email",
+      "pattern": "^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$",
       "type": "string",
     },
     "postmarkFromEmailCommand": {

--- a/packages/openclaw-plugin/tests/package-structure.test.ts
+++ b/packages/openclaw-plugin/tests/package-structure.test.ts
@@ -105,6 +105,16 @@ describe('Package Structure', () => {
       expect(manifest.configSchema.properties).toHaveProperty('apiKeyFile');
       expect(manifest.configSchema.properties).toHaveProperty('apiKeyCommand');
     });
+
+    it('should not use "format" validators (OpenClaw Ajv does not load ajv-formats)', () => {
+      const manifestPath = join(packageRoot, 'openclaw.plugin.json');
+      const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8'));
+      const properties = manifest.configSchema.properties;
+      const propsWithFormat = Object.entries(properties)
+        .filter(([, schema]) => typeof schema === 'object' && schema !== null && 'format' in (schema as Record<string, unknown>))
+        .map(([name]) => name);
+      expect(propsWithFormat).toEqual([]);
+    });
   });
 
   describe('package.json', () => {


### PR DESCRIPTION
## Summary

Closes #1179

The plugin's `openclaw.plugin.json` uses `format: "email"` and `format: "uri"` validators, but OpenClaw's Ajv instance doesn't load `ajv-formats`. This produces warnings on every startup and config validation.

### Changes

- **`postmarkFromEmail`**: Replaced `"format": "email"` with `"pattern": "^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$"` (basic email regex)
- **`baseUrl`**: Replaced `"format": "uri"` with `"pattern": "^https?://"` (URL prefix check)
- **Added test** in `package-structure.test.ts` to prevent `format` validators from being reintroduced
- **Updated snapshot** in `schema-snapshots.test.ts.snap` to match the new schema

### Why `pattern` instead of just removing?

Using `pattern` preserves basic validation (email has `@` and domain, URL starts with `http(s)://`) while being compatible with any standard Ajv instance without extra plugins.