### PR TITLE
[#1344] Remove dead code: buildSpawnAgentPayload()

### DIFF
--- a/src/api/webhooks/payloads.test.ts
+++ b/src/api/webhooks/payloads.test.ts
@@ -8,7 +8,6 @@ import {
   buildEmailReceivedPayload,
   buildReminderDuePayload,
   buildDeadlineApproachingPayload,
-  buildSpawnAgentPayload,
 } from './payloads.ts';
 
 describe('webhook payloads — agentId', () => {
@@ -125,27 +124,4 @@ describe('webhook payloads — agentId', () => {
     });
   });
 
-  describe('buildSpawnAgentPayload', () => {
-    const baseParams = {
-      agentType: 'coder',
-      repository: 'test/repo',
-      workItemId: 'wi-3',
-      workItemTitle: 'Implement feature',
-    };
-
-    it('includes agentId at top level when provided', () => {
-      const payload = buildSpawnAgentPayload({ ...baseParams, agentId: 'agent@example.com' });
-      expect(payload.agentId).toBe('agent@example.com');
-    });
-
-    it('includes agent_id in context when agentId is provided', () => {
-      const payload = buildSpawnAgentPayload({ ...baseParams, agentId: 'agent@example.com' });
-      expect(payload.context.agent_id).toBe('agent@example.com');
-    });
-
-    it('omits agentId when not provided', () => {
-      const payload = buildSpawnAgentPayload(baseParams);
-      expect(payload.agentId).toBeUndefined();
-    });
-  });
 });

--- a/src/api/webhooks/payloads.ts
+++ b/src/api/webhooks/payloads.ts
@@ -153,44 +153,6 @@ export function buildDeadlineApproachingPayload(params: {
 }
 
 /**
- * Build payload for spawn agent event.
- */
-export function buildSpawnAgentPayload(params: {
-  agentType: string;
-  repository?: string;
-  epicNumber?: number;
-  workItemId?: string;
-  workItemTitle?: string;
-  instructions?: string;
-  /** Agent identifier for multi-agent routing. Maps to user_email scope. */
-  agentId?: string;
-}): AgentHookPayload {
-  const config = getOpenClawConfig();
-
-  return {
-    message: `Spawn ${params.agentType} agent${params.repository ? ` for ${params.repository}` : ''}${params.epicNumber ? ` (Epic #${params.epicNumber})` : ''}\n\n${params.instructions || 'No specific instructions provided.'}`,
-    name: `${params.agentType} Spawner`,
-    sessionKey: params.workItemId ? `spawn:work_item:${params.workItemId}` : `spawn:${params.agentType}:${Date.now()}`,
-    wakeMode: 'now',
-    deliver: false,
-    channel: 'new',
-    model: config?.defaultModel || 'anthropic/claude-sonnet-4-20250514',
-    timeoutSeconds: config?.timeoutSeconds || 600,
-    ...(params.agentId ? { agentId: params.agentId } : {}),
-    context: {
-      event_type: 'spawn_agent',
-      agent_type: params.agentType,
-      repository: params.repository,
-      epic_number: params.epicNumber,
-      work_item_id: params.workItemId,
-      work_item_title: params.workItemTitle,
-      instructions: params.instructions,
-      ...(params.agentId ? { agent_id: params.agentId } : {}),
-    },
-  };
-}
-
-/**
  * Get the correct webhook destination for an event type.
  */
 export function getWebhookDestination(eventType: string): string {

--- a/tests/webhooks/payloads.test.ts
+++ b/tests/webhooks/payloads.test.ts
@@ -4,7 +4,6 @@ import {
   buildEmailReceivedPayload,
   buildReminderDuePayload,
   buildDeadlineApproachingPayload,
-  buildSpawnAgentPayload,
   getWebhookDestination,
 } from '../../src/api/webhooks/payloads.ts';
 import { clearConfigCache } from '../../src/api/webhooks/config.ts';
@@ -138,39 +137,6 @@ describe('Webhook Payloads', () => {
       expect(payload.text).toContain('24 hours');
       expect(payload.text).toContain('issue');
       expect(payload.mode).toBe('now');
-    });
-  });
-
-  describe('buildSpawnAgentPayload', () => {
-    it('builds correct payload structure', () => {
-      const payload = buildSpawnAgentPayload({
-        agentType: 'dev-major',
-        repository: 'troykelly/my-app',
-        epicNumber: 42,
-        workItemId: 'epic-123',
-        workItemTitle: 'Implement feature X',
-        instructions: 'Focus on the API endpoints first.',
-      });
-
-      expect(payload.name).toBe('dev-major Spawner');
-      expect(payload.deliver).toBe(false);
-      expect(payload.channel).toBe('new');
-      expect(payload.message).toContain('dev-major');
-      expect(payload.message).toContain('troykelly/my-app');
-      expect(payload.message).toContain('Epic #42');
-      expect(payload.context.event_type).toBe('spawn_agent');
-      expect(payload.context.agent_type).toBe('dev-major');
-      expect(payload.context.repository).toBe('troykelly/my-app');
-      expect(payload.context.epic_number).toBe(42);
-    });
-
-    it('handles missing optional fields', () => {
-      const payload = buildSpawnAgentPayload({
-        agentType: 'helper',
-      });
-
-      expect(payload.name).toBe('helper Spawner');
-      expect(payload.sessionKey).toMatch(/^spawn:helper:\d+$/);
     });
   });
 


### PR DESCRIPTION
## Summary

- Removed `buildSpawnAgentPayload()` function from `src/api/webhooks/payloads.ts` — it was never imported or called anywhere in the codebase
- Removed the import and tests for the function from both test files

Closes #1344