### PR TITLE
[#1325] Update existing tests for JWT auth migration

### DIFF
--- a/tests/app_frontend.test.ts
+++ b/tests/app_frontend.test.ts
@@ -3,11 +3,17 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { buildServer } from '../src/api/server.ts';
 import { createTestPool, truncateAllTables } from './helpers/db.ts';
 import { runMigrate } from './helpers/migrate.ts';
+import { createHash, randomBytes } from 'node:crypto';
+import { createPool } from '../src/db.ts';
+
+// JWT signing requires a secret.
+process.env.JWT_SECRET = 'test-jwt-secret-at-least-32-bytes-long!!';
 
 /**
  * New frontend entrypoints.
  *
  * These tests drive the initial scaffold for issue #52.
+ * Updated for JWT auth migration (Issue #1325).
  */
 describe('/app frontend', () => {
   const app = buildServer();
@@ -28,24 +34,26 @@ describe('/app frontend', () => {
     await pool.end();
   });
 
-  async function getSessionCookie(): Promise<string> {
-    const request = await app.inject({
-      method: 'POST',
-      url: '/api/auth/request-link',
-      payload: { email: 'app@example.com' },
-    });
-    const { loginUrl } = request.json() as { loginUrl: string };
-    const token = new URL(loginUrl).searchParams.get('token');
+  /** Get a JWT access token by creating and consuming a magic link directly in the DB. */
+  async function getAccessToken(): Promise<string> {
+    const rawToken = randomBytes(32).toString('base64url');
+    const tokenSha = createHash('sha256').update(rawToken).digest('hex');
+    const dbPool = createPool({ max: 1 });
+    await dbPool.query(
+      `INSERT INTO auth_magic_link (email, token_sha256, expires_at)
+       VALUES ($1, $2, now() + interval '15 minutes')`,
+      ['app@example.com', tokenSha],
+    );
+    await dbPool.end();
 
     const consume = await app.inject({
-      method: 'GET',
-      url: `/api/auth/consume?token=${token}`,
-      headers: { accept: 'application/json' },
+      method: 'POST',
+      url: '/api/auth/consume',
+      payload: { token: rawToken },
     });
 
-    const setCookie = consume.headers['set-cookie'];
-    const cookieHeader = Array.isArray(setCookie) ? setCookie[0] : setCookie;
-    return cookieHeader.split(';')[0];
+    const { accessToken } = consume.json() as { accessToken: string };
+    return accessToken;
   }
 
   // Issue #1166: GET / serves a landing page (not a redirect)
@@ -58,11 +66,11 @@ describe('/app frontend', () => {
   });
 
   it('serves landing page at GET / with dashboard link when authenticated', async () => {
-    const sessionCookie = await getSessionCookie();
+    const accessToken = await getAccessToken();
     const res = await app.inject({
       method: 'GET',
       url: '/',
-      headers: { cookie: sessionCookie },
+      headers: { authorization: `Bearer ${accessToken}` },
     });
     expect(res.statusCode).toBe(200);
     expect(res.headers['content-type']).toMatch(/text\/html/);
@@ -76,20 +84,18 @@ describe('/app frontend', () => {
     expect(res.headers.location).toBe('/app');
   });
 
-  it('requires auth (shows login UI) when not authenticated', async () => {
+  it('requires auth (returns 401) when not authenticated', async () => {
     const res = await app.inject({ method: 'GET', url: '/app/work-items' });
-    expect(res.statusCode).toBe(200);
-    expect(res.headers['content-type']).toMatch(/text\/html/);
-    expect(res.body).toContain('Sign in');
+    expect(res.statusCode).toBe(401);
   });
 
   it('serves the app shell for list + detail pages when authenticated', async () => {
-    const sessionCookie = await getSessionCookie();
+    const accessToken = await getAccessToken();
 
     const list = await app.inject({
       method: 'GET',
       url: '/app/work-items',
-      headers: { cookie: sessionCookie },
+      headers: { authorization: `Bearer ${accessToken}` },
     });
 
     expect(list.statusCode).toBe(200);
@@ -100,7 +106,7 @@ describe('/app frontend', () => {
     const detail = await app.inject({
       method: 'GET',
       url: '/app/work-items/123',
-      headers: { cookie: sessionCookie },
+      headers: { authorization: `Bearer ${accessToken}` },
     });
 
     expect(detail.statusCode).toBe(200);
@@ -110,7 +116,7 @@ describe('/app frontend', () => {
   // Issue #1166: Login page uses inline CSS (not broken /static/app.css reference)
   it('login page does not reference non-existent /static/app.css', async () => {
     const res = await app.inject({ method: 'GET', url: '/app/work-items' });
-    expect(res.statusCode).toBe(200);
+    // Even on 401 response, check the body doesn't reference old CSS
     expect(res.body).not.toContain('href="/static/app.css"');
   });
 });

--- a/tests/app_work_items_list.test.ts
+++ b/tests/app_work_items_list.test.ts
@@ -3,9 +3,15 @@ import { Pool } from 'pg';
 import { runMigrate } from './helpers/migrate.ts';
 import { createTestPool, truncateAllTables } from './helpers/db.ts';
 import { buildServer } from '../src/api/server.ts';
+import { createHash, randomBytes } from 'node:crypto';
+import { createPool } from '../src/db.ts';
+
+// JWT signing requires a secret.
+process.env.JWT_SECRET = 'test-jwt-secret-at-least-32-bytes-long!!';
 
 /**
  * Issue #59: bootstrap /app/work-items list data into the HTML so server-side tests can assert on it.
+ * Updated for JWT auth migration (Issue #1325).
  */
 describe('/app work items list', () => {
   const app = buildServer();
@@ -26,31 +32,31 @@ describe('/app work items list', () => {
     await pool.end();
   });
 
-  async function getSessionCookie(): Promise<string> {
-    const request = await app.inject({
-      method: 'POST',
-      url: '/api/auth/request-link',
-      payload: { email: 'app-list@example.com' },
-    });
-
-    const { loginUrl } = request.json() as { loginUrl: string };
-    const token = new URL(loginUrl).searchParams.get('token');
+  /** Get a JWT access token by creating and consuming a magic link directly in the DB. */
+  async function getAccessToken(): Promise<string> {
+    const rawToken = randomBytes(32).toString('base64url');
+    const tokenSha = createHash('sha256').update(rawToken).digest('hex');
+    const dbPool = createPool({ max: 1 });
+    await dbPool.query(
+      `INSERT INTO auth_magic_link (email, token_sha256, expires_at)
+       VALUES ($1, $2, now() + interval '15 minutes')`,
+      ['app-list@example.com', tokenSha],
+    );
+    await dbPool.end();
 
     const consume = await app.inject({
-      method: 'GET',
-      url: `/api/auth/consume?token=${token}`,
-      headers: { accept: 'application/json' },
+      method: 'POST',
+      url: '/api/auth/consume',
+      payload: { token: rawToken },
     });
 
-    const setCookie = consume.headers['set-cookie'];
-    const cookieHeader = Array.isArray(setCookie) ? setCookie[0] : setCookie;
-    return cookieHeader.split(';')[0];
+    const { accessToken } = consume.json() as { accessToken: string };
+    return accessToken;
   }
 
   it('shows login UI when not authenticated', async () => {
     const res = await app.inject({ method: 'GET', url: '/app/work-items' });
-    expect(res.statusCode).toBe(200);
-    expect(res.body).toContain('Sign in');
+    expect(res.statusCode).toBe(401);
   });
 
   it('renders HTML containing work item title when authenticated', async () => {
@@ -60,12 +66,12 @@ describe('/app work items list', () => {
       payload: { title: 'List Item' },
     });
 
-    const cookie = await getSessionCookie();
+    const accessToken = await getAccessToken();
 
     const res = await app.inject({
       method: 'GET',
       url: '/app/work-items',
-      headers: { cookie },
+      headers: { authorization: `Bearer ${accessToken}` },
     });
 
     expect(res.statusCode).toBe(200);


### PR DESCRIPTION
## Summary

Follow-up to PR #1384 which added JWT auth endpoints. The squash merge missed this commit that updates 8 existing test files to work with the new JWT-only auth flow:

- Replace `GET /api/auth/consume` with `POST /api/auth/consume` + `{ token }` payload
- Replace `getSessionCookie()` helpers with `getAccessToken()` helpers
- Replace `cookie: sessionCookie` headers with `authorization: Bearer ${accessToken}` headers  
- Update "shows login UI" tests (expected 200 with "Sign in") to "returns 401" for unauthenticated requests
- Add `JWT_SECRET` env var to all test files that need JWT auth

### Affected test files
- `tests/magic_link_single_use.test.ts`
- `tests/secret-auth.test.ts`
- `tests/app_frontend.test.ts`
- `tests/app_work_items_list.test.ts`
- `tests/app_work_item_detail.test.ts`
- `tests/app_frontend_assets.test.ts`
- `tests/sidebar_navigation.test.ts`
- `tests/notes_e2e.test.ts`

Closes #1325

## Test plan
- [ ] CI test suite passes (these tests were previously broken by the JWT migration)
- [ ] No regressions in other test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)