### PR TITLE
[#1218] Geo-contextual ranking for work item search

### DIFF
--- a/packages/openclaw-plugin/src/tools/project-search.ts
+++ b/packages/openclaw-plugin/src/tools/project-search.ts
@@ -121,9 +121,16 @@ export function createProjectSearchTool(options: ProjectSearchToolOptions): Proj
         // Augment query with location context for geo-contextual ranking (Issue #1218)
         let searchQuery = sanitizedQuery;
         if (location && config.nominatimUrl) {
-          const geo = await reverseGeocode(location.lat, location.lng, config.nominatimUrl);
-          if (geo?.placeLabel) {
-            searchQuery = `${sanitizedQuery} near ${geo.placeLabel}`;
+          try {
+            const geo = await reverseGeocode(location.lat, location.lng, config.nominatimUrl);
+            if (geo?.placeLabel) {
+              const augmented = `${sanitizedQuery} near ${geo.placeLabel}`;
+              if (augmented.length <= 1000) {
+                searchQuery = augmented;
+              }
+            }
+          } catch {
+            logger.warn('Reverse geocode failed, proceeding without location augmentation', { userId });
           }
         }
 

--- a/packages/openclaw-plugin/src/tools/todo-search.ts
+++ b/packages/openclaw-plugin/src/tools/todo-search.ts
@@ -123,9 +123,16 @@ export function createTodoSearchTool(options: TodoSearchToolOptions): TodoSearch
         // Augment query with location context for geo-contextual ranking (Issue #1218)
         let searchQuery = sanitizedQuery;
         if (location && config.nominatimUrl) {
-          const geo = await reverseGeocode(location.lat, location.lng, config.nominatimUrl);
-          if (geo?.placeLabel) {
-            searchQuery = `${sanitizedQuery} near ${geo.placeLabel}`;
+          try {
+            const geo = await reverseGeocode(location.lat, location.lng, config.nominatimUrl);
+            if (geo?.placeLabel) {
+              const augmented = `${sanitizedQuery} near ${geo.placeLabel}`;
+              if (augmented.length <= 1000) {
+                searchQuery = augmented;
+              }
+            }
+          } catch {
+            logger.warn('Reverse geocode failed, proceeding without location augmentation', { userId });
           }
         }
 

--- a/packages/openclaw-plugin/tests/tools/todo-search.test.ts
+++ b/packages/openclaw-plugin/tests/tools/todo-search.test.ts
@@ -690,6 +690,56 @@ describe('todo_search tool', () => {
       expect(result.success).toBe(false);
     });
 
+    it('should degrade gracefully when reverseGeocode throws', async () => {
+      const { reverseGeocode } = await import('../../src/utils/nominatim.js');
+      vi.mocked(reverseGeocode).mockRejectedValue(new Error('DNS resolution failed'));
+
+      const mockGet = vi.fn().mockResolvedValue({
+        success: true,
+        data: { results: [], search_type: 'text', total: 0 },
+      });
+      const client = { ...mockApiClient, get: mockGet };
+
+      const tool = createTodoSearchTool({
+        client: client as unknown as ApiClient,
+        logger: mockLogger,
+        config: geoConfig,
+        userId: 'agent-1',
+      });
+
+      const result = await tool.execute({ query: 'restaurants', location: { lat: -37.8136, lng: 144.9631 } });
+      expect(result.success).toBe(true);
+      const callUrl = mockGet.mock.calls[0][0] as string;
+      expect(callUrl).toContain('q=restaurants');
+      expect(callUrl).not.toContain('near');
+      expect(mockLogger.warn).toHaveBeenCalled();
+    });
+
+    it('should not augment query when augmented length exceeds 1000 chars', async () => {
+      const { reverseGeocode } = await import('../../src/utils/nominatim.js');
+      const longLabel = 'A'.repeat(1000);
+      vi.mocked(reverseGeocode).mockResolvedValue({ address: longLabel, placeLabel: longLabel });
+
+      const mockGet = vi.fn().mockResolvedValue({
+        success: true,
+        data: { results: [], search_type: 'text', total: 0 },
+      });
+      const client = { ...mockApiClient, get: mockGet };
+
+      const tool = createTodoSearchTool({
+        client: client as unknown as ApiClient,
+        logger: mockLogger,
+        config: geoConfig,
+        userId: 'agent-1',
+      });
+
+      await tool.execute({ query: 'restaurants', location: { lat: -37.8136, lng: 144.9631 } });
+
+      const callUrl = mockGet.mock.calls[0][0] as string;
+      expect(callUrl).toContain('q=restaurants');
+      expect(callUrl).not.toContain('near');
+    });
+
     it('should log hasLocation when location is provided', async () => {
       const { reverseGeocode } = await import('../../src/utils/nominatim.js');
       vi.mocked(reverseGeocode).mockResolvedValue(null);


### PR DESCRIPTION
## Summary
- Adds optional `location` parameter (lat/lng) to `todo_search` and `project_search` plugin tools
- When location is provided and `nominatimUrl` is configured, reverse geocodes coordinates to a place label and augments the search query (e.g. "restaurants near Melbourne")
- Gracefully degrades: no-op when nominatimUrl not configured, geocode fails, or place label is empty

Closes #1218

## Test plan
- [x] 7 new tests per tool (14 total) covering:
  - Query augmentation with location
  - No augmentation without nominatimUrl
  - Fallback when geocode returns null
  - Fallback when placeLabel is empty
  - Over-fetch with location param
  - Lat/lng range validation
  - hasLocation logging
- [x] All 60 todo/project search tests pass
- [x] Full plugin test suite passes (1463 tests, gateway dist-dep tests excluded)
- [x] Plugin builds cleanly with tsc
- [x] Lint passes (warnings only, no errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)