### PR TITLE
[#1298] Add extra_hosts for gateway access from containers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -257,7 +257,10 @@ SEAWEEDFS_VOLUME_SIZE_LIMIT_MB=1000
 # =============================================================================
 
 # OpenClaw gateway URL for hooks and callbacks
-# OPENCLAW_GATEWAY_URL=https://gateway.openclaw.ai
+# For docker-compose.traefik.yml (gateway runs on host):
+#   OPENCLAW_GATEWAY_URL=http://host.docker.internal:18789
+# For docker-compose.full.yml (gateway runs in Docker): auto-configured
+# OPENCLAW_GATEWAY_URL=http://host.docker.internal:18789
 
 # Authentication token for OpenClaw webhooks
 # OPENCLAW_HOOK_TOKEN=your-hook-token

--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -461,6 +461,9 @@ services:
       timeout: 5s
       retries: 10
       start_period: 15s
+    # Allow containers to reach services on the Docker host (e.g. OpenClaw gateway)
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     # Container hardening
     read_only: true
     tmpfs:
@@ -524,6 +527,9 @@ services:
       timeout: 5s
       retries: 3
       start_period: 10s
+    # Allow containers to reach services on the Docker host (e.g. OpenClaw gateway)
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     # Container hardening
     read_only: true
     tmpfs:


### PR DESCRIPTION
## Summary
- Add `extra_hosts: ["host.docker.internal:host-gateway"]` to API and worker services in `docker-compose.traefik.yml`
- Update `.env.example` default for `OPENCLAW_GATEWAY_URL` to `http://host.docker.internal:18789`

Worker and API containers could not reach the OpenClaw gateway running on the host because `127.0.0.1` inside a container resolves to the container's own loopback, not the host. The `host.docker.internal` mapping solves this.

Note: `docker-compose.full.yml` is unaffected — the gateway runs as a container in the same Docker network, so `http://openclaw-gateway:18789` (already hardcoded) works correctly.

Closes #1298

## Test plan
- [x] `docker compose -f docker-compose.traefik.yml config` validates successfully
- [x] `extra_hosts` appears on both api and worker services in resolved config
- [x] Compose structure tests pass (57 tests in basic-compose.test.ts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)