### PR TITLE
[#1287] Add structured agent identity management with versioning

### DIFF
--- a/migrations/076_agent_identity.down.sql
+++ b/migrations/076_agent_identity.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS agent_identity_history;
+DROP TABLE IF EXISTS agent_identity;

--- a/migrations/076_agent_identity.up.sql
+++ b/migrations/076_agent_identity.up.sql
@@ -1,0 +1,37 @@
+-- Issue #1287: Structured agent identity management with versioning
+-- One identity per agent persona. Agents propose changes, users approve.
+
+CREATE TABLE IF NOT EXISTS agent_identity (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  name            text NOT NULL UNIQUE,
+  display_name    text NOT NULL,
+  emoji           text,
+  avatar_s3_key   text,
+  persona         text NOT NULL,
+  principles      text[] NOT NULL DEFAULT '{}',
+  quirks          text[] NOT NULL DEFAULT '{}',
+  voice_config    jsonb,
+  is_active       boolean NOT NULL DEFAULT true,
+  version         integer NOT NULL DEFAULT 1,
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  updated_at      timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS agent_identity_history (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  identity_id     uuid NOT NULL REFERENCES agent_identity(id) ON DELETE CASCADE,
+  version         integer NOT NULL,
+  changed_by      text NOT NULL,
+  change_type     text NOT NULL,
+  change_reason   text,
+  field_changed   text,
+  previous_value  text,
+  new_value       text,
+  full_snapshot   jsonb NOT NULL,
+  approved_by     text,
+  approved_at     timestamptz,
+  created_at      timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_identity_history ON agent_identity_history (identity_id, version DESC);
+CREATE INDEX IF NOT EXISTS idx_identity_history_pending ON agent_identity_history (change_type) WHERE change_type = 'propose';

--- a/src/ui/components/identity/identity-history.tsx
+++ b/src/ui/components/identity/identity-history.tsx
@@ -1,0 +1,68 @@
+/**
+ * Timeline view of identity version history with rollback support.
+ */
+import { Badge } from '@/ui/components/ui/badge';
+import { Button } from '@/ui/components/ui/button';
+import { RotateCcwIcon } from 'lucide-react';
+import { useAgentIdentityHistory, useRollbackIdentity } from '@/ui/hooks/queries/use-agent-identity';
+
+const TYPE_LABELS: Record<string, string> = {
+  create: 'Created',
+  update: 'Updated',
+  propose: 'Proposed',
+  approve: 'Approved',
+  reject: 'Rejected',
+  rollback: 'Rolled back',
+};
+
+export interface IdentityHistoryProps {
+  identityName: string;
+}
+
+export function IdentityHistory({ identityName }: IdentityHistoryProps) {
+  const { data, isLoading } = useAgentIdentityHistory(identityName);
+  const rollbackMutation = useRollbackIdentity();
+
+  if (isLoading) {
+    return <div className="text-sm text-muted-foreground">Loading history...</div>;
+  }
+
+  const history = data?.history ?? [];
+
+  if (history.length === 0) {
+    return <p className="text-sm text-muted-foreground">No history available.</p>;
+  }
+
+  return (
+    <div className="space-y-3">
+      <h3 className="text-sm font-medium">Version History</h3>
+      <div className="space-y-2">
+        {history.map((entry) => (
+          <div key={entry.id} className="flex items-start justify-between rounded-md border p-2 text-xs">
+            <div>
+              <div className="flex items-center gap-2">
+                <Badge variant="outline">{TYPE_LABELS[entry.change_type] ?? entry.change_type}</Badge>
+                <span className="text-muted-foreground">v{entry.version}</span>
+                {entry.field_changed && <span>field: {entry.field_changed}</span>}
+              </div>
+              <div className="mt-0.5 text-muted-foreground">
+                {entry.changed_by} &middot; {new Date(entry.created_at).toLocaleString()}
+              </div>
+              {entry.change_reason && <p className="mt-0.5">{entry.change_reason}</p>}
+            </div>
+            {entry.change_type !== 'propose' && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => rollbackMutation.mutate({ name: identityName, version: entry.version })}
+                title={`Rollback to v${entry.version}`}
+              >
+                <RotateCcwIcon className="h-3 w-3" />
+              </Button>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/ui/components/identity/identity-settings.tsx
+++ b/src/ui/components/identity/identity-settings.tsx
@@ -1,0 +1,96 @@
+/**
+ * Settings panel for viewing and editing the agent identity.
+ */
+import * as React from 'react';
+import { Badge } from '@/ui/components/ui/badge';
+import { Button } from '@/ui/components/ui/button';
+import { Input } from '@/ui/components/ui/input';
+import { Label } from '@/ui/components/ui/label';
+import { Textarea } from '@/ui/components/ui/textarea';
+import { useAgentIdentity, useSaveAgentIdentity } from '@/ui/hooks/queries/use-agent-identity';
+
+export function IdentitySettings() {
+  const { data: identity, isLoading } = useAgentIdentity();
+  const saveMutation = useSaveAgentIdentity();
+
+  const [name, setName] = React.useState('');
+  const [displayName, setDisplayName] = React.useState('');
+  const [emoji, setEmoji] = React.useState('');
+  const [persona, setPersona] = React.useState('');
+  const [principles, setPrinciples] = React.useState('');
+  const [quirks, setQuirks] = React.useState('');
+
+  React.useEffect(() => {
+    if (identity) {
+      setName(identity.name);
+      setDisplayName(identity.display_name);
+      setEmoji(identity.emoji ?? '');
+      setPersona(identity.persona);
+      setPrinciples(identity.principles.join('\n'));
+      setQuirks(identity.quirks.join('\n'));
+    }
+  }, [identity]);
+
+  const handleSave = () => {
+    saveMutation.mutate({
+      name,
+      display_name: displayName,
+      emoji: emoji || undefined,
+      persona,
+      principles: principles.split('\n').filter(Boolean),
+      quirks: quirks.split('\n').filter(Boolean),
+    });
+  };
+
+  if (isLoading) {
+    return <div className="text-sm text-muted-foreground">Loading identity...</div>;
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className="text-lg font-medium">Agent Identity</h3>
+        {identity && (
+          <Badge variant="outline">v{identity.version}</Badge>
+        )}
+      </div>
+
+      <div className="grid gap-4">
+        <div className="grid grid-cols-2 gap-4">
+          <div className="grid gap-2">
+            <Label htmlFor="identity-name">Name</Label>
+            <Input id="identity-name" value={name} onChange={(e) => setName(e.target.value)} placeholder="quasar" />
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="identity-display-name">Display Name</Label>
+            <Input id="identity-display-name" value={displayName} onChange={(e) => setDisplayName(e.target.value)} placeholder="Quasar" />
+          </div>
+        </div>
+
+        <div className="grid gap-2">
+          <Label htmlFor="identity-emoji">Emoji</Label>
+          <Input id="identity-emoji" value={emoji} onChange={(e) => setEmoji(e.target.value)} placeholder="✦" className="w-20" />
+        </div>
+
+        <div className="grid gap-2">
+          <Label htmlFor="identity-persona">Persona</Label>
+          <Textarea id="identity-persona" value={persona} onChange={(e) => setPersona(e.target.value)} rows={4} placeholder="Core personality description..." />
+        </div>
+
+        <div className="grid gap-2">
+          <Label htmlFor="identity-principles">Principles (one per line)</Label>
+          <Textarea id="identity-principles" value={principles} onChange={(e) => setPrinciples(e.target.value)} rows={3} placeholder="Be helpful\nBe honest" />
+        </div>
+
+        <div className="grid gap-2">
+          <Label htmlFor="identity-quirks">Quirks (one per line)</Label>
+          <Textarea id="identity-quirks" value={quirks} onChange={(e) => setQuirks(e.target.value)} rows={3} placeholder="Uses bullet points for status updates" />
+        </div>
+
+        <Button onClick={handleSave} disabled={!name || !persona || saveMutation.isPending}>
+          {saveMutation.isPending ? 'Saving...' : 'Save Identity'}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/components/identity/index.ts
+++ b/src/ui/components/identity/index.ts
@@ -1,0 +1,3 @@
+export { IdentitySettings } from './identity-settings';
+export { ProposalReview } from './proposal-review';
+export { IdentityHistory } from './identity-history';

--- a/src/ui/components/identity/proposal-review.tsx
+++ b/src/ui/components/identity/proposal-review.tsx
@@ -1,0 +1,87 @@
+/**
+ * Component for reviewing pending identity change proposals from agents.
+ */
+import { Badge } from '@/ui/components/ui/badge';
+import { Button } from '@/ui/components/ui/button';
+import { CheckIcon, XIcon } from 'lucide-react';
+import {
+  useAgentIdentityHistory,
+  useApproveProposal,
+  useRejectProposal,
+} from '@/ui/hooks/queries/use-agent-identity';
+import type { AgentIdentityHistoryEntry } from '@/ui/lib/api-types';
+
+export interface ProposalReviewProps {
+  identityName: string;
+}
+
+function ProposalCard({
+  entry,
+  onApprove,
+  onReject,
+}: {
+  entry: AgentIdentityHistoryEntry;
+  onApprove: (id: string) => void;
+  onReject: (id: string) => void;
+}) {
+  return (
+    <div className="rounded-md border p-3 text-sm">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Badge variant="secondary">Proposal</Badge>
+          <span className="font-medium">{entry.field_changed}</span>
+          <span className="text-xs text-muted-foreground">by {entry.changed_by}</span>
+        </div>
+        <div className="flex gap-1">
+          <Button variant="ghost" size="sm" onClick={() => onApprove(entry.id)} title="Approve">
+            <CheckIcon className="h-3 w-3 text-green-600" />
+          </Button>
+          <Button variant="ghost" size="sm" onClick={() => onReject(entry.id)} title="Reject">
+            <XIcon className="h-3 w-3 text-destructive" />
+          </Button>
+        </div>
+      </div>
+      {entry.change_reason && (
+        <p className="mt-1 text-xs text-muted-foreground">Reason: {entry.change_reason}</p>
+      )}
+      <div className="mt-2 grid grid-cols-2 gap-2 text-xs">
+        {entry.previous_value && (
+          <div>
+            <span className="text-muted-foreground">Previous:</span>
+            <p className="mt-0.5 rounded bg-muted p-1">{entry.previous_value}</p>
+          </div>
+        )}
+        <div>
+          <span className="text-muted-foreground">Proposed:</span>
+          <p className="mt-0.5 rounded bg-muted p-1">{entry.new_value}</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function ProposalReview({ identityName }: ProposalReviewProps) {
+  const { data } = useAgentIdentityHistory(identityName);
+  const approveMutation = useApproveProposal();
+  const rejectMutation = useRejectProposal();
+
+  const proposals = (data?.history ?? []).filter((e) => e.change_type === 'propose');
+
+  if (proposals.length === 0) {
+    return <p className="text-sm text-muted-foreground">No pending proposals.</p>;
+  }
+
+  return (
+    <div className="space-y-3">
+      <h3 className="text-sm font-medium">Pending Proposals</h3>
+      {proposals.map((entry) => (
+        <ProposalCard
+          key={entry.id}
+          entry={entry}
+          onApprove={(id) => approveMutation.mutate(id)}
+          onReject={(id) => rejectMutation.mutate({ proposalId: id })}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/ui/hooks/queries/use-agent-identity.ts
+++ b/src/ui/hooks/queries/use-agent-identity.ts
@@ -1,0 +1,135 @@
+/**
+ * TanStack Query hooks for agent identity management (Issue #1287).
+ *
+ * Provides queries for fetching identity/history and mutations for
+ * creating, updating, proposing changes, and approving/rejecting.
+ */
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { apiClient } from '@/ui/lib/api-client.ts';
+import type {
+  AgentIdentity,
+  AgentIdentityHistoryResponse,
+  AgentIdentityHistoryEntry,
+  CreateAgentIdentityBody,
+  ProposeIdentityChangeBody,
+} from '@/ui/lib/api-types.ts';
+
+/** Query key factory for agent identity. */
+export const identityKeys = {
+  all: ['agent-identity'] as const,
+  current: (name?: string) => [...identityKeys.all, 'current', name] as const,
+  history: (name: string) => [...identityKeys.all, 'history', name] as const,
+};
+
+/**
+ * Fetch the current agent identity.
+ */
+export function useAgentIdentity(name?: string) {
+  const url = name ? `/api/identity?name=${encodeURIComponent(name)}` : '/api/identity';
+  return useQuery({
+    queryKey: identityKeys.current(name),
+    queryFn: ({ signal }) => apiClient.get<AgentIdentity>(url, { signal }),
+  });
+}
+
+/**
+ * Fetch identity version history.
+ */
+export function useAgentIdentityHistory(name: string) {
+  return useQuery({
+    queryKey: identityKeys.history(name),
+    queryFn: ({ signal }) =>
+      apiClient.get<AgentIdentityHistoryResponse>(`/api/identity/history?name=${encodeURIComponent(name)}`, { signal }),
+    enabled: !!name,
+  });
+}
+
+/**
+ * Mutation: create or replace an identity.
+ */
+export function useSaveAgentIdentity() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (body: CreateAgentIdentityBody) =>
+      apiClient.put<AgentIdentity>('/api/identity', body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: identityKeys.all });
+    },
+  });
+}
+
+/**
+ * Mutation: partially update an identity.
+ */
+export function useUpdateAgentIdentity() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (body: Record<string, unknown> & { name: string }) =>
+      apiClient.patch<AgentIdentity>('/api/identity', body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: identityKeys.all });
+    },
+  });
+}
+
+/**
+ * Mutation: propose an identity change (agent-initiated).
+ */
+export function useProposeIdentityChange() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (body: ProposeIdentityChangeBody) =>
+      apiClient.post<AgentIdentityHistoryEntry>('/api/identity/proposals', body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: identityKeys.all });
+    },
+  });
+}
+
+/**
+ * Mutation: approve a pending proposal.
+ */
+export function useApproveProposal() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (proposalId: string) =>
+      apiClient.post<AgentIdentityHistoryEntry>(`/api/identity/proposals/${proposalId}/approve`, {}),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: identityKeys.all });
+    },
+  });
+}
+
+/**
+ * Mutation: reject a pending proposal.
+ */
+export function useRejectProposal() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ proposalId, reason }: { proposalId: string; reason?: string }) =>
+      apiClient.post<AgentIdentityHistoryEntry>(`/api/identity/proposals/${proposalId}/reject`, { reason }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: identityKeys.all });
+    },
+  });
+}
+
+/**
+ * Mutation: rollback to a previous version.
+ */
+export function useRollbackIdentity() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ name, version }: { name: string; version: number }) =>
+      apiClient.post<AgentIdentity>('/api/identity/rollback', { name, version }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: identityKeys.all });
+    },
+  });
+}

--- a/src/ui/lib/api-types.ts
+++ b/src/ui/lib/api-types.ts
@@ -911,6 +911,68 @@ export interface SkillStoreSearchResponse {
 }
 
 // ---------------------------------------------------------------------------
+// Agent Identity (Issue #1287)
+// ---------------------------------------------------------------------------
+
+/** The agent's core identity/persona. */
+export interface AgentIdentity {
+  id: string;
+  name: string;
+  display_name: string;
+  emoji: string | null;
+  avatar_s3_key: string | null;
+  persona: string;
+  principles: string[];
+  quirks: string[];
+  voice_config: Record<string, unknown> | null;
+  is_active: boolean;
+  version: number;
+  created_at: string;
+  updated_at: string;
+}
+
+/** A history entry tracking identity changes. */
+export interface AgentIdentityHistoryEntry {
+  id: string;
+  identity_id: string;
+  version: number;
+  changed_by: string;
+  change_type: 'create' | 'update' | 'propose' | 'approve' | 'reject' | 'rollback';
+  change_reason: string | null;
+  field_changed: string | null;
+  previous_value: string | null;
+  new_value: string | null;
+  full_snapshot: Record<string, unknown>;
+  approved_by: string | null;
+  approved_at: string | null;
+  created_at: string;
+}
+
+/** Response from GET /api/identity/history */
+export interface AgentIdentityHistoryResponse {
+  history: AgentIdentityHistoryEntry[];
+}
+
+/** Body for PUT /api/identity */
+export interface CreateAgentIdentityBody {
+  name: string;
+  display_name?: string;
+  emoji?: string;
+  persona: string;
+  principles?: string[];
+  quirks?: string[];
+}
+
+/** Body for POST /api/identity/proposals */
+export interface ProposeIdentityChangeBody {
+  name: string;
+  field: string;
+  new_value: string;
+  reason?: string;
+  proposed_by: string;
+}
+
+// ---------------------------------------------------------------------------
 // Bootstrap (server-injected data)
 // ---------------------------------------------------------------------------
 

--- a/tests/agent_identity_api.test.ts
+++ b/tests/agent_identity_api.test.ts
@@ -1,0 +1,407 @@
+/**
+ * Integration tests for agent identity management (Issue #1287).
+ *
+ * Tests CRUD for agent identities, proposal workflow, history,
+ * and rollback functionality.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { buildServer } from '../src/api/server.js';
+import { createTestPool } from './helpers/db.js';
+
+const TEST_EMAIL = 'identity-test@example.com';
+
+describe('Agent Identity API (Issue #1287)', () => {
+  let app: Awaited<ReturnType<typeof buildServer>>;
+  let pool: ReturnType<typeof createTestPool>;
+
+  beforeAll(async () => {
+    pool = createTestPool();
+    app = await buildServer();
+
+    // Clean up any leftover test data
+    await pool.query(`DELETE FROM agent_identity_history`);
+    await pool.query(`DELETE FROM agent_identity WHERE name LIKE 'test-%'`);
+  });
+
+  afterAll(async () => {
+    await pool.query(`DELETE FROM agent_identity_history`);
+    await pool.query(`DELETE FROM agent_identity WHERE name LIKE 'test-%'`);
+    await pool.end();
+    await app.close();
+  });
+
+  // ─── Schema ────────────────────────────────────────────────────────────
+
+  describe('Schema', () => {
+    it('agent_identity table exists with expected columns', async () => {
+      const result = await pool.query(
+        `SELECT column_name FROM information_schema.columns
+         WHERE table_name = 'agent_identity'
+         ORDER BY ordinal_position`,
+      );
+      const columns = result.rows.map((r) => r.column_name);
+      expect(columns).toContain('id');
+      expect(columns).toContain('name');
+      expect(columns).toContain('display_name');
+      expect(columns).toContain('persona');
+      expect(columns).toContain('principles');
+      expect(columns).toContain('quirks');
+      expect(columns).toContain('version');
+    });
+
+    it('agent_identity_history table exists with expected columns', async () => {
+      const result = await pool.query(
+        `SELECT column_name FROM information_schema.columns
+         WHERE table_name = 'agent_identity_history'
+         ORDER BY ordinal_position`,
+      );
+      const columns = result.rows.map((r) => r.column_name);
+      expect(columns).toContain('id');
+      expect(columns).toContain('identity_id');
+      expect(columns).toContain('version');
+      expect(columns).toContain('changed_by');
+      expect(columns).toContain('change_type');
+      expect(columns).toContain('full_snapshot');
+    });
+  });
+
+  // ─── GET /api/identity ─────────────────────────────────────────────────
+
+  describe('GET /api/identity', () => {
+    it('returns the current identity (or 404 if none exists)', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/identity',
+        headers: { 'x-user-email': TEST_EMAIL },
+      });
+
+      // Could be 200 or 404 depending on whether one exists
+      expect([200, 404]).toContain(res.statusCode);
+    });
+  });
+
+  // ─── PUT /api/identity ─────────────────────────────────────────────────
+
+  describe('PUT /api/identity', () => {
+    it('creates or updates the identity', async () => {
+      const res = await app.inject({
+        method: 'PUT',
+        url: '/api/identity',
+        headers: { 'content-type': 'application/json', 'x-user-email': TEST_EMAIL },
+        payload: {
+          name: 'test-quasar',
+          display_name: 'Test Quasar',
+          emoji: '✦',
+          persona: 'A helpful, curious AI assistant that values clarity.',
+          principles: ['Be helpful', 'Be honest', 'Be concise'],
+          quirks: ['Uses bullet points for status updates'],
+        },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.name).toBe('test-quasar');
+      expect(body.display_name).toBe('Test Quasar');
+      expect(body.persona).toContain('helpful');
+      expect(body.principles).toContain('Be helpful');
+      expect(body.version).toBe(1);
+    });
+
+    it('returns 400 when name is missing', async () => {
+      const res = await app.inject({
+        method: 'PUT',
+        url: '/api/identity',
+        headers: { 'content-type': 'application/json', 'x-user-email': TEST_EMAIL },
+        payload: { display_name: 'No Name' },
+      });
+
+      expect(res.statusCode).toBe(400);
+    });
+  });
+
+  // ─── PATCH /api/identity ───────────────────────────────────────────────
+
+  describe('PATCH /api/identity', () => {
+    it('updates identity fields and bumps version', async () => {
+      // Ensure identity exists
+      await app.inject({
+        method: 'PUT',
+        url: '/api/identity',
+        headers: { 'content-type': 'application/json', 'x-user-email': TEST_EMAIL },
+        payload: {
+          name: 'test-patch',
+          display_name: 'Patch Test',
+          persona: 'Original persona text.',
+        },
+      });
+
+      const res = await app.inject({
+        method: 'PATCH',
+        url: '/api/identity',
+        headers: { 'content-type': 'application/json', 'x-user-email': TEST_EMAIL },
+        payload: {
+          name: 'test-patch',
+          persona: 'Updated persona with more detail.',
+          quirks: ['Prefers markdown formatting'],
+        },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.persona).toBe('Updated persona with more detail.');
+      expect(body.quirks).toContain('Prefers markdown formatting');
+      expect(body.version).toBeGreaterThanOrEqual(2);
+    });
+
+    it('returns 404 for non-existent identity', async () => {
+      const res = await app.inject({
+        method: 'PATCH',
+        url: '/api/identity',
+        headers: { 'content-type': 'application/json', 'x-user-email': TEST_EMAIL },
+        payload: {
+          name: 'does-not-exist-999',
+          persona: 'test',
+        },
+      });
+
+      expect(res.statusCode).toBe(404);
+    });
+  });
+
+  // ─── POST /api/identity/proposals ──────────────────────────────────────
+
+  describe('POST /api/identity/proposals', () => {
+    it('creates a proposal for an identity change', async () => {
+      // Ensure identity exists
+      await app.inject({
+        method: 'PUT',
+        url: '/api/identity',
+        headers: { 'content-type': 'application/json', 'x-user-email': TEST_EMAIL },
+        payload: {
+          name: 'test-proposals',
+          display_name: 'Proposal Test',
+          persona: 'A test persona.',
+        },
+      });
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/identity/proposals',
+        headers: { 'content-type': 'application/json', 'x-user-email': TEST_EMAIL },
+        payload: {
+          name: 'test-proposals',
+          field: 'quirks',
+          new_value: 'Prefers bullet points for status updates',
+          reason: 'Observed over 20+ interactions',
+          proposed_by: 'agent:claude-code',
+        },
+      });
+
+      expect(res.statusCode).toBe(201);
+      const body = res.json();
+      expect(body.change_type).toBe('propose');
+      expect(body.field_changed).toBe('quirks');
+      expect(body.new_value).toBe('Prefers bullet points for status updates');
+    });
+
+    it('returns 404 for non-existent identity', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/identity/proposals',
+        headers: { 'content-type': 'application/json', 'x-user-email': TEST_EMAIL },
+        payload: {
+          name: 'does-not-exist-999',
+          field: 'quirks',
+          new_value: 'test',
+          proposed_by: 'agent:test',
+        },
+      });
+
+      expect(res.statusCode).toBe(404);
+    });
+  });
+
+  // ─── POST /api/identity/proposals/:id/approve ─────────────────────────
+
+  describe('POST /api/identity/proposals/:id/approve', () => {
+    it('approves a pending proposal and updates the identity', async () => {
+      // Ensure identity
+      await app.inject({
+        method: 'PUT',
+        url: '/api/identity',
+        headers: { 'content-type': 'application/json', 'x-user-email': TEST_EMAIL },
+        payload: {
+          name: 'test-approve',
+          display_name: 'Approve Test',
+          persona: 'A test persona.',
+          quirks: [],
+        },
+      });
+
+      // Create a proposal
+      const proposalRes = await app.inject({
+        method: 'POST',
+        url: '/api/identity/proposals',
+        headers: { 'content-type': 'application/json', 'x-user-email': TEST_EMAIL },
+        payload: {
+          name: 'test-approve',
+          field: 'quirks',
+          new_value: 'Loves semicolons',
+          reason: 'Test proposal',
+          proposed_by: 'agent:test',
+        },
+      });
+      const proposalId = proposalRes.json().id;
+
+      // Approve it
+      const res = await app.inject({
+        method: 'POST',
+        url: `/api/identity/proposals/${proposalId}/approve`,
+        headers: { 'content-type': 'application/json', 'x-user-email': TEST_EMAIL },
+        payload: {},
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.change_type).toBe('approve');
+      expect(body.approved_by).toBe(TEST_EMAIL);
+    });
+
+    it('returns 404 for non-existent proposal', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/identity/proposals/00000000-0000-0000-0000-000000000099/approve',
+        headers: { 'content-type': 'application/json', 'x-user-email': TEST_EMAIL },
+        payload: {},
+      });
+
+      expect(res.statusCode).toBe(404);
+    });
+  });
+
+  // ─── POST /api/identity/proposals/:id/reject ──────────────────────────
+
+  describe('POST /api/identity/proposals/:id/reject', () => {
+    it('rejects a pending proposal', async () => {
+      // Ensure identity
+      await app.inject({
+        method: 'PUT',
+        url: '/api/identity',
+        headers: { 'content-type': 'application/json', 'x-user-email': TEST_EMAIL },
+        payload: {
+          name: 'test-reject',
+          display_name: 'Reject Test',
+          persona: 'A test persona.',
+        },
+      });
+
+      // Create a proposal
+      const proposalRes = await app.inject({
+        method: 'POST',
+        url: '/api/identity/proposals',
+        headers: { 'content-type': 'application/json', 'x-user-email': TEST_EMAIL },
+        payload: {
+          name: 'test-reject',
+          field: 'persona',
+          new_value: 'A totally different persona',
+          reason: 'Just testing',
+          proposed_by: 'agent:test',
+        },
+      });
+      const proposalId = proposalRes.json().id;
+
+      const res = await app.inject({
+        method: 'POST',
+        url: `/api/identity/proposals/${proposalId}/reject`,
+        headers: { 'content-type': 'application/json', 'x-user-email': TEST_EMAIL },
+        payload: { reason: 'Not aligned with personality' },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.change_type).toBe('reject');
+    });
+  });
+
+  // ─── GET /api/identity/history ─────────────────────────────────────────
+
+  describe('GET /api/identity/history', () => {
+    it('returns version history for an identity', async () => {
+      // Ensure we have an identity with some history
+      await app.inject({
+        method: 'PUT',
+        url: '/api/identity',
+        headers: { 'content-type': 'application/json', 'x-user-email': TEST_EMAIL },
+        payload: {
+          name: 'test-history',
+          display_name: 'History Test',
+          persona: 'A test persona.',
+        },
+      });
+
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/identity/history?name=test-history',
+        headers: { 'x-user-email': TEST_EMAIL },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.history).toBeDefined();
+      expect(Array.isArray(body.history)).toBe(true);
+      expect(body.history.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  // ─── POST /api/identity/rollback ───────────────────────────────────────
+
+  describe('POST /api/identity/rollback', () => {
+    it('rolls back to a previous version', async () => {
+      // Create identity
+      await app.inject({
+        method: 'PUT',
+        url: '/api/identity',
+        headers: { 'content-type': 'application/json', 'x-user-email': TEST_EMAIL },
+        payload: {
+          name: 'test-rollback',
+          display_name: 'Rollback Test',
+          persona: 'Version 1 persona.',
+        },
+      });
+
+      // Update to v2
+      await app.inject({
+        method: 'PATCH',
+        url: '/api/identity',
+        headers: { 'content-type': 'application/json', 'x-user-email': TEST_EMAIL },
+        payload: {
+          name: 'test-rollback',
+          persona: 'Version 2 persona.',
+        },
+      });
+
+      // Rollback to v1
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/identity/rollback',
+        headers: { 'content-type': 'application/json', 'x-user-email': TEST_EMAIL },
+        payload: { name: 'test-rollback', version: 1 },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.persona).toBe('Version 1 persona.');
+    });
+
+    it('returns 404 for non-existent identity', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/identity/rollback',
+        headers: { 'content-type': 'application/json', 'x-user-email': TEST_EMAIL },
+        payload: { name: 'does-not-exist-999', version: 1 },
+      });
+
+      expect(res.statusCode).toBe(404);
+    });
+  });
+});

--- a/tests/helpers/db.ts
+++ b/tests/helpers/db.ts
@@ -75,6 +75,9 @@ const APPLICATION_TABLES = [
   'skill_store_activity',
   'skill_store_schedule',
   'skill_store_item',
+  // Agent identity (Issue #1287)
+  'agent_identity_history',
+  'agent_identity',
   // Async/queue tables (no FKs today, but still want consistent cleanup)
   'webhook_outbox',
   'internal_job',


### PR DESCRIPTION
## Summary

- Add migration 076 with `agent_identity` (one row per persona, versioned) and `agent_identity_history` (full change tracking with snapshots) tables
- Implement 8 API routes:
  - `GET /api/identity` — fetch current identity (by name or first active)
  - `PUT /api/identity` — create or fully replace (upsert on name)
  - `PATCH /api/identity` — partial updates with version bump
  - `POST /api/identity/proposals` — agents propose changes (cannot modify directly)
  - `POST /api/identity/proposals/:id/approve` — user approves, applies change
  - `POST /api/identity/proposals/:id/reject` — user rejects with reason
  - `GET /api/identity/history` — full version timeline
  - `POST /api/identity/rollback` — restore from any historical snapshot
- Every change records a full JSON snapshot for safe rollback
- Array fields (principles, quirks) are appended on proposal approval
- Add frontend types, TanStack Query hooks, and 3 UI components (`IdentitySettings`, `ProposalReview`, `IdentityHistory`)
- 15 integration tests covering schema, CRUD, proposal workflow, approve/reject, history, and rollback

Closes #1287

## Test plan

- [x] 15 integration tests pass (`pnpm exec vitest run tests/agent_identity_api.test.ts`)
- [x] Frontend build succeeds (`pnpm run app:build`)
- [x] Linter clean (only pre-existing warnings)
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)