### PR TITLE
[#1195] Add agentId to webhook payloads

### DIFF
--- a/src/api/jobs/processor.ts
+++ b/src/api/jobs/processor.ts
@@ -78,7 +78,8 @@ async function handleReminderJob(pool: Pool, job: InternalJob): Promise<JobProce
        title,
        description,
        work_item_kind::text as kind,
-       status
+       status,
+       user_email
      FROM work_item
      WHERE id = $1`,
     [workItemId],
@@ -97,6 +98,7 @@ async function handleReminderJob(pool: Pool, job: InternalJob): Promise<JobProce
     description: string | null;
     kind: string;
     status: string;
+    user_email: string | null;
   };
 
   // Skip if already completed
@@ -111,6 +113,7 @@ async function handleReminderJob(pool: Pool, job: InternalJob): Promise<JobProce
     workItemDescription: workItem.description || undefined,
     workItemKind: workItem.kind,
     notBefore,
+    agentId: workItem.user_email || undefined,
   });
 
   const destination = getWebhookDestination('reminder_due');
@@ -138,7 +141,8 @@ async function handleNudgeJob(pool: Pool, job: InternalJob): Promise<JobProcesso
        id::text as id,
        title,
        work_item_kind::text as kind,
-       status
+       status,
+       user_email
      FROM work_item
      WHERE id = $1`,
     [workItemId],
@@ -156,6 +160,7 @@ async function handleNudgeJob(pool: Pool, job: InternalJob): Promise<JobProcesso
     title: string;
     kind: string;
     status: string;
+    user_email: string | null;
   };
 
   // Skip if already completed
@@ -173,6 +178,7 @@ async function handleNudgeJob(pool: Pool, job: InternalJob): Promise<JobProcesso
     workItemKind: workItem.kind,
     notAfter,
     hoursRemaining,
+    agentId: workItem.user_email || undefined,
   });
 
   const destination = getWebhookDestination('deadline_approaching');

--- a/src/api/webhooks/payloads.test.ts
+++ b/src/api/webhooks/payloads.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Tests for webhook payload builders — agentId support.
+ * Issue #1195: Webhook payloads must include agentId for multi-agent routing.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  buildSmsReceivedPayload,
+  buildEmailReceivedPayload,
+  buildReminderDuePayload,
+  buildDeadlineApproachingPayload,
+  buildSpawnAgentPayload,
+} from './payloads.ts';
+
+describe('webhook payloads — agentId', () => {
+  beforeEach(() => {
+    vi.stubEnv('OPENCLAW_GATEWAY_URL', 'https://gateway.test');
+    vi.stubEnv('OPENCLAW_HOOK_TOKEN', 'test-token');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    // Clear the cached config between tests
+    vi.resetModules();
+  });
+
+  describe('buildSmsReceivedPayload', () => {
+    const baseParams = {
+      contactId: 'contact-1',
+      contactName: 'Alice',
+      endpointType: 'phone',
+      endpointValue: '+61400000000',
+      threadId: 'thread-1',
+      messageId: 'msg-1',
+      messageBody: 'Hello',
+    };
+
+    it('includes agentId at top level when provided', () => {
+      const payload = buildSmsReceivedPayload({ ...baseParams, agentId: 'agent@example.com' });
+      expect(payload.agentId).toBe('agent@example.com');
+    });
+
+    it('includes agent_id in context when agentId is provided', () => {
+      const payload = buildSmsReceivedPayload({ ...baseParams, agentId: 'agent@example.com' });
+      expect(payload.context.agent_id).toBe('agent@example.com');
+    });
+
+    it('omits agentId from top level when not provided', () => {
+      const payload = buildSmsReceivedPayload(baseParams);
+      expect(payload.agentId).toBeUndefined();
+    });
+
+    it('omits agent_id from context when not provided', () => {
+      const payload = buildSmsReceivedPayload(baseParams);
+      expect(payload.context.agent_id).toBeUndefined();
+    });
+  });
+
+  describe('buildEmailReceivedPayload', () => {
+    const baseParams = {
+      contactId: 'contact-2',
+      contactName: 'Bob',
+      fromEmail: 'bob@example.com',
+      threadId: 'thread-2',
+      messageId: 'msg-2',
+      messageBody: 'Hi there',
+    };
+
+    it('includes agentId at top level when provided', () => {
+      const payload = buildEmailReceivedPayload({ ...baseParams, agentId: 'agent@example.com' });
+      expect(payload.agentId).toBe('agent@example.com');
+    });
+
+    it('includes agent_id in context when agentId is provided', () => {
+      const payload = buildEmailReceivedPayload({ ...baseParams, agentId: 'agent@example.com' });
+      expect(payload.context.agent_id).toBe('agent@example.com');
+    });
+
+    it('omits agentId when not provided', () => {
+      const payload = buildEmailReceivedPayload(baseParams);
+      expect(payload.agentId).toBeUndefined();
+    });
+  });
+
+  describe('buildReminderDuePayload', () => {
+    const baseParams = {
+      workItemId: 'wi-1',
+      workItemTitle: 'Buy groceries',
+      workItemKind: 'task',
+      notBefore: new Date('2026-02-14T10:00:00Z'),
+    };
+
+    it('includes agentId at top level when provided', () => {
+      const payload = buildReminderDuePayload({ ...baseParams, agentId: 'agent@example.com' });
+      expect(payload.agentId).toBe('agent@example.com');
+    });
+
+    it('includes agent_id in context when agentId is provided', () => {
+      const payload = buildReminderDuePayload({ ...baseParams, agentId: 'agent@example.com' });
+      expect(payload.context.agent_id).toBe('agent@example.com');
+    });
+
+    it('omits agentId when not provided', () => {
+      const payload = buildReminderDuePayload(baseParams);
+      expect(payload.agentId).toBeUndefined();
+    });
+  });
+
+  describe('buildDeadlineApproachingPayload', () => {
+    const baseParams = {
+      workItemId: 'wi-2',
+      workItemTitle: 'Submit report',
+      workItemKind: 'task',
+      notAfter: new Date('2026-02-15T10:00:00Z'),
+      hoursRemaining: 24,
+    };
+
+    it('includes agentId at top level when provided', () => {
+      const payload = buildDeadlineApproachingPayload({ ...baseParams, agentId: 'agent@example.com' });
+      expect(payload.agentId).toBe('agent@example.com');
+    });
+
+    it('omits agentId when not provided', () => {
+      const payload = buildDeadlineApproachingPayload(baseParams);
+      expect(payload.agentId).toBeUndefined();
+    });
+  });
+
+  describe('buildSpawnAgentPayload', () => {
+    const baseParams = {
+      agentType: 'coder',
+      repository: 'test/repo',
+      workItemId: 'wi-3',
+      workItemTitle: 'Implement feature',
+    };
+
+    it('includes agentId at top level when provided', () => {
+      const payload = buildSpawnAgentPayload({ ...baseParams, agentId: 'agent@example.com' });
+      expect(payload.agentId).toBe('agent@example.com');
+    });
+
+    it('includes agent_id in context when agentId is provided', () => {
+      const payload = buildSpawnAgentPayload({ ...baseParams, agentId: 'agent@example.com' });
+      expect(payload.context.agent_id).toBe('agent@example.com');
+    });
+
+    it('omits agentId when not provided', () => {
+      const payload = buildSpawnAgentPayload(baseParams);
+      expect(payload.agentId).toBeUndefined();
+    });
+  });
+});

--- a/src/api/webhooks/payloads.ts
+++ b/src/api/webhooks/payloads.ts
@@ -19,6 +19,8 @@ export function buildSmsReceivedPayload(params: {
   threadId: string;
   messageId: string;
   messageBody: string;
+  /** Agent identifier for multi-agent routing. Maps to user_email scope. */
+  agentId?: string;
 }): AgentHookPayload {
   const config = getOpenClawConfig();
 
@@ -31,6 +33,7 @@ export function buildSmsReceivedPayload(params: {
     channel: 'last',
     model: config?.defaultModel || 'anthropic/claude-sonnet-4-20250514',
     timeoutSeconds: config?.timeoutSeconds || 300,
+    ...(params.agentId ? { agentId: params.agentId } : {}),
     context: {
       event_type: 'sms_received',
       contact_id: params.contactId,
@@ -42,6 +45,7 @@ export function buildSmsReceivedPayload(params: {
       thread_id: params.threadId,
       message_id: params.messageId,
       message_body: params.messageBody,
+      ...(params.agentId ? { agent_id: params.agentId } : {}),
     },
   };
 }
@@ -58,6 +62,8 @@ export function buildEmailReceivedPayload(params: {
   threadId: string;
   messageId: string;
   messageBody: string;
+  /** Agent identifier for multi-agent routing. Maps to user_email scope. */
+  agentId?: string;
 }): AgentHookPayload {
   const config = getOpenClawConfig();
 
@@ -70,6 +76,7 @@ export function buildEmailReceivedPayload(params: {
     channel: 'last',
     model: config?.defaultModel || 'anthropic/claude-sonnet-4-20250514',
     timeoutSeconds: config?.timeoutSeconds || 300,
+    ...(params.agentId ? { agentId: params.agentId } : {}),
     context: {
       event_type: 'email_received',
       contact_id: params.contactId,
@@ -80,6 +87,7 @@ export function buildEmailReceivedPayload(params: {
       thread_id: params.threadId,
       message_id: params.messageId,
       message_body: params.messageBody,
+      ...(params.agentId ? { agent_id: params.agentId } : {}),
     },
   };
 }
@@ -95,6 +103,8 @@ export function buildReminderDuePayload(params: {
   notBefore: Date;
   contactId?: string;
   contactName?: string;
+  /** Agent identifier for multi-agent routing. Maps to user_email scope. */
+  agentId?: string;
 }): AgentHookPayload {
   const config = getOpenClawConfig();
 
@@ -107,6 +117,7 @@ export function buildReminderDuePayload(params: {
     channel: 'last',
     model: config?.defaultModel || 'anthropic/claude-sonnet-4-20250514',
     timeoutSeconds: config?.timeoutSeconds || 120,
+    ...(params.agentId ? { agentId: params.agentId } : {}),
     context: {
       event_type: 'reminder_due',
       work_item_id: params.workItemId,
@@ -116,6 +127,7 @@ export function buildReminderDuePayload(params: {
       not_before: params.notBefore.toISOString(),
       contact_id: params.contactId,
       contact_name: params.contactName,
+      ...(params.agentId ? { agent_id: params.agentId } : {}),
     },
   };
 }
@@ -130,10 +142,13 @@ export function buildDeadlineApproachingPayload(params: {
   workItemKind: string;
   notAfter: Date;
   hoursRemaining: number;
+  /** Agent identifier for multi-agent routing. Maps to user_email scope. */
+  agentId?: string;
 }): WakeHookPayload {
   return {
     text: `Deadline approaching: "${params.workItemTitle}" (${params.workItemKind}) is due in ${params.hoursRemaining} hours (${params.notAfter.toISOString()})`,
     mode: 'now',
+    ...(params.agentId ? { agentId: params.agentId } : {}),
   };
 }
 
@@ -147,6 +162,8 @@ export function buildSpawnAgentPayload(params: {
   workItemId?: string;
   workItemTitle?: string;
   instructions?: string;
+  /** Agent identifier for multi-agent routing. Maps to user_email scope. */
+  agentId?: string;
 }): AgentHookPayload {
   const config = getOpenClawConfig();
 
@@ -159,6 +176,7 @@ export function buildSpawnAgentPayload(params: {
     channel: 'new',
     model: config?.defaultModel || 'anthropic/claude-sonnet-4-20250514',
     timeoutSeconds: config?.timeoutSeconds || 600,
+    ...(params.agentId ? { agentId: params.agentId } : {}),
     context: {
       event_type: 'spawn_agent',
       agent_type: params.agentType,
@@ -167,6 +185,7 @@ export function buildSpawnAgentPayload(params: {
       work_item_id: params.workItemId,
       work_item_title: params.workItemTitle,
       instructions: params.instructions,
+      ...(params.agentId ? { agent_id: params.agentId } : {}),
     },
   };
 }

--- a/src/api/webhooks/types.ts
+++ b/src/api/webhooks/types.ts
@@ -38,6 +38,8 @@ export interface AgentHookPayload {
   channel?: 'last' | 'new';
   model?: string;
   timeoutSeconds?: number;
+  /** Agent identifier for multi-agent routing in OpenClaw gateway. Maps to user_email scope. */
+  agentId?: string;
   context: Record<string, unknown>;
   [key: string]: unknown;
 }
@@ -45,6 +47,8 @@ export interface AgentHookPayload {
 export interface WakeHookPayload {
   text: string;
   mode?: 'now' | 'schedule';
+  /** Agent identifier for multi-agent routing in OpenClaw gateway. Maps to user_email scope. */
+  agentId?: string;
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
## Summary

Closes #1195

Webhook payloads dispatched to the OpenClaw gateway now include an `agentId` field, enabling multi-agent routing for reminders, nudges, and other events.

### Changes

- **`src/api/webhooks/types.ts`**: Added `agentId?: string` to `AgentHookPayload` and `WakeHookPayload` interfaces
- **`src/api/webhooks/payloads.ts`**: All 5 payload builders (`buildSmsReceivedPayload`, `buildEmailReceivedPayload`, `buildReminderDuePayload`, `buildDeadlineApproachingPayload`, `buildSpawnAgentPayload`) now accept an optional `agentId` parameter and include it:
  - At the top level of the payload (for gateway routing)
  - In the `context` object as `agent_id` (for `AgentHookPayload` builders)
- **`src/api/jobs/processor.ts`**: Updated `handleReminderJob` and `handleNudgeJob` to fetch `user_email` from work items and pass it as `agentId` to payload builders
- **`src/api/webhooks/payloads.test.ts`**: 15 new tests covering agentId presence/absence across all 5 builders

### How it works

The `agentId` maps to the `user_email` scope on work items. When a webhook fires (e.g., reminder due), the processor now includes the work item's `user_email` as `agentId` so the OpenClaw gateway can route the notification to the correct agent.

## Test plan

- [x] All 15 new payload tests pass
- [x] Existing tests unaffected
- [x] No lint errors in changed files
- [x] No type errors in changed files