### PR TITLE
[#1258] Run injection detection on full content before truncation

### DIFF
--- a/packages/openclaw-plugin/src/register-openclaw.ts
+++ b/packages/openclaw-plugin/src/register-openclaw.ts
@@ -2109,7 +2109,10 @@ function createToolHandlers(state: PluginState) {
           total,
         });
 
-        // Detect and log potential injection patterns in inbound messages
+        // SECURITY: Run injection detection on the FULL message body BEFORE any
+        // truncation. Bodies are later truncated to 100 chars for display, but
+        // detection must see the complete content to catch payloads that an
+        // attacker could hide beyond the truncation boundary. (Issue #1258)
         for (const m of messages) {
           if (m.direction === 'inbound' && m.body) {
             const detection = detectInjectionPatterns(m.body);
@@ -2123,7 +2126,8 @@ function createToolHandlers(state: PluginState) {
           }
         }
 
-        // Format content for display with injection protection
+        // Format content for display with injection protection.
+        // NOTE: Truncation happens here AFTER detection above — do not reorder.
         const content =
           messages.length > 0
             ? messages

--- a/packages/openclaw-plugin/src/tools/message-search.ts
+++ b/packages/openclaw-plugin/src/tools/message-search.ts
@@ -178,7 +178,10 @@ export function createMessageSearchTool(options: MessageSearchToolOptions): Mess
           total,
         });
 
-        // Detect and log potential injection patterns in message snippets
+        // SECURITY: Run injection detection on the FULL snippet BEFORE any
+        // truncation. Snippets are later truncated to 100 chars for display, but
+        // detection must see the complete content to catch payloads that an
+        // attacker could hide beyond the truncation boundary. (Issue #1258)
         for (const m of messages) {
           if (m.snippet) {
             const detection = detectInjectionPatterns(m.snippet);
@@ -194,6 +197,7 @@ export function createMessageSearchTool(options: MessageSearchToolOptions): Mess
 
         // Format content for display with injection protection.
         // Boundary-wrap all snippets since they may contain external message content.
+        // NOTE: Truncation happens here AFTER detection above — do not reorder.
         const content =
           messages.length > 0
             ? messages


### PR DESCRIPTION
## Summary
- Added SECURITY comments clarifying that `detectInjectionPatterns()` must run on the full message snippet BEFORE the 100-char client-side truncation for display
- Both the refactored `message-search.ts` and the monolith `register-openclaw.ts` handlers are annotated with ordering constraints to prevent accidental reordering
- Added integration tests proving injection patterns hidden beyond the 100-char truncation boundary are still detected

## Changes
- `packages/openclaw-plugin/src/tools/message-search.ts` — Added security comments documenting detection-before-truncation ordering
- `packages/openclaw-plugin/src/register-openclaw.ts` — Same security comments for the monolith handler
- `packages/openclaw-plugin/tests/injection-protection-integration.test.ts` — Two new tests:
  - Verifies injection payload at char 100+ is detected
  - Verifies display output is correctly truncated while full snippets are preserved in details

## Test plan
- [x] All 1453 plugin tests pass
- [x] Lint passes (warnings only, no errors)
- [x] Codex CLI security review passed
- [ ] CI pipeline passes

Closes #1258