### PR TITLE
[#1252] Add retention pgcron job for geo location data

### DIFF
--- a/migrations/068_geo_retention_job.down.sql
+++ b/migrations/068_geo_retention_job.down.sql
@@ -1,0 +1,13 @@
+-- Down migration 068: Remove geo location retention pgcron job
+-- Reverse of 068_geo_retention_job.up.sql
+
+-- 1. Unschedule the pgcron job
+DO $do$
+BEGIN
+  IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'geo_retention_cleanup') THEN
+    PERFORM cron.unschedule('geo_retention_cleanup');
+  END IF;
+END $do$;
+
+-- 2. Drop the retention function
+DROP FUNCTION IF EXISTS geo_retention_cleanup();

--- a/migrations/068_geo_retention_job.up.sql
+++ b/migrations/068_geo_retention_job.up.sql
@@ -1,0 +1,87 @@
+-- Migration 068: Geo location retention pgcron job
+-- Part of Epic #1242, Issue #1252
+-- Creates geo_retention_cleanup() function and schedules daily pgcron job
+-- Downsamples high-res data and deletes records beyond general retention window
+
+-- ============================================================
+-- 1. geo_retention_cleanup() — per-user retention enforcement
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION geo_retention_cleanup()
+RETURNS TABLE(users_processed int, records_downsampled bigint, records_expired bigint) AS $$
+DECLARE
+  setting RECORD;
+  high_res_cutoff timestamptz;
+  general_cutoff timestamptz;
+  total_users int := 0;
+  total_downsampled bigint := 0;
+  total_expired bigint := 0;
+  deleted_count bigint;
+BEGIN
+  FOR setting IN
+    SELECT email, geo_high_res_retention_hours, geo_general_retention_days
+    FROM user_setting
+    WHERE geo_high_res_retention_hours IS NOT NULL
+      AND geo_general_retention_days IS NOT NULL
+  LOOP
+    total_users := total_users + 1;
+    high_res_cutoff := now() - (setting.geo_high_res_retention_hours || ' hours')::interval;
+    general_cutoff := now() - (setting.geo_general_retention_days || ' days')::interval;
+
+    -- Step 1: Delete ALL records beyond general retention window
+    DELETE FROM geo_location
+    WHERE user_email = setting.email
+      AND time < general_cutoff;
+    GET DIAGNOSTICS deleted_count = ROW_COUNT;
+    total_expired := total_expired + deleted_count;
+
+    -- Step 2: Downsample between high_res_cutoff and general_cutoff
+    -- Keep only the best-accuracy record per (user, provider, entity, hour).
+    -- Use an EXISTS-based anti-join to avoid ctid issues with TimescaleDB hypertables.
+    DELETE FROM geo_location gl
+    WHERE gl.user_email = setting.email
+      AND gl.time < high_res_cutoff
+      AND gl.time >= general_cutoff
+      AND EXISTS (
+        SELECT 1 FROM geo_location gl2
+        WHERE gl2.user_email = gl.user_email
+          AND gl2.provider_id = gl.provider_id
+          AND gl2.entity_id IS NOT DISTINCT FROM gl.entity_id
+          AND date_trunc('hour', gl2.time) = date_trunc('hour', gl.time)
+          AND (
+            -- gl2 has better (lower) accuracy than gl
+            (gl2.accuracy_m IS NOT NULL AND gl.accuracy_m IS NOT NULL AND gl2.accuracy_m < gl.accuracy_m)
+            -- gl2 has accuracy, gl does not
+            OR (gl2.accuracy_m IS NOT NULL AND gl.accuracy_m IS NULL)
+            -- same accuracy, break ties by keeping the more recent record
+            OR (gl2.accuracy_m IS NOT DISTINCT FROM gl.accuracy_m AND gl2.time > gl.time)
+          )
+      );
+    GET DIAGNOSTICS deleted_count = ROW_COUNT;
+    total_downsampled := total_downsampled + deleted_count;
+  END LOOP;
+
+  users_processed := total_users;
+  records_downsampled := total_downsampled;
+  records_expired := total_expired;
+  RETURN NEXT;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION geo_retention_cleanup() IS
+  'Per-user geo_location retention: downsample high-res data and delete expired records (Issue #1252)';
+
+-- ============================================================
+-- 2. Register pgcron job — daily at 03:00 UTC, idempotent
+-- ============================================================
+
+DO $do$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'geo_retention_cleanup') THEN
+    PERFORM cron.schedule(
+      'geo_retention_cleanup',
+      '0 3 * * *',
+      $cmd$SELECT * FROM geo_retention_cleanup();$cmd$
+    );
+  END IF;
+END $do$;

--- a/src/api/geolocation/retention.test.ts
+++ b/src/api/geolocation/retention.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Tests for geo location retention cleanup wrapper.
+ * Issue #1252
+ */
+
+import type { Pool } from 'pg';
+import { describe, expect, it, vi } from 'vitest';
+import { runRetentionCleanup } from './retention.ts';
+
+function mockPool(rows: Record<string, unknown>[]): Pool {
+  return {
+    query: vi.fn().mockResolvedValue({ rows, rowCount: rows.length }),
+  } as unknown as Pool;
+}
+
+describe('runRetentionCleanup', () => {
+  it('returns stats from the PL/pgSQL function', async () => {
+    const pool = mockPool([{ users_processed: 3, records_downsampled: '42', records_expired: '100' }]);
+
+    const result = await runRetentionCleanup(pool);
+
+    expect(result).toEqual({
+      usersProcessed: 3,
+      recordsDownsampled: 42,
+      recordsExpired: 100,
+    });
+    expect(pool.query).toHaveBeenCalledWith('SELECT * FROM geo_retention_cleanup()');
+  });
+
+  it('returns zeroes when the function returns no rows', async () => {
+    const pool = mockPool([]);
+
+    const result = await runRetentionCleanup(pool);
+
+    expect(result).toEqual({
+      usersProcessed: 0,
+      recordsDownsampled: 0,
+      recordsExpired: 0,
+    });
+  });
+
+  it('handles zero-value results', async () => {
+    const pool = mockPool([{ users_processed: 0, records_downsampled: '0', records_expired: '0' }]);
+
+    const result = await runRetentionCleanup(pool);
+
+    expect(result).toEqual({
+      usersProcessed: 0,
+      recordsDownsampled: 0,
+      recordsExpired: 0,
+    });
+  });
+
+  it('converts bigint string values to numbers', async () => {
+    const pool = mockPool([
+      {
+        users_processed: 1,
+        records_downsampled: '9999999999',
+        records_expired: '1234567890',
+      },
+    ]);
+
+    const result = await runRetentionCleanup(pool);
+
+    expect(result.recordsDownsampled).toBe(9999999999);
+    expect(result.recordsExpired).toBe(1234567890);
+  });
+
+  it('propagates database errors', async () => {
+    const pool = {
+      query: vi.fn().mockRejectedValue(new Error('connection refused')),
+    } as unknown as Pool;
+
+    await expect(runRetentionCleanup(pool)).rejects.toThrow('connection refused');
+  });
+});

--- a/src/api/geolocation/retention.ts
+++ b/src/api/geolocation/retention.ts
@@ -1,0 +1,42 @@
+/**
+ * Geo location retention cleanup wrapper.
+ * Calls the geo_retention_cleanup() PL/pgSQL function for manual triggering.
+ *
+ * Issue #1252
+ */
+
+import type { Pool } from 'pg';
+
+export interface RetentionResult {
+  usersProcessed: number;
+  recordsDownsampled: number;
+  recordsExpired: number;
+}
+
+/**
+ * Run the geo location retention cleanup.
+ * Delegates to the `geo_retention_cleanup()` PL/pgSQL function which:
+ * - Iterates per-user settings from `user_setting`
+ * - Deletes all geo_location records beyond the general retention window
+ * - Downsamples high-res data to best-accuracy-per-hour beyond the high-res window
+ *
+ * Only touches geo_location — never memories or embeddings.
+ */
+export async function runRetentionCleanup(pool: Pool): Promise<RetentionResult> {
+  const { rows } = await pool.query<{
+    users_processed: number;
+    records_downsampled: string;
+    records_expired: string;
+  }>('SELECT * FROM geo_retention_cleanup()');
+
+  const row = rows[0];
+  if (!row) {
+    return { usersProcessed: 0, recordsDownsampled: 0, recordsExpired: 0 };
+  }
+
+  return {
+    usersProcessed: row.users_processed,
+    recordsDownsampled: Number(row.records_downsampled),
+    recordsExpired: Number(row.records_expired),
+  };
+}


### PR DESCRIPTION
## Summary
- Added `geo_retention_cleanup()` PL/pgSQL function for per-user retention enforcement
- High-res downsampling: keeps best-accuracy record per hour beyond retention window
- General deletion: removes all records beyond general retention window
- pgcron schedule: daily at 03:00 UTC
- TypeScript wrapper for manual triggering
- NEVER touches memories or embeddings — only raw geo_location records

## Test plan
- [x] Returns stats from the PL/pgSQL function
- [x] Returns zeroes when no rows returned
- [x] Handles zero-value results
- [x] Converts bigint string values to numbers
- [x] Propagates database errors
- [x] All tests pass (`pnpm exec vitest run src/api/geolocation/retention.test.ts`)
- [x] Lint clean (`pnpm exec biome check src/api/geolocation/`)

Closes #1252

🤖 Generated with [Claude Code](https://claude.com/claude-code)