### PR TITLE
[#1330] Add frontend API base URL derivation from hostname

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -510,6 +510,17 @@ JWT_SECRET=
 # SLACK_SIGNING_SECRET=your-signing-secret
 
 # =============================================================================
+# Frontend (Vite build-time)
+# =============================================================================
+
+# Override the API base URL for the frontend SPA (optional).
+# When unset, the frontend derives the URL from the hostname:
+#   localhost/127.0.0.1 → same-origin (empty, nginx proxy)
+#   production → https://api.{domain}
+# Set this for custom deployments where the convention doesn't apply.
+# VITE_API_URL=
+
+# =============================================================================
 # Development/Testing
 # =============================================================================
 

--- a/src/ui/app/vite-env.d.ts
+++ b/src/ui/app/vite-env.d.ts
@@ -1,1 +1,10 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  /** Build-time override for the API base URL (optional). */
+  readonly VITE_API_URL?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/src/ui/lib/api-client.ts
+++ b/src/ui/lib/api-client.ts
@@ -2,9 +2,12 @@
  * Typed API client for openclaw-projects.
  *
  * Wraps fetch() with consistent error handling, base URL resolution,
- * and typed request/response methods. Auth is handled via session cookie
- * (no explicit token management needed).
+ * and typed request/response methods. Base URL is derived from the
+ * hostname via {@link getApiBaseUrl} — same-origin for localhost,
+ * cross-origin (`api.{domain}`) for production.
  */
+
+import { getApiBaseUrl } from './api-config.ts';
 
 /** Standard error shape returned by the API. */
 export interface ApiError {
@@ -34,6 +37,11 @@ export interface RequestOptions {
   headers?: Record<string, string>;
 }
 
+/** Resolve a path against the API base URL. */
+function resolveUrl(path: string): string {
+  return `${getApiBaseUrl()}${path}`;
+}
+
 /**
  * Parse an API error response body into a structured error.
  * Falls back to a generic message if the body is not JSON.
@@ -61,8 +69,9 @@ async function parseErrorResponse(res: Response): Promise<ApiRequestError> {
 /**
  * Typed API client singleton.
  *
- * All methods use the browser's built-in fetch and rely on session cookies
- * for authentication (same-origin requests).
+ * All methods use the browser's built-in fetch with `credentials: 'include'`
+ * for cross-origin cookie support. The base URL is resolved via
+ * {@link getApiBaseUrl} — same-origin for localhost, `api.{domain}` in production.
  */
 export const apiClient = {
   /**
@@ -75,8 +84,9 @@ export const apiClient = {
    * @throws {ApiRequestError} on non-2xx responses
    */
   async get<T>(path: string, opts?: RequestOptions): Promise<T> {
-    const res = await fetch(path, {
+    const res = await fetch(resolveUrl(path), {
       method: 'GET',
+      credentials: 'include',
       headers: {
         accept: 'application/json',
         ...opts?.headers,
@@ -102,8 +112,9 @@ export const apiClient = {
    * @throws {ApiRequestError} on non-2xx responses
    */
   async post<T>(path: string, body: unknown, opts?: RequestOptions): Promise<T> {
-    const res = await fetch(path, {
+    const res = await fetch(resolveUrl(path), {
       method: 'POST',
+      credentials: 'include',
       headers: {
         'content-type': 'application/json',
         accept: 'application/json',
@@ -131,8 +142,9 @@ export const apiClient = {
    * @throws {ApiRequestError} on non-2xx responses
    */
   async put<T>(path: string, body: unknown, opts?: RequestOptions): Promise<T> {
-    const res = await fetch(path, {
+    const res = await fetch(resolveUrl(path), {
       method: 'PUT',
+      credentials: 'include',
       headers: {
         'content-type': 'application/json',
         accept: 'application/json',
@@ -160,8 +172,9 @@ export const apiClient = {
    * @throws {ApiRequestError} on non-2xx responses
    */
   async patch<T>(path: string, body: unknown, opts?: RequestOptions): Promise<T> {
-    const res = await fetch(path, {
+    const res = await fetch(resolveUrl(path), {
       method: 'PATCH',
+      credentials: 'include',
       headers: {
         'content-type': 'application/json',
         accept: 'application/json',
@@ -188,8 +201,9 @@ export const apiClient = {
    * @throws {ApiRequestError} on non-2xx responses
    */
   async delete<T = void>(path: string, opts?: RequestOptions): Promise<T> {
-    const res = await fetch(path, {
+    const res = await fetch(resolveUrl(path), {
       method: 'DELETE',
+      credentials: 'include',
       headers: {
         accept: 'application/json',
         ...opts?.headers,

--- a/src/ui/lib/api-config.ts
+++ b/src/ui/lib/api-config.ts
@@ -1,0 +1,60 @@
+/**
+ * API base URL derivation from hostname.
+ *
+ * Convention-based URL resolution for cross-origin API requests:
+ * - localhost / 127.0.0.1 / [::1]: same-origin (empty string, nginx proxy)
+ * - Production: derive `${protocol}//api.${domain}` (strips `www.` prefix)
+ * - Build-time override via `VITE_API_URL` env var takes precedence
+ */
+
+/** Returns true when the hostname is a loopback address. */
+function isLoopback(hostname: string): boolean {
+  return (
+    hostname === 'localhost' ||
+    hostname === '127.0.0.1' ||
+    hostname === '[::1]'
+  );
+}
+
+/**
+ * Derive the HTTP(S) API base URL from the current browser location.
+ *
+ * Priority:
+ * 1. `VITE_API_URL` build-time override (if non-empty)
+ * 2. Loopback hostnames → empty string (same-origin proxy)
+ * 3. Production → `${protocol}//api.${domain}` (www. stripped)
+ *
+ * @returns Absolute base URL (no trailing slash) or empty string for same-origin
+ */
+export function getApiBaseUrl(): string {
+  const override = import.meta.env.VITE_API_URL;
+  if (override) {
+    return override.replace(/\/+$/, '');
+  }
+
+  const { hostname, protocol } = window.location;
+
+  if (isLoopback(hostname)) {
+    return '';
+  }
+
+  const domain = hostname.replace(/^www\./, '');
+  return `${protocol}//api.${domain}`;
+}
+
+/**
+ * Derive the WebSocket base URL from the current browser location.
+ *
+ * Converts `https:` → `wss:` and `http:` → `ws:`.
+ * For loopback addresses, returns empty string (same-origin upgrade).
+ *
+ * @returns Absolute WebSocket base URL or empty string for same-origin
+ */
+export function getWsBaseUrl(): string {
+  const apiUrl = getApiBaseUrl();
+  if (!apiUrl) {
+    return '';
+  }
+
+  return apiUrl.replace(/^https:/, 'wss:').replace(/^http:/, 'ws:');
+}

--- a/tests/ui/api-client.test.ts
+++ b/tests/ui/api-client.test.ts
@@ -41,6 +41,7 @@ describe('apiClient', () => {
 
       expect(fetchMock).toHaveBeenCalledWith('/api/work-items', {
         method: 'GET',
+        credentials: 'include',
         headers: { accept: 'application/json' },
         signal: undefined,
       });
@@ -138,6 +139,7 @@ describe('apiClient', () => {
 
       expect(fetchMock).toHaveBeenCalledWith('/api/work-items', {
         method: 'POST',
+        credentials: 'include',
         headers: {
           'content-type': 'application/json',
           accept: 'application/json',
@@ -180,6 +182,7 @@ describe('apiClient', () => {
 
       expect(fetchMock).toHaveBeenCalledWith('/api/work-items/1', {
         method: 'PUT',
+        credentials: 'include',
         headers: {
           'content-type': 'application/json',
           accept: 'application/json',
@@ -203,6 +206,7 @@ describe('apiClient', () => {
 
       expect(fetchMock).toHaveBeenCalledWith('/api/memories/1', {
         method: 'PATCH',
+        credentials: 'include',
         headers: {
           'content-type': 'application/json',
           accept: 'application/json',
@@ -227,6 +231,7 @@ describe('apiClient', () => {
 
       expect(fetchMock).toHaveBeenCalledWith('/api/work-items/1', {
         method: 'DELETE',
+        credentials: 'include',
         headers: { accept: 'application/json' },
         signal: undefined,
       });

--- a/tests/ui/api-config.test.ts
+++ b/tests/ui/api-config.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Tests for API base URL derivation from hostname.
+ *
+ * Verifies that getApiBaseUrl() and getWsBaseUrl() produce correct
+ * URLs for localhost, production, and override scenarios.
+ */
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// We need to dynamically import the module so we can control import.meta.env per test.
+// Each test will mock window.location and import.meta.env before importing.
+
+/** Helper: set window.location for jsdom tests. */
+function setLocation(hostname: string, protocol = 'https:', port = '') {
+  Object.defineProperty(window, 'location', {
+    value: { hostname, protocol, port },
+    writable: true,
+    configurable: true,
+  });
+}
+
+describe('getApiBaseUrl', () => {
+  let getApiBaseUrl: typeof import('../../src/ui/lib/api-config.ts').getApiBaseUrl;
+
+  beforeEach(async () => {
+    // Reset module registry so import.meta.env changes take effect
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('should return empty string for localhost', async () => {
+    setLocation('localhost', 'http:', '5173');
+    vi.stubEnv('VITE_API_URL', '');
+    const mod = await import('../../src/ui/lib/api-config.ts');
+    getApiBaseUrl = mod.getApiBaseUrl;
+
+    expect(getApiBaseUrl()).toBe('');
+  });
+
+  it('should return empty string for 127.0.0.1', async () => {
+    setLocation('127.0.0.1', 'http:', '5173');
+    vi.stubEnv('VITE_API_URL', '');
+    const mod = await import('../../src/ui/lib/api-config.ts');
+    getApiBaseUrl = mod.getApiBaseUrl;
+
+    expect(getApiBaseUrl()).toBe('');
+  });
+
+  it('should derive api.{domain} for production hostname', async () => {
+    setLocation('example.invalid', 'https:');
+    vi.stubEnv('VITE_API_URL', '');
+    const mod = await import('../../src/ui/lib/api-config.ts');
+    getApiBaseUrl = mod.getApiBaseUrl;
+
+    expect(getApiBaseUrl()).toBe('https://api.example.invalid');
+  });
+
+  it('should strip www. prefix and derive api.{domain}', async () => {
+    setLocation('www.example.invalid', 'https:');
+    vi.stubEnv('VITE_API_URL', '');
+    const mod = await import('../../src/ui/lib/api-config.ts');
+    getApiBaseUrl = mod.getApiBaseUrl;
+
+    expect(getApiBaseUrl()).toBe('https://api.example.invalid');
+  });
+
+  it('should use VITE_API_URL override when set', async () => {
+    setLocation('example.invalid', 'https:');
+    vi.stubEnv('VITE_API_URL', 'https://custom-api.example.invalid');
+    const mod = await import('../../src/ui/lib/api-config.ts');
+    getApiBaseUrl = mod.getApiBaseUrl;
+
+    expect(getApiBaseUrl()).toBe('https://custom-api.example.invalid');
+  });
+
+  it('should strip trailing slash from VITE_API_URL', async () => {
+    setLocation('example.invalid', 'https:');
+    vi.stubEnv('VITE_API_URL', 'https://custom-api.example.invalid/');
+    const mod = await import('../../src/ui/lib/api-config.ts');
+    getApiBaseUrl = mod.getApiBaseUrl;
+
+    expect(getApiBaseUrl()).toBe('https://custom-api.example.invalid');
+  });
+
+  it('should preserve http: protocol for non-localhost production', async () => {
+    setLocation('staging.example.invalid', 'http:');
+    vi.stubEnv('VITE_API_URL', '');
+    const mod = await import('../../src/ui/lib/api-config.ts');
+    getApiBaseUrl = mod.getApiBaseUrl;
+
+    expect(getApiBaseUrl()).toBe('http://api.staging.example.invalid');
+  });
+
+  it('should return empty string for [::1] (IPv6 loopback)', async () => {
+    setLocation('[::1]', 'http:', '5173');
+    vi.stubEnv('VITE_API_URL', '');
+    const mod = await import('../../src/ui/lib/api-config.ts');
+    getApiBaseUrl = mod.getApiBaseUrl;
+
+    expect(getApiBaseUrl()).toBe('');
+  });
+});
+
+describe('getWsBaseUrl', () => {
+  let getWsBaseUrl: typeof import('../../src/ui/lib/api-config.ts').getWsBaseUrl;
+
+  beforeEach(async () => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('should return empty string for localhost', async () => {
+    setLocation('localhost', 'http:', '5173');
+    vi.stubEnv('VITE_API_URL', '');
+    const mod = await import('../../src/ui/lib/api-config.ts');
+    getWsBaseUrl = mod.getWsBaseUrl;
+
+    expect(getWsBaseUrl()).toBe('');
+  });
+
+  it('should derive wss://api.{domain} for https: production', async () => {
+    setLocation('example.invalid', 'https:');
+    vi.stubEnv('VITE_API_URL', '');
+    const mod = await import('../../src/ui/lib/api-config.ts');
+    getWsBaseUrl = mod.getWsBaseUrl;
+
+    expect(getWsBaseUrl()).toBe('wss://api.example.invalid');
+  });
+
+  it('should derive ws://api.{domain} for http: production', async () => {
+    setLocation('staging.example.invalid', 'http:');
+    vi.stubEnv('VITE_API_URL', '');
+    const mod = await import('../../src/ui/lib/api-config.ts');
+    getWsBaseUrl = mod.getWsBaseUrl;
+
+    expect(getWsBaseUrl()).toBe('ws://api.staging.example.invalid');
+  });
+
+  it('should convert VITE_API_URL https: to wss:', async () => {
+    setLocation('example.invalid', 'https:');
+    vi.stubEnv('VITE_API_URL', 'https://custom-api.example.invalid');
+    const mod = await import('../../src/ui/lib/api-config.ts');
+    getWsBaseUrl = mod.getWsBaseUrl;
+
+    expect(getWsBaseUrl()).toBe('wss://custom-api.example.invalid');
+  });
+
+  it('should convert VITE_API_URL http: to ws:', async () => {
+    setLocation('example.invalid', 'http:');
+    vi.stubEnv('VITE_API_URL', 'http://custom-api.example.invalid');
+    const mod = await import('../../src/ui/lib/api-config.ts');
+    getWsBaseUrl = mod.getWsBaseUrl;
+
+    expect(getWsBaseUrl()).toBe('ws://custom-api.example.invalid');
+  });
+
+  it('should strip www. and derive wss://api.{domain}', async () => {
+    setLocation('www.example.invalid', 'https:');
+    vi.stubEnv('VITE_API_URL', '');
+    const mod = await import('../../src/ui/lib/api-config.ts');
+    getWsBaseUrl = mod.getWsBaseUrl;
+
+    expect(getWsBaseUrl()).toBe('wss://api.example.invalid');
+  });
+});


### PR DESCRIPTION
## Summary
- Create `src/ui/lib/api-config.ts` with `getApiBaseUrl()` and `getWsBaseUrl()`
- Convention-based: `api.{domain}` for production, same-origin for localhost/127.0.0.1/[::1]
- Build-time override via `VITE_API_URL` env var takes precedence
- Update `api-client.ts` to prepend base URL via `resolveUrl()` helper
- Add `credentials: 'include'` to all fetch calls for cross-origin cookie support
- Add `VITE_API_URL` to `.env.example` and `vite-env.d.ts` type declarations
- 14 new unit tests for URL derivation (localhost, production, www stripping, override, WebSocket)
- Update existing api-client tests for `credentials: 'include'`

## Test plan
- [x] Unit tests for localhost -> empty string
- [x] Unit tests for 127.0.0.1 -> empty string
- [x] Unit tests for [::1] -> empty string
- [x] Unit tests for production hostname -> https://api.{domain}
- [x] Unit tests for www.{domain} -> strips www prefix
- [x] Unit tests for VITE_API_URL override takes precedence
- [x] Unit tests for trailing slash stripping on override
- [x] WebSocket URL derivation (https->wss, http->ws)
- [x] Existing API client tests updated and passing
- [x] All existing call sites unchanged (apiClient.get('/api/...') still works)
- [x] Lint passes (warnings only, pre-existing)

Closes #1330

🤖 Generated with [Claude Code](https://claude.com/claude-code)