### PR TITLE
[#1352] Add not_before/not_after to bulk work-items endpoint

### DIFF
--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -2690,6 +2690,8 @@ export function buildServer(options: ProjectsApiOptions = {}): FastifyInstance {
         priority?: string;
         description?: string;
         labels?: string[];
+        not_before?: string | null; // Issue #1352: reminder date
+        not_after?: string | null; // Issue #1352: deadline date
       }>;
       user_email?: string; // Issue #1172: per-user scoping
     };
@@ -2735,10 +2737,38 @@ export function buildServer(options: ProjectsApiOptions = {}): FastifyInstance {
           continue;
         }
 
+        // Issue #1352: Validate not_before / not_after dates
+        let notBefore: Date | null = null;
+        let notAfter: Date | null = null;
+
+        if (item.not_before) {
+          notBefore = new Date(item.not_before);
+          if (isNaN(notBefore.getTime())) {
+            results.push({ index: i, status: 'failed', error: 'Invalid not_before date format' });
+            failedCount++;
+            continue;
+          }
+        }
+
+        if (item.not_after) {
+          notAfter = new Date(item.not_after);
+          if (isNaN(notAfter.getTime())) {
+            results.push({ index: i, status: 'failed', error: 'Invalid not_after date format' });
+            failedCount++;
+            continue;
+          }
+        }
+
+        if (notBefore && notAfter && notBefore > notAfter) {
+          results.push({ index: i, status: 'failed', error: 'not_before must be before or equal to not_after' });
+          failedCount++;
+          continue;
+        }
+
         try {
           const result = await client.query(
-            `INSERT INTO work_item (title, work_item_kind, parent_work_item_id, status, priority, description, user_email)
-             VALUES ($1, $2, $3, COALESCE($4, 'backlog'), COALESCE($5::work_item_priority, 'P2'), $6, $7)
+            `INSERT INTO work_item (title, work_item_kind, parent_work_item_id, status, priority, description, user_email, not_before, not_after)
+             VALUES ($1, $2, $3, COALESCE($4, 'backlog'), COALESCE($5::work_item_priority, 'P2'), $6, $7, $8::timestamptz, $9::timestamptz)
              RETURNING id::text as id`,
             [
               item.title,
@@ -2748,6 +2778,8 @@ export function buildServer(options: ProjectsApiOptions = {}): FastifyInstance {
               item.priority || null,
               item.description || null,
               bulkUserEmail,
+              notBefore,
+              notAfter,
             ],
           );
           const workItemId = result.rows[0].id;
@@ -2756,7 +2788,7 @@ export function buildServer(options: ProjectsApiOptions = {}): FastifyInstance {
           if (item.labels && item.labels.length > 0) {
             await client.query('SELECT set_work_item_labels($1, $2)', [workItemId, item.labels]);
           }
-          results.push({ index: i, id: result.rows[0].id, status: 'created' });
+          results.push({ index: i, id: result.rows[0].id, status: 'created', _notBefore: notBefore, _notAfter: notAfter } as any);
           createdCount++;
         } catch (err) {
           const errorMsg = err instanceof Error ? err.message : 'unknown error';
@@ -2773,6 +2805,24 @@ export function buildServer(options: ProjectsApiOptions = {}): FastifyInstance {
       }
 
       client.release();
+
+      // Issue #1352: Schedule reminder/nudge jobs for items with dates (after COMMIT)
+      if (createdCount > 0) {
+        for (const r of results) {
+          if (r.status === 'created' && r.id) {
+            const rAny = r as any;
+            const nb: Date | null = rAny._notBefore ?? null;
+            const na: Date | null = rAny._notAfter ?? null;
+            if (nb || na) {
+              await scheduleWorkItemReminders(pool, r.id, nb, na);
+            }
+            // Clean up internal fields before sending response
+            delete rAny._notBefore;
+            delete rAny._notAfter;
+          }
+        }
+      }
+
       await pool.end();
 
       return reply.code(failedCount > 0 && createdCount === 0 ? 400 : 200).send({

--- a/tests/bulk_work_items_dates.test.ts
+++ b/tests/bulk_work_items_dates.test.ts
@@ -1,0 +1,306 @@
+/**
+ * Tests for issue #1352: POST /api/work-items/bulk drops not_before, not_after.
+ *
+ * Verifies:
+ * - Bulk endpoint accepts not_before and not_after per item
+ * - Dates are persisted in the work_item table
+ * - internal_job entries are created for items with dates
+ * - Items without dates still work (backwards compatibility)
+ * - Invalid date formats are handled gracefully
+ * - Date range validation (not_before must be before not_after)
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { Pool } from 'pg';
+import { runMigrate } from './helpers/migrate.ts';
+import { createTestPool, truncateAllTables } from './helpers/db.ts';
+import { buildServer } from '../src/api/server.ts';
+
+/**
+ * Query helper that retries on empty results to handle transient
+ * visibility delays between the server's pool and the test pool.
+ */
+async function queryWithRetry(
+  pool: Pool,
+  sql: string,
+  params: unknown[],
+  { maxRetries = 5, delayMs = 100 } = {},
+): Promise<{ rows: Record<string, unknown>[] }> {
+  for (let i = 0; i < maxRetries; i++) {
+    const result = await pool.query(sql, params);
+    if (result.rows.length > 0) return result;
+    await new Promise((r) => setTimeout(r, delayMs));
+  }
+  return pool.query(sql, params);
+}
+
+describe('POST /api/work-items/bulk — not_before/not_after (Issue #1352)', () => {
+  const app = buildServer();
+  let pool: Pool;
+
+  beforeAll(async () => {
+    await runMigrate('up');
+    pool = createTestPool();
+    await app.ready();
+  });
+
+  beforeEach(async () => {
+    await truncateAllTables(pool);
+  });
+
+  afterAll(async () => {
+    await app.close();
+    await pool.end();
+  });
+
+  it('persists not_before and not_after for bulk items', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/work-items/bulk',
+      payload: {
+        items: [
+          {
+            title: 'Task with reminder',
+            not_before: '2026-06-01T09:00:00Z',
+          },
+          {
+            title: 'Task with deadline',
+            not_after: '2026-07-15T17:00:00Z',
+          },
+          {
+            title: 'Task with both dates',
+            not_before: '2026-08-01T00:00:00Z',
+            not_after: '2026-08-31T23:59:59Z',
+          },
+        ],
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as { created: number; results: Array<{ id: string; status: string }> };
+    expect(body.created).toBe(3);
+
+    // Check first item: not_before set
+    const row1 = await pool.query(
+      'SELECT not_before, not_after FROM work_item WHERE id = $1',
+      [body.results[0].id],
+    );
+    expect(row1.rows.length).toBe(1);
+    expect(row1.rows[0].not_before).not.toBeNull();
+    expect(new Date(row1.rows[0].not_before as string).toISOString()).toContain('2026-06-01');
+    expect(row1.rows[0].not_after).toBeNull();
+
+    // Check second item: not_after set
+    const row2 = await pool.query(
+      'SELECT not_before, not_after FROM work_item WHERE id = $1',
+      [body.results[1].id],
+    );
+    expect(row2.rows[0].not_before).toBeNull();
+    expect(row2.rows[0].not_after).not.toBeNull();
+    expect(new Date(row2.rows[0].not_after as string).toISOString()).toContain('2026-07-15');
+
+    // Check third item: both dates set
+    const row3 = await pool.query(
+      'SELECT not_before, not_after FROM work_item WHERE id = $1',
+      [body.results[2].id],
+    );
+    expect(row3.rows[0].not_before).not.toBeNull();
+    expect(row3.rows[0].not_after).not.toBeNull();
+    expect(new Date(row3.rows[0].not_before as string).toISOString()).toContain('2026-08-01');
+    expect(new Date(row3.rows[0].not_after as string).toISOString()).toContain('2026-08-31');
+  });
+
+  it('creates internal_job entries for items with dates', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/work-items/bulk',
+      payload: {
+        items: [
+          {
+            title: 'Reminder item',
+            not_before: '2026-06-01T09:00:00Z',
+          },
+          {
+            title: 'Deadline item',
+            not_after: '2026-07-15T17:00:00Z',
+          },
+        ],
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as { created: number; results: Array<{ id: string; status: string }> };
+    expect(body.created).toBe(2);
+
+    // Check reminder job for first item
+    const reminderJobs = await queryWithRetry(
+      pool,
+      `SELECT kind, payload->>'work_item_id' as work_item_id
+         FROM internal_job
+        WHERE kind = 'reminder.work_item.not_before'
+          AND payload->>'work_item_id' = $1`,
+      [body.results[0].id],
+    );
+    expect(reminderJobs.rows.length).toBe(1);
+    expect(reminderJobs.rows[0].work_item_id).toBe(body.results[0].id);
+
+    // Check nudge job for second item
+    const nudgeJobs = await queryWithRetry(
+      pool,
+      `SELECT kind, payload->>'work_item_id' as work_item_id
+         FROM internal_job
+        WHERE kind = 'nudge.work_item.not_after'
+          AND payload->>'work_item_id' = $1`,
+      [body.results[1].id],
+    );
+    expect(nudgeJobs.rows.length).toBe(1);
+    expect(nudgeJobs.rows[0].work_item_id).toBe(body.results[1].id);
+  });
+
+  it('creates both reminder and nudge jobs when both dates are set', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/work-items/bulk',
+      payload: {
+        items: [
+          {
+            title: 'Both dates item',
+            not_before: '2026-06-01T09:00:00Z',
+            not_after: '2026-06-30T17:00:00Z',
+          },
+        ],
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as { created: number; results: Array<{ id: string; status: string }> };
+    expect(body.created).toBe(1);
+    const itemId = body.results[0].id;
+
+    const reminderJobs = await queryWithRetry(
+      pool,
+      `SELECT kind FROM internal_job
+        WHERE kind = 'reminder.work_item.not_before'
+          AND payload->>'work_item_id' = $1`,
+      [itemId],
+    );
+    expect(reminderJobs.rows.length).toBe(1);
+
+    const nudgeJobs = await queryWithRetry(
+      pool,
+      `SELECT kind FROM internal_job
+        WHERE kind = 'nudge.work_item.not_after'
+          AND payload->>'work_item_id' = $1`,
+      [itemId],
+    );
+    expect(nudgeJobs.rows.length).toBe(1);
+  });
+
+  it('does not create jobs for items without dates', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/work-items/bulk',
+      payload: {
+        items: [
+          { title: 'No dates item' },
+        ],
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as { created: number; results: Array<{ id: string; status: string }> };
+    expect(body.created).toBe(1);
+
+    // Small delay to let any potential jobs be created
+    await new Promise((r) => setTimeout(r, 100));
+
+    const jobs = await pool.query(
+      `SELECT kind FROM internal_job WHERE payload->>'work_item_id' = $1`,
+      [body.results[0].id],
+    );
+    expect(jobs.rows.length).toBe(0);
+  });
+
+  it('handles mix of items with and without dates', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/work-items/bulk',
+      payload: {
+        items: [
+          { title: 'No dates' },
+          { title: 'With reminder', not_before: '2026-06-01T09:00:00Z' },
+          { title: 'Also no dates' },
+        ],
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as { created: number; results: Array<{ id: string; status: string }> };
+    expect(body.created).toBe(3);
+
+    // Only item at index 1 should have a job
+    const jobs = await queryWithRetry(
+      pool,
+      `SELECT payload->>'work_item_id' as work_item_id
+         FROM internal_job
+        WHERE kind = 'reminder.work_item.not_before'`,
+      [],
+    );
+    expect(jobs.rows.length).toBe(1);
+    expect(jobs.rows[0].work_item_id).toBe(body.results[1].id);
+  });
+
+  it('rejects items with invalid not_before date', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/work-items/bulk',
+      payload: {
+        items: [
+          { title: 'Bad date', not_before: 'not-a-date' },
+        ],
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+    const body = res.json() as { results: Array<{ status: string; error?: string }> };
+    expect(body.results[0].status).toBe('failed');
+    expect(body.results[0].error).toContain('not_before');
+  });
+
+  it('rejects items with invalid not_after date', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/work-items/bulk',
+      payload: {
+        items: [
+          { title: 'Bad date', not_after: 'garbage' },
+        ],
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+    const body = res.json() as { results: Array<{ status: string; error?: string }> };
+    expect(body.results[0].status).toBe('failed');
+    expect(body.results[0].error).toContain('not_after');
+  });
+
+  it('rejects items where not_before is after not_after', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/work-items/bulk',
+      payload: {
+        items: [
+          {
+            title: 'Backwards dates',
+            not_before: '2026-09-01T00:00:00Z',
+            not_after: '2026-06-01T00:00:00Z',
+          },
+        ],
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+    const body = res.json() as { results: Array<{ status: string; error?: string }> };
+    expect(body.results[0].status).toBe('failed');
+    expect(body.results[0].error).toContain('not_before');
+  });
+});


### PR DESCRIPTION
## Summary
- `POST /api/work-items/bulk` silently dropped `not_before` and `not_after` date fields because they were missing from the item type definition and INSERT query.
- Added `not_before` and `not_after` to the bulk item schema, INSERT statement, and date validation (format + range consistency).
- After COMMIT, calls `scheduleWorkItemReminders()` for each created item that has dates, creating `internal_job` entries for reminders and nudges — matching the single-item POST behavior.

## Test plan
- [x] Bulk items with not_before and/or not_after are persisted correctly
- [x] internal_job entries are created for items with dates (reminder and nudge)
- [x] Both reminder and nudge jobs created when both dates set
- [x] Items without dates produce no jobs (backwards compatibility)
- [x] Mix of items with and without dates handled correctly
- [x] Invalid not_before date format rejected
- [x] Invalid not_after date format rejected
- [x] not_before > not_after rejected

Closes #1352

🤖 Generated with [Claude Code](https://claude.com/claude-code)