### PR TITLE
[#1274] Add ad-hoc webhook ingestion linked to projects

### DIFF
--- a/migrations/071_project_webhooks.down.sql
+++ b/migrations/071_project_webhooks.down.sql
@@ -1,0 +1,3 @@
+-- Issue #1274: Rollback project webhooks
+DROP TABLE IF EXISTS project_event;
+DROP TABLE IF EXISTS project_webhook;

--- a/migrations/071_project_webhooks.up.sql
+++ b/migrations/071_project_webhooks.up.sql
@@ -1,0 +1,33 @@
+-- Issue #1274: Ad-hoc webhook ingestion linked to projects
+--
+-- project_webhook: configurable inbound webhook endpoints per project
+-- project_event: stores received webhook payloads as project activity
+
+CREATE TABLE project_webhook (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id      uuid NOT NULL REFERENCES work_item(id) ON DELETE CASCADE,
+  user_email      text REFERENCES user_setting(email) ON DELETE SET NULL,
+  label           text NOT NULL,
+  token           text NOT NULL,
+  is_active       boolean NOT NULL DEFAULT true,
+  last_received   timestamptz,
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  updated_at      timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_project_webhook_project ON project_webhook (project_id);
+CREATE UNIQUE INDEX idx_project_webhook_token ON project_webhook (token);
+
+CREATE TABLE project_event (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id      uuid NOT NULL REFERENCES work_item(id) ON DELETE CASCADE,
+  webhook_id      uuid REFERENCES project_webhook(id) ON DELETE SET NULL,
+  user_email      text,
+  event_type      text NOT NULL DEFAULT 'webhook',
+  summary         text,
+  raw_payload     jsonb,
+  created_at      timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_project_event_project ON project_event (project_id, created_at DESC);
+CREATE INDEX idx_project_event_webhook ON project_event (webhook_id);

--- a/tests/project_webhooks.test.ts
+++ b/tests/project_webhooks.test.ts
@@ -1,0 +1,372 @@
+/**
+ * Tests for ad-hoc webhook ingestion linked to projects (Issue #1274).
+ * Covers schema, webhook CRUD, ingestion endpoint, and event listing.
+ */
+
+import type { Pool } from 'pg';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { buildServer } from '../src/api/server.ts';
+import { createTestPool, truncateAllTables } from './helpers/db.ts';
+import { runMigrate } from './helpers/migrate.ts';
+
+describe('Project Webhooks (Issue #1274)', () => {
+  const app = buildServer();
+  let pool: Pool;
+  let projectId: string;
+
+  beforeAll(async () => {
+    await runMigrate('up');
+    pool = createTestPool();
+    await app.ready();
+  });
+
+  beforeEach(async () => {
+    await truncateAllTables(pool);
+    // Create a project (work_item with kind='project') for tests
+    const result = await pool.query(
+      `INSERT INTO work_item (title, kind) VALUES ('Test Project', 'project')
+       RETURNING id::text as id`,
+    );
+    projectId = (result.rows[0] as { id: string }).id;
+  });
+
+  afterAll(async () => {
+    await app.close();
+    await pool.end();
+  });
+
+  // ── Schema ──────────────────────────────────────────────
+
+  describe('schema', () => {
+    it('project_webhook table exists with expected columns', async () => {
+      const result = await pool.query(
+        `SELECT column_name
+         FROM information_schema.columns
+         WHERE table_name = 'project_webhook'
+         ORDER BY ordinal_position`,
+      );
+      const cols = result.rows.map((r) => (r as { column_name: string }).column_name);
+      expect(cols).toContain('id');
+      expect(cols).toContain('project_id');
+      expect(cols).toContain('user_email');
+      expect(cols).toContain('label');
+      expect(cols).toContain('token');
+      expect(cols).toContain('is_active');
+      expect(cols).toContain('last_received');
+    });
+
+    it('project_event table exists with expected columns', async () => {
+      const result = await pool.query(
+        `SELECT column_name
+         FROM information_schema.columns
+         WHERE table_name = 'project_event'
+         ORDER BY ordinal_position`,
+      );
+      const cols = result.rows.map((r) => (r as { column_name: string }).column_name);
+      expect(cols).toContain('id');
+      expect(cols).toContain('project_id');
+      expect(cols).toContain('webhook_id');
+      expect(cols).toContain('event_type');
+      expect(cols).toContain('summary');
+      expect(cols).toContain('raw_payload');
+    });
+
+    it('project_webhook.project_id cascades on delete', async () => {
+      const result = await pool.query(
+        `SELECT rc.delete_rule
+         FROM information_schema.referential_constraints rc
+         JOIN information_schema.key_column_usage kcu
+           ON rc.constraint_name = kcu.constraint_name
+         WHERE kcu.table_name = 'project_webhook'
+           AND kcu.column_name = 'project_id'`,
+      );
+      expect(result.rows.length).toBe(1);
+      expect((result.rows[0] as { delete_rule: string }).delete_rule).toBe('CASCADE');
+    });
+  });
+
+  // ── POST /api/projects/:id/webhooks — create webhook ──
+
+  describe('POST /api/projects/:id/webhooks', () => {
+    it('creates a webhook and returns it with a token', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: `/api/projects/${projectId}/webhooks`,
+        payload: { label: 'CI Notifications' },
+      });
+
+      expect(res.statusCode).toBe(201);
+      const body = res.json();
+      expect(body.label).toBe('CI Notifications');
+      expect(body.token).toBeDefined();
+      expect(body.token.length).toBeGreaterThan(20);
+      expect(body.project_id).toBe(projectId);
+      expect(body.is_active).toBe(true);
+    });
+
+    it('rejects without a label', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: `/api/projects/${projectId}/webhooks`,
+        payload: {},
+      });
+
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('returns 404 for non-existent project', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/projects/00000000-0000-0000-0000-000000000000/webhooks',
+        payload: { label: 'Test' },
+      });
+
+      expect(res.statusCode).toBe(404);
+    });
+  });
+
+  // ── GET /api/projects/:id/webhooks — list webhooks ────
+
+  describe('GET /api/projects/:id/webhooks', () => {
+    it('returns empty array when no webhooks exist', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: `/api/projects/${projectId}/webhooks`,
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toEqual([]);
+    });
+
+    it('returns created webhooks', async () => {
+      await app.inject({
+        method: 'POST',
+        url: `/api/projects/${projectId}/webhooks`,
+        payload: { label: 'Hook A' },
+      });
+      await app.inject({
+        method: 'POST',
+        url: `/api/projects/${projectId}/webhooks`,
+        payload: { label: 'Hook B' },
+      });
+
+      const res = await app.inject({
+        method: 'GET',
+        url: `/api/projects/${projectId}/webhooks`,
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json().length).toBe(2);
+    });
+  });
+
+  // ── DELETE /api/projects/:id/webhooks/:webhook_id ─────
+
+  describe('DELETE /api/projects/:id/webhooks/:webhook_id', () => {
+    it('deletes a webhook', async () => {
+      const createRes = await app.inject({
+        method: 'POST',
+        url: `/api/projects/${projectId}/webhooks`,
+        payload: { label: 'Delete Me' },
+      });
+      const webhookId = createRes.json().id;
+
+      const deleteRes = await app.inject({
+        method: 'DELETE',
+        url: `/api/projects/${projectId}/webhooks/${webhookId}`,
+      });
+
+      expect(deleteRes.statusCode).toBe(204);
+
+      // Confirm it's gone
+      const listRes = await app.inject({
+        method: 'GET',
+        url: `/api/projects/${projectId}/webhooks`,
+      });
+      expect(listRes.json().length).toBe(0);
+    });
+  });
+
+  // ── POST /api/webhooks/:webhook_id — ingestion ────────
+
+  describe('POST /api/webhooks/:webhook_id (ingestion)', () => {
+    it('ingests a payload with valid bearer token', async () => {
+      const createRes = await app.inject({
+        method: 'POST',
+        url: `/api/projects/${projectId}/webhooks`,
+        payload: { label: 'GitHub Actions' },
+      });
+      const webhook = createRes.json();
+
+      const ingestRes = await app.inject({
+        method: 'POST',
+        url: `/api/webhooks/${webhook.id}`,
+        headers: { authorization: `Bearer ${webhook.token}` },
+        payload: {
+          action: 'completed',
+          status: 'success',
+          repository: 'my-repo',
+        },
+      });
+
+      expect(ingestRes.statusCode).toBe(201);
+      const body = ingestRes.json();
+      expect(body.event_type).toBe('webhook');
+      expect(body.raw_payload).toBeDefined();
+      expect(body.project_id).toBe(projectId);
+    });
+
+    it('rejects with invalid token', async () => {
+      const createRes = await app.inject({
+        method: 'POST',
+        url: `/api/projects/${projectId}/webhooks`,
+        payload: { label: 'Auth Test' },
+      });
+      const webhook = createRes.json();
+
+      const ingestRes = await app.inject({
+        method: 'POST',
+        url: `/api/webhooks/${webhook.id}`,
+        headers: { authorization: 'Bearer wrong-token' },
+        payload: { data: 'test' },
+      });
+
+      expect(ingestRes.statusCode).toBe(401);
+    });
+
+    it('rejects with no authorization header', async () => {
+      const createRes = await app.inject({
+        method: 'POST',
+        url: `/api/projects/${projectId}/webhooks`,
+        payload: { label: 'No Auth Test' },
+      });
+      const webhook = createRes.json();
+
+      const ingestRes = await app.inject({
+        method: 'POST',
+        url: `/api/webhooks/${webhook.id}`,
+        payload: { data: 'test' },
+      });
+
+      expect(ingestRes.statusCode).toBe(401);
+    });
+
+    it('returns 404 for non-existent webhook', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/webhooks/00000000-0000-0000-0000-000000000000',
+        headers: { authorization: 'Bearer some-token' },
+        payload: { data: 'test' },
+      });
+
+      expect(res.statusCode).toBe(404);
+    });
+
+    it('updates last_received timestamp on ingestion', async () => {
+      const createRes = await app.inject({
+        method: 'POST',
+        url: `/api/projects/${projectId}/webhooks`,
+        payload: { label: 'Timestamp Test' },
+      });
+      const webhook = createRes.json();
+      expect(webhook.last_received).toBeNull();
+
+      await app.inject({
+        method: 'POST',
+        url: `/api/webhooks/${webhook.id}`,
+        headers: { authorization: `Bearer ${webhook.token}` },
+        payload: { data: 'ping' },
+      });
+
+      // Verify via list
+      const listRes = await app.inject({
+        method: 'GET',
+        url: `/api/projects/${projectId}/webhooks`,
+      });
+      const updated = listRes.json().find((w: { id: string }) => w.id === webhook.id);
+      expect(updated.last_received).not.toBeNull();
+    });
+  });
+
+  // ── GET /api/projects/:id/events — list events ────────
+
+  describe('GET /api/projects/:id/events', () => {
+    it('returns empty array when no events exist', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: `/api/projects/${projectId}/events`,
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json().events).toEqual([]);
+    });
+
+    it('returns events after webhook ingestion', async () => {
+      const createRes = await app.inject({
+        method: 'POST',
+        url: `/api/projects/${projectId}/webhooks`,
+        payload: { label: 'Events Test' },
+      });
+      const webhook = createRes.json();
+
+      // Ingest two events
+      await app.inject({
+        method: 'POST',
+        url: `/api/webhooks/${webhook.id}`,
+        headers: { authorization: `Bearer ${webhook.token}` },
+        payload: { event: 'build_started' },
+      });
+      await app.inject({
+        method: 'POST',
+        url: `/api/webhooks/${webhook.id}`,
+        headers: { authorization: `Bearer ${webhook.token}` },
+        payload: { event: 'build_completed' },
+      });
+
+      const res = await app.inject({
+        method: 'GET',
+        url: `/api/projects/${projectId}/events`,
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.events.length).toBe(2);
+      expect(body.events[0].webhook_id).toBe(webhook.id);
+    });
+
+    it('supports pagination with limit and offset', async () => {
+      const createRes = await app.inject({
+        method: 'POST',
+        url: `/api/projects/${projectId}/webhooks`,
+        payload: { label: 'Pagination Test' },
+      });
+      const webhook = createRes.json();
+
+      // Ingest 3 events
+      for (let i = 0; i < 3; i++) {
+        await app.inject({
+          method: 'POST',
+          url: `/api/webhooks/${webhook.id}`,
+          headers: { authorization: `Bearer ${webhook.token}` },
+          payload: { index: i },
+        });
+      }
+
+      const res = await app.inject({
+        method: 'GET',
+        url: `/api/projects/${projectId}/events?limit=2&offset=0`,
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json().events.length).toBe(2);
+
+      const res2 = await app.inject({
+        method: 'GET',
+        url: `/api/projects/${projectId}/events?limit=2&offset=2`,
+      });
+
+      expect(res2.statusCode).toBe(200);
+      expect(res2.json().events.length).toBe(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `project_webhook` and `project_event` tables (migration 071) for configurable inbound webhook endpoints per project
- Webhook creation generates a secure bearer token (`randomBytes(32).toString('base64url')`) for authentication
- Public ingestion endpoint (`POST /api/webhooks/:webhook_id`) validates bearer token, stores raw JSON payload, extracts summary, and updates `last_received`
- Paginated event listing (`GET /api/projects/:id/events`) with `limit` and `offset` support
- Route metadata registered in `/api` discovery endpoint

## Test plan

- [x] 17 integration tests covering schema, webhook CRUD, bearer token auth (valid/invalid/missing), ingestion, last_received update, event listing, and pagination
- [x] TypeScript type check clean
- [x] Lint clean (warnings only, no errors)

Closes #1274

🤖 Generated with [Claude Code](https://claude.com/claude-code)