### PR TITLE
[#1257] Rate-limit injection detection logging

### DIFF
--- a/packages/openclaw-plugin/src/utils/injection-log-rate-limiter.ts
+++ b/packages/openclaw-plugin/src/utils/injection-log-rate-limiter.ts
@@ -1,0 +1,177 @@
+/**
+ * Rate limiter for injection detection logging.
+ *
+ * Prevents log flooding when an attacker sends many injection-containing
+ * messages. Logs the first N detections per key (sender/userId) per window,
+ * then samples at a configurable rate. Emits summary entries for suppressed
+ * counts when a new window begins.
+ *
+ * Memory-bounded via maxEntries with LRU eviction of oldest keys.
+ *
+ * Issue #1257
+ */
+
+/** Configuration for the injection log rate limiter */
+export interface InjectionLogRateLimiterConfig {
+  /** Sliding window duration in milliseconds */
+  windowMs: number;
+  /** Maximum number of log entries allowed per key per window before sampling */
+  maxLogsPerWindow: number;
+  /** Probability (0-1) of logging after exceeding maxLogsPerWindow */
+  sampleRate: number;
+  /** Maximum number of tracked key entries (LRU eviction when exceeded) */
+  maxEntries: number;
+}
+
+/** Result of a shouldLog check */
+export interface InjectionLogResult {
+  /** Whether this detection should be logged */
+  log: boolean;
+  /** Number of suppressed detections (in the current or previous window) */
+  suppressed: number;
+  /** Whether this is a summary entry reporting prior-window suppressions */
+  summary: boolean;
+}
+
+/** Stats about the rate limiter's current state */
+export interface InjectionLogRateLimiterStats {
+  /** Number of currently tracked keys */
+  activeKeys: number;
+  /** Total number of suppressed detections across all keys */
+  totalSuppressed: number;
+}
+
+/** Default configuration */
+export const DEFAULT_INJECTION_LOG_RATE_LIMITER_CONFIG: InjectionLogRateLimiterConfig = {
+  windowMs: 60_000,
+  maxLogsPerWindow: 10,
+  sampleRate: 0.1,
+  maxEntries: 10_000,
+};
+
+/** Internal state per tracked key */
+interface KeyState {
+  /** Timestamp of the window start */
+  windowStart: number;
+  /** Number of detections logged in current window */
+  logCount: number;
+  /** Number of detections suppressed in current window */
+  suppressedCount: number;
+  /** Last activity timestamp (for LRU eviction) */
+  lastSeen: number;
+}
+
+/** Injection log rate limiter instance */
+export interface InjectionLogRateLimiter {
+  /** Check whether a detection for the given key should be logged */
+  shouldLog(key: string): InjectionLogResult;
+  /** Get current stats */
+  getStats(): InjectionLogRateLimiterStats;
+}
+
+/**
+ * Create a new injection log rate limiter.
+ *
+ * @param config - Configuration overrides (defaults to DEFAULT_INJECTION_LOG_RATE_LIMITER_CONFIG)
+ * @param randomFn - Optional random function for testing (defaults to Math.random)
+ */
+export function createInjectionLogRateLimiter(
+  config: InjectionLogRateLimiterConfig = DEFAULT_INJECTION_LOG_RATE_LIMITER_CONFIG,
+  randomFn: () => number = Math.random,
+): InjectionLogRateLimiter {
+  const entries = new Map<string, KeyState>();
+
+  function now(): number {
+    return Date.now();
+  }
+
+  function evictIfNeeded(): void {
+    if (entries.size <= config.maxEntries) return;
+
+    // Sort by lastSeen ascending (oldest first), evict until at maxEntries
+    const sorted = [...entries.entries()].sort((a, b) => a[1].lastSeen - b[1].lastSeen);
+    const toEvict = sorted.length - config.maxEntries;
+    for (let i = 0; i < toEvict; i++) {
+      entries.delete(sorted[i][0]);
+    }
+  }
+
+  function shouldLog(key: string): InjectionLogResult {
+    const currentTime = now();
+    const existing = entries.get(key);
+
+    // Check if we need to start a new window
+    if (existing && currentTime - existing.windowStart >= config.windowMs) {
+      // Window expired — check if there were suppressions to report
+      const previousSuppressed = existing.suppressedCount;
+
+      // Reset to new window
+      existing.windowStart = currentTime;
+      existing.logCount = 1;
+      existing.suppressedCount = 0;
+      existing.lastSeen = currentTime;
+
+      if (previousSuppressed > 0) {
+        // Emit a summary log entry reporting previous window suppressions
+        return { log: true, suppressed: previousSuppressed, summary: true };
+      }
+
+      // Normal first log in new window, no summary needed
+      return { log: true, suppressed: 0, summary: false };
+    }
+
+    if (!existing) {
+      // First detection for this key
+      entries.set(key, {
+        windowStart: currentTime,
+        logCount: 1,
+        suppressedCount: 0,
+        lastSeen: currentTime,
+      });
+
+      evictIfNeeded();
+      return { log: true, suppressed: 0, summary: false };
+    }
+
+    // Within the same window
+    existing.lastSeen = currentTime;
+
+    if (existing.logCount < config.maxLogsPerWindow) {
+      // Still under the limit
+      existing.logCount++;
+      return { log: true, suppressed: 0, summary: false };
+    }
+
+    // Over the limit — apply sampling
+    existing.suppressedCount++;
+
+    if (config.sampleRate > 0 && randomFn() < config.sampleRate) {
+      // Sampled in — log it
+      existing.logCount++;
+      return { log: true, suppressed: existing.suppressedCount, summary: false };
+    }
+
+    // Suppressed
+    return { log: false, suppressed: existing.suppressedCount, summary: false };
+  }
+
+  function getStats(): InjectionLogRateLimiterStats {
+    let totalSuppressed = 0;
+    for (const state of entries.values()) {
+      totalSuppressed += state.suppressedCount;
+    }
+    return {
+      activeKeys: entries.size,
+      totalSuppressed,
+    };
+  }
+
+  return { shouldLog, getStats };
+}
+
+/**
+ * Shared singleton rate limiter for injection detection logging.
+ * All callsites in the plugin share this instance so that rate limiting
+ * is coordinated across tools and hooks within the same process.
+ */
+export const injectionLogLimiter = createInjectionLogRateLimiter();

--- a/packages/openclaw-plugin/tests/utils/injection-log-rate-limiter.test.ts
+++ b/packages/openclaw-plugin/tests/utils/injection-log-rate-limiter.test.ts
@@ -1,0 +1,297 @@
+/**
+ * Tests for injection detection log rate limiter.
+ *
+ * Ensures that rapid injection detections only log the first N per key
+ * per window, then sample at a configurable rate, and emit periodic
+ * summary entries for suppressed detections.
+ *
+ * Issue #1257
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createInjectionLogRateLimiter, DEFAULT_INJECTION_LOG_RATE_LIMITER_CONFIG } from '../../src/utils/injection-log-rate-limiter.js';
+
+describe('injection-log-rate-limiter', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('defaults', () => {
+    it('should export sensible default config', () => {
+      expect(DEFAULT_INJECTION_LOG_RATE_LIMITER_CONFIG).toEqual({
+        windowMs: 60_000,
+        maxLogsPerWindow: 10,
+        sampleRate: 0.1,
+        maxEntries: 10_000,
+      });
+    });
+  });
+
+  describe('basic window behaviour', () => {
+    it('should allow the first N logs for a key within the window', () => {
+      const limiter = createInjectionLogRateLimiter({
+        windowMs: 60_000,
+        maxLogsPerWindow: 3,
+        sampleRate: 0, // no sampling — only first N
+        maxEntries: 100,
+      });
+
+      for (let i = 0; i < 3; i++) {
+        const result = limiter.shouldLog('sender-a');
+        expect(result.log).toBe(true);
+        expect(result.suppressed).toBe(0);
+        expect(result.summary).toBe(false);
+      }
+    });
+
+    it('should suppress logs after exceeding maxLogsPerWindow (with sampleRate=0)', () => {
+      const limiter = createInjectionLogRateLimiter({
+        windowMs: 60_000,
+        maxLogsPerWindow: 2,
+        sampleRate: 0, // always suppress after limit
+        maxEntries: 100,
+      });
+
+      // First 2 allowed
+      expect(limiter.shouldLog('sender-a').log).toBe(true);
+      expect(limiter.shouldLog('sender-a').log).toBe(true);
+
+      // 3rd and beyond suppressed
+      const result3 = limiter.shouldLog('sender-a');
+      expect(result3.log).toBe(false);
+      expect(result3.suppressed).toBe(1);
+
+      const result4 = limiter.shouldLog('sender-a');
+      expect(result4.log).toBe(false);
+      expect(result4.suppressed).toBe(2);
+    });
+
+    it('should reset counts after the window expires', () => {
+      const limiter = createInjectionLogRateLimiter({
+        windowMs: 60_000,
+        maxLogsPerWindow: 2,
+        sampleRate: 0,
+        maxEntries: 100,
+      });
+
+      // Use only 1 of 2 allowed logs (no suppressions)
+      expect(limiter.shouldLog('sender-a').log).toBe(true);
+
+      // Advance past the window
+      vi.advanceTimersByTime(61_000);
+
+      // Should be allowed again with fresh window (no summary since no suppressions)
+      const result = limiter.shouldLog('sender-a');
+      expect(result.log).toBe(true);
+      expect(result.suppressed).toBe(0);
+      expect(result.summary).toBe(false);
+    });
+
+    it('should report previous-window suppressions via summary on window reset', () => {
+      const limiter = createInjectionLogRateLimiter({
+        windowMs: 60_000,
+        maxLogsPerWindow: 1,
+        sampleRate: 0,
+        maxEntries: 100,
+      });
+
+      expect(limiter.shouldLog('sender-a').log).toBe(true);
+      expect(limiter.shouldLog('sender-a').log).toBe(false); // suppressed
+
+      // Advance past the window
+      vi.advanceTimersByTime(61_000);
+
+      // First log in new window should be a summary with previous suppressions
+      const result = limiter.shouldLog('sender-a');
+      expect(result.log).toBe(true);
+      expect(result.suppressed).toBe(1);
+      expect(result.summary).toBe(true);
+    });
+  });
+
+  describe('sampling after limit', () => {
+    it('should sample at the configured rate after exceeding limit', () => {
+      const limiter = createInjectionLogRateLimiter({
+        windowMs: 60_000,
+        maxLogsPerWindow: 1,
+        sampleRate: 1.0, // always sample — every log after limit is allowed
+        maxEntries: 100,
+      });
+
+      // First log allowed normally
+      expect(limiter.shouldLog('sender-a').log).toBe(true);
+
+      // With sampleRate=1.0, every subsequent should also be allowed (sampled)
+      for (let i = 0; i < 5; i++) {
+        const result = limiter.shouldLog('sender-a');
+        expect(result.log).toBe(true);
+      }
+    });
+
+    it('should never sample when sampleRate is 0', () => {
+      const limiter = createInjectionLogRateLimiter({
+        windowMs: 60_000,
+        maxLogsPerWindow: 1,
+        sampleRate: 0,
+        maxEntries: 100,
+      });
+
+      expect(limiter.shouldLog('sender-a').log).toBe(true);
+
+      // All subsequent should be suppressed
+      for (let i = 0; i < 10; i++) {
+        expect(limiter.shouldLog('sender-a').log).toBe(false);
+      }
+    });
+
+    it('should include suppressed count in sampled log results', () => {
+      const limiter = createInjectionLogRateLimiter({
+        windowMs: 60_000,
+        maxLogsPerWindow: 1,
+        sampleRate: 1.0, // always sample
+        maxEntries: 100,
+      });
+
+      // First log
+      expect(limiter.shouldLog('sender-a').log).toBe(true);
+
+      // Suppress a few (but they will be sampled because sampleRate=1.0)
+      // The suppressed count should still track the excess calls
+      const result = limiter.shouldLog('sender-a');
+      expect(result.log).toBe(true);
+      expect(result.suppressed).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe('summary emission', () => {
+    it('should emit summary when window expires and there were suppressions', () => {
+      const limiter = createInjectionLogRateLimiter({
+        windowMs: 60_000,
+        maxLogsPerWindow: 1,
+        sampleRate: 0,
+        maxEntries: 100,
+      });
+
+      // First log OK
+      limiter.shouldLog('sender-a');
+      // Suppress 3 more
+      limiter.shouldLog('sender-a');
+      limiter.shouldLog('sender-a');
+      limiter.shouldLog('sender-a');
+
+      // Advance past window
+      vi.advanceTimersByTime(61_000);
+
+      // Next call for same key should trigger summary
+      const result = limiter.shouldLog('sender-a');
+      expect(result.log).toBe(true);
+      expect(result.summary).toBe(true);
+      expect(result.suppressed).toBe(3); // reports the suppressions from previous window
+    });
+
+    it('should not emit summary when there were no suppressions', () => {
+      const limiter = createInjectionLogRateLimiter({
+        windowMs: 60_000,
+        maxLogsPerWindow: 10,
+        sampleRate: 0,
+        maxEntries: 100,
+      });
+
+      // Only one detection, well under the limit
+      limiter.shouldLog('sender-a');
+
+      // Advance past window
+      vi.advanceTimersByTime(61_000);
+
+      // Next call should NOT have summary since nothing was suppressed
+      const result = limiter.shouldLog('sender-a');
+      expect(result.log).toBe(true);
+      expect(result.summary).toBe(false);
+      expect(result.suppressed).toBe(0);
+    });
+  });
+
+  describe('per-key isolation', () => {
+    it('should track different keys independently', () => {
+      const limiter = createInjectionLogRateLimiter({
+        windowMs: 60_000,
+        maxLogsPerWindow: 1,
+        sampleRate: 0,
+        maxEntries: 100,
+      });
+
+      expect(limiter.shouldLog('sender-a').log).toBe(true);
+      expect(limiter.shouldLog('sender-b').log).toBe(true);
+
+      // sender-a is now rate-limited
+      expect(limiter.shouldLog('sender-a').log).toBe(false);
+      // sender-b is now rate-limited
+      expect(limiter.shouldLog('sender-b').log).toBe(false);
+      // sender-c is fresh
+      expect(limiter.shouldLog('sender-c').log).toBe(true);
+    });
+  });
+
+  describe('memory bounds', () => {
+    it('should evict oldest entries when maxEntries is exceeded', () => {
+      const limiter = createInjectionLogRateLimiter({
+        windowMs: 60_000,
+        maxLogsPerWindow: 1,
+        sampleRate: 0,
+        maxEntries: 50,
+      });
+
+      // Create 100 unique keys
+      for (let i = 0; i < 100; i++) {
+        limiter.shouldLog(`sender-${i}`);
+      }
+
+      // Should have evicted old entries to stay at or below maxEntries
+      const stats = limiter.getStats();
+      expect(stats.activeKeys).toBeLessThanOrEqual(50);
+    });
+
+    it('should not crash with many unique keys', () => {
+      const limiter = createInjectionLogRateLimiter({
+        windowMs: 60_000,
+        maxLogsPerWindow: 5,
+        sampleRate: 0.1,
+        maxEntries: 1000,
+      });
+
+      // Simulate 500 unique senders
+      for (let i = 0; i < 500; i++) {
+        const result = limiter.shouldLog(`sender-${i}`);
+        expect(result.log).toBe(true);
+      }
+
+      const stats = limiter.getStats();
+      expect(stats.activeKeys).toBeLessThanOrEqual(1000);
+    });
+  });
+
+  describe('getStats', () => {
+    it('should report active keys and total suppressed count', () => {
+      const limiter = createInjectionLogRateLimiter({
+        windowMs: 60_000,
+        maxLogsPerWindow: 1,
+        sampleRate: 0,
+        maxEntries: 100,
+      });
+
+      limiter.shouldLog('sender-a');
+      limiter.shouldLog('sender-b');
+      limiter.shouldLog('sender-a'); // suppressed
+      limiter.shouldLog('sender-a'); // suppressed
+      limiter.shouldLog('sender-b'); // suppressed
+
+      const stats = limiter.getStats();
+      expect(stats.activeKeys).toBe(2);
+      expect(stats.totalSuppressed).toBe(3);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a new `injection-log-rate-limiter.ts` utility that implements per-key sliding window rate limiting for detection log entries
- Logs the first 10 detections per userId per 60-second window, then samples at 10% probability
- Emits summary log entries with suppressed counts when a new window begins after suppressions
- Memory-bounded via LRU eviction (max 10,000 tracked keys)
- Integrated at all 4 injection detection logging callsites:
  - `register-openclaw.ts` inline message_search handler
  - `register-openclaw.ts` inline thread_get handler
  - `tools/message-search.ts` standalone tool
  - `tools/threads.ts` standalone tool

Closes #1257

## Test plan

- [x] 14 unit tests covering window behavior, sampling, summary emission, per-key isolation, memory bounds, and stats
- [x] All 1482 existing plugin tests pass (48 test files)
- [x] Lint clean on all new and modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)