### PR TITLE
[#1276] Add entity linking for outbound actions

### DIFF
--- a/migrations/073_entity_links.down.sql
+++ b/migrations/073_entity_links.down.sql
@@ -1,0 +1,2 @@
+-- Issue #1276: Rollback entity linking
+DROP TABLE IF EXISTS entity_link;

--- a/migrations/073_entity_links.up.sql
+++ b/migrations/073_entity_links.up.sql
@@ -1,0 +1,27 @@
+-- Issue #1276: Entity linking for outbound actions
+--
+-- Generic many-to-many entity link table so outbound actions (sent SMS,
+-- emails, calls) can be associated with projects, contacts, and todos.
+
+CREATE TABLE IF NOT EXISTS entity_link (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  source_type     text NOT NULL,
+  source_id       uuid NOT NULL,
+  target_type     text NOT NULL,
+  target_id       uuid NOT NULL,
+  link_type       text NOT NULL DEFAULT 'related',
+  created_by      text,
+  user_email      text,
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT uq_entity_link UNIQUE (source_type, source_id, target_type, target_id, link_type)
+);
+
+CREATE INDEX IF NOT EXISTS idx_entity_link_source ON entity_link (source_type, source_id);
+CREATE INDEX IF NOT EXISTS idx_entity_link_target ON entity_link (target_type, target_id);
+CREATE INDEX IF NOT EXISTS idx_entity_link_user_email ON entity_link (user_email);
+
+COMMENT ON TABLE entity_link IS 'Generic entity-to-entity links for tracking outbound actions and cross-entity relationships';
+COMMENT ON COLUMN entity_link.source_type IS 'Source entity type: message, thread, memory, todo, project_event';
+COMMENT ON COLUMN entity_link.target_type IS 'Target entity type: project, contact, todo, memory';
+COMMENT ON COLUMN entity_link.link_type IS 'Relationship kind: related, caused_by, resulted_in, about';
+COMMENT ON COLUMN entity_link.created_by IS 'Creator identifier: auto, agent, or user_email';

--- a/src/ui/components/entity-links/entity-link-badge.tsx
+++ b/src/ui/components/entity-links/entity-link-badge.tsx
@@ -1,0 +1,78 @@
+/**
+ * Badge component for a single entity link (Issue #1276).
+ *
+ * Displays the linked entity type and link relationship with an icon,
+ * and supports click-to-navigate and optional remove action.
+ */
+import { Brain, CheckSquare, Folder, Mail, MessageSquare, User, X } from 'lucide-react';
+import { Badge } from '@/ui/components/ui/badge';
+import type { EntityLink } from '@/ui/lib/api-types';
+
+const TYPE_ICONS: Record<string, React.FC<{ className?: string }>> = {
+  message: Mail,
+  thread: MessageSquare,
+  memory: Brain,
+  todo: CheckSquare,
+  project: Folder,
+  project_event: Folder,
+  contact: User,
+};
+
+const TYPE_LABELS: Record<string, string> = {
+  message: 'Message',
+  thread: 'Thread',
+  memory: 'Memory',
+  todo: 'Todo',
+  project: 'Project',
+  project_event: 'Event',
+  contact: 'Contact',
+};
+
+const LINK_TYPE_LABELS: Record<string, string> = {
+  related: 'Related',
+  caused_by: 'Caused by',
+  resulted_in: 'Resulted in',
+  about: 'About',
+};
+
+interface EntityLinkBadgeProps {
+  link: EntityLink;
+  /** Which side of the link to display (source or target). */
+  side: 'source' | 'target';
+  onClick?: () => void;
+  onRemove?: () => void;
+}
+
+export function EntityLinkBadge({ link, side, onClick, onRemove }: EntityLinkBadgeProps) {
+  const entityType = side === 'source' ? link.source_type : link.target_type;
+  const Icon = TYPE_ICONS[entityType] ?? MessageSquare;
+  const label = TYPE_LABELS[entityType] ?? entityType;
+  const linkLabel = LINK_TYPE_LABELS[link.link_type] ?? link.link_type;
+
+  return (
+    <Badge
+      variant="outline"
+      className="gap-1 pr-1 cursor-pointer hover:bg-accent transition-colors"
+      onClick={onClick}
+      data-testid="entity-link-badge"
+    >
+      <Icon className="size-3" />
+      <span className="text-xs">
+        {linkLabel}: {label}
+      </span>
+      {onRemove && (
+        <button
+          type="button"
+          className="ml-0.5 rounded-full p-0.5 hover:bg-muted-foreground/20"
+          onClick={(e) => {
+            e.stopPropagation();
+            onRemove();
+          }}
+          data-testid="entity-link-remove"
+        >
+          <X className="size-3" />
+        </button>
+      )}
+    </Badge>
+  );
+}

--- a/src/ui/components/entity-links/entity-link-manager.tsx
+++ b/src/ui/components/entity-links/entity-link-manager.tsx
@@ -1,0 +1,222 @@
+/**
+ * Entity link manager section (Issue #1276).
+ *
+ * Displays all entity links for a given entity (as source or target)
+ * with a "Link to..." button for creating new links.
+ */
+import { Link2, Plus } from 'lucide-react';
+import React, { useState } from 'react';
+import { EmptyState } from '@/ui/components/feedback';
+import { Button } from '@/ui/components/ui/button';
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/ui/components/ui/dialog';
+import { Input } from '@/ui/components/ui/input';
+import { apiClient } from '@/ui/lib/api-client';
+import type { CreateEntityLinkBody, EntityLinkRelType, EntityLinkSourceType, EntityLinkTargetType } from '@/ui/lib/api-types';
+import { useEntityLinksFromSource, useEntityLinksToTarget } from '@/ui/hooks/queries/use-entity-links';
+import { EntityLinkBadge } from './entity-link-badge';
+
+interface EntityLinkManagerProps {
+  /** The type of the current entity. */
+  entityType: EntityLinkSourceType | EntityLinkTargetType;
+  /** The ID of the current entity. */
+  entityId: string;
+  /** Whether to query as source or target. */
+  direction: 'source' | 'target';
+  /** Called when a linked entity badge is clicked. */
+  onLinkClick?: (entityType: string, entityId: string) => void;
+}
+
+export function EntityLinkManager({ entityType, entityId, direction, onLinkClick }: EntityLinkManagerProps) {
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  const sourceQuery = useEntityLinksFromSource(entityType, entityId);
+  const targetQuery = useEntityLinksToTarget(entityType, entityId);
+  const query = direction === 'source' ? sourceQuery : targetQuery;
+  const links = query.data?.links ?? [];
+
+  const handleRemove = async (linkId: string) => {
+    try {
+      await apiClient.delete(`/api/entity-links/${linkId}`);
+      query.refetch();
+    } catch (err) {
+      console.error('Failed to remove entity link:', err);
+    }
+  };
+
+  return (
+    <div data-testid="entity-link-manager">
+      <div className="flex items-center justify-between mb-2">
+        <h3 className="text-sm font-medium flex items-center gap-1">
+          <Link2 className="size-4" />
+          Linked Entities
+        </h3>
+        <Button variant="ghost" size="sm" onClick={() => setDialogOpen(true)} data-testid="add-entity-link-button">
+          <Plus className="size-3 mr-1" />
+          Link
+        </Button>
+      </div>
+
+      {links.length > 0 ? (
+        <div className="flex flex-wrap gap-1.5">
+          {links.map((link) => (
+            <EntityLinkBadge
+              key={link.id}
+              link={link}
+              side={direction === 'source' ? 'target' : 'source'}
+              onClick={() => {
+                const clickType = direction === 'source' ? link.target_type : link.source_type;
+                const clickId = direction === 'source' ? link.target_id : link.source_id;
+                onLinkClick?.(clickType, clickId);
+              }}
+              onRemove={() => handleRemove(link.id)}
+            />
+          ))}
+        </div>
+      ) : (
+        <p className="text-xs text-muted-foreground">No linked entities yet.</p>
+      )}
+
+      <CreateEntityLinkDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        entityType={entityType}
+        entityId={entityId}
+        direction={direction}
+        onCreated={() => query.refetch()}
+      />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// CreateEntityLinkDialog
+// ---------------------------------------------------------------------------
+
+const TARGET_TYPE_OPTIONS: Array<{ value: EntityLinkTargetType; label: string }> = [
+  { value: 'project', label: 'Project' },
+  { value: 'contact', label: 'Contact' },
+  { value: 'todo', label: 'Todo' },
+  { value: 'memory', label: 'Memory' },
+];
+
+const LINK_TYPE_OPTIONS: Array<{ value: EntityLinkRelType; label: string }> = [
+  { value: 'related', label: 'Related' },
+  { value: 'caused_by', label: 'Caused by' },
+  { value: 'resulted_in', label: 'Resulted in' },
+  { value: 'about', label: 'About' },
+];
+
+interface CreateEntityLinkDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  entityType: string;
+  entityId: string;
+  direction: 'source' | 'target';
+  onCreated: () => void;
+}
+
+function CreateEntityLinkDialog({ open, onOpenChange, entityType, entityId, direction, onCreated }: CreateEntityLinkDialogProps) {
+  const [targetType, setTargetType] = useState<EntityLinkTargetType>('project');
+  const [targetId, setTargetId] = useState('');
+  const [linkType, setLinkType] = useState<EntityLinkRelType>('related');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!targetId.trim()) return;
+
+    setIsSubmitting(true);
+    try {
+      const body: CreateEntityLinkBody =
+        direction === 'source'
+          ? {
+              source_type: entityType as EntityLinkSourceType,
+              source_id: entityId,
+              target_type: targetType,
+              target_id: targetId.trim(),
+              link_type: linkType,
+            }
+          : {
+              source_type: targetType as EntityLinkSourceType,
+              source_id: targetId.trim(),
+              target_type: entityType as EntityLinkTargetType,
+              target_id: entityId,
+              link_type: linkType,
+            };
+
+      await apiClient.post('/api/entity-links', body);
+      onCreated();
+      onOpenChange(false);
+      setTargetId('');
+    } catch (err) {
+      console.error('Failed to create entity link:', err);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-sm" data-testid="create-entity-link-dialog">
+        <DialogHeader>
+          <DialogTitle>Link Entity</DialogTitle>
+          <DialogDescription>Create a link to another entity.</DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <label htmlFor="link-target-type" className="text-sm font-medium">
+              Entity Type
+            </label>
+            <select
+              id="link-target-type"
+              value={targetType}
+              onChange={(e) => setTargetType(e.target.value as EntityLinkTargetType)}
+              className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            >
+              {TARGET_TYPE_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="space-y-2">
+            <label htmlFor="link-target-id" className="text-sm font-medium">
+              Entity ID
+            </label>
+            <Input id="link-target-id" placeholder="UUID of the entity" value={targetId} onChange={(e) => setTargetId(e.target.value)} required />
+          </div>
+
+          <div className="space-y-2">
+            <label htmlFor="link-type" className="text-sm font-medium">
+              Relationship
+            </label>
+            <select
+              id="link-type"
+              value={linkType}
+              onChange={(e) => setLinkType(e.target.value as EntityLinkRelType)}
+              className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            >
+              {LINK_TYPE_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={!targetId.trim() || isSubmitting}>
+              Link
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/ui/components/entity-links/index.ts
+++ b/src/ui/components/entity-links/index.ts
@@ -1,0 +1,3 @@
+export { EntityLinkBadge } from './entity-link-badge';
+export { EntityLinkManager } from './entity-link-manager';
+export { RelatedCommunications } from './related-communications';

--- a/src/ui/components/entity-links/related-communications.tsx
+++ b/src/ui/components/entity-links/related-communications.tsx
@@ -1,0 +1,73 @@
+/**
+ * Related communications section for work item detail (Issue #1276).
+ *
+ * Shows outbound messages linked to a work item (project or todo)
+ * via the entity_link table.
+ */
+import { Mail, MessageSquare } from 'lucide-react';
+import { Badge } from '@/ui/components/ui/badge';
+import { Card, CardContent } from '@/ui/components/ui/card';
+import type { EntityLink } from '@/ui/lib/api-types';
+import { useEntityLinksToTarget } from '@/ui/hooks/queries/use-entity-links';
+
+const SOURCE_ICONS: Record<string, React.FC<{ className?: string }>> = {
+  message: Mail,
+  thread: MessageSquare,
+};
+
+interface RelatedCommunicationsProps {
+  /** 'project' or 'todo' */
+  targetType: 'project' | 'todo';
+  targetId: string;
+}
+
+export function RelatedCommunications({ targetType, targetId }: RelatedCommunicationsProps) {
+  const { data, isLoading } = useEntityLinksToTarget(targetType, targetId);
+  const links = data?.links ?? [];
+
+  // Only show message/thread source types
+  const commLinks = links.filter((l) => l.source_type === 'message' || l.source_type === 'thread');
+
+  if (isLoading) {
+    return <p className="text-xs text-muted-foreground">Loading communications...</p>;
+  }
+
+  if (commLinks.length === 0) {
+    return null;
+  }
+
+  return (
+    <div data-testid="related-communications">
+      <h4 className="text-xs font-medium text-muted-foreground mb-2">Related Communications</h4>
+      <div className="space-y-1.5">
+        {commLinks.map((link) => (
+          <RelatedCommItem key={link.id} link={link} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function RelatedCommItem({ link }: { link: EntityLink }) {
+  const Icon = SOURCE_ICONS[link.source_type] ?? MessageSquare;
+  const date = new Date(link.created_at);
+
+  return (
+    <Card className="shadow-none" data-testid="related-comm-item">
+      <CardContent className="p-2 flex items-center gap-2">
+        <Icon className="size-4 text-muted-foreground shrink-0" />
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-1.5">
+            <Badge variant="outline" className="text-xs">
+              {link.source_type}
+            </Badge>
+            <Badge variant="secondary" className="text-xs">
+              {link.link_type}
+            </Badge>
+          </div>
+        </div>
+        <span className="text-xs text-muted-foreground shrink-0">{date.toLocaleDateString()}</span>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/ui/hooks/queries/use-entity-links.ts
+++ b/src/ui/hooks/queries/use-entity-links.ts
@@ -1,0 +1,36 @@
+/**
+ * TanStack Query hooks for entity links (Issue #1276).
+ *
+ * Provides queries for fetching links from a source entity
+ * or to a target entity.
+ */
+import { useQuery } from '@tanstack/react-query';
+import { apiClient } from '@/ui/lib/api-client.ts';
+import type { EntityLinksResponse } from '@/ui/lib/api-types.ts';
+
+/** Query key factory for entity links. */
+export const entityLinkKeys = {
+  all: ['entity-links'] as const,
+  fromSource: (sourceType: string, sourceId: string) => [...entityLinkKeys.all, 'source', sourceType, sourceId] as const,
+  toTarget: (targetType: string, targetId: string) => [...entityLinkKeys.all, 'target', targetType, targetId] as const,
+};
+
+/** Fetch entity links where the given entity is the source. */
+export function useEntityLinksFromSource(sourceType: string, sourceId: string) {
+  return useQuery({
+    queryKey: entityLinkKeys.fromSource(sourceType, sourceId),
+    queryFn: ({ signal }) =>
+      apiClient.get<EntityLinksResponse>(`/api/entity-links?source_type=${sourceType}&source_id=${sourceId}`, { signal }),
+    enabled: !!sourceId,
+  });
+}
+
+/** Fetch entity links where the given entity is the target. */
+export function useEntityLinksToTarget(targetType: string, targetId: string) {
+  return useQuery({
+    queryKey: entityLinkKeys.toTarget(targetType, targetId),
+    queryFn: ({ signal }) =>
+      apiClient.get<EntityLinksResponse>(`/api/entity-links?target_type=${targetType}&target_id=${targetId}`, { signal }),
+    enabled: !!targetId,
+  });
+}

--- a/src/ui/lib/api-types.ts
+++ b/src/ui/lib/api-types.ts
@@ -398,6 +398,46 @@ export interface MessageLinkContactResponse {
 }
 
 // ---------------------------------------------------------------------------
+// Entity Links (Issue #1276)
+// ---------------------------------------------------------------------------
+
+/** Source entity type for entity links. */
+export type EntityLinkSourceType = 'message' | 'thread' | 'memory' | 'todo' | 'project_event';
+
+/** Target entity type for entity links. */
+export type EntityLinkTargetType = 'project' | 'contact' | 'todo' | 'memory';
+
+/** Relationship kind for entity links. */
+export type EntityLinkRelType = 'related' | 'caused_by' | 'resulted_in' | 'about';
+
+/** Single entity link from GET /api/entity-links. */
+export interface EntityLink {
+  id: string;
+  source_type: EntityLinkSourceType;
+  source_id: string;
+  target_type: EntityLinkTargetType;
+  target_id: string;
+  link_type: EntityLinkRelType;
+  created_by: string | null;
+  created_at: string;
+}
+
+/** Response from GET /api/entity-links. */
+export interface EntityLinksResponse {
+  links: EntityLink[];
+}
+
+/** Body for POST /api/entity-links. */
+export interface CreateEntityLinkBody {
+  source_type: EntityLinkSourceType;
+  source_id: string;
+  target_type: EntityLinkTargetType;
+  target_id: string;
+  link_type?: EntityLinkRelType;
+  created_by?: string;
+}
+
+// ---------------------------------------------------------------------------
 // Notes
 // ---------------------------------------------------------------------------
 

--- a/tests/entity_links_api.test.ts
+++ b/tests/entity_links_api.test.ts
@@ -1,0 +1,431 @@
+/**
+ * Tests for entity links API (Issue #1276).
+ * Verifies schema, CRUD, validation, idempotency, and user_email scoping.
+ */
+
+import type { Pool } from 'pg';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { buildServer } from '../src/api/server.ts';
+import { createTestPool, truncateAllTables } from './helpers/db.ts';
+import { runMigrate } from './helpers/migrate.ts';
+
+describe('Entity Links API (Issue #1276)', () => {
+  const app = buildServer();
+  let pool: Pool;
+
+  beforeAll(async () => {
+    await runMigrate('up');
+    pool = createTestPool();
+    await app.ready();
+  });
+
+  beforeEach(async () => {
+    await truncateAllTables(pool);
+  });
+
+  afterAll(async () => {
+    await app.close();
+    await pool.end();
+  });
+
+  // ── Schema ──────────────────────────────────────────────
+
+  describe('schema', () => {
+    it('entity_link table exists with expected columns', async () => {
+      const result = await pool.query(
+        `SELECT column_name, data_type
+         FROM information_schema.columns
+         WHERE table_name = 'entity_link'
+         ORDER BY ordinal_position`,
+      );
+      const cols = result.rows.map((r) => (r as { column_name: string }).column_name);
+      expect(cols).toContain('id');
+      expect(cols).toContain('source_type');
+      expect(cols).toContain('source_id');
+      expect(cols).toContain('target_type');
+      expect(cols).toContain('target_id');
+      expect(cols).toContain('link_type');
+      expect(cols).toContain('created_by');
+      expect(cols).toContain('user_email');
+      expect(cols).toContain('created_at');
+    });
+
+    it('has unique constraint on (source_type, source_id, target_type, target_id, link_type)', async () => {
+      const result = await pool.query(
+        `SELECT constraint_name FROM information_schema.table_constraints
+         WHERE table_name = 'entity_link' AND constraint_type = 'UNIQUE'`,
+      );
+      expect(result.rows.length).toBeGreaterThanOrEqual(1);
+      const names = result.rows.map((r) => (r as { constraint_name: string }).constraint_name);
+      expect(names).toContain('uq_entity_link');
+    });
+  });
+
+  // ── POST /api/entity-links ──────────────────────────────
+
+  describe('POST /api/entity-links', () => {
+    const validPayload = {
+      source_type: 'message',
+      source_id: '00000000-0000-0000-0000-000000000001',
+      target_type: 'project',
+      target_id: '00000000-0000-0000-0000-000000000002',
+    };
+
+    it('creates a link and returns 201', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/entity-links',
+        payload: validPayload,
+      });
+
+      expect(res.statusCode).toBe(201);
+      const body = res.json();
+      expect(body.id).toBeDefined();
+      expect(body.source_type).toBe('message');
+      expect(body.source_id).toBe(validPayload.source_id);
+      expect(body.target_type).toBe('project');
+      expect(body.target_id).toBe(validPayload.target_id);
+      expect(body.link_type).toBe('related');
+      expect(body.created_at).toBeDefined();
+    });
+
+    it('defaults link_type to related', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/entity-links',
+        payload: validPayload,
+      });
+
+      expect(res.statusCode).toBe(201);
+      expect(res.json().link_type).toBe('related');
+    });
+
+    it('accepts explicit link_type', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/entity-links',
+        payload: { ...validPayload, link_type: 'caused_by' },
+      });
+
+      expect(res.statusCode).toBe(201);
+      expect(res.json().link_type).toBe('caused_by');
+    });
+
+    it('accepts created_by field', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/entity-links',
+        payload: { ...validPayload, created_by: 'agent' },
+      });
+
+      expect(res.statusCode).toBe(201);
+      expect(res.json().created_by).toBe('agent');
+    });
+
+    it('is idempotent (upsert on duplicate)', async () => {
+      const res1 = await app.inject({
+        method: 'POST',
+        url: '/api/entity-links',
+        payload: { ...validPayload, created_by: 'auto' },
+      });
+      expect(res1.statusCode).toBe(201);
+      const id1 = res1.json().id;
+
+      const res2 = await app.inject({
+        method: 'POST',
+        url: '/api/entity-links',
+        payload: { ...validPayload, created_by: 'agent' },
+      });
+      expect(res2.statusCode).toBe(201);
+      expect(res2.json().id).toBe(id1);
+      expect(res2.json().created_by).toBe('agent');
+    });
+
+    it('allows different link_types between same source and target', async () => {
+      const res1 = await app.inject({
+        method: 'POST',
+        url: '/api/entity-links',
+        payload: { ...validPayload, link_type: 'related' },
+      });
+      expect(res1.statusCode).toBe(201);
+
+      const res2 = await app.inject({
+        method: 'POST',
+        url: '/api/entity-links',
+        payload: { ...validPayload, link_type: 'caused_by' },
+      });
+      expect(res2.statusCode).toBe(201);
+      expect(res2.json().id).not.toBe(res1.json().id);
+    });
+
+    it('returns 400 for missing required fields', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/entity-links',
+        payload: { source_type: 'message' },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(res.json().error).toBeDefined();
+    });
+
+    it('returns 400 for invalid source_type', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/entity-links',
+        payload: { ...validPayload, source_type: 'invalid' },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(res.json().error).toContain('source_type');
+    });
+
+    it('returns 400 for invalid target_type', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/entity-links',
+        payload: { ...validPayload, target_type: 'invalid' },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(res.json().error).toContain('target_type');
+    });
+
+    it('returns 400 for invalid link_type', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/entity-links',
+        payload: { ...validPayload, link_type: 'bad_type' },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(res.json().error).toContain('link_type');
+    });
+
+    it('returns 400 for invalid UUID format', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/entity-links',
+        payload: { ...validPayload, source_id: 'not-a-uuid' },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(res.json().error).toContain('UUID');
+    });
+  });
+
+  // ── GET /api/entity-links ──────────────────────────────
+
+  describe('GET /api/entity-links', () => {
+    const sourceId = '00000000-0000-0000-0000-000000000001';
+    const targetId = '00000000-0000-0000-0000-000000000002';
+
+    beforeEach(async () => {
+      await truncateAllTables(pool);
+      // Create two links
+      await app.inject({
+        method: 'POST',
+        url: '/api/entity-links',
+        payload: {
+          source_type: 'message',
+          source_id: sourceId,
+          target_type: 'project',
+          target_id: targetId,
+          link_type: 'related',
+        },
+      });
+      await app.inject({
+        method: 'POST',
+        url: '/api/entity-links',
+        payload: {
+          source_type: 'message',
+          source_id: sourceId,
+          target_type: 'contact',
+          target_id: '00000000-0000-0000-0000-000000000003',
+          link_type: 'about',
+        },
+      });
+    });
+
+    it('returns links by source', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: `/api/entity-links?source_type=message&source_id=${sourceId}`,
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.links).toHaveLength(2);
+    });
+
+    it('returns links by target', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: `/api/entity-links?target_type=project&target_id=${targetId}`,
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.links).toHaveLength(1);
+      expect(body.links[0].target_id).toBe(targetId);
+    });
+
+    it('filters by link_type', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: `/api/entity-links?source_type=message&source_id=${sourceId}&link_type=about`,
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json().links).toHaveLength(1);
+      expect(res.json().links[0].link_type).toBe('about');
+    });
+
+    it('returns empty array when no links exist', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/entity-links?source_type=thread&source_id=00000000-0000-0000-0000-000000000099',
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json().links).toHaveLength(0);
+    });
+
+    it('returns 400 when neither source nor target provided', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/entity-links',
+      });
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('returns 400 when only source_type without source_id', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/entity-links?source_type=message',
+      });
+      expect(res.statusCode).toBe(400);
+    });
+  });
+
+  // ── GET /api/entity-links/:id ──────────────────────────
+
+  describe('GET /api/entity-links/:id', () => {
+    it('returns a single link by id', async () => {
+      const createRes = await app.inject({
+        method: 'POST',
+        url: '/api/entity-links',
+        payload: {
+          source_type: 'todo',
+          source_id: '00000000-0000-0000-0000-000000000010',
+          target_type: 'contact',
+          target_id: '00000000-0000-0000-0000-000000000020',
+        },
+      });
+      const linkId = createRes.json().id;
+
+      const res = await app.inject({
+        method: 'GET',
+        url: `/api/entity-links/${linkId}`,
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json().id).toBe(linkId);
+      expect(res.json().source_type).toBe('todo');
+    });
+
+    it('returns 404 for non-existent link', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/entity-links/00000000-0000-0000-0000-999999999999',
+      });
+      expect(res.statusCode).toBe(404);
+    });
+
+    it('returns 400 for invalid id format', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/entity-links/not-a-uuid',
+      });
+      expect(res.statusCode).toBe(400);
+    });
+  });
+
+  // ── DELETE /api/entity-links/:id ───────────────────────
+
+  describe('DELETE /api/entity-links/:id', () => {
+    it('removes a link and returns 204', async () => {
+      const createRes = await app.inject({
+        method: 'POST',
+        url: '/api/entity-links',
+        payload: {
+          source_type: 'thread',
+          source_id: '00000000-0000-0000-0000-000000000030',
+          target_type: 'todo',
+          target_id: '00000000-0000-0000-0000-000000000040',
+        },
+      });
+      const linkId = createRes.json().id;
+
+      const delRes = await app.inject({
+        method: 'DELETE',
+        url: `/api/entity-links/${linkId}`,
+      });
+      expect(delRes.statusCode).toBe(204);
+
+      // Verify it's gone
+      const getRes = await app.inject({
+        method: 'GET',
+        url: `/api/entity-links/${linkId}`,
+      });
+      expect(getRes.statusCode).toBe(404);
+    });
+
+    it('returns 404 for non-existent link', async () => {
+      const delRes = await app.inject({
+        method: 'DELETE',
+        url: '/api/entity-links/00000000-0000-0000-0000-999999999999',
+      });
+      expect(delRes.statusCode).toBe(404);
+    });
+  });
+
+  // ── user_email scoping ─────────────────────────────────
+
+  describe('user_email scoping', () => {
+    it('link created with user_email is visible when queried with same email', async () => {
+      await app.inject({
+        method: 'POST',
+        url: '/api/entity-links?user_email=alice@example.com',
+        payload: {
+          source_type: 'message',
+          source_id: '00000000-0000-0000-0000-000000000050',
+          target_type: 'project',
+          target_id: '00000000-0000-0000-0000-000000000060',
+        },
+      });
+
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/entity-links?source_type=message&source_id=00000000-0000-0000-0000-000000000050&user_email=alice@example.com',
+      });
+      expect(res.statusCode).toBe(200);
+      expect(res.json().links).toHaveLength(1);
+    });
+
+    it('link created without user_email is visible to all users', async () => {
+      await app.inject({
+        method: 'POST',
+        url: '/api/entity-links',
+        payload: {
+          source_type: 'message',
+          source_id: '00000000-0000-0000-0000-000000000050',
+          target_type: 'project',
+          target_id: '00000000-0000-0000-0000-000000000060',
+        },
+      });
+
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/entity-links?source_type=message&source_id=00000000-0000-0000-0000-000000000050&user_email=bob@example.com',
+      });
+      expect(res.statusCode).toBe(200);
+      expect(res.json().links).toHaveLength(1);
+    });
+  });
+});

--- a/tests/helpers/db.ts
+++ b/tests/helpers/db.ts
@@ -80,6 +80,8 @@ const APPLICATION_TABLES = [
   // Agent identity (Issue #1287)
   'agent_identity_history',
   'agent_identity',
+  // Entity links (no FKs, polymorphic references)
+  'entity_link',
   // Async/queue tables (no FKs today, but still want consistent cleanup)
   'webhook_outbox',
   'internal_job',


### PR DESCRIPTION
## Summary

- Adds `entity_link` table (migration 073) with polymorphic source/target references and unique constraint for idempotent upserts
- Implements 4 API routes: `POST /api/entity-links`, `GET /api/entity-links` (list with filters), `GET /api/entity-links/:id`, `DELETE /api/entity-links/:id`
- Adds frontend types (`EntityLink`, `EntityLinksResponse`, `CreateEntityLinkBody`), TanStack Query hooks, and 3 UI components (`EntityLinkBadge`, `EntityLinkManager`, `RelatedCommunications`)
- 26 integration tests covering CRUD, validation, idempotency, and user_email scoping

Closes #1276

## Test plan

- [x] 26 integration tests pass (`pnpm test -- tests/entity_links_api.test.ts`)
- [x] Frontend builds successfully (`pnpm run app:build`)
- [x] Lint passes (no new errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)