### PR TITLE
[#1262] Add Docker Compose profiles for optional services

### DIFF
--- a/docker-compose.full.yml
+++ b/docker-compose.full.yml
@@ -547,6 +547,7 @@ services:
   # If Nominatim is unavailable, geo features silently degrade.
   nominatim:
     image: mediagis/nominatim:4.4
+    profiles: ["geo"]
     container_name: openclaw-nominatim
     restart: unless-stopped
     environment:

--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -556,6 +556,7 @@ services:
   # If Nominatim is unavailable, geo features silently degrade.
   nominatim:
     image: mediagis/nominatim:4.4
+    profiles: ["geo"]
     container_name: openclaw-nominatim
     restart: unless-stopped
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -306,6 +306,7 @@ services:
   # If Nominatim is unavailable, geo features silently degrade.
   nominatim:
     image: mediagis/nominatim:4.4
+    profiles: ["geo"]
     container_name: openclaw-nominatim
     restart: unless-stopped
     environment:

--- a/tests/docker/optional-services.test.ts
+++ b/tests/docker/optional-services.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Tests that optional services (Nominatim, PromptGuard) are documented
+ * and can be disabled via Docker Compose profiles or overrides.
+ *
+ * Issue #1262
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { parse } from 'yaml';
+
+const ROOT_DIR = resolve(__dirname, '../..');
+
+interface ComposeService {
+  profiles?: string[];
+  environment?: Record<string, string> | string[];
+  [key: string]: unknown;
+}
+
+interface ComposeFile {
+  services: Record<string, ComposeService>;
+  [key: string]: unknown;
+}
+
+function loadCompose(filename: string): ComposeFile {
+  const content = readFileSync(resolve(ROOT_DIR, filename), 'utf-8');
+  return parse(content) as ComposeFile;
+}
+
+function loadDeploymentDocs(): string {
+  return readFileSync(resolve(ROOT_DIR, 'docs/deployment.md'), 'utf-8');
+}
+
+describe('Optional services configuration', () => {
+  describe('Nominatim in docker-compose.traefik.yml', () => {
+    let compose: ComposeFile;
+
+    beforeAll(() => {
+      compose = loadCompose('docker-compose.traefik.yml');
+    });
+
+    it('should have nominatim service defined', () => {
+      expect(compose.services.nominatim).toBeDefined();
+    });
+
+    it('should have nominatim behind a profile', () => {
+      expect(compose.services.nominatim.profiles).toBeDefined();
+      expect(compose.services.nominatim.profiles).toContain('geo');
+    });
+  });
+
+  describe('Nominatim in docker-compose.full.yml', () => {
+    let compose: ComposeFile;
+
+    beforeAll(() => {
+      compose = loadCompose('docker-compose.full.yml');
+    });
+
+    it('should have nominatim service defined', () => {
+      expect(compose.services.nominatim).toBeDefined();
+    });
+
+    it('should have nominatim behind a profile', () => {
+      expect(compose.services.nominatim.profiles).toBeDefined();
+      expect(compose.services.nominatim.profiles).toContain('geo');
+    });
+  });
+
+  describe('PromptGuard profile consistency', () => {
+    it('should have prompt-guard behind ml profile in traefik compose', () => {
+      const compose = loadCompose('docker-compose.traefik.yml');
+      expect(compose.services['prompt-guard']?.profiles).toContain('ml');
+    });
+
+    it('should have prompt-guard behind ml profile in full compose', () => {
+      const compose = loadCompose('docker-compose.full.yml');
+      expect(compose.services['prompt-guard']?.profiles).toContain('ml');
+    });
+  });
+
+  describe('Deployment documentation', () => {
+    let docs: string;
+
+    beforeAll(() => {
+      docs = loadDeploymentDocs();
+    });
+
+    it('should document optional services section', () => {
+      expect(docs).toContain('Optional Services');
+    });
+
+    it('should document how to enable Nominatim', () => {
+      expect(docs).toContain('--profile geo');
+    });
+
+    it('should document how to enable PromptGuard', () => {
+      expect(docs).toContain('--profile ml');
+    });
+
+    it('should document that Nominatim is opt-in', () => {
+      expect(docs).toMatch(/[Nn]ominatim/);
+      expect(docs).toMatch(/geo.*profile|profile.*geo/i);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Put Nominatim behind `profiles: ["geo"]` in all three compose files (`docker-compose.yml`, `docker-compose.full.yml`, `docker-compose.traefik.yml`) so it only starts when explicitly enabled
- Add "Optional Services" section to `docs/deployment.md` documenting how to enable Nominatim (`--profile geo`) and PromptGuard (`--profile ml`)
- Add TDD tests validating profile assignment and documentation completeness

Closes #1262

## Test plan

- [x] 10 new tests in `tests/docker/optional-services.test.ts` all pass
- [x] Nominatim service has `profiles: ["geo"]` in all compose files
- [x] PromptGuard service has `profiles: ["ml"]` in traefik and full compose files
- [x] Deployment docs contain "Optional Services" section with enable commands
- [x] Existing docker tests unaffected (262 passing, 3 pre-existing Docker credential failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)