### PR TITLE
[#1199] Exclude test files from typecheck build

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,5 +1,5 @@
 {
   "extends": "./tsconfig.json",
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "tests/**/*", "src/ui/**/*"]
+  "exclude": ["node_modules", "dist", "tests/**/*", "src/ui/**/*", "src/**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary

- Add `src/**/*.test.ts` to the `exclude` array in `tsconfig.build.json`
- This prevents test files under `src/` from being included in the production typecheck build
- Fixes `TS6059` error where `src/api/memory/deduplication.test.ts` imports from `tests/helpers/db.ts` (outside `rootDir`)

## Test plan

- [x] Verified `pnpm exec tsc -p tsconfig.build.json --noEmit` fails before the fix
- [x] Verified `pnpm exec tsc -p tsconfig.build.json --noEmit` passes after the fix
- [x] Ran `pnpm run lint` - no new issues introduced
- [x] Ran `pnpm test` - no new failures introduced

Closes #1199