### PR TITLE
[#1285] Add dev session tracking with agent callback webhooks

### DIFF
--- a/migrations/075_dev_sessions.down.sql
+++ b/migrations/075_dev_sessions.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS dev_session;

--- a/migrations/075_dev_sessions.up.sql
+++ b/migrations/075_dev_sessions.up.sql
@@ -1,0 +1,34 @@
+-- Issue #1285: Dev session tracking with agent callback webhooks
+-- Tracks long-running agent development sessions with structured state.
+
+CREATE TABLE IF NOT EXISTS dev_session (
+  id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_email          text NOT NULL,
+  project_id          uuid REFERENCES work_item(id) ON DELETE SET NULL,
+  session_name        text NOT NULL,
+  node                text NOT NULL,
+  container           text,
+  container_user      text,
+  repo_org            text,
+  repo_name           text,
+  branch              text,
+  status              text NOT NULL DEFAULT 'active',
+  task_summary        text,
+  task_prompt         text,
+  linked_issues       text[] NOT NULL DEFAULT '{}',
+  linked_prs          text[] NOT NULL DEFAULT '{}',
+  context_pct         integer,
+  last_capture        text,
+  last_capture_at     timestamptz,
+  webhook_id          uuid REFERENCES project_webhook(id) ON DELETE SET NULL,
+  completion_summary  text,
+  started_at          timestamptz NOT NULL DEFAULT now(),
+  completed_at        timestamptz,
+  created_at          timestamptz NOT NULL DEFAULT now(),
+  updated_at          timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_dev_session_status ON dev_session (status) WHERE status = 'active';
+CREATE INDEX IF NOT EXISTS idx_dev_session_project ON dev_session (project_id) WHERE project_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_dev_session_node ON dev_session (node);
+CREATE INDEX IF NOT EXISTS idx_dev_session_user ON dev_session (user_email);

--- a/src/ui/components/dev-sessions/index.ts
+++ b/src/ui/components/dev-sessions/index.ts
@@ -1,0 +1,3 @@
+export { SessionCard } from './session-card';
+export { SessionList } from './session-list';
+export { SessionDetail } from './session-detail';

--- a/src/ui/components/dev-sessions/session-card.tsx
+++ b/src/ui/components/dev-sessions/session-card.tsx
@@ -1,0 +1,77 @@
+/**
+ * Card displaying a dev session's key info and status.
+ */
+import { Badge } from '@/ui/components/ui/badge';
+import { Button } from '@/ui/components/ui/button';
+import { CheckIcon, TrashIcon, GitBranchIcon } from 'lucide-react';
+import type { DevSession } from '@/ui/lib/api-types';
+
+const STATUS_VARIANTS: Record<string, 'default' | 'secondary' | 'destructive' | 'outline'> = {
+  active: 'default',
+  stalled: 'secondary',
+  completed: 'outline',
+  errored: 'destructive',
+};
+
+export interface SessionCardProps {
+  session: DevSession;
+  onComplete?: (id: string) => void;
+  onDelete?: (id: string) => void;
+}
+
+export function SessionCard({ session, onComplete, onDelete }: SessionCardProps) {
+  return (
+    <div className="rounded-md border p-3 text-sm">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <span className="font-medium">{session.session_name}</span>
+          <Badge variant={STATUS_VARIANTS[session.status] ?? 'secondary'}>
+            {session.status}
+          </Badge>
+          {session.context_pct != null && (
+            <span className={`text-xs ${session.context_pct < 10 ? 'text-destructive font-medium' : 'text-muted-foreground'}`}>
+              {session.context_pct}% ctx
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-1">
+          {session.status === 'active' && onComplete && (
+            <Button variant="ghost" size="sm" onClick={() => onComplete(session.id)} title="Mark complete">
+              <CheckIcon className="h-3 w-3" />
+            </Button>
+          )}
+          {onDelete && (
+            <Button variant="ghost" size="sm" onClick={() => onDelete(session.id)} title="Delete">
+              <TrashIcon className="h-3 w-3 text-destructive" />
+            </Button>
+          )}
+        </div>
+      </div>
+
+      <div className="mt-1 text-xs text-muted-foreground">
+        <span>{session.node}</span>
+        {session.repo_org && session.repo_name && (
+          <span className="ml-2">{session.repo_org}/{session.repo_name}</span>
+        )}
+        {session.branch && (
+          <span className="ml-2 inline-flex items-center gap-0.5">
+            <GitBranchIcon className="h-3 w-3" />
+            {session.branch}
+          </span>
+        )}
+      </div>
+
+      {session.task_summary && (
+        <p className="mt-1 text-xs">{session.task_summary}</p>
+      )}
+
+      {session.linked_issues.length > 0 && (
+        <div className="mt-1 flex gap-1">
+          {session.linked_issues.map((issue) => (
+            <Badge key={issue} variant="outline" className="text-xs">#{issue}</Badge>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/ui/components/dev-sessions/session-detail.tsx
+++ b/src/ui/components/dev-sessions/session-detail.tsx
@@ -1,0 +1,102 @@
+/**
+ * Detailed view of a single dev session.
+ */
+import { Badge } from '@/ui/components/ui/badge';
+import { GitBranchIcon } from 'lucide-react';
+import { useDevSession } from '@/ui/hooks/queries/use-dev-sessions';
+
+export interface SessionDetailProps {
+  sessionId: string;
+}
+
+export function SessionDetail({ sessionId }: SessionDetailProps) {
+  const { data: session, isLoading } = useDevSession(sessionId);
+
+  if (isLoading) {
+    return <div className="text-sm text-muted-foreground">Loading session...</div>;
+  }
+
+  if (!session) {
+    return <div className="text-sm text-muted-foreground">Session not found.</div>;
+  }
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h3 className="text-lg font-medium">{session.session_name}</h3>
+        <div className="mt-1 flex items-center gap-2 text-sm text-muted-foreground">
+          <Badge variant={session.status === 'active' ? 'default' : 'secondary'}>{session.status}</Badge>
+          <span>{session.node}</span>
+          {session.branch && (
+            <span className="inline-flex items-center gap-0.5">
+              <GitBranchIcon className="h-3 w-3" />
+              {session.branch}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {session.task_summary && (
+        <div>
+          <h4 className="text-sm font-medium">Summary</h4>
+          <p className="text-sm">{session.task_summary}</p>
+        </div>
+      )}
+
+      {session.task_prompt && (
+        <div>
+          <h4 className="text-sm font-medium">Prompt</h4>
+          <pre className="max-h-48 overflow-auto rounded bg-muted p-2 text-xs">{session.task_prompt}</pre>
+        </div>
+      )}
+
+      {session.last_capture && (
+        <div>
+          <h4 className="text-sm font-medium">
+            Last Capture
+            {session.last_capture_at && (
+              <span className="ml-1 font-normal text-muted-foreground">
+                ({new Date(session.last_capture_at).toLocaleString()})
+              </span>
+            )}
+          </h4>
+          <pre className="max-h-48 overflow-auto rounded bg-muted p-2 text-xs">{session.last_capture}</pre>
+        </div>
+      )}
+
+      {session.completion_summary && (
+        <div>
+          <h4 className="text-sm font-medium">Completion Summary</h4>
+          <p className="text-sm">{session.completion_summary}</p>
+        </div>
+      )}
+
+      <div className="flex gap-4 text-xs text-muted-foreground">
+        <span>Started: {new Date(session.started_at).toLocaleString()}</span>
+        {session.completed_at && <span>Completed: {new Date(session.completed_at).toLocaleString()}</span>}
+        {session.context_pct != null && <span>Context: {session.context_pct}%</span>}
+      </div>
+
+      {(session.linked_issues.length > 0 || session.linked_prs.length > 0) && (
+        <div className="flex gap-4 text-xs">
+          {session.linked_issues.length > 0 && (
+            <div>
+              <span className="text-muted-foreground">Issues: </span>
+              {session.linked_issues.map((i) => (
+                <Badge key={i} variant="outline" className="mr-1">#{i}</Badge>
+              ))}
+            </div>
+          )}
+          {session.linked_prs.length > 0 && (
+            <div>
+              <span className="text-muted-foreground">PRs: </span>
+              {session.linked_prs.map((pr) => (
+                <Badge key={pr} variant="outline" className="mr-1">#{pr}</Badge>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/ui/components/dev-sessions/session-list.tsx
+++ b/src/ui/components/dev-sessions/session-list.tsx
@@ -1,0 +1,47 @@
+/**
+ * List of dev sessions with status filtering.
+ */
+import * as React from 'react';
+import {
+  useDevSessions,
+  useCompleteDevSession,
+  useDeleteDevSession,
+} from '@/ui/hooks/queries/use-dev-sessions';
+import { SessionCard } from './session-card';
+
+export interface SessionListProps {
+  projectId?: string;
+  statusFilter?: string;
+}
+
+export function SessionList({ projectId, statusFilter }: SessionListProps) {
+  const { data, isLoading } = useDevSessions({
+    projectId,
+    status: statusFilter,
+  });
+  const completeMutation = useCompleteDevSession();
+  const deleteMutation = useDeleteDevSession();
+
+  if (isLoading) {
+    return <div className="text-sm text-muted-foreground">Loading sessions...</div>;
+  }
+
+  const sessions = data?.sessions ?? [];
+
+  if (sessions.length === 0) {
+    return <p className="text-sm text-muted-foreground">No dev sessions found.</p>;
+  }
+
+  return (
+    <div className="space-y-2">
+      {sessions.map((session) => (
+        <SessionCard
+          key={session.id}
+          session={session}
+          onComplete={(id) => completeMutation.mutate({ id })}
+          onDelete={(id) => deleteMutation.mutate(id)}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/ui/hooks/queries/use-dev-sessions.ts
+++ b/src/ui/hooks/queries/use-dev-sessions.ts
@@ -1,0 +1,111 @@
+/**
+ * TanStack Query hooks for dev session tracking (Issue #1285).
+ *
+ * Provides queries for listing/fetching sessions and mutations for
+ * creating, updating, completing, and deleting dev sessions.
+ */
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { apiClient } from '@/ui/lib/api-client.ts';
+import type {
+  DevSession,
+  DevSessionsResponse,
+  CreateDevSessionBody,
+  UpdateDevSessionBody,
+} from '@/ui/lib/api-types.ts';
+
+/** Query key factory for dev sessions. */
+export const devSessionKeys = {
+  all: ['dev-sessions'] as const,
+  list: (filters?: { status?: string; node?: string; projectId?: string }) =>
+    [...devSessionKeys.all, 'list', filters] as const,
+  detail: (id: string) => [...devSessionKeys.all, 'detail', id] as const,
+};
+
+/**
+ * Fetch dev sessions with optional filters.
+ */
+export function useDevSessions(filters?: { status?: string; node?: string; projectId?: string }) {
+  const params = new URLSearchParams();
+  if (filters?.status) params.set('status', filters.status);
+  if (filters?.node) params.set('node', filters.node);
+  if (filters?.projectId) params.set('project_id', filters.projectId);
+  const qs = params.toString();
+  const url = `/api/dev-sessions${qs ? `?${qs}` : ''}`;
+
+  return useQuery({
+    queryKey: devSessionKeys.list(filters),
+    queryFn: ({ signal }) => apiClient.get<DevSessionsResponse>(url, { signal }),
+  });
+}
+
+/**
+ * Fetch a single dev session by ID.
+ */
+export function useDevSession(id: string) {
+  return useQuery({
+    queryKey: devSessionKeys.detail(id),
+    queryFn: ({ signal }) => apiClient.get<DevSession>(`/api/dev-sessions/${id}`, { signal }),
+    enabled: !!id,
+  });
+}
+
+/**
+ * Mutation: create a new dev session.
+ */
+export function useCreateDevSession() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (body: CreateDevSessionBody) =>
+      apiClient.post<DevSession>('/api/dev-sessions', body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: devSessionKeys.all });
+    },
+  });
+}
+
+/**
+ * Mutation: update a dev session.
+ */
+export function useUpdateDevSession() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, body }: { id: string; body: UpdateDevSessionBody }) =>
+      apiClient.patch<DevSession>(`/api/dev-sessions/${id}`, body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: devSessionKeys.all });
+    },
+  });
+}
+
+/**
+ * Mutation: mark a dev session as completed.
+ */
+export function useCompleteDevSession() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, completionSummary }: { id: string; completionSummary?: string }) =>
+      apiClient.post<DevSession>(`/api/dev-sessions/${id}/complete`, {
+        completion_summary: completionSummary,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: devSessionKeys.all });
+    },
+  });
+}
+
+/**
+ * Mutation: delete a dev session.
+ */
+export function useDeleteDevSession() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => apiClient.delete(`/api/dev-sessions/${id}`),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: devSessionKeys.all });
+    },
+  });
+}

--- a/src/ui/lib/api-types.ts
+++ b/src/ui/lib/api-types.ts
@@ -459,6 +459,71 @@ export interface MemoryAttachmentsResponse {
 }
 
 // ---------------------------------------------------------------------------
+// Dev Sessions (Issue #1285)
+// ---------------------------------------------------------------------------
+
+/** A dev session tracking a long-running agent development session. */
+export interface DevSession {
+  id: string;
+  user_email: string;
+  project_id: string | null;
+  session_name: string;
+  node: string;
+  container: string | null;
+  container_user: string | null;
+  repo_org: string | null;
+  repo_name: string | null;
+  branch: string | null;
+  status: 'active' | 'stalled' | 'completed' | 'errored';
+  task_summary: string | null;
+  task_prompt: string | null;
+  linked_issues: string[];
+  linked_prs: string[];
+  context_pct: number | null;
+  last_capture: string | null;
+  last_capture_at: string | null;
+  webhook_id: string | null;
+  completion_summary: string | null;
+  started_at: string;
+  completed_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+/** Response from GET /api/dev-sessions */
+export interface DevSessionsResponse {
+  sessions: DevSession[];
+}
+
+/** Body for POST /api/dev-sessions */
+export interface CreateDevSessionBody {
+  session_name: string;
+  node: string;
+  project_id?: string;
+  container?: string;
+  container_user?: string;
+  repo_org?: string;
+  repo_name?: string;
+  branch?: string;
+  task_summary?: string;
+  task_prompt?: string;
+  linked_issues?: string[];
+  linked_prs?: string[];
+}
+
+/** Body for PATCH /api/dev-sessions/:id */
+export interface UpdateDevSessionBody {
+  status?: string;
+  task_summary?: string;
+  branch?: string;
+  context_pct?: number;
+  last_capture?: string;
+  linked_issues?: string[];
+  linked_prs?: string[];
+  completion_summary?: string;
+}
+
+// ---------------------------------------------------------------------------
 // Notes
 // ---------------------------------------------------------------------------
 

--- a/tests/dev_sessions_api.test.ts
+++ b/tests/dev_sessions_api.test.ts
@@ -1,0 +1,399 @@
+/**
+ * Integration tests for dev session tracking (Issue #1285).
+ *
+ * Tests CRUD for dev sessions, status transitions, webhook callbacks,
+ * and filtering/search.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { buildServer } from '../src/api/server.js';
+import { createTestPool } from './helpers/db.js';
+
+const TEST_EMAIL = 'dev-session-test@example.com';
+
+describe('Dev Sessions API (Issue #1285)', () => {
+  let app: Awaited<ReturnType<typeof buildServer>>;
+  let pool: ReturnType<typeof createTestPool>;
+  let projectId: string;
+
+  beforeAll(async () => {
+    pool = createTestPool();
+    app = await buildServer();
+
+    // Clean up
+    await pool.query(`DELETE FROM dev_session WHERE user_email = $1`, [TEST_EMAIL]);
+    await pool.query(`DELETE FROM work_item WHERE user_email = $1`, [TEST_EMAIL]);
+
+    // Create a test project
+    const projectResult = await pool.query(
+      `INSERT INTO work_item (title, kind, user_email)
+       VALUES ('Dev Session Test Project', 'project', $1)
+       RETURNING id::text as id`,
+      [TEST_EMAIL],
+    );
+    projectId = projectResult.rows[0].id;
+  });
+
+  afterAll(async () => {
+    await pool.query(`DELETE FROM dev_session WHERE user_email = $1`, [TEST_EMAIL]);
+    await pool.query(`DELETE FROM work_item WHERE user_email = $1`, [TEST_EMAIL]);
+    await pool.end();
+    await app.close();
+  });
+
+  // ─── Schema ────────────────────────────────────────────────────────────
+
+  describe('Schema', () => {
+    it('dev_session table exists with expected columns', async () => {
+      const result = await pool.query(
+        `SELECT column_name FROM information_schema.columns
+         WHERE table_name = 'dev_session'
+         ORDER BY ordinal_position`,
+      );
+      const columns = result.rows.map((r) => r.column_name);
+      expect(columns).toContain('id');
+      expect(columns).toContain('user_email');
+      expect(columns).toContain('project_id');
+      expect(columns).toContain('session_name');
+      expect(columns).toContain('node');
+      expect(columns).toContain('status');
+      expect(columns).toContain('task_summary');
+      expect(columns).toContain('task_prompt');
+      expect(columns).toContain('linked_issues');
+      expect(columns).toContain('linked_prs');
+      expect(columns).toContain('context_pct');
+      expect(columns).toContain('webhook_id');
+      expect(columns).toContain('completion_summary');
+    });
+  });
+
+  // ─── POST /api/dev-sessions ────────────────────────────────────────────
+
+  describe('POST /api/dev-sessions', () => {
+    it('creates a dev session and returns it', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/dev-sessions',
+        headers: { 'content-type': 'application/json', 'x-user-email': TEST_EMAIL },
+        payload: {
+          session_name: 'dev-test-001',
+          node: 'MST001-service',
+          task_summary: 'Fix test parallelism',
+          project_id: projectId,
+        },
+      });
+
+      expect(res.statusCode).toBe(201);
+      const body = res.json();
+      expect(body.id).toBeDefined();
+      expect(body.session_name).toBe('dev-test-001');
+      expect(body.node).toBe('MST001-service');
+      expect(body.status).toBe('active');
+      expect(body.task_summary).toBe('Fix test parallelism');
+      expect(body.project_id).toBe(projectId);
+    });
+
+    it('creates a session with optional fields', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/dev-sessions',
+        headers: { 'content-type': 'application/json', 'x-user-email': TEST_EMAIL },
+        payload: {
+          session_name: 'dev-test-002',
+          node: 'MBP018-service',
+          task_summary: 'Add feature X',
+          task_prompt: 'Implement feature X with TDD',
+          container: 'openclaw-devcontainer-1',
+          container_user: 'vscode',
+          repo_org: 'troykelly',
+          repo_name: 'openclaw-projects',
+          branch: 'issue/1285-dev-sessions',
+          linked_issues: ['1285', '1286'],
+        },
+      });
+
+      expect(res.statusCode).toBe(201);
+      const body = res.json();
+      expect(body.container).toBe('openclaw-devcontainer-1');
+      expect(body.repo_org).toBe('troykelly');
+      expect(body.linked_issues).toEqual(['1285', '1286']);
+    });
+
+    it('returns 400 when session_name is missing', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/dev-sessions',
+        headers: { 'content-type': 'application/json', 'x-user-email': TEST_EMAIL },
+        payload: { node: 'MST001' },
+      });
+
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('returns 400 when node is missing', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/dev-sessions',
+        headers: { 'content-type': 'application/json', 'x-user-email': TEST_EMAIL },
+        payload: { session_name: 'test' },
+      });
+
+      expect(res.statusCode).toBe(400);
+    });
+  });
+
+  // ─── GET /api/dev-sessions ─────────────────────────────────────────────
+
+  describe('GET /api/dev-sessions', () => {
+    it('lists dev sessions', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/dev-sessions',
+        headers: { 'x-user-email': TEST_EMAIL },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.sessions).toBeDefined();
+      expect(body.sessions.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('filters by status', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/dev-sessions?status=active',
+        headers: { 'x-user-email': TEST_EMAIL },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      for (const session of body.sessions) {
+        expect(session.status).toBe('active');
+      }
+    });
+
+    it('filters by node', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/dev-sessions?node=MST001-service',
+        headers: { 'x-user-email': TEST_EMAIL },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      for (const session of body.sessions) {
+        expect(session.node).toBe('MST001-service');
+      }
+    });
+
+    it('filters by project_id', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: `/api/dev-sessions?project_id=${projectId}`,
+        headers: { 'x-user-email': TEST_EMAIL },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      for (const session of body.sessions) {
+        expect(session.project_id).toBe(projectId);
+      }
+    });
+  });
+
+  // ─── GET /api/dev-sessions/:id ─────────────────────────────────────────
+
+  describe('GET /api/dev-sessions/:id', () => {
+    it('returns a specific session by id', async () => {
+      // Create one first
+      const createRes = await app.inject({
+        method: 'POST',
+        url: '/api/dev-sessions',
+        headers: { 'content-type': 'application/json', 'x-user-email': TEST_EMAIL },
+        payload: {
+          session_name: 'get-test-001',
+          node: 'MST001-service',
+          task_summary: 'Get test',
+        },
+      });
+      const sessionId = createRes.json().id;
+
+      const res = await app.inject({
+        method: 'GET',
+        url: `/api/dev-sessions/${sessionId}`,
+        headers: { 'x-user-email': TEST_EMAIL },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.id).toBe(sessionId);
+      expect(body.session_name).toBe('get-test-001');
+    });
+
+    it('returns 404 for non-existent session', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/dev-sessions/00000000-0000-0000-0000-000000000099',
+        headers: { 'x-user-email': TEST_EMAIL },
+      });
+
+      expect(res.statusCode).toBe(404);
+    });
+  });
+
+  // ─── PATCH /api/dev-sessions/:id ───────────────────────────────────────
+
+  describe('PATCH /api/dev-sessions/:id', () => {
+    it('updates session fields', async () => {
+      const createRes = await app.inject({
+        method: 'POST',
+        url: '/api/dev-sessions',
+        headers: { 'content-type': 'application/json', 'x-user-email': TEST_EMAIL },
+        payload: {
+          session_name: 'patch-test-001',
+          node: 'MST001-service',
+          task_summary: 'Patch test',
+        },
+      });
+      const sessionId = createRes.json().id;
+
+      const res = await app.inject({
+        method: 'PATCH',
+        url: `/api/dev-sessions/${sessionId}`,
+        headers: { 'content-type': 'application/json', 'x-user-email': TEST_EMAIL },
+        payload: {
+          status: 'stalled',
+          context_pct: 5,
+          branch: 'fix/stalled-branch',
+        },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.status).toBe('stalled');
+      expect(body.context_pct).toBe(5);
+      expect(body.branch).toBe('fix/stalled-branch');
+    });
+
+    it('updates linked_prs and linked_issues', async () => {
+      const createRes = await app.inject({
+        method: 'POST',
+        url: '/api/dev-sessions',
+        headers: { 'content-type': 'application/json', 'x-user-email': TEST_EMAIL },
+        payload: {
+          session_name: 'patch-test-002',
+          node: 'MST001-service',
+          task_summary: 'PR link test',
+        },
+      });
+      const sessionId = createRes.json().id;
+
+      const res = await app.inject({
+        method: 'PATCH',
+        url: `/api/dev-sessions/${sessionId}`,
+        headers: { 'content-type': 'application/json', 'x-user-email': TEST_EMAIL },
+        payload: {
+          linked_prs: ['1290', '1291'],
+          linked_issues: ['1285'],
+        },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.linked_prs).toEqual(['1290', '1291']);
+      expect(body.linked_issues).toEqual(['1285']);
+    });
+
+    it('returns 404 for non-existent session', async () => {
+      const res = await app.inject({
+        method: 'PATCH',
+        url: '/api/dev-sessions/00000000-0000-0000-0000-000000000099',
+        headers: { 'content-type': 'application/json', 'x-user-email': TEST_EMAIL },
+        payload: { status: 'completed' },
+      });
+
+      expect(res.statusCode).toBe(404);
+    });
+  });
+
+  // ─── POST /api/dev-sessions/:id/complete ───────────────────────────────
+
+  describe('POST /api/dev-sessions/:id/complete', () => {
+    it('marks a session as completed', async () => {
+      const createRes = await app.inject({
+        method: 'POST',
+        url: '/api/dev-sessions',
+        headers: { 'content-type': 'application/json', 'x-user-email': TEST_EMAIL },
+        payload: {
+          session_name: 'complete-test-001',
+          node: 'MST001-service',
+          task_summary: 'Complete test',
+        },
+      });
+      const sessionId = createRes.json().id;
+
+      const res = await app.inject({
+        method: 'POST',
+        url: `/api/dev-sessions/${sessionId}/complete`,
+        headers: { 'content-type': 'application/json', 'x-user-email': TEST_EMAIL },
+        payload: { completion_summary: 'Split tests into parallel projects' },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.status).toBe('completed');
+      expect(body.completion_summary).toBe('Split tests into parallel projects');
+      expect(body.completed_at).toBeDefined();
+    });
+
+    it('returns 404 for non-existent session', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/dev-sessions/00000000-0000-0000-0000-000000000099/complete',
+        headers: { 'content-type': 'application/json', 'x-user-email': TEST_EMAIL },
+        payload: {},
+      });
+
+      expect(res.statusCode).toBe(404);
+    });
+  });
+
+  // ─── DELETE /api/dev-sessions/:id ──────────────────────────────────────
+
+  describe('DELETE /api/dev-sessions/:id', () => {
+    it('deletes a session and returns 204', async () => {
+      const createRes = await app.inject({
+        method: 'POST',
+        url: '/api/dev-sessions',
+        headers: { 'content-type': 'application/json', 'x-user-email': TEST_EMAIL },
+        payload: {
+          session_name: 'delete-test-001',
+          node: 'MST001-service',
+          task_summary: 'Delete test',
+        },
+      });
+      const sessionId = createRes.json().id;
+
+      const res = await app.inject({
+        method: 'DELETE',
+        url: `/api/dev-sessions/${sessionId}`,
+        headers: { 'x-user-email': TEST_EMAIL },
+      });
+
+      expect(res.statusCode).toBe(204);
+
+      // Verify deleted
+      const check = await pool.query(`SELECT id FROM dev_session WHERE id = $1`, [sessionId]);
+      expect(check.rows.length).toBe(0);
+    });
+
+    it('returns 404 for non-existent session', async () => {
+      const res = await app.inject({
+        method: 'DELETE',
+        url: '/api/dev-sessions/00000000-0000-0000-0000-000000000099',
+        headers: { 'x-user-email': TEST_EMAIL },
+      });
+
+      expect(res.statusCode).toBe(404);
+    });
+  });
+});

--- a/tests/helpers/db.ts
+++ b/tests/helpers/db.ts
@@ -82,6 +82,8 @@ const APPLICATION_TABLES = [
   'agent_identity',
   // Entity links (no FKs, polymorphic references)
   'entity_link',
+  // Dev sessions (Issue #1285)
+  'dev_session',
   // Async/queue tables (no FKs today, but still want consistent cleanup)
   'webhook_outbox',
   'internal_job',


### PR DESCRIPTION
## Summary

- Add migration 075 with `dev_session` table tracking long-running agent development sessions (node, container, branch, status, context %, linked issues/PRs, task prompt, captures)
- Implement 6 API routes: full CRUD on `/api/dev-sessions`, plus `/api/dev-sessions/:id/complete` for marking sessions done with a completion summary
- Uses `x-user-email` header/query param for agent-friendly auth (matches existing API patterns)
- FK to `work_item(id)` for project linking, FK to `project_webhook(id)` for callback webhook integration (#1274)
- Add frontend types (`DevSession`, `CreateDevSessionBody`, etc.), TanStack Query hooks for all operations, and 3 UI components (`SessionCard`, `SessionList`, `SessionDetail`)
- 18 integration tests covering schema validation, CRUD, status filtering, field updates, completion flow, and 404 handling

Closes #1285

## Test plan

- [x] 18 integration tests pass (`pnpm exec vitest run tests/dev_sessions_api.test.ts`)
- [x] Frontend build succeeds (`pnpm run app:build`)
- [x] Linter clean (only pre-existing warnings)
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)