### PR TITLE
[#1320] Fix S3 presigned URL signature mismatch on external endpoint

### DIFF
--- a/src/api/file-storage/types.ts
+++ b/src/api/file-storage/types.ts
@@ -8,6 +8,7 @@
  */
 export interface S3Config {
   endpoint?: string;
+  externalEndpoint?: string;
   bucket: string;
   region: string;
   accessKeyId: string;
@@ -22,6 +23,8 @@ export interface FileStorage {
   upload(key: string, data: Buffer, contentType: string): Promise<string>;
   download(key: string): Promise<Buffer>;
   getSignedUrl(key: string, expiresIn: number): Promise<string>;
+  /** Get a signed URL using the external endpoint (for browser-facing presigned URLs). Falls back to internal client when no external endpoint is configured. */
+  getExternalSignedUrl(key: string, expiresIn: number): Promise<string>;
   delete(key: string): Promise<void>;
   exists(key: string): Promise<boolean>;
 }

--- a/tests/file-storage/s3-presigned-external-endpoint.test.ts
+++ b/tests/file-storage/s3-presigned-external-endpoint.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Tests for S3 presigned URL generation with external endpoints.
+ * Part of Issue #1320 - S3 presigned URL signature mismatch when using
+ * external endpoint (FILE_SHARE_MODE=presigned).
+ *
+ * Verifies that presigned URLs are generated using the external endpoint
+ * (when configured) so that the Signature V4 Host matches the endpoint
+ * the browser actually hits.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { S3Storage } from '../../src/api/file-storage/s3-storage.ts';
+import type { S3Config } from '../../src/api/file-storage/types.ts';
+
+/** Track S3Client instances created by the mock */
+const s3Instances: Array<{ _config: Record<string, unknown> }> = [];
+
+// Mock AWS SDK modules — all exports that are used with `new` must be classes
+vi.mock('@aws-sdk/client-s3', () => {
+  class MockS3Client {
+    _config: Record<string, unknown>;
+    send = vi.fn();
+    constructor(config: Record<string, unknown>) {
+      this._config = config;
+      s3Instances.push(this);
+    }
+  }
+  class MockGetObjectCommand {
+    input: Record<string, unknown>;
+    constructor(input: Record<string, unknown>) {
+      this.input = input;
+    }
+  }
+  class MockPutObjectCommand {
+    constructor(public input: Record<string, unknown>) {}
+  }
+  class MockDeleteObjectCommand {
+    constructor(public input: Record<string, unknown>) {}
+  }
+  class MockHeadObjectCommand {
+    constructor(public input: Record<string, unknown>) {}
+  }
+  return {
+    S3Client: MockS3Client,
+    PutObjectCommand: MockPutObjectCommand,
+    GetObjectCommand: MockGetObjectCommand,
+    DeleteObjectCommand: MockDeleteObjectCommand,
+    HeadObjectCommand: MockHeadObjectCommand,
+  };
+});
+
+vi.mock('@aws-sdk/s3-request-presigner', () => ({
+  getSignedUrl: vi.fn().mockImplementation(async (client: { _config: { endpoint?: string } }) => {
+    const endpoint = client._config.endpoint ?? 'https://s3.amazonaws.com';
+    return `${endpoint}/test-bucket/test-key?X-Amz-Signature=abc123`;
+  }),
+}));
+
+describe('S3Storage external endpoint presigning', () => {
+  const baseConfig: S3Config = {
+    endpoint: 'http://seaweedfs:8333',
+    bucket: 'test-bucket',
+    region: 'us-east-1',
+    accessKeyId: 'test-key',
+    secretAccessKey: 'test-secret',
+    forcePathStyle: true,
+  };
+
+  beforeEach(() => {
+    s3Instances.length = 0;
+    vi.clearAllMocks();
+  });
+
+  describe('getExternalSignedUrl', () => {
+    it('uses external endpoint for signing when externalEndpoint is configured', async () => {
+      const storage = new S3Storage({
+        ...baseConfig,
+        externalEndpoint: 'https://s3.execdesk.ai',
+      });
+
+      const url = await storage.getExternalSignedUrl('test-key', 3600);
+
+      // The URL should be signed against the external endpoint
+      expect(url).toContain('https://s3.execdesk.ai');
+      expect(url).not.toContain('seaweedfs:8333');
+    });
+
+    it('falls back to internal client when no externalEndpoint is configured', async () => {
+      const storage = new S3Storage(baseConfig);
+
+      const url = await storage.getExternalSignedUrl('test-key', 3600);
+
+      // Should use the internal endpoint since no external is configured
+      expect(url).toContain('http://seaweedfs:8333');
+    });
+
+    it('creates a separate client for external signing (not reusing internal client)', async () => {
+      const storage = new S3Storage({
+        ...baseConfig,
+        externalEndpoint: 'https://s3.execdesk.ai',
+      });
+
+      // After constructor: 1 instance (internal client)
+      expect(s3Instances).toHaveLength(1);
+
+      await storage.getExternalSignedUrl('test-key', 3600);
+
+      // After first external call: 2 instances (internal + external)
+      expect(s3Instances).toHaveLength(2);
+
+      // The second instance should have the external endpoint
+      expect(s3Instances[1]._config.endpoint).toBe('https://s3.execdesk.ai');
+    });
+
+    it('reuses the external client on subsequent calls (lazy singleton)', async () => {
+      const storage = new S3Storage({
+        ...baseConfig,
+        externalEndpoint: 'https://s3.execdesk.ai',
+      });
+
+      await storage.getExternalSignedUrl('key1', 3600);
+      await storage.getExternalSignedUrl('key2', 3600);
+
+      // Should still only be 2 instances total (1 internal + 1 external, reused)
+      expect(s3Instances).toHaveLength(2);
+    });
+
+    it('preserves other client config (region, credentials, forcePathStyle) on external client', async () => {
+      const storage = new S3Storage({
+        ...baseConfig,
+        externalEndpoint: 'https://s3.execdesk.ai',
+      });
+
+      await storage.getExternalSignedUrl('test-key', 3600);
+
+      const externalClientConfig = s3Instances[1]._config;
+      expect(externalClientConfig.region).toBe('us-east-1');
+      expect(externalClientConfig.credentials).toEqual({
+        accessKeyId: 'test-key',
+        secretAccessKey: 'test-secret',
+      });
+      expect(externalClientConfig.forcePathStyle).toBe(true);
+    });
+  });
+
+  describe('getSignedUrl (internal, unchanged)', () => {
+    it('still uses internal endpoint for regular signed URLs', async () => {
+      const storage = new S3Storage({
+        ...baseConfig,
+        externalEndpoint: 'https://s3.execdesk.ai',
+      });
+
+      const url = await storage.getSignedUrl('test-key', 3600);
+
+      // Regular getSignedUrl should still use internal endpoint
+      expect(url).toContain('http://seaweedfs:8333');
+    });
+  });
+});
+
+describe('createS3StorageFromEnv with S3_EXTERNAL_ENDPOINT', () => {
+  const envBackup: Record<string, string | undefined> = {};
+  const envKeys = [
+    'S3_BUCKET', 'S3_REGION', 'S3_ACCESS_KEY', 'S3_SECRET_KEY',
+    'S3_ENDPOINT', 'S3_EXTERNAL_ENDPOINT', 'S3_FORCE_PATH_STYLE',
+  ];
+
+  beforeEach(() => {
+    s3Instances.length = 0;
+    for (const key of envKeys) {
+      envBackup[key] = process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of envKeys) {
+      if (envBackup[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = envBackup[key];
+      }
+    }
+  });
+
+  it('passes S3_EXTERNAL_ENDPOINT to storage when set', async () => {
+    process.env.S3_BUCKET = 'test-bucket';
+    process.env.S3_REGION = 'us-east-1';
+    process.env.S3_ACCESS_KEY = 'key';
+    process.env.S3_SECRET_KEY = 'secret';
+    process.env.S3_ENDPOINT = 'http://seaweedfs:8333';
+    process.env.S3_EXTERNAL_ENDPOINT = 'https://s3.execdesk.ai';
+
+    const { createS3StorageFromEnv } = await import('../../src/api/file-storage/s3-storage.ts');
+    const storage = createS3StorageFromEnv();
+
+    expect(storage).not.toBeNull();
+
+    const url = await storage!.getExternalSignedUrl('test-key', 3600);
+    expect(url).toContain('https://s3.execdesk.ai');
+  });
+
+  it('works without S3_EXTERNAL_ENDPOINT (fallback to internal)', async () => {
+    process.env.S3_BUCKET = 'test-bucket';
+    process.env.S3_REGION = 'us-east-1';
+    process.env.S3_ACCESS_KEY = 'key';
+    process.env.S3_SECRET_KEY = 'secret';
+    process.env.S3_ENDPOINT = 'http://seaweedfs:8333';
+    delete process.env.S3_EXTERNAL_ENDPOINT;
+
+    const { createS3StorageFromEnv } = await import('../../src/api/file-storage/s3-storage.ts');
+    const storage = createS3StorageFromEnv();
+
+    expect(storage).not.toBeNull();
+
+    const url = await storage!.getExternalSignedUrl('test-key', 3600);
+    expect(url).toContain('http://seaweedfs:8333');
+  });
+});

--- a/tests/file-storage/sharing-presigned-url.test.ts
+++ b/tests/file-storage/sharing-presigned-url.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Tests for presigned URL generation in file sharing.
+ * Part of Issue #1320 - Ensures sharing.ts uses getExternalSignedUrl()
+ * instead of the string-replace hack.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { FileStorage, FileAttachment } from '../../src/api/file-storage/types.ts';
+import type { Pool } from 'pg';
+
+// Mock the service module
+vi.mock('../../src/api/file-storage/service.ts', () => ({
+  getFileMetadata: vi.fn(),
+  getFileUrl: vi.fn(),
+  FileNotFoundError: class FileNotFoundError extends Error {
+    constructor(public fileId: string) {
+      super(`File not found: ${fileId}`);
+      this.name = 'FileNotFoundError';
+    }
+  },
+}));
+
+describe('createFileShare presigned mode', () => {
+  const envBackup: Record<string, string | undefined> = {};
+  const envKeys = ['FILE_SHARE_MODE', 'S3_ENDPOINT', 'S3_EXTERNAL_ENDPOINT', 'APP_BASE_URL'];
+
+  beforeEach(() => {
+    for (const key of envKeys) {
+      envBackup[key] = process.env[key];
+    }
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    for (const key of envKeys) {
+      if (envBackup[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = envBackup[key];
+      }
+    }
+    vi.restoreAllMocks();
+  });
+
+  function createMockStorage(signedUrl: string, externalSignedUrl?: string): FileStorage {
+    return {
+      upload: vi.fn(),
+      download: vi.fn(),
+      getSignedUrl: vi.fn().mockResolvedValue(signedUrl),
+      getExternalSignedUrl: vi.fn().mockResolvedValue(externalSignedUrl ?? signedUrl),
+      delete: vi.fn(),
+      exists: vi.fn(),
+    };
+  }
+
+  function createMockPool(): Pool {
+    return {} as Pool;
+  }
+
+  const mockMetadata: FileAttachment = {
+    id: 'file-123',
+    storageKey: '2026/02/15/test-uuid.pdf',
+    originalFilename: 'report.pdf',
+    contentType: 'application/pdf',
+    sizeBytes: 1024,
+    createdAt: new Date('2026-02-15'),
+  };
+
+  it('calls getExternalSignedUrl (not getSignedUrl) in presigned mode', async () => {
+    process.env.FILE_SHARE_MODE = 'presigned';
+    delete process.env.S3_EXTERNAL_ENDPOINT;
+
+    const { getFileMetadata } = await import('../../src/api/file-storage/service.ts');
+    (getFileMetadata as ReturnType<typeof vi.fn>).mockResolvedValue(mockMetadata);
+
+    const { createFileShare } = await import('../../src/api/file-storage/sharing.ts');
+
+    const storage = createMockStorage(
+      'http://seaweedfs:8333/test-bucket/key?sig=internal',
+      'https://s3.execdesk.ai/test-bucket/key?sig=external',
+    );
+
+    const result = await createFileShare(createMockPool(), storage, {
+      fileId: 'file-123',
+      expiresIn: 3600,
+    });
+
+    // Should call getExternalSignedUrl, NOT getSignedUrl
+    expect(storage.getExternalSignedUrl).toHaveBeenCalledWith(mockMetadata.storageKey, 3600);
+    expect(storage.getSignedUrl).not.toHaveBeenCalled();
+  });
+
+  it('returns the URL from getExternalSignedUrl without any string replacement', async () => {
+    process.env.FILE_SHARE_MODE = 'presigned';
+    delete process.env.S3_EXTERNAL_ENDPOINT;
+
+    const { getFileMetadata } = await import('../../src/api/file-storage/service.ts');
+    (getFileMetadata as ReturnType<typeof vi.fn>).mockResolvedValue(mockMetadata);
+
+    const { createFileShare } = await import('../../src/api/file-storage/sharing.ts');
+
+    const externalUrl = 'https://s3.execdesk.ai/test-bucket/key?X-Amz-Signature=valid123';
+    const storage = createMockStorage(
+      'http://seaweedfs:8333/test-bucket/key?X-Amz-Signature=internal123',
+      externalUrl,
+    );
+
+    const result = await createFileShare(createMockPool(), storage, {
+      fileId: 'file-123',
+      expiresIn: 3600,
+    });
+
+    // URL should be exactly what getExternalSignedUrl returned (no manipulation)
+    expect(result.url).toBe(externalUrl);
+  });
+
+  it('does not reference S3_EXTERNAL_ENDPOINT or S3_ENDPOINT env vars in sharing logic', async () => {
+    // This test validates that sharing.ts no longer reads S3_EXTERNAL_ENDPOINT itself.
+    // The external endpoint logic is now entirely in s3-storage.ts.
+    process.env.FILE_SHARE_MODE = 'presigned';
+    process.env.S3_ENDPOINT = 'http://seaweedfs:8333';
+    process.env.S3_EXTERNAL_ENDPOINT = 'https://s3.execdesk.ai';
+
+    const { getFileMetadata } = await import('../../src/api/file-storage/service.ts');
+    (getFileMetadata as ReturnType<typeof vi.fn>).mockResolvedValue(mockMetadata);
+
+    const { createFileShare } = await import('../../src/api/file-storage/sharing.ts');
+
+    // Even with S3_EXTERNAL_ENDPOINT set, sharing.ts should NOT do string replacement
+    const externalUrl = 'https://s3.execdesk.ai/test-bucket/key?X-Amz-Signature=correct';
+    const storage = createMockStorage(
+      'http://seaweedfs:8333/test-bucket/key?X-Amz-Signature=internal',
+      externalUrl,
+    );
+
+    const result = await createFileShare(createMockPool(), storage, {
+      fileId: 'file-123',
+      expiresIn: 3600,
+    });
+
+    // URL should be exactly the external signed URL, not a string-replaced version
+    expect(result.url).toBe(externalUrl);
+  });
+});

--- a/vitest.config.unit.ts
+++ b/vitest.config.unit.ts
@@ -47,6 +47,8 @@ export default defineProject({
       'tests/embeddings/providers.test.ts',
       'tests/embeddings/service.test.ts',
       'tests/file-storage/content-disposition-sanitization.test.ts',
+      'tests/file-storage/s3-presigned-external-endpoint.test.ts',
+      'tests/file-storage/sharing-presigned-url.test.ts',
       'tests/oauth/config.test.ts',
       'tests/openclaw-contract/**/*.test.ts',
       'tests/postmark/email-utils.test.ts',


### PR DESCRIPTION
## Summary
- Created separate S3 client (`getExternalSignedUrl()`) for presigning URLs with the external endpoint, so Signature V4 Host header matches what browsers send
- Removed invalid string-replace hack in `sharing.ts` that broke signatures when `S3_EXTERNAL_ENDPOINT` differed from `S3_ENDPOINT`
- Added `externalEndpoint` to `S3Config` and `getExternalSignedUrl()` to `FileStorage` interface
- External client is lazily initialized and reused across calls

Closes #1320

## Test plan
- [x] Unit tests for external presigned URL generation (8 tests in `s3-presigned-external-endpoint.test.ts`)
- [x] Unit tests verifying sharing.ts uses `getExternalSignedUrl` not string-replace (3 tests in `sharing-presigned-url.test.ts`)
- [x] Verify fallback when `S3_EXTERNAL_ENDPOINT` not set
- [x] Verify internal `getSignedUrl()` still uses internal endpoint
- [x] Local test suite passes (`pnpm test:unit`)
- [x] Lint passes (`pnpm run lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)