### PR TITLE
[#1279] Add meal log — track what was eaten, source, and preferences

### DIFF
--- a/migrations/079_meal_log.down.sql
+++ b/migrations/079_meal_log.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS meal_log;

--- a/migrations/079_meal_log.up.sql
+++ b/migrations/079_meal_log.up.sql
@@ -1,0 +1,26 @@
+-- Issue #1279: Meal log — track what was eaten, source, and preferences.
+
+CREATE TABLE IF NOT EXISTS meal_log (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_email      text NOT NULL,
+  meal_date       date NOT NULL,
+  meal_type       text NOT NULL,
+  title           text NOT NULL,
+  source          text NOT NULL,
+  recipe_id       uuid REFERENCES recipe(id) ON DELETE SET NULL,
+  order_ref       text,
+  restaurant      text,
+  cuisine         text,
+  who_ate         text[] NOT NULL DEFAULT '{}',
+  who_cooked      text,
+  rating          integer CHECK (rating BETWEEN 1 AND 5),
+  notes           text,
+  leftovers_stored boolean NOT NULL DEFAULT false,
+  image_s3_key    text,
+  created_at      timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_meal_log_user ON meal_log (user_email);
+CREATE INDEX IF NOT EXISTS idx_meal_log_date ON meal_log (meal_date DESC);
+CREATE INDEX IF NOT EXISTS idx_meal_log_cuisine ON meal_log (cuisine);
+CREATE INDEX IF NOT EXISTS idx_meal_log_source ON meal_log (source);

--- a/src/ui/components/meal-log/index.ts
+++ b/src/ui/components/meal-log/index.ts
@@ -1,0 +1,3 @@
+export { MealLogList } from './meal-log-list';
+export { MealLogStats } from './meal-log-stats';
+export { MealLogForm } from './meal-log-form';

--- a/src/ui/components/meal-log/meal-log-form.tsx
+++ b/src/ui/components/meal-log/meal-log-form.tsx
@@ -1,0 +1,95 @@
+import { useState } from 'react';
+import { useCreateMealLog } from '@/ui/hooks/queries/use-meal-log.ts';
+import { Button } from '@/ui/components/ui/button.tsx';
+import { Input } from '@/ui/components/ui/input.tsx';
+import { Label } from '@/ui/components/ui/label.tsx';
+
+interface MealLogFormProps {
+  onCreated?: () => void;
+}
+
+const MEAL_TYPES = ['breakfast', 'lunch', 'dinner', 'snack'] as const;
+const SOURCES = ['home_cooked', 'ordered', 'leftovers', 'ate_out', 'other'] as const;
+
+export function MealLogForm({ onCreated }: MealLogFormProps) {
+  const createMeal = useCreateMealLog();
+  const [title, setTitle] = useState('');
+  const [mealType, setMealType] = useState<string>('dinner');
+  const [source, setSource] = useState<string>('home_cooked');
+  const [cuisine, setCuisine] = useState('');
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!title.trim()) return;
+
+    createMeal.mutate(
+      {
+        title: title.trim(),
+        meal_date: new Date().toISOString().split('T')[0],
+        meal_type: mealType,
+        source,
+        cuisine: cuisine || undefined,
+      },
+      { onSuccess: () => { setTitle(''); onCreated?.(); } },
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-3">
+      <div className="space-y-1">
+        <Label htmlFor="meal-title">What did you eat?</Label>
+        <Input
+          id="meal-title"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="e.g. Pad Thai"
+          required
+        />
+      </div>
+
+      <div className="grid grid-cols-3 gap-3">
+        <div className="space-y-1">
+          <Label htmlFor="meal-type">Meal</Label>
+          <select
+            id="meal-type"
+            value={mealType}
+            onChange={(e) => setMealType(e.target.value)}
+            className="w-full rounded border px-2 py-1.5 text-sm"
+          >
+            {MEAL_TYPES.map((t) => (
+              <option key={t} value={t}>{t}</option>
+            ))}
+          </select>
+        </div>
+
+        <div className="space-y-1">
+          <Label htmlFor="meal-source">Source</Label>
+          <select
+            id="meal-source"
+            value={source}
+            onChange={(e) => setSource(e.target.value)}
+            className="w-full rounded border px-2 py-1.5 text-sm"
+          >
+            {SOURCES.map((s) => (
+              <option key={s} value={s}>{s.replace('_', ' ')}</option>
+            ))}
+          </select>
+        </div>
+
+        <div className="space-y-1">
+          <Label htmlFor="meal-cuisine">Cuisine</Label>
+          <Input
+            id="meal-cuisine"
+            value={cuisine}
+            onChange={(e) => setCuisine(e.target.value)}
+            placeholder="e.g. Thai"
+          />
+        </div>
+      </div>
+
+      <Button type="submit" disabled={createMeal.isPending}>
+        Log Meal
+      </Button>
+    </form>
+  );
+}

--- a/src/ui/components/meal-log/meal-log-list.tsx
+++ b/src/ui/components/meal-log/meal-log-list.tsx
@@ -1,0 +1,59 @@
+import { useMealLog, useDeleteMealLog } from '@/ui/hooks/queries/use-meal-log.ts';
+import { Badge } from '@/ui/components/ui/badge.tsx';
+import { Button } from '@/ui/components/ui/button.tsx';
+import type { MealLogEntry } from '@/ui/lib/api-types.ts';
+
+interface MealLogListProps {
+  onSelect: (meal: MealLogEntry) => void;
+  filters?: Record<string, string>;
+}
+
+export function MealLogList({ onSelect, filters }: MealLogListProps) {
+  const { data, isLoading } = useMealLog(filters);
+  const deleteMeal = useDeleteMealLog();
+
+  if (isLoading) return <div className="p-4 text-muted-foreground">Loading meals…</div>;
+
+  const meals = data?.meals ?? [];
+
+  return (
+    <div className="space-y-3">
+      {meals.length === 0 && (
+        <p className="text-sm text-muted-foreground">No meals logged yet.</p>
+      )}
+
+      <ul className="divide-y">
+        {meals.map((meal) => (
+          <li key={meal.id} className="flex items-center justify-between py-3">
+            <button
+              type="button"
+              className="flex flex-col gap-1 text-left hover:underline"
+              onClick={() => onSelect(meal)}
+            >
+              <div className="flex items-center gap-2">
+                <span className="font-medium">{meal.title}</span>
+                <Badge variant="outline">{meal.meal_type}</Badge>
+                <Badge variant="secondary">{meal.source.replace('_', ' ')}</Badge>
+              </div>
+              <div className="text-xs text-muted-foreground">
+                {meal.meal_date}
+                {meal.cuisine && ` · ${meal.cuisine}`}
+                {meal.restaurant && ` · ${meal.restaurant}`}
+                {meal.rating && ` · ${'★'.repeat(meal.rating)}`}
+              </div>
+            </button>
+
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => deleteMeal.mutate(meal.id)}
+              disabled={deleteMeal.isPending}
+            >
+              Delete
+            </Button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/ui/components/meal-log/meal-log-stats.tsx
+++ b/src/ui/components/meal-log/meal-log-stats.tsx
@@ -1,0 +1,48 @@
+import { useMealLogStats } from '@/ui/hooks/queries/use-meal-log.ts';
+
+interface MealLogStatsProps {
+  days?: number;
+}
+
+export function MealLogStats({ days = 30 }: MealLogStatsProps) {
+  const { data, isLoading } = useMealLogStats(days);
+
+  if (isLoading) return <div className="p-4 text-muted-foreground">Loading stats…</div>;
+  if (!data) return null;
+
+  return (
+    <div className="space-y-4">
+      <div className="text-sm text-muted-foreground">
+        {data.total} meals in the last {data.days} days
+      </div>
+
+      {data.by_source.length > 0 && (
+        <div>
+          <h4 className="mb-1 text-sm font-medium">By Source</h4>
+          <ul className="space-y-1 text-sm">
+            {data.by_source.map((s) => (
+              <li key={s.source} className="flex justify-between">
+                <span>{s.source.replace('_', ' ')}</span>
+                <span className="text-muted-foreground">{s.count}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {data.by_cuisine.length > 0 && (
+        <div>
+          <h4 className="mb-1 text-sm font-medium">By Cuisine</h4>
+          <ul className="space-y-1 text-sm">
+            {data.by_cuisine.map((c) => (
+              <li key={c.cuisine} className="flex justify-between">
+                <span>{c.cuisine}</span>
+                <span className="text-muted-foreground">{c.count}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/ui/hooks/queries/use-meal-log.ts
+++ b/src/ui/hooks/queries/use-meal-log.ts
@@ -1,0 +1,72 @@
+/**
+ * TanStack Query hooks for Meal Log (Issue #1279).
+ */
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { apiClient } from '@/ui/lib/api-client.ts';
+import type {
+  MealLogResponse,
+  MealLogEntry,
+  CreateMealLogBody,
+  UpdateMealLogBody,
+  MealLogStats,
+} from '@/ui/lib/api-types.ts';
+
+export const mealLogKeys = {
+  all: ['meal-log'] as const,
+  list: (filters?: Record<string, string>) => [...mealLogKeys.all, 'list', filters] as const,
+  detail: (id: string) => [...mealLogKeys.all, 'detail', id] as const,
+  stats: (days?: number) => [...mealLogKeys.all, 'stats', days] as const,
+};
+
+export function useMealLog(filters?: Record<string, string>) {
+  const params = filters ? '?' + new URLSearchParams(filters).toString() : '';
+  return useQuery({
+    queryKey: mealLogKeys.list(filters),
+    queryFn: ({ signal }) => apiClient.get<MealLogResponse>(`/api/meal-log${params}`, { signal }),
+  });
+}
+
+export function useMealLogDetail(id: string) {
+  return useQuery({
+    queryKey: mealLogKeys.detail(id),
+    queryFn: ({ signal }) => apiClient.get<MealLogEntry>(`/api/meal-log/${id}`, { signal }),
+    enabled: !!id,
+  });
+}
+
+export function useMealLogStats(days?: number) {
+  const params = days ? `?days=${days}` : '';
+  return useQuery({
+    queryKey: mealLogKeys.stats(days),
+    queryFn: ({ signal }) => apiClient.get<MealLogStats>(`/api/meal-log/stats${params}`, { signal }),
+  });
+}
+
+export function useCreateMealLog() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: CreateMealLogBody) => apiClient.post<MealLogEntry>('/api/meal-log', body),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: mealLogKeys.all });
+    },
+  });
+}
+
+export function useUpdateMealLog(id: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: UpdateMealLogBody) => apiClient.patch<MealLogEntry>(`/api/meal-log/${id}`, body),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: mealLogKeys.detail(id) });
+      qc.invalidateQueries({ queryKey: mealLogKeys.all });
+    },
+  });
+}
+
+export function useDeleteMealLog() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => apiClient.delete(`/api/meal-log/${id}`),
+    onSuccess: () => qc.invalidateQueries({ queryKey: mealLogKeys.all }),
+  });
+}

--- a/src/ui/lib/api-types.ts
+++ b/src/ui/lib/api-types.ts
@@ -619,6 +619,63 @@ export interface UpdateRecipeBody {
 }
 
 // ---------------------------------------------------------------------------
+// Meal Log (Issue #1279)
+// ---------------------------------------------------------------------------
+
+export interface MealLogEntry {
+  id: string;
+  user_email: string;
+  meal_date: string;
+  meal_type: string;
+  title: string;
+  source: string;
+  recipe_id: string | null;
+  order_ref: string | null;
+  restaurant: string | null;
+  cuisine: string | null;
+  who_ate: string[];
+  who_cooked: string | null;
+  rating: number | null;
+  notes: string | null;
+  leftovers_stored: boolean;
+  image_s3_key: string | null;
+  created_at: string;
+}
+
+export interface MealLogResponse {
+  meals: MealLogEntry[];
+}
+
+export interface CreateMealLogBody {
+  meal_date: string;
+  meal_type: string;
+  title: string;
+  source: string;
+  recipe_id?: string;
+  restaurant?: string;
+  cuisine?: string;
+  who_ate?: string[];
+  who_cooked?: string;
+  rating?: number;
+  notes?: string;
+  leftovers_stored?: boolean;
+}
+
+export interface UpdateMealLogBody {
+  rating?: number;
+  notes?: string;
+  cuisine?: string;
+  leftovers_stored?: boolean;
+}
+
+export interface MealLogStats {
+  total: number;
+  days: number;
+  by_source: Array<{ source: string; count: number }>;
+  by_cuisine: Array<{ cuisine: string; count: number }>;
+}
+
+// ---------------------------------------------------------------------------
 // Notes
 // ---------------------------------------------------------------------------
 

--- a/tests/helpers/db.ts
+++ b/tests/helpers/db.ts
@@ -89,6 +89,8 @@ const APPLICATION_TABLES = [
   'recipe_step',
   'recipe_ingredient',
   'recipe',
+  // Meal log (Issue #1279)
+  'meal_log',
   // Async/queue tables (no FKs today, but still want consistent cleanup)
   'webhook_outbox',
   'internal_job',

--- a/tests/meal_log_api.test.ts
+++ b/tests/meal_log_api.test.ts
@@ -1,0 +1,295 @@
+/**
+ * Integration tests for meal log API (Issue #1279).
+ *
+ * Tests CRUD for meal log entries, search, and stats.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { buildServer } from '../src/api/server.js';
+import { createTestPool } from './helpers/db.js';
+
+const TEST_EMAIL = 'meal-log-test@example.com';
+
+describe('Meal Log API (Issue #1279)', () => {
+  let app: Awaited<ReturnType<typeof buildServer>>;
+  let pool: ReturnType<typeof createTestPool>;
+
+  beforeAll(async () => {
+    pool = createTestPool();
+    app = await buildServer();
+
+    await pool.query(`DELETE FROM meal_log WHERE user_email = $1`, [TEST_EMAIL]);
+  });
+
+  afterAll(async () => {
+    await pool.query(`DELETE FROM meal_log WHERE user_email = $1`, [TEST_EMAIL]);
+    await pool.end();
+    await app.close();
+  });
+
+  // ─── Schema ────────────────────────────────────────────────────────────
+
+  describe('Schema', () => {
+    it('meal_log table exists with expected columns', async () => {
+      const result = await pool.query(
+        `SELECT column_name FROM information_schema.columns
+         WHERE table_name = 'meal_log' ORDER BY ordinal_position`,
+      );
+      const columns = result.rows.map((r) => r.column_name);
+      expect(columns).toContain('id');
+      expect(columns).toContain('user_email');
+      expect(columns).toContain('meal_date');
+      expect(columns).toContain('meal_type');
+      expect(columns).toContain('title');
+      expect(columns).toContain('source');
+      expect(columns).toContain('cuisine');
+      expect(columns).toContain('who_ate');
+      expect(columns).toContain('rating');
+      expect(columns).toContain('leftovers_stored');
+    });
+  });
+
+  // ─── POST /api/meal-log ─────────────────────────────────────────────
+
+  describe('POST /api/meal-log', () => {
+    it('logs a meal', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/meal-log',
+        headers: { 'content-type': 'application/json', 'x-user-email': TEST_EMAIL },
+        payload: {
+          meal_date: '2026-02-15',
+          meal_type: 'dinner',
+          title: 'Pad Thai',
+          source: 'ordered',
+          cuisine: 'thai',
+          restaurant: 'Thai Express',
+          who_ate: ['alice', 'bob'],
+          rating: 4,
+        },
+      });
+
+      expect(res.statusCode).toBe(201);
+      const body = res.json();
+      expect(body.id).toBeDefined();
+      expect(body.title).toBe('Pad Thai');
+      expect(body.source).toBe('ordered');
+      expect(body.cuisine).toBe('thai');
+    });
+
+    it('returns 400 when title is missing', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/meal-log',
+        headers: { 'content-type': 'application/json', 'x-user-email': TEST_EMAIL },
+        payload: { meal_date: '2026-02-15', meal_type: 'lunch', source: 'home_cooked' },
+      });
+
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('logs a home-cooked meal', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/meal-log',
+        headers: { 'content-type': 'application/json', 'x-user-email': TEST_EMAIL },
+        payload: {
+          meal_date: '2026-02-14',
+          meal_type: 'dinner',
+          title: 'Spaghetti Bolognese',
+          source: 'home_cooked',
+          cuisine: 'italian',
+          who_cooked: 'alice',
+          who_ate: ['alice', 'bob'],
+          rating: 5,
+          leftovers_stored: true,
+        },
+      });
+
+      expect(res.statusCode).toBe(201);
+      expect(res.json().leftovers_stored).toBe(true);
+    });
+  });
+
+  // ─── GET /api/meal-log ──────────────────────────────────────────────
+
+  describe('GET /api/meal-log', () => {
+    it('lists recent meals', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/meal-log',
+        headers: { 'x-user-email': TEST_EMAIL },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.meals).toBeDefined();
+      expect(body.meals.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('filters by cuisine', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/meal-log?cuisine=thai',
+        headers: { 'x-user-email': TEST_EMAIL },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.meals.length).toBeGreaterThanOrEqual(1);
+      for (const meal of body.meals) {
+        expect(meal.cuisine).toBe('thai');
+      }
+    });
+
+    it('filters by source', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/meal-log?source=home_cooked',
+        headers: { 'x-user-email': TEST_EMAIL },
+      });
+
+      expect(res.statusCode).toBe(200);
+      for (const meal of res.json().meals) {
+        expect(meal.source).toBe('home_cooked');
+      }
+    });
+
+    it('filters by meal_type', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/meal-log?meal_type=dinner',
+        headers: { 'x-user-email': TEST_EMAIL },
+      });
+
+      expect(res.statusCode).toBe(200);
+      for (const meal of res.json().meals) {
+        expect(meal.meal_type).toBe('dinner');
+      }
+    });
+  });
+
+  // ─── GET /api/meal-log/:id ──────────────────────────────────────────
+
+  describe('GET /api/meal-log/:id', () => {
+    it('returns a specific meal entry', async () => {
+      const createRes = await app.inject({
+        method: 'POST',
+        url: '/api/meal-log',
+        headers: { 'content-type': 'application/json', 'x-user-email': TEST_EMAIL },
+        payload: {
+          meal_date: '2026-02-13',
+          meal_type: 'lunch',
+          title: 'Detail Test Meal',
+          source: 'ate_out',
+          restaurant: 'Cafe Roma',
+        },
+      });
+      const mealId = createRes.json().id;
+
+      const res = await app.inject({
+        method: 'GET',
+        url: `/api/meal-log/${mealId}`,
+        headers: { 'x-user-email': TEST_EMAIL },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json().id).toBe(mealId);
+      expect(res.json().title).toBe('Detail Test Meal');
+    });
+
+    it('returns 404 for non-existent meal', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/meal-log/00000000-0000-0000-0000-000000000099',
+        headers: { 'x-user-email': TEST_EMAIL },
+      });
+
+      expect(res.statusCode).toBe(404);
+    });
+  });
+
+  // ─── PATCH /api/meal-log/:id ────────────────────────────────────────
+
+  describe('PATCH /api/meal-log/:id', () => {
+    it('updates meal fields', async () => {
+      const createRes = await app.inject({
+        method: 'POST',
+        url: '/api/meal-log',
+        headers: { 'content-type': 'application/json', 'x-user-email': TEST_EMAIL },
+        payload: {
+          meal_date: '2026-02-12',
+          meal_type: 'snack',
+          title: 'Update Test',
+          source: 'other',
+        },
+      });
+      const mealId = createRes.json().id;
+
+      const res = await app.inject({
+        method: 'PATCH',
+        url: `/api/meal-log/${mealId}`,
+        headers: { 'content-type': 'application/json', 'x-user-email': TEST_EMAIL },
+        payload: { rating: 3, notes: 'Pretty good actually' },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json().rating).toBe(3);
+      expect(res.json().notes).toBe('Pretty good actually');
+    });
+  });
+
+  // ─── DELETE /api/meal-log/:id ───────────────────────────────────────
+
+  describe('DELETE /api/meal-log/:id', () => {
+    it('deletes a meal entry', async () => {
+      const createRes = await app.inject({
+        method: 'POST',
+        url: '/api/meal-log',
+        headers: { 'content-type': 'application/json', 'x-user-email': TEST_EMAIL },
+        payload: {
+          meal_date: '2026-02-11',
+          meal_type: 'breakfast',
+          title: 'Delete Test',
+          source: 'home_cooked',
+        },
+      });
+      const mealId = createRes.json().id;
+
+      const res = await app.inject({
+        method: 'DELETE',
+        url: `/api/meal-log/${mealId}`,
+        headers: { 'x-user-email': TEST_EMAIL },
+      });
+
+      expect(res.statusCode).toBe(204);
+    });
+
+    it('returns 404 for non-existent meal', async () => {
+      const res = await app.inject({
+        method: 'DELETE',
+        url: '/api/meal-log/00000000-0000-0000-0000-000000000099',
+        headers: { 'x-user-email': TEST_EMAIL },
+      });
+
+      expect(res.statusCode).toBe(404);
+    });
+  });
+
+  // ─── GET /api/meal-log/stats ────────────────────────────────────────
+
+  describe('GET /api/meal-log/stats', () => {
+    it('returns meal statistics', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/meal-log/stats',
+        headers: { 'x-user-email': TEST_EMAIL },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.total).toBeDefined();
+      expect(body.by_source).toBeDefined();
+      expect(body.by_cuisine).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `meal_log` table (migration 079) with indexes on user_email, date, cuisine, and source
- Implements 7 API routes: create meal, list with filters (cuisine, source, meal_type, days), get detail, update (PATCH), delete, and stats endpoint with by-source/by-cuisine breakdowns
- 14 integration tests covering CRUD, filtering, statistics, and error cases
- Frontend types (`MealLogEntry`, `MealLogStats`), TanStack Query hooks, and 3 UI components (`MealLogList`, `MealLogStats`, `MealLogForm`)

Closes #1279

## Test plan

- [x] All 14 integration tests pass locally
- [x] Lint clean
- [x] Frontend build succeeds
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)