### PR TITLE
[#1250] Add geo auto-injection preHandler hook

### DIFF
--- a/src/api/geolocation/auto-inject.test.ts
+++ b/src/api/geolocation/auto-inject.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Tests for geo auto-injection preHandler hook.
+ * Issue #1250.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { FastifyRequest, FastifyReply } from 'fastify';
+import { geoAutoInjectHook } from './auto-inject.ts';
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+
+const mockQuery = vi.fn();
+const mockEnd = vi.fn();
+const mockPool = { query: mockQuery, end: mockEnd };
+const createPool = vi.fn(() => mockPool as any);
+
+vi.mock('./service.ts', () => ({
+  getCurrentLocation: vi.fn(),
+}));
+
+import { getCurrentLocation } from './service.ts';
+const mockGetCurrentLocation = getCurrentLocation as ReturnType<typeof vi.fn>;
+
+function makeReq(overrides: {
+  body?: Record<string, unknown> | null;
+  email?: string | null;
+}): FastifyRequest {
+  return {
+    body: 'body' in overrides ? overrides.body : {},
+    headers: {},
+    session: overrides.email !== null ? { email: overrides.email ?? 'user@example.com' } : undefined,
+  } as unknown as FastifyRequest;
+}
+
+const noopReply = {} as FastifyReply;
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('geoAutoInjectHook', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockEnd.mockResolvedValue(undefined);
+  });
+
+  it('injects location when auto_inject enabled and location available', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ geo_auto_inject: true }] });
+    mockGetCurrentLocation.mockResolvedValueOnce({
+      lat: -33.8688,
+      lng: 151.2093,
+      address: '123 George St, Sydney',
+      placeLabel: 'Sydney CBD',
+    });
+
+    const req = makeReq({ body: { content: 'Test memory' } });
+    const hook = geoAutoInjectHook(createPool);
+    await hook(req, noopReply);
+
+    const body = req.body as Record<string, unknown>;
+    expect(body.lat).toBe(-33.8688);
+    expect(body.lng).toBe(151.2093);
+    expect(body.address).toBe('123 George St, Sydney');
+    expect(body.place_label).toBe('Sydney CBD');
+    expect(req.headers['x-geo-source']).toBe('auto');
+  });
+
+  it('does not overwrite explicit lat/lng', async () => {
+    const req = makeReq({
+      body: { content: 'Test', lat: 40.7128, lng: -74.006 },
+    });
+    const hook = geoAutoInjectHook(createPool);
+    await hook(req, noopReply);
+
+    const body = req.body as Record<string, unknown>;
+    expect(body.lat).toBe(40.7128);
+    expect(body.lng).toBe(-74.006);
+    expect(req.headers['x-geo-source']).toBe('explicit');
+    // Should not have called DB at all
+    expect(createPool).not.toHaveBeenCalled();
+  });
+
+  it('skips when geo_auto_inject is false', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ geo_auto_inject: false }] });
+
+    const req = makeReq({ body: { content: 'Test' } });
+    const hook = geoAutoInjectHook(createPool);
+    await hook(req, noopReply);
+
+    const body = req.body as Record<string, unknown>;
+    expect(body.lat).toBeUndefined();
+    expect(body.lng).toBeUndefined();
+    expect(mockGetCurrentLocation).not.toHaveBeenCalled();
+  });
+
+  it('skips when no current location is available', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ geo_auto_inject: true }] });
+    mockGetCurrentLocation.mockResolvedValueOnce(null);
+
+    const req = makeReq({ body: { content: 'Test' } });
+    const hook = geoAutoInjectHook(createPool);
+    await hook(req, noopReply);
+
+    const body = req.body as Record<string, unknown>;
+    expect(body.lat).toBeUndefined();
+    expect(body.lng).toBeUndefined();
+    expect(req.headers['x-geo-source']).toBeUndefined();
+  });
+
+  it('skips when user has no settings row', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const req = makeReq({ body: { content: 'Test' } });
+    const hook = geoAutoInjectHook(createPool);
+    await hook(req, noopReply);
+
+    const body = req.body as Record<string, unknown>;
+    expect(body.lat).toBeUndefined();
+    expect(mockGetCurrentLocation).not.toHaveBeenCalled();
+  });
+
+  it('skips when no session email', async () => {
+    const req = makeReq({ body: { content: 'Test' }, email: null });
+    const hook = geoAutoInjectHook(createPool);
+    await hook(req, noopReply);
+
+    expect(createPool).not.toHaveBeenCalled();
+  });
+
+  it('skips when body is null', async () => {
+    const req = makeReq({ body: null });
+    const hook = geoAutoInjectHook(createPool);
+    await hook(req, noopReply);
+
+    expect(createPool).not.toHaveBeenCalled();
+  });
+
+  it('does not inject address/place_label when location lacks them', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ geo_auto_inject: true }] });
+    mockGetCurrentLocation.mockResolvedValueOnce({
+      lat: -33.8688,
+      lng: 151.2093,
+      address: null,
+      placeLabel: null,
+    });
+
+    const req = makeReq({ body: { content: 'Test' } });
+    const hook = geoAutoInjectHook(createPool);
+    await hook(req, noopReply);
+
+    const body = req.body as Record<string, unknown>;
+    expect(body.lat).toBe(-33.8688);
+    expect(body.lng).toBe(151.2093);
+    expect(body.address).toBeUndefined();
+    expect(body.place_label).toBeUndefined();
+  });
+
+  it('always releases pool', async () => {
+    mockQuery.mockRejectedValueOnce(new Error('DB error'));
+
+    const req = makeReq({ body: { content: 'Test' } });
+    const hook = geoAutoInjectHook(createPool);
+
+    await expect(hook(req, noopReply)).rejects.toThrow('DB error');
+    expect(mockEnd).toHaveBeenCalled();
+  });
+});

--- a/src/api/geolocation/auto-inject.ts
+++ b/src/api/geolocation/auto-inject.ts
@@ -1,0 +1,64 @@
+/**
+ * Geo auto-injection preHandler hook for memory routes.
+ * Automatically injects the user's current location into memory
+ * create/bulk requests when geo_auto_inject is enabled and no
+ * explicit location is provided.
+ * Issue #1250.
+ */
+
+import type { FastifyRequest, FastifyReply } from 'fastify';
+import type { Pool } from 'pg';
+
+/**
+ * Create a Fastify preHandler that auto-injects current geolocation
+ * into the request body if:
+ *   1. The body doesn't already have explicit lat/lng
+ *   2. The user's geo_auto_inject setting is true
+ *   3. A current location is available
+ *
+ * Sets X-Geo-Source header: "explicit" when body has coords,
+ * "auto" when injected, omitted otherwise.
+ */
+export function geoAutoInjectHook(createPool: () => Pool) {
+  return async (req: FastifyRequest, _reply: FastifyReply): Promise<void> => {
+    const body = req.body as Record<string, unknown> | null | undefined;
+    if (body === null || body === undefined || typeof body !== 'object' || Array.isArray(body)) return;
+
+    // If explicit lat/lng already provided, mark as explicit and skip
+    if (typeof body.lat === 'number' && typeof body.lng === 'number') {
+      req.headers['x-geo-source'] = 'explicit';
+      return;
+    }
+
+    // Need the user's email to look up settings and location
+    const session = (req as unknown as { session?: { email?: string } }).session;
+    const email = session?.email;
+    if (!email) return;
+
+    const pool = createPool();
+    try {
+      // Check user's geo_auto_inject setting
+      const settingResult = await pool.query(
+        `SELECT geo_auto_inject FROM user_setting WHERE user_email = $1`,
+        [email],
+      );
+      const autoInject = settingResult.rows[0]?.geo_auto_inject;
+      if (!autoInject) return;
+
+      // Get current location
+      const { getCurrentLocation } = await import('./service.ts');
+      const location = await getCurrentLocation(pool, email);
+      if (!location) return;
+
+      // Inject location into body
+      body.lat = location.lat;
+      body.lng = location.lng;
+      if (location.address) body.address = location.address;
+      if (location.placeLabel) body.place_label = location.placeLabel;
+
+      req.headers['x-geo-source'] = 'auto';
+    } finally {
+      await pool.end();
+    }
+  };
+}

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -24,6 +24,7 @@ import {
 } from './webhooks/index.ts';
 import { twilioIPWhitelistMiddleware, postmarkIPWhitelistMiddleware, getClientIP } from './webhooks/ip-whitelist.ts';
 import { createRateLimitKeyGenerator, getEndpointRateLimitCategory, getRateLimitConfig, type GetSessionEmailFn } from './rate-limit/per-user.ts';
+import { geoAutoInjectHook } from './geolocation/auto-inject.ts';
 import {
   processTwilioSms,
   type TwilioSmsWebhookPayload,
@@ -6498,7 +6499,7 @@ export function buildServer(options: ProjectsApiOptions = {}): FastifyInstance {
   });
 
   // POST /api/memories/unified - Create memory with flexible scoping (issue #209)
-  app.post('/api/memories/unified', async (req, reply) => {
+  app.post('/api/memories/unified', { preHandler: [geoAutoInjectHook(createPool)] }, async (req, reply) => {
     const { createMemory, isValidMemoryType, generateTitleFromContent } = await import('./memory/index.ts');
 
     const body = req.body as {
@@ -6590,7 +6591,7 @@ export function buildServer(options: ProjectsApiOptions = {}): FastifyInstance {
   });
 
   // POST /api/memories/bulk - Bulk create memories (Issue #218)
-  app.post('/api/memories/bulk', async (req, reply) => {
+  app.post('/api/memories/bulk', { preHandler: [geoAutoInjectHook(createPool)] }, async (req, reply) => {
     const { createMemory, isValidMemoryType } = await import('./memory/index.ts');
 
     const body = req.body as {


### PR DESCRIPTION
## Summary
- Fastify preHandler hook that auto-injects current geolocation into memory operations
- Applied to POST /api/memories/unified and POST /api/memories/bulk
- Respects user `geo_auto_inject` setting
- Preserves explicit location when provided (sets `X-Geo-Source: explicit`)
- Sets `X-Geo-Source: auto` header when auto-injecting
- 9 unit tests covering all paths (inject, skip, explicit, null body, no email, no setting, no location, missing address, pool release)

Closes #1250

🤖 Generated with [Claude Code](https://claude.com/claude-code)