### PR TITLE
[#1260] Add Nominatim service to Docker Compose files

### DIFF
--- a/.devcontainer/docker-compose.devcontainer.yml
+++ b/.devcontainer/docker-compose.devcontainer.yml
@@ -16,6 +16,8 @@ services:
       S3_FORCE_PATH_STYLE: "true"
       # Claude Code agent teams (experimental) — enables parallel coordination
       CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: "1"
+      # Nominatim (reverse geocoding for geo-contextual search)
+      NOMINATIM_URL: http://nominatim:8080
     volumes:
       - ..:/workspaces/openclaw-projects:cached
       # ┌─────────────────────────────────────────────────────────────────┐

--- a/.env.example
+++ b/.env.example
@@ -225,6 +225,34 @@ SEAWEEDFS_VOLUME_SIZE_LIMIT_MB=1000
 # OAUTH_TOKEN_ENCRYPTION_KEY=
 
 # =============================================================================
+# Nominatim (Reverse Geocoding)
+# =============================================================================
+
+# Self-hosted OpenStreetMap geocoder for geo-contextual search features.
+# On first start, imports the PBF extract (this takes 10+ minutes depending
+# on region size). After import, the service provides fast local geocoding.
+# If NOMINATIM_URL is not set, geo features silently degrade (no error).
+
+# Internal URL for the API to reach Nominatim (auto-configured in compose)
+# NOMINATIM_URL=http://nominatim:8080
+
+# OpenStreetMap PBF extract to import (determines which region is available)
+# Find regional extracts at: https://download.geofabrik.de/
+# Default: Australia (change to your deployment region)
+# NOMINATIM_PBF_URL=https://download.geofabrik.de/australia-oceania/australia-latest.osm.pbf
+
+# Replication URL for incremental updates from OpenStreetMap
+# Must correspond to the PBF extract region
+# NOMINATIM_REPLICATION_URL=https://download.geofabrik.de/australia-oceania/australia-updates/
+
+# Password for the Nominatim internal PostgreSQL database
+# NOMINATIM_PASSWORD=openclaw
+
+# Nominatim host port (default: 8180 to avoid conflicts with other services)
+# For basic compose: NOMINATIM_PORT=8180
+# For traefik/full compose: NOMINATIM_HOST_PORT=8180
+
+# =============================================================================
 # OpenClaw Integration
 # =============================================================================
 

--- a/docker-compose.full.yml
+++ b/docker-compose.full.yml
@@ -403,6 +403,8 @@ services:
       WEBHOOK_IP_WHITELIST_DISABLED: ${WEBHOOK_IP_WHITELIST_DISABLED:-false}
       OPENCLAW_GATEWAY_URL: http://openclaw-gateway:18789
       OPENCLAW_HOOK_TOKEN: ${OPENCLAW_GATEWAY_TOKEN:-}
+      # Nominatim (reverse geocoding for geo-contextual search)
+      NOMINATIM_URL: ${NOMINATIM_URL:-http://nominatim:8080}
       MAX_FILE_SIZE_BYTES: ${MAX_FILE_SIZE_BYTES:-10485760}
     # Publish to localhost for Traefik (host networking mode)
     ports:
@@ -537,6 +539,48 @@ services:
     # (dynamic-config.yml.template) which routes DOMAIN/www.DOMAIN -> app
 
   # =============================================================================
+  # Nominatim (Reverse Geocoding)
+  # =============================================================================
+  # Self-hosted OpenStreetMap geocoder for geo-contextual search features.
+  # On first start, imports the PBF extract (this takes 10+ minutes depending
+  # on region size). After import, the service provides fast local geocoding.
+  # If Nominatim is unavailable, geo features silently degrade.
+  nominatim:
+    image: mediagis/nominatim:4.4
+    container_name: openclaw-nominatim
+    restart: unless-stopped
+    environment:
+      # OpenStreetMap PBF extract to import
+      # Find regional extracts at: https://download.geofabrik.de/
+      PBF_URL: ${NOMINATIM_PBF_URL:-https://download.geofabrik.de/australia-oceania/australia-latest.osm.pbf}
+      REPLICATION_URL: ${NOMINATIM_REPLICATION_URL:-https://download.geofabrik.de/australia-oceania/australia-updates/}
+      NOMINATIM_PASSWORD: ${NOMINATIM_PASSWORD:-openclaw}
+    volumes:
+      - nominatim_data:/var/lib/postgresql/14/main
+    # Publish to localhost for potential external access
+    ports:
+      - "[::1]:${NOMINATIM_HOST_PORT:-8180}:8080"       # IPv6 (preferred)
+      - "127.0.0.1:${NOMINATIM_HOST_PORT:-8180}:8080"  # IPv4 fallback
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/status"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 600s
+    # Container hardening
+    # Note: Nominatim runs PostgreSQL internally and requires more capabilities
+    security_opt:
+      - no-new-privileges:true
+    deploy:
+      resources:
+        limits:
+          cpus: "2"
+          memory: 4G
+        reservations:
+          cpus: "0.5"
+          memory: 1G
+
+  # =============================================================================
   # OpenClaw Gateway (AI Agent Gateway)
   # =============================================================================
   # The OpenClaw gateway manages AI agent sessions, routes messages from
@@ -622,6 +666,7 @@ services:
 volumes:
   db_data:
   seaweedfs_data:
+  nominatim_data:
   traefik_dynamic:
   # ModSecurity named volumes — auto-populated from the CRS image on first run.
   # Required because the CRS entrypoint modifies files that ship inside the image

--- a/docker-compose.quickstart.yml
+++ b/docker-compose.quickstart.yml
@@ -157,6 +157,8 @@ services:
       GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET:-}
       OAUTH_REDIRECT_URI: ${OAUTH_REDIRECT_URI:-}
       OAUTH_TOKEN_ENCRYPTION_KEY: ${OAUTH_TOKEN_ENCRYPTION_KEY:-}
+      # Optional — Nominatim (reverse geocoding for geo-contextual search)
+      NOMINATIM_URL: ${NOMINATIM_URL:-http://nominatim:8080}
     ports:
       - "[::1]:${API_PORT:-3000}:3000"       # IPv6 (preferred)
       - "127.0.0.1:${API_PORT:-3000}:3000"  # IPv4 fallback
@@ -166,6 +168,36 @@ services:
       timeout: 5s
       retries: 10
       start_period: 15s
+
+  # ---------------------------------------------------------------------------
+  # Nominatim (Reverse Geocoding)
+  # ---------------------------------------------------------------------------
+  # Self-hosted OpenStreetMap geocoder for geo-contextual search features.
+  # On first start, imports the PBF extract (this takes 10+ minutes depending
+  # on region size). After import, the service provides fast local geocoding.
+  # If Nominatim is unavailable, geo features silently degrade.
+  nominatim:
+    image: mediagis/nominatim:4.4
+    container_name: openclaw-qs-nominatim
+    restart: unless-stopped
+    environment:
+      # OpenStreetMap PBF extract to import
+      # Find regional extracts at: https://download.geofabrik.de/
+      PBF_URL: ${NOMINATIM_PBF_URL:-https://download.geofabrik.de/australia-oceania/australia-latest.osm.pbf}
+      REPLICATION_URL: ${NOMINATIM_REPLICATION_URL:-https://download.geofabrik.de/australia-oceania/australia-updates/}
+      NOMINATIM_PASSWORD: ${NOMINATIM_PASSWORD:-openclaw}
+    volumes:
+      - nominatim_data:/var/lib/postgresql/14/main
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/status"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 600s
+    # Container hardening
+    # Note: Nominatim runs PostgreSQL internally and requires more capabilities
+    security_opt:
+      - no-new-privileges:true
 
   # ---------------------------------------------------------------------------
   # Background Worker (job processing, notifications, embeddings)
@@ -201,3 +233,4 @@ services:
 volumes:
   db_data:
   seaweedfs_data:
+  nominatim_data:

--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -447,6 +447,8 @@ services:
       # OpenClaw integration
       OPENCLAW_GATEWAY_URL: ${OPENCLAW_GATEWAY_URL:-}
       OPENCLAW_HOOK_TOKEN: ${OPENCLAW_HOOK_TOKEN:-}
+      # Nominatim (reverse geocoding for geo-contextual search)
+      NOMINATIM_URL: ${NOMINATIM_URL:-http://nominatim:8080}
       # File upload
       MAX_FILE_SIZE_BYTES: ${MAX_FILE_SIZE_BYTES:-10485760}
     # Publish to localhost for Traefik (host networking mode)
@@ -540,6 +542,48 @@ services:
           memory: 128M
 
   # =============================================================================
+  # Nominatim (Reverse Geocoding)
+  # =============================================================================
+  # Self-hosted OpenStreetMap geocoder for geo-contextual search features.
+  # On first start, imports the PBF extract (this takes 10+ minutes depending
+  # on region size). After import, the service provides fast local geocoding.
+  # If Nominatim is unavailable, geo features silently degrade.
+  nominatim:
+    image: mediagis/nominatim:4.4
+    container_name: openclaw-nominatim
+    restart: unless-stopped
+    environment:
+      # OpenStreetMap PBF extract to import
+      # Find regional extracts at: https://download.geofabrik.de/
+      PBF_URL: ${NOMINATIM_PBF_URL:-https://download.geofabrik.de/australia-oceania/australia-latest.osm.pbf}
+      REPLICATION_URL: ${NOMINATIM_REPLICATION_URL:-https://download.geofabrik.de/australia-oceania/australia-updates/}
+      NOMINATIM_PASSWORD: ${NOMINATIM_PASSWORD:-openclaw}
+    volumes:
+      - nominatim_data:/var/lib/postgresql/14/main
+    # Publish to localhost for potential external access
+    ports:
+      - "[::1]:${NOMINATIM_HOST_PORT:-8180}:8080"       # IPv6 (preferred)
+      - "127.0.0.1:${NOMINATIM_HOST_PORT:-8180}:8080"  # IPv4 fallback
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/status"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 600s
+    # Container hardening
+    # Note: Nominatim runs PostgreSQL internally and requires more capabilities
+    security_opt:
+      - no-new-privileges:true
+    deploy:
+      resources:
+        limits:
+          cpus: "2"
+          memory: 4G
+        reservations:
+          cpus: "0.5"
+          memory: 1G
+
+  # =============================================================================
   # Frontend App (React SPA served via static server)
   # =============================================================================
   app:
@@ -592,6 +636,7 @@ services:
 volumes:
   db_data:
   seaweedfs_data:
+  nominatim_data:
   traefik_dynamic:
   # ModSecurity named volumes — auto-populated from the CRS image on first run.
   # Required because the CRS entrypoint modifies files that ship inside the image

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -208,6 +208,8 @@ services:
       # OpenClaw integration
       OPENCLAW_GATEWAY_URL: ${OPENCLAW_GATEWAY_URL:-}
       OPENCLAW_HOOK_TOKEN: ${OPENCLAW_HOOK_TOKEN:-}
+      # Nominatim (reverse geocoding for geo-contextual search)
+      NOMINATIM_URL: ${NOMINATIM_URL:-http://nominatim:8080}
       # File upload
       MAX_FILE_SIZE_BYTES: ${MAX_FILE_SIZE_BYTES:-10485760}
     ports:
@@ -296,6 +298,47 @@ services:
           memory: 128M
 
   # =============================================================================
+  # Nominatim (Reverse Geocoding)
+  # =============================================================================
+  # Self-hosted OpenStreetMap geocoder for geo-contextual search features.
+  # On first start, imports the PBF extract (this takes 10+ minutes depending
+  # on region size). After import, the service provides fast local geocoding.
+  # If Nominatim is unavailable, geo features silently degrade.
+  nominatim:
+    image: mediagis/nominatim:4.4
+    container_name: openclaw-nominatim
+    restart: unless-stopped
+    environment:
+      # OpenStreetMap PBF extract to import
+      # Find regional extracts at: https://download.geofabrik.de/
+      PBF_URL: ${NOMINATIM_PBF_URL:-https://download.geofabrik.de/australia-oceania/australia-latest.osm.pbf}
+      REPLICATION_URL: ${NOMINATIM_REPLICATION_URL:-https://download.geofabrik.de/australia-oceania/australia-updates/}
+      NOMINATIM_PASSWORD: ${NOMINATIM_PASSWORD:-openclaw}
+    volumes:
+      - nominatim_data:/var/lib/postgresql/14/main
+    ports:
+      - "[::1]:${NOMINATIM_PORT:-8180}:8080"       # IPv6 (preferred)
+      - "127.0.0.1:${NOMINATIM_PORT:-8180}:8080"  # IPv4 fallback
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/status"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 600s
+    # Container hardening
+    # Note: Nominatim runs PostgreSQL internally and requires more capabilities
+    security_opt:
+      - no-new-privileges:true
+    deploy:
+      resources:
+        limits:
+          cpus: "2"
+          memory: 4G
+        reservations:
+          cpus: "0.5"
+          memory: 1G
+
+  # =============================================================================
   # Frontend App (React SPA served via static server)
   # =============================================================================
   app:
@@ -343,3 +386,4 @@ services:
 volumes:
   db_data:
   seaweedfs_data:
+  nominatim_data:

--- a/packages/openclaw-plugin/openclaw.plugin.json
+++ b/packages/openclaw-plugin/openclaw.plugin.json
@@ -145,6 +145,11 @@
         "type": "string",
         "pattern": "^https?://",
         "description": "Base URL for web app (used for generating note/notebook URLs)"
+      },
+      "nominatimUrl": {
+        "type": "string",
+        "pattern": "^https?://",
+        "description": "Nominatim reverse geocoding URL (e.g., http://nominatim:8080)"
       }
     },
     "additionalProperties": false,
@@ -287,6 +292,12 @@
       "label": "Web App URL",
       "placeholder": "https://app.example.com",
       "help": "Base URL for the web app (used for generating links)",
+      "group": "Advanced"
+    },
+    "nominatimUrl": {
+      "label": "Nominatim URL",
+      "placeholder": "http://nominatim:8080",
+      "help": "URL for self-hosted Nominatim reverse geocoding service (enables geo-contextual search)",
       "group": "Advanced"
     }
   }

--- a/packages/openclaw-plugin/tests/__snapshots__/schema-snapshots.test.ts.snap
+++ b/packages/openclaw-plugin/tests/__snapshots__/schema-snapshots.test.ts.snap
@@ -107,6 +107,11 @@ exports[`Schema Snapshots > Manifest configSchema > configSchema should match sn
       "minimum": 0,
       "type": "number",
     },
+    "nominatimUrl": {
+      "description": "Nominatim reverse geocoding URL (e.g., http://nominatim:8080)",
+      "pattern": "^https?://",
+      "type": "string",
+    },
     "postmarkFromEmail": {
       "description": "Postmark From Email address (direct value)",
       "pattern": "^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$",
@@ -271,6 +276,12 @@ exports[`Schema Snapshots > Manifest configSchema > manifest uiHints should matc
     "group": "Memory",
     "help": "Minimum relevance score (0-1) for auto-recall",
     "label": "Min Recall Score",
+  },
+  "nominatimUrl": {
+    "group": "Advanced",
+    "help": "URL for self-hosted Nominatim reverse geocoding service (enables geo-contextual search)",
+    "label": "Nominatim URL",
+    "placeholder": "http://nominatim:8080",
   },
   "postmarkFromEmail": {
     "group": "Postmark Email",


### PR DESCRIPTION
## Summary

- Add self-hosted Nominatim reverse geocoding service to all 4 production Docker Compose files (`docker-compose.yml`, `quickstart`, `traefik`, `full`)
- Add `NOMINATIM_URL` env var to API services and devcontainer workspace
- Add `nominatimUrl` to `openclaw.plugin.json` configSchema (was missing — gateway would reject the field)
- Add Nominatim configuration section to `.env.example` with configurable PBF/replication URLs
- Update schema snapshot tests

Closes #1260

## Design Decisions

- **No `depends_on`** from api → nominatim: first PBF import takes 10+ minutes; API should start immediately and degrade gracefully
- **Host port 8180** (not 8080): avoids conflict with FRONTEND_PORT (basic compose) and MODSEC_HOST_PORT (traefik/full)
- **Configurable PBF_URL/REPLICATION_URL**: different deployments serve different geographic regions
- **Container hardening**: matches `db` pattern (no-new-privileges, no cap_drop since PostgreSQL runs internally)

## Codex CLI Review

Security + blindspot review completed. Findings addressed:
1. Plugin JSON schema missing `nominatimUrl` → Fixed
2. Container hardening inconsistency in quickstart → Fixed
3. SSRF via `nominatimUrl` → Accepted design (same as existing Nominatim usage, internal service only)
4. Default password → Consistent with existing devcontainer pattern

## Test plan
- [x] All 4 compose files validate (`docker compose config` passes)
- [x] Plugin test suite passes (1451/1451 tests)
- [x] Schema snapshot tests updated and passing (44/44)
- [x] Lint passes (exit 0, pre-existing warnings only)
- [ ] CI pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)