### PR TITLE
[#1354] Return 501 for unimplemented calendar sync endpoint

### DIFF
--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -12645,36 +12645,11 @@ export function buildServer(options: ProjectsApiOptions = {}): FastifyInstance {
     });
   });
 
-  // POST /api/sync/calendar - Trigger calendar sync
-  app.post('/api/sync/calendar', async (req, reply) => {
-    const body = req.body as { connectionId: string };
-    const pool = createPool();
-
-    if (!body.connectionId) {
-      await pool.end();
-      return reply.code(400).send({ error: 'connectionId is required' });
-    }
-
-    // Look up connection by ID and verify calendar scope
-    const connection = await getConnection(pool, body.connectionId);
-
-    if (!connection) {
-      await pool.end();
-      return reply.code(400).send({ error: 'No OAuth connection found' });
-    }
-
-    if (!connection.scopes.includes('calendar') && !connection.scopes.some((s) => s.includes('calendar') || s.includes('Calendar'))) {
-      await pool.end();
-      return reply.code(400).send({ error: 'No OAuth connection found with calendar scope' });
-    }
-
-    await pool.end();
-
-    return reply.code(202).send({
-      status: 'sync_initiated',
-      connectionId: connection.id,
-      userEmail: connection.userEmail,
-      provider: connection.provider,
+  // POST /api/sync/calendar - Calendar sync (stub — not yet implemented)
+  app.post('/api/sync/calendar', async (_req, reply) => {
+    return reply.code(501).send({
+      error: 'Calendar sync is not yet implemented',
+      status: 'not_implemented',
     });
   });
 
@@ -12768,8 +12743,8 @@ export function buildServer(options: ProjectsApiOptions = {}): FastifyInstance {
       return reply.code(400).send({ error: 'No OAuth connection found' });
     }
 
-    // In production, this would create the event via the provider API first
-    // For now, create it locally with a generated external ID
+    // Local-only: events are stored in our DB but not synced to the external provider.
+    // See follow-up issue for actual calendar sync implementation.
     const externalEventId = `local-${Date.now()}-${randomBytes(8).toString('hex')}`;
 
     const result = await pool.query(

--- a/tests/email_calendar_sync_api.test.ts
+++ b/tests/email_calendar_sync_api.test.ts
@@ -311,7 +311,7 @@ describe('Email & Calendar Sync API', () => {
 
   describe('Calendar Sync', () => {
     describe('POST /api/sync/calendar', () => {
-      it('triggers calendar sync for a user', async () => {
+      it('returns 501 not implemented', async () => {
         const connResult = await pool.query(
           `INSERT INTO oauth_connection (user_email, provider, access_token, refresh_token, scopes, expires_at)
            VALUES ('user@example.com', 'google', 'test-token', 'refresh', ARRAY['calendar'], now() + interval '1 hour')
@@ -327,9 +327,10 @@ describe('Email & Calendar Sync API', () => {
           },
         });
 
-        expect(response.statusCode).toBe(202);
+        expect(response.statusCode).toBe(501);
         const body = response.json();
-        expect(body.status).toBe('sync_initiated');
+        expect(body.error).toBe('Calendar sync is not yet implemented');
+        expect(body.status).toBe('not_implemented');
       });
     });
 


### PR DESCRIPTION
## Summary

- Changed `POST /api/sync/calendar` from returning a fake `202 sync_initiated` to returning `501 Not Implemented` with a clear error message
- Cleaned up misleading comment in `POST /api/calendar/events` that implied future production sync
- Updated test to expect the new 501 response

Closes #1354

Follow-up issue created: #1362 — Implement actual calendar sync with Google Calendar and Microsoft Graph