### PR TITLE
[#1326] Replace session cookie auth with unified JWT middleware

### DIFF
--- a/src/api/auth/middleware.test.ts
+++ b/src/api/auth/middleware.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { FastifyRequest } from 'fastify';
+
+const TEST_SECRET = 'a]Uf9$Lx2!Qm7Kp@Wz4Rn8Yb6Hd3Jt0Vs'; // 36 chars, > 32 bytes
+
+describe('JWT auth middleware', () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    vi.stubEnv('JWT_SECRET', TEST_SECRET);
+    vi.stubEnv('OPENCLAW_PROJECTS_AUTH_DISABLED', '');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  /** Create a minimal fake FastifyRequest with the given headers. */
+  function fakeRequest(headers: Record<string, string | undefined> = {}): FastifyRequest {
+    return { headers } as unknown as FastifyRequest;
+  }
+
+  async function loadMiddleware() {
+    return import('./middleware.ts');
+  }
+
+  async function loadJwt() {
+    return import('./jwt.ts');
+  }
+
+  describe('getAuthIdentity', () => {
+    it('should return identity for a valid user JWT', async () => {
+      const { signAccessToken } = await loadJwt();
+      const token = await signAccessToken('user@example.com');
+      const { getAuthIdentity } = await loadMiddleware();
+
+      const identity = await getAuthIdentity(
+        fakeRequest({ authorization: `Bearer ${token}` }),
+      );
+
+      expect(identity).not.toBeNull();
+      expect(identity!.email).toBe('user@example.com');
+      expect(identity!.type).toBe('user');
+      expect(identity!.scopes).toBeUndefined();
+    });
+
+    it('should return identity for a valid M2M JWT with scopes', async () => {
+      const { signAccessToken } = await loadJwt();
+      const token = await signAccessToken('service@example.com', {
+        type: 'm2m',
+        scopes: ['read:work-items', 'write:work-items'],
+      });
+      const { getAuthIdentity } = await loadMiddleware();
+
+      const identity = await getAuthIdentity(
+        fakeRequest({ authorization: `Bearer ${token}` }),
+      );
+
+      expect(identity).not.toBeNull();
+      expect(identity!.email).toBe('service@example.com');
+      expect(identity!.type).toBe('m2m');
+      expect(identity!.scopes).toEqual(['read:work-items', 'write:work-items']);
+    });
+
+    it('should return null when no Authorization header is present', async () => {
+      const { getAuthIdentity } = await loadMiddleware();
+
+      const identity = await getAuthIdentity(fakeRequest());
+      expect(identity).toBeNull();
+    });
+
+    it('should return null for non-Bearer authorization', async () => {
+      const { getAuthIdentity } = await loadMiddleware();
+
+      const identity = await getAuthIdentity(
+        fakeRequest({ authorization: 'Basic dXNlcjpwYXNz' }),
+      );
+      expect(identity).toBeNull();
+    });
+
+    it('should return null for empty Bearer token', async () => {
+      const { getAuthIdentity } = await loadMiddleware();
+
+      const identity = await getAuthIdentity(
+        fakeRequest({ authorization: 'Bearer ' }),
+      );
+      expect(identity).toBeNull();
+    });
+
+    it('should return null for an invalid JWT', async () => {
+      const { getAuthIdentity } = await loadMiddleware();
+
+      const identity = await getAuthIdentity(
+        fakeRequest({ authorization: 'Bearer not-a-valid-jwt' }),
+      );
+      expect(identity).toBeNull();
+    });
+
+    it('should return null for an expired JWT', async () => {
+      const { SignJWT } = await import('jose');
+
+      const nowSec = Math.floor(Date.now() / 1000);
+      const expiredToken = await new SignJWT({ type: 'user' })
+        .setProtectedHeader({ alg: 'HS256', kid: 'test' })
+        .setSubject('user@example.com')
+        .setIssuedAt(nowSec - 20 * 60)
+        .setExpirationTime(nowSec - 2 * 60)
+        .setJti('expired-jti')
+        .sign(new TextEncoder().encode(TEST_SECRET));
+
+      const { getAuthIdentity } = await loadMiddleware();
+
+      const identity = await getAuthIdentity(
+        fakeRequest({ authorization: `Bearer ${expiredToken}` }),
+      );
+      expect(identity).toBeNull();
+    });
+
+    it('should return null for a JWT signed with wrong secret', async () => {
+      const { SignJWT } = await import('jose');
+
+      const nowSec = Math.floor(Date.now() / 1000);
+      const wrongKeyToken = await new SignJWT({ type: 'user' })
+        .setProtectedHeader({ alg: 'HS256', kid: 'test' })
+        .setSubject('user@example.com')
+        .setIssuedAt(nowSec)
+        .setExpirationTime(nowSec + 900)
+        .setJti('wrong-key-jti')
+        .sign(new TextEncoder().encode('Z9a8b7c6d5e4f3g2h1i0j9k8l7m6n5o4'));
+
+      const { getAuthIdentity } = await loadMiddleware();
+
+      const identity = await getAuthIdentity(
+        fakeRequest({ authorization: `Bearer ${wrongKeyToken}` }),
+      );
+      expect(identity).toBeNull();
+    });
+
+    it('should return E2E bypass identity when auth disabled and E2E email set', async () => {
+      vi.stubEnv('OPENCLAW_PROJECTS_AUTH_DISABLED', 'true');
+      vi.stubEnv('OPENCLAW_E2E_SESSION_EMAIL', 'e2e@test.com');
+      vi.resetModules();
+
+      const { getAuthIdentity } = await loadMiddleware();
+
+      const identity = await getAuthIdentity(fakeRequest());
+      expect(identity).not.toBeNull();
+      expect(identity!.email).toBe('e2e@test.com');
+      expect(identity!.type).toBe('user');
+    });
+
+    it('should NOT E2E bypass when only auth is disabled (no E2E email)', async () => {
+      vi.stubEnv('OPENCLAW_PROJECTS_AUTH_DISABLED', 'true');
+      vi.resetModules();
+
+      const { getAuthIdentity } = await loadMiddleware();
+
+      const identity = await getAuthIdentity(fakeRequest());
+      expect(identity).toBeNull();
+    });
+
+    it('should NOT E2E bypass when only E2E email is set (auth not disabled)', async () => {
+      vi.stubEnv('OPENCLAW_PROJECTS_AUTH_DISABLED', '');
+      vi.stubEnv('OPENCLAW_E2E_SESSION_EMAIL', 'e2e@test.com');
+      vi.resetModules();
+
+      const { getAuthIdentity } = await loadMiddleware();
+
+      // No JWT → null (E2E bypass requires BOTH conditions)
+      const identity = await getAuthIdentity(fakeRequest());
+      expect(identity).toBeNull();
+    });
+  });
+
+  describe('getSessionEmail', () => {
+    it('should return the email from a valid JWT', async () => {
+      const { signAccessToken } = await loadJwt();
+      const token = await signAccessToken('user@example.com');
+      const { getSessionEmail } = await loadMiddleware();
+
+      const email = await getSessionEmail(
+        fakeRequest({ authorization: `Bearer ${token}` }),
+      );
+
+      expect(email).toBe('user@example.com');
+    });
+
+    it('should return null when no valid JWT is present', async () => {
+      const { getSessionEmail } = await loadMiddleware();
+
+      const email = await getSessionEmail(fakeRequest());
+      expect(email).toBeNull();
+    });
+
+    it('should return E2E email when E2E bypass is active', async () => {
+      vi.stubEnv('OPENCLAW_PROJECTS_AUTH_DISABLED', 'true');
+      vi.stubEnv('OPENCLAW_E2E_SESSION_EMAIL', 'e2e@test.com');
+      vi.resetModules();
+
+      const { getSessionEmail } = await loadMiddleware();
+
+      const email = await getSessionEmail(fakeRequest());
+      expect(email).toBe('e2e@test.com');
+    });
+
+    it('should return email from M2M token', async () => {
+      const { signAccessToken } = await loadJwt();
+      const token = await signAccessToken('service@example.com', { type: 'm2m' });
+      const { getSessionEmail } = await loadMiddleware();
+
+      const email = await getSessionEmail(
+        fakeRequest({ authorization: `Bearer ${token}` }),
+      );
+
+      expect(email).toBe('service@example.com');
+    });
+  });
+});

--- a/src/api/auth/middleware.ts
+++ b/src/api/auth/middleware.ts
@@ -1,0 +1,67 @@
+import type { FastifyRequest } from 'fastify';
+
+import { isAuthDisabled } from './secret.ts';
+import { verifyAccessToken, type JwtPayload } from './jwt.ts';
+
+/** Represents an authenticated identity extracted from a JWT. */
+export interface AuthIdentity {
+  /** The user's email address or M2M service identifier. */
+  email: string;
+  /** Token type: 'user' for interactive sessions, 'm2m' for machine-to-machine. */
+  type: 'user' | 'm2m';
+  /** Space-delimited scopes parsed into an array (optional, mainly for M2M tokens). */
+  scopes?: string[];
+}
+
+/**
+ * Extracts an authenticated identity from the request.
+ *
+ * Checks (in order):
+ * 1. E2E bypass: if `isAuthDisabled()` AND `OPENCLAW_E2E_SESSION_EMAIL` is set, returns a synthetic user identity.
+ * 2. `Authorization: Bearer <jwt>` header: verifies the JWT and returns the identity.
+ *
+ * @returns The authenticated identity, or `null` if no valid credentials are present.
+ */
+export async function getAuthIdentity(req: FastifyRequest): Promise<AuthIdentity | null> {
+  // E2E bypass: requires both auth disabled AND the explicit session email env var
+  const e2eEmail = process.env.OPENCLAW_E2E_SESSION_EMAIL;
+  if (e2eEmail && isAuthDisabled()) {
+    return { email: e2eEmail, type: 'user' };
+  }
+
+  // Extract JWT from Authorization header
+  const authHeader = req.headers.authorization;
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return null;
+  }
+
+  const token = authHeader.slice(7); // Remove 'Bearer ' prefix
+  if (!token) {
+    return null;
+  }
+
+  try {
+    const payload: JwtPayload = await verifyAccessToken(token);
+    const identity: AuthIdentity = {
+      email: payload.sub,
+      type: payload.type,
+    };
+    if (payload.scope) {
+      identity.scopes = payload.scope.split(' ');
+    }
+    return identity;
+  } catch {
+    // Invalid/expired token
+    return null;
+  }
+}
+
+/**
+ * Convenience wrapper: extracts just the email from the auth identity.
+ *
+ * @returns The authenticated user's email, or `null` if unauthenticated.
+ */
+export async function getSessionEmail(req: FastifyRequest): Promise<string | null> {
+  const identity = await getAuthIdentity(req);
+  return identity?.email ?? null;
+}


### PR DESCRIPTION
## Summary
- Create `AuthIdentity` interface and `getAuthIdentity()` in `src/api/auth/middleware.ts`
- JWT `Authorization: Bearer` header auth for all endpoints
- `getSessionEmail()` convenience wrapper delegates to `getAuthIdentity()`
- `requireDashboardSession()` returns 401 JSON (no login page HTML redirect)
- Remove session cookie reading logic, `sessionCookieName`, `renderLoginPage()`
- Replace static secret comparison (`getCachedSecret`/`compareSecrets`) with JWT verification
- WebSocket auth updated to JWT (header + query string fallback)
- Magic link consume returns JWT `accessToken` instead of session cookie
- E2E bypass preserved (`isAuthDisabled()` + `OPENCLAW_E2E_SESSION_EMAIL`)
- 15 unit tests covering JWT auth, M2M auth, no-auth 401, E2E bypass, invalid tokens

## Test plan
- [x] 30 middleware tests pass (unit + integration)
- [x] JWT auth validates Bearer tokens correctly
- [x] M2M tokens with scopes handled
- [x] E2E bypass works (both conditions required)
- [x] Invalid/expired/wrong-key tokens return null
- [x] Lint passes (no new warnings)
- [x] All existing tests still pass (except pre-existing #1376)

Closes #1326

🤖 Generated with [Claude Code](https://claude.com/claude-code)