### PR TITLE
[#1177] Fix email_send to use Postmark endpoint

### DIFF
--- a/packages/openclaw-plugin/src/register-openclaw.ts
+++ b/packages/openclaw-plugin/src/register-openclaw.ts
@@ -1552,7 +1552,7 @@ function createToolHandlers(state: PluginState) {
           messageId: string;
           threadId?: string;
           status: string;
-        }>('/api/email/messages/send', { to, subject, body, htmlBody, threadId, idempotencyKey }, { userId });
+        }>('/api/postmark/email/send', { to, subject, body, htmlBody, threadId, idempotencyKey }, { userId });
 
         if (!response.success) {
           logger.error('email_send API error', {


### PR DESCRIPTION
## Summary

Fixes the `email_send` inline handler in `register-openclaw.ts` to call the correct Postmark endpoint.

- **Bug**: `email_send` called `/api/email/messages/send` (OAuth email endpoint), which requires a `connectionId` and fails with `{"error":"connectionId is required"}`
- **Fix**: Changed endpoint to `/api/postmark/email/send` (the correct Postmark-backed endpoint)
- **Test**: Added regression test verifying the inline handler calls the correct endpoint

The refactored tool module (`src/tools/email-send.ts`) already used the correct endpoint, but the inline handler in `register-openclaw.ts` (which is what actually runs) still had the old URL.

Closes #1177