### PR TITLE
[#1283] Split test suite into parallel unit and serial integration projects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,12 @@ jobs:
         run: |
           docker compose -f .devcontainer/docker-compose.devcontainer.yml exec -T workspace bash -lc "cd /workspaces/openclaw-projects && pnpm --filter @troykelly/openclaw-projects run build"
 
-      - name: Run tests
+      - name: Run unit tests (parallel, no DB)
+        run: |
+          docker compose -f .devcontainer/docker-compose.devcontainer.yml exec -T \
+            workspace bash -lc "cd /workspaces/openclaw-projects && pnpm -s test:unit"
+
+      - name: Run integration tests (serial, DB)
         env:
           VOYAGERAI_API_KEY: ${{ secrets.VOYAGERAI_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -82,7 +87,7 @@ jobs:
             -e VOYAGERAI_API_KEY \
             -e OPENAI_API_KEY \
             -e GEMINI_API_KEY \
-            workspace bash -lc "cd /workspaces/openclaw-projects && pnpm -s test"
+            workspace bash -lc "cd /workspaces/openclaw-projects && pnpm -s test:integration"
 
       - name: Start E2E services
         run: |

--- a/CODING.md
+++ b/CODING.md
@@ -14,9 +14,21 @@ These principles are **non-negotiable**. They apply to all contributors — huma
 
 - Write failing tests **before** implementation code
 - Tests must cover expected usage, edge cases, and error conditions
-- “Minimal TDD to satisfy TDD” is not acceptable — coverage must be meaningful
+- "Minimal TDD to satisfy TDD" is not acceptable — coverage must be meaningful
 - Run tests frequently during development, not just at completion
 - Commit only when tests pass
+
+### Test commands for development
+
+| Command | When to use |
+|---------|-------------|
+| `pnpm test:changed` | **During active development** — runs only tests affected by uncommitted changes |
+| `pnpm test:unit` | Quick feedback — pure tests (no DB), runs in parallel |
+| `pnpm test:integration` | DB-dependent tests — runs serially |
+| `pnpm test` | **Before committing/pushing** — runs both unit + integration |
+| `pnpm run test:e2e` | Level 2 E2E tests (requires Docker backend) |
+
+Prefer `pnpm test:changed` during iterative development to keep the feedback loop fast. Always run `pnpm test` before pushing.
 
 ## Test Against Real Services
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json --noEmit",
     "test": "vitest run",
+    "test:unit": "vitest run --project unit",
+    "test:integration": "vitest run --project integration",
+    "test:changed": "vitest run --changed",
     "test:watch": "vitest",
     "test:e2e": "RUN_E2E=true vitest run --config vitest.config.e2e.ts",
     "test:gateway": "vitest run packages/openclaw-plugin/tests/gateway",

--- a/vitest.config.integration.ts
+++ b/vitest.config.integration.ts
@@ -1,0 +1,114 @@
+import { defineProject } from 'vitest/config';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const gatewayRoot = path.resolve(__dirname, '.local/openclaw-gateway');
+const hasGateway = fs.existsSync(gatewayRoot);
+
+/**
+ * Integration test project — tests that require Postgres or a running server.
+ *
+ * Parallelism is disabled because these tests share one local Postgres
+ * instance with per-test TRUNCATE cleanup.
+ *
+ * Pure unit tests (no DB, no HTTP) live in vitest.config.unit.ts and run
+ * in parallel for speed. See that file for the classification heuristic.
+ */
+export default defineProject({
+  test: {
+    name: 'integration',
+    globals: true,
+    testTimeout: 30000,
+
+    // Tests share one local Postgres database with per-test TRUNCATE cleanup.
+    // Parallelism is disabled to avoid migration race conditions.
+    fileParallelism: false,
+
+    exclude: [
+      // ── Unit tests (run by the unit project) ───────────────────────
+      'tests/ui/**',
+      'tests/devcontainer/**',
+      'tests/docker/**',
+      'tests/frontend/**',
+      'tests/workflows/**',
+      'tests/openclaw-contract/**',
+      'tests/command_palette.test.ts',
+      'tests/generate_title.test.ts',
+      'tests/layout_components.test.ts',
+      'tests/note_presence_cursor_rate_limit.test.ts',
+      'tests/note_presence_timeout.test.ts',
+      'tests/ui_components.test.ts',
+      'tests/webhook_ssrf.test.ts',
+      'tests/api/dual-stack-binding.test.ts',
+      'tests/api/ip-whitelist.test.ts',
+      'tests/api/per-user-rate-limit.test.ts',
+      'tests/embeddings/config.test.ts',
+      'tests/embeddings/errors.test.ts',
+      'tests/embeddings/providers.test.ts',
+      'tests/embeddings/service.test.ts',
+      'tests/file-storage/content-disposition-sanitization.test.ts',
+      'tests/oauth/config.test.ts',
+      'tests/postmark/email-utils.test.ts',
+      'tests/realtime/emitter.test.ts',
+      'tests/realtime/hub.test.ts',
+      'tests/recurrence/parser.test.ts',
+      'tests/twilio/phone-utils.test.ts',
+      'tests/webhooks/config.test.ts',
+      'tests/webhooks/payloads.test.ts',
+      'tests/webhooks/verification.test.ts',
+      'tests/worker/**',
+      // Co-located src/ unit tests
+      'src/api/oauth/**/*.test.ts',
+      'src/api/memory/keyword-boost-unit.test.ts',
+      'src/api/webhooks/payloads.test.ts',
+      'src/api/geolocation/network-guard.test.ts',
+      'src/api/geolocation/registry.test.ts',
+      'src/api/geolocation/crypto.test.ts',
+      'src/worker/**/*.test.ts',
+
+      // ── E2E / Playwright / external ────────────────────────────────
+      'tests/e2e-playwright/**',
+      'packages/openclaw-plugin/tests/e2e/**',
+      ...(hasGateway ? [] : ['packages/openclaw-plugin/tests/gateway/**']),
+      'node_modules/**',
+      '**/node_modules/**',
+      '.local/openclaw-gateway/**/*.e2e.test.ts',
+      '.local/openclaw-gateway/**/*.browser.test.ts',
+      '.local/openclaw-gateway/ui/**',
+      '.local/openclaw-gateway/**/vendor/**',
+      '.local/openclaw-gateway/dist/**',
+      // CWD-dependent: resolve files relative to gateway root via process.cwd()
+      '.local/openclaw-gateway/src/docs/slash-commands-doc.test.ts',
+      '.local/openclaw-gateway/src/cron/cron-protocol-conformance.test.ts',
+      '.local/openclaw-gateway/src/canvas-host/server.test.ts',
+      '.local/openclaw-gateway/src/cli/gateway.sigterm.test.ts',
+      '.local/openclaw-gateway/src/infra/run-node.test.ts',
+      '.local/openclaw-gateway/src/process/child-process-bridge.test.ts',
+      '.local/openclaw-gateway/src/web/qr-image.test.ts',
+      '.local/openclaw-gateway/src/agents/skills.summarize-skill-description.test.ts',
+      '.local/openclaw-gateway/src/cli/browser-cli-extension.test.ts',
+      // Stale import: deliverWebReply moved to auto-reply/deliver-reply.ts
+      '.local/openclaw-gateway/test/auto-reply.retry.test.ts',
+    ],
+
+    // setup-api.ts disables bearer token auth for tests
+    // Gateway setup registers channel plugins needed by gateway unit tests
+    setupFiles: [
+      './tests/setup-api.ts',
+      ...(hasGateway ? ['./tests/setup-gateway.ts'] : []),
+    ],
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+      ...(hasGateway
+        ? {
+            'openclaw/plugin-sdk': path.join(gatewayRoot, 'src', 'plugin-sdk', 'index.ts'),
+            'openclaw-gateway/plugins/loader': path.join(gatewayRoot, 'src', 'plugins', 'loader.ts'),
+            'openclaw-gateway/plugins/hooks': path.join(gatewayRoot, 'src', 'plugins', 'hooks.ts'),
+            'openclaw-gateway/plugins/registry': path.join(gatewayRoot, 'src', 'plugins', 'registry.ts'),
+          }
+        : {}),
+    },
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,81 +1,20 @@
 import { defineConfig } from 'vitest/config';
-import fs from 'node:fs';
-import path from 'node:path';
 
-const gatewayRoot = path.resolve(__dirname, '.local/openclaw-gateway');
-const hasGateway = fs.existsSync(gatewayRoot);
-
+/**
+ * Root vitest config — splits the test suite into two projects:
+ *
+ *   unit         — pure tests (no DB, no HTTP), fileParallelism: true
+ *   integration  — DB-dependent tests, fileParallelism: false (serial)
+ *
+ * Run both:          pnpm test
+ * Run unit only:     pnpm test:unit
+ * Run integration:   pnpm test:integration
+ *
+ * The E2E tests (Level 2) are NOT part of this config; they use their
+ * own config via `pnpm run test:e2e` (vitest.config.e2e.ts).
+ */
 export default defineConfig({
   test: {
-    globals: true,
-    testTimeout: 30000,
-
-    // Tests share one local Postgres database with per-test TRUNCATE cleanup.
-    // Parallelism is disabled to avoid migration race conditions. If migrating
-    // to per-file temp databases, this could be re-enabled.
-    fileParallelism: false,
-
-    // Exclude E2E tests from default test run (Level 2 requires Docker backend)
-    // E2E tests are run separately via `pnpm run test:e2e` with RUN_E2E=true
-    // Also exclude Playwright E2E tests (they use their own runner) and node_modules
-    // Gateway E2E tests require a running gateway server and are excluded here;
-    // they run via the gateway's own vitest config.
-    // Gateway UI tests (ui/) use vitest browser mode with Playwright and have
-    // their own vitest config; exclude them from the root run.
-    // Gateway browser tests (*.browser.test.ts) need a DOM environment.
-    // Gateway CWD-dependent tests use process.cwd() to resolve paths relative to
-    // the gateway root; they must be run via the gateway's own vitest config.
-    // Gateway test/ directory tests are not included by the gateway's own config
-    // (except format-error.test.ts) and have stale imports.
-    exclude: [
-      'tests/e2e-playwright/**',
-      'packages/openclaw-plugin/tests/e2e/**',
-      // Gateway loader integration tests require .local/openclaw-gateway source;
-      // skip them in environments (like CI) where the gateway is not available
-      ...(hasGateway ? [] : ['packages/openclaw-plugin/tests/gateway/**']),
-      'node_modules/**',
-      '**/node_modules/**',
-      '.local/openclaw-gateway/**/*.e2e.test.ts',
-      '.local/openclaw-gateway/**/*.browser.test.ts',
-      '.local/openclaw-gateway/ui/**',
-      '.local/openclaw-gateway/**/vendor/**',
-      '.local/openclaw-gateway/dist/**',
-      // CWD-dependent: resolve files relative to gateway root via process.cwd()
-      '.local/openclaw-gateway/src/docs/slash-commands-doc.test.ts',
-      '.local/openclaw-gateway/src/cron/cron-protocol-conformance.test.ts',
-      '.local/openclaw-gateway/src/canvas-host/server.test.ts',
-      '.local/openclaw-gateway/src/cli/gateway.sigterm.test.ts',
-      '.local/openclaw-gateway/src/infra/run-node.test.ts',
-      '.local/openclaw-gateway/src/process/child-process-bridge.test.ts',
-      '.local/openclaw-gateway/src/web/qr-image.test.ts',
-      '.local/openclaw-gateway/src/agents/skills.summarize-skill-description.test.ts',
-      '.local/openclaw-gateway/src/cli/browser-cli-extension.test.ts',
-      // Stale import: deliverWebReply moved to auto-reply/deliver-reply.ts
-      '.local/openclaw-gateway/test/auto-reply.retry.test.ts',
-    ],
-
-    // UI component tests use jsdom environment
-    environmentMatchGlobs: [['tests/ui/**', 'jsdom']],
-    // setup-api.ts disables bearer token auth for tests
-    // setup-ui.ts configures jsdom mocks for UI tests
-    // Gateway setup registers channel plugins needed by gateway unit tests
-    setupFiles: [
-      './tests/setup-api.ts',
-      './tests/setup-ui.ts',
-      ...(hasGateway ? ['./tests/setup-gateway.ts'] : []),
-    ],
-  },
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './src'),
-      ...(hasGateway
-        ? {
-            'openclaw/plugin-sdk': path.join(gatewayRoot, 'src', 'plugin-sdk', 'index.ts'),
-            'openclaw-gateway/plugins/loader': path.join(gatewayRoot, 'src', 'plugins', 'loader.ts'),
-            'openclaw-gateway/plugins/hooks': path.join(gatewayRoot, 'src', 'plugins', 'hooks.ts'),
-            'openclaw-gateway/plugins/registry': path.join(gatewayRoot, 'src', 'plugins', 'registry.ts'),
-          }
-        : {}),
-    },
+    projects: ['vitest.config.unit.ts', 'vitest.config.integration.ts'],
   },
 });

--- a/vitest.config.unit.ts
+++ b/vitest.config.unit.ts
@@ -1,0 +1,85 @@
+import { defineProject } from 'vitest/config';
+import path from 'node:path';
+
+/**
+ * Unit test project — pure tests with NO database or server dependencies.
+ *
+ * These tests run with fileParallelism: true for speed. If you add a test
+ * file here that needs Postgres, move it to the integration project
+ * (the root vitest.config.ts) instead.
+ *
+ * How to decide:
+ *   - Imports buildServer / createTestPool / truncateAllTables / pg Pool → integration
+ *   - Pure functions, React components, mocks only → unit (add pattern here)
+ */
+export default defineProject({
+  test: {
+    name: 'unit',
+    globals: true,
+    testTimeout: 15000,
+    fileParallelism: true,
+
+    include: [
+      // ── React component tests (jsdom) ──────────────────────────────
+      'tests/ui/**/*.test.{ts,tsx}',
+
+      // ── Docker / devcontainer / workflow config tests ──────────────
+      'tests/devcontainer/**/*.test.ts',
+      'tests/docker/**/*.test.ts',
+      'tests/frontend/**/*.test.ts',
+      'tests/workflows/**/*.test.ts',
+
+      // ── Pure utility / logic tests under tests/ ────────────────────
+      'tests/command_palette.test.ts',
+      'tests/generate_title.test.ts',
+      'tests/layout_components.test.ts',
+      'tests/note_presence_cursor_rate_limit.test.ts',
+      'tests/note_presence_timeout.test.ts',
+      'tests/ui_components.test.ts',
+      'tests/webhook_ssrf.test.ts',
+
+      // ── Subdirectory unit tests (config, parsing, utilities) ───────
+      'tests/api/dual-stack-binding.test.ts',
+      'tests/api/ip-whitelist.test.ts',
+      'tests/api/per-user-rate-limit.test.ts',
+      'tests/embeddings/config.test.ts',
+      'tests/embeddings/errors.test.ts',
+      'tests/embeddings/providers.test.ts',
+      'tests/embeddings/service.test.ts',
+      'tests/file-storage/content-disposition-sanitization.test.ts',
+      'tests/oauth/config.test.ts',
+      'tests/openclaw-contract/**/*.test.ts',
+      'tests/postmark/email-utils.test.ts',
+      'tests/realtime/emitter.test.ts',
+      'tests/realtime/hub.test.ts',
+      'tests/recurrence/parser.test.ts',
+      'tests/twilio/phone-utils.test.ts',
+      'tests/webhooks/config.test.ts',
+      'tests/webhooks/payloads.test.ts',
+      'tests/webhooks/verification.test.ts',
+      'tests/worker/**/*.test.ts',
+
+      // ── Pure unit tests co-located in src/ ─────────────────────────
+      'src/api/oauth/**/*.test.ts',
+      'src/api/memory/keyword-boost-unit.test.ts',
+      'src/api/webhooks/payloads.test.ts',
+      'src/api/geolocation/network-guard.test.ts',
+      'src/api/geolocation/registry.test.ts',
+      'src/api/geolocation/crypto.test.ts',
+      'src/worker/**/*.test.ts',
+    ],
+
+    exclude: ['node_modules/**', '**/node_modules/**'],
+
+    // jsdom for React component tests
+    environmentMatchGlobs: [['tests/ui/**', 'jsdom']],
+
+    // UI setup (jsdom mocks) — safe as a no-op in Node environment
+    setupFiles: ['./tests/setup-ui.ts'],
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+});


### PR DESCRIPTION
## Summary

- Splits vitest config into two projects using vitest 4.x `projects` array:
  - **unit** (`vitest.config.unit.ts`): 140 pure test files, `fileParallelism: true` — no DB/server dependencies
  - **integration** (`vitest.config.integration.ts`): ~1175 test files, `fileParallelism: false` — share Postgres, run serially
- Adds `test:unit`, `test:integration`, and `test:changed` scripts to package.json
- Updates CI workflow to run unit and integration as separate named steps (unit first, then integration with DB secrets)
- Updates CODING.md with test command table for developer guidance

## How it works

- Root `vitest.config.ts` now defines `projects: ['vitest.config.unit.ts', 'vitest.config.integration.ts']`
- `pnpm test` still runs everything (both projects)
- `pnpm test:unit` runs only parallel unit tests (~3 seconds)
- `pnpm test:integration` runs only serial integration tests
- `pnpm test:changed` runs only tests affected by uncommitted changes
- Classification is by explicit include patterns (unit) and exclude patterns (integration), not file moves

## Test plan

- [x] `pnpm test:unit` runs 140 files, 3240 tests (137 pass, 3 pre-existing Docker/flaky failures)
- [x] `pnpm test:integration` runs 1175 files, 9390 tests (all DB-dependent tests now actually run instead of skip)
- [x] `pnpm test` runs both projects together
- [x] No files moved — include/exclude patterns only
- [x] vitest.config.e2e.ts unchanged
- [x] Lint passes
- [ ] CI pipeline passes with split test steps

Closes #1283

🤖 Generated with [Claude Code](https://claude.com/claude-code)