### PR TITLE
[#1347] Add item_type alias to POST /api/work-items

### DIFF
--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -3034,6 +3034,7 @@ export function buildServer(options: ProjectsApiOptions = {}): FastifyInstance {
       description?: string | null;
       kind?: string;
       type?: string; // Alias for 'kind' for client compatibility
+      item_type?: string; // Alias used by OpenClaw plugin (Issue #1347)
       parentId?: string | null;
       estimateMinutes?: number | null;
       actualMinutes?: number | null;
@@ -3048,11 +3049,11 @@ export function buildServer(options: ProjectsApiOptions = {}): FastifyInstance {
       return reply.code(400).send({ error: 'title is required' });
     }
 
-    // Accept 'type' or 'kind' parameter (type takes precedence for client compatibility)
-    const kind = body.type ?? body.kind ?? 'issue';
+    // Accept 'type', 'kind', or 'item_type' parameter (type takes precedence, then kind, then item_type)
+    const kind = body.type ?? body.kind ?? body.item_type ?? 'issue';
     const allowedKinds = new Set(['project', 'initiative', 'epic', 'issue', 'task']);
     if (!allowedKinds.has(kind)) {
-      return reply.code(400).send({ error: 'kind/type must be one of project|initiative|epic|issue|task' });
+      return reply.code(400).send({ error: 'kind/type/item_type must be one of project|initiative|epic|issue|task' });
     }
 
     // Validate estimate/actual constraints before hitting DB

--- a/tests/work_item_item_type_alias.test.ts
+++ b/tests/work_item_item_type_alias.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Tests for issue #1347: Plugin sends item_type which POST /api/work-items silently ignores.
+ *
+ * Verifies:
+ * - POST /api/work-items accepts `item_type` as alias for `kind`/`type`
+ * - `item_type` is respected when `type` and `kind` are absent
+ * - `type` still takes precedence over `item_type` when both are present
+ * - `kind` takes precedence over `item_type` when `type` is absent
+ * - Invalid `item_type` values are rejected
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { Pool } from 'pg';
+import { runMigrate } from './helpers/migrate.ts';
+import { createTestPool, truncateAllTables } from './helpers/db.ts';
+import { buildServer } from '../src/api/server.ts';
+
+describe('POST /api/work-items — item_type alias (Issue #1347)', () => {
+  const app = buildServer();
+  let pool: Pool;
+
+  beforeAll(async () => {
+    await runMigrate('up');
+    pool = createTestPool();
+    await app.ready();
+  });
+
+  beforeEach(async () => {
+    await truncateAllTables(pool);
+  });
+
+  afterAll(async () => {
+    await app.close();
+    await pool.end();
+  });
+
+  it('accepts item_type as work_item_kind', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/work-items',
+      payload: {
+        title: 'My project via item_type',
+        item_type: 'project',
+      },
+    });
+
+    expect(res.statusCode).toBe(201);
+    const body = res.json() as { id: string; kind: string };
+    expect(body.id).toBeDefined();
+    // Verify work_item_kind in DB
+    const row = await pool.query(
+      'SELECT work_item_kind FROM work_item WHERE id = $1',
+      [body.id],
+    );
+    expect(row.rows.length).toBe(1);
+    expect(row.rows[0].work_item_kind).toBe('project');
+  });
+
+  it('uses item_type: task correctly', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/work-items',
+      payload: {
+        title: 'A task via item_type',
+        item_type: 'task',
+      },
+    });
+
+    expect(res.statusCode).toBe(201);
+    const row = await pool.query(
+      'SELECT work_item_kind FROM work_item WHERE id = $1',
+      [res.json<{ id: string }>().id],
+    );
+    expect(row.rows[0].work_item_kind).toBe('task');
+  });
+
+  it('type takes precedence over item_type', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/work-items',
+      payload: {
+        title: 'Precedence test',
+        type: 'task',
+        item_type: 'project',
+      },
+    });
+
+    expect(res.statusCode).toBe(201);
+    const row = await pool.query(
+      'SELECT work_item_kind FROM work_item WHERE id = $1',
+      [res.json<{ id: string }>().id],
+    );
+    expect(row.rows[0].work_item_kind).toBe('task');
+  });
+
+  it('kind takes precedence over item_type when type is absent', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/work-items',
+      payload: {
+        title: 'Kind precedence test',
+        kind: 'task',
+        item_type: 'project',
+      },
+    });
+
+    expect(res.statusCode).toBe(201);
+    const row = await pool.query(
+      'SELECT work_item_kind FROM work_item WHERE id = $1',
+      [res.json<{ id: string }>().id],
+    );
+    expect(row.rows[0].work_item_kind).toBe('task');
+  });
+
+  it('defaults to issue when no type/kind/item_type provided', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/work-items',
+      payload: {
+        title: 'Default kind test',
+      },
+    });
+
+    expect(res.statusCode).toBe(201);
+    const row = await pool.query(
+      'SELECT work_item_kind FROM work_item WHERE id = $1',
+      [res.json<{ id: string }>().id],
+    );
+    expect(row.rows[0].work_item_kind).toBe('issue');
+  });
+
+  it('rejects invalid item_type value', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/work-items',
+      payload: {
+        title: 'Invalid item_type',
+        item_type: 'banana',
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+    const body = res.json() as { error: string };
+    expect(body.error).toContain('must be one of');
+  });
+});


### PR DESCRIPTION
## Summary
- The OpenClaw plugin sends `item_type` when creating work items, but `POST /api/work-items` only accepted `type` and `kind`, silently ignoring the plugin field and defaulting everything to `'issue'`.
- Added `item_type` as a third alias in the precedence chain: `type > kind > item_type > 'issue'` (one line in body type definition + one line in resolution logic).
- Added comprehensive tests covering: `item_type` acceptance, precedence over defaults, `type` and `kind` taking precedence over `item_type`, default fallback, and invalid value rejection.

## Test plan
- [x] Test that `item_type: 'project'` creates a project work item
- [x] Test that `item_type: 'task'` creates a task work item
- [x] Test that `type` takes precedence over `item_type`
- [x] Test that `kind` takes precedence over `item_type`
- [x] Test that omitting all three defaults to `'issue'`
- [x] Test that invalid `item_type` returns 400

Closes #1347

🤖 Generated with [Claude Code](https://claude.com/claude-code)