### PR TITLE
[#1299] Add /api path routing and root redirect for app domain

### DIFF
--- a/docker/traefik/dynamic-config.yml.template
+++ b/docker/traefik/dynamic-config.yml.template
@@ -59,6 +59,13 @@ http:
         excludedContentTypes:
           - text/event-stream
 
+    # Redirect bare root (/) to /app for the SPA
+    root-redirect:
+      redirectRegex:
+        regex: "^https?://[^/]+/$"
+        replacement: "/app"
+        permanent: false
+
   # Routers
   routers:
     # API router - routes through ModSecurity WAF for full request/response inspection
@@ -71,6 +78,39 @@ http:
       middlewares:
         - security-headers
         - rate-limit
+      tls:
+        certResolver: letsencrypt
+        options: default
+
+    # API path router - routes /api/* on the app domain through ModSecurity WAF
+    # The web UI makes API calls to /api/* on the same origin (DOMAIN), so these
+    # must be forwarded to the API via ModSecurity rather than nginx.
+    # Priority 100 ensures this matches before the catch-all app-router.
+    api-path-router:
+      rule: "(Host(`${DOMAIN}`) || Host(`www.${DOMAIN}`)) && PathPrefix(`/api`)"
+      service: modsecurity-service
+      priority: 100
+      entryPoints:
+        - websecure
+      middlewares:
+        - security-headers
+        - rate-limit
+      tls:
+        certResolver: letsencrypt
+        options: default
+
+    # Root redirect router - redirects / to /app on the app domain
+    # React Router uses basename="/app" so the bare root must redirect.
+    # Priority 200 ensures exact root match takes precedence.
+    root-redirect-router:
+      rule: "(Host(`${DOMAIN}`) || Host(`www.${DOMAIN}`)) && Path(`/`)"
+      service: app-service
+      priority: 200
+      entryPoints:
+        - websecure
+      middlewares:
+        - root-redirect
+        - security-headers
       tls:
         certResolver: letsencrypt
         options: default


### PR DESCRIPTION
## Summary
- Add `api-path-router` in Traefik dynamic config to route `/api/*` on the app domain through ModSecurity WAF to the API server (priority 100)
- Add `root-redirect-router` to redirect `/` to `/app` for the React SPA (priority 200)
- Add `root-redirect` middleware using Traefik's `redirectRegex`

The web UI at `DOMAIN` makes API calls to `/api/*` on the same origin, but Traefik was routing all `DOMAIN` traffic to nginx (app-service), which has no `/api` handler — causing 502 errors. Additionally, visiting `/` triggered a React Router warning because the SPA uses `basename="/app"`.

Closes #1299

## Test plan
- [x] YAML template parses correctly with all routers, middlewares, and services
- [x] `api-path-router` has priority 100 (matches before app-router)
- [x] `root-redirect-router` has priority 200 (matches before app-router)
- [x] Traefik entrypoint tests pass (6/6)
- [ ] `curl -sk https://DOMAIN/api/me` returns 401 (not 502)
- [ ] `curl -sk https://DOMAIN/` redirects to `/app`

🤖 Generated with [Claude Code](https://claude.com/claude-code)