### PR TITLE
[#1337] Remove legacy session cookie auth infrastructure

### DIFF
--- a/migrations/021_user_settings.up.sql
+++ b/migrations/021_user_settings.up.sql
@@ -3,7 +3,7 @@
 
 CREATE TABLE IF NOT EXISTS user_setting (
   id uuid PRIMARY KEY DEFAULT new_uuid(),
-  email text NOT NULL UNIQUE,  -- Links to auth_session.email
+  email text NOT NULL UNIQUE,  -- User's email address (authenticated via JWT)
 
   -- Theme preference
   theme text NOT NULL DEFAULT 'system' CHECK (theme IN ('light', 'dark', 'system')),

--- a/migrations/084_drop_auth_session.down.sql
+++ b/migrations/084_drop_auth_session.down.sql
@@ -1,0 +1,12 @@
+-- Issue #1337: Restore auth_session table for rollback
+
+CREATE TABLE IF NOT EXISTS auth_session (
+  id uuid PRIMARY KEY DEFAULT new_uuid(),
+  email text NOT NULL CHECK (position('@' in email) > 1),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  expires_at timestamptz NOT NULL,
+  revoked_at timestamptz
+);
+
+CREATE INDEX IF NOT EXISTS auth_session_email_idx ON auth_session(email);
+CREATE INDEX IF NOT EXISTS auth_session_expires_at_idx ON auth_session(expires_at);

--- a/migrations/084_drop_auth_session.up.sql
+++ b/migrations/084_drop_auth_session.up.sql
@@ -1,0 +1,4 @@
+-- Issue #1337: Drop legacy auth_session table
+-- Session cookie auth has been replaced by JWT bearer tokens.
+
+DROP TABLE IF EXISTS auth_session;

--- a/src/api/geolocation/routes.test.ts
+++ b/src/api/geolocation/routes.test.ts
@@ -97,7 +97,6 @@ function mockRequest(overrides: {
 }): FastifyRequest {
   return {
     session: overrides.email !== undefined ? { email: overrides.email } : { email: OWNER_EMAIL },
-    cookies: { projects_session: overrides.email !== null ? 'valid-session' : undefined },
     body: overrides.body ?? null,
     params: overrides.params ?? {},
     query: overrides.query ?? {},

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -1019,13 +1019,8 @@ export function buildServer(options: ProjectsApiOptions = {}): FastifyInstance {
         bearerAuth: {
           type: 'http',
           scheme: 'bearer',
-          description: 'Bearer token authentication using shared secret',
-        },
-        cookieAuth: {
-          type: 'apiKey',
-          in: 'cookie',
-          name: 'projects_session',
-          description: 'Session cookie from magic link authentication',
+          bearerFormat: 'JWT',
+          description: 'JWT Bearer token authentication',
         },
       },
       schemas: {
@@ -1078,7 +1073,7 @@ export function buildServer(options: ProjectsApiOptions = {}): FastifyInstance {
         },
       },
     },
-    security: [{ bearerAuth: [] }, { cookieAuth: [] }],
+    security: [{ bearerAuth: [] }],
     paths: {
       '/api/work-items': {
         get: {
@@ -1459,7 +1454,7 @@ export function buildServer(options: ProjectsApiOptions = {}): FastifyInstance {
     return reply.redirect('/app');
   });
 
-  // New frontend (issue #52). These routes are protected by the existing dashboard session cookie.
+  // New frontend (issue #52). These routes are protected by JWT authentication.
 
   // Issue #129: New navigation routes
   app.get('/app/activity', async (req, reply) => {
@@ -11372,8 +11367,6 @@ export function buildServer(options: ProjectsApiOptions = {}): FastifyInstance {
          SELECT user_email as email FROM work_item_comment
          UNION
          SELECT user_email as email FROM notification
-         UNION
-         SELECT email FROM auth_session
        ) users
        WHERE email ILIKE $1
        ORDER BY email

--- a/tests/activity_feed_page.test.ts
+++ b/tests/activity_feed_page.test.ts
@@ -43,27 +43,21 @@ describe('Activity Feed Page', () => {
     });
 
     it('returns bootstrap data with activity route', async () => {
-      // Create a session cookie for authentication
-      const pool2 = createTestPool();
-      const session = await pool2.query(
-        `INSERT INTO auth_session (email, expires_at)
-         VALUES ('test@example.com', now() + interval '1 hour')
-         RETURNING id::text as id`,
-      );
-      const sessionId = (session.rows[0] as { id: string }).id;
-      await pool2.end();
+      // Use E2E bypass for authentication (JWT replaced session cookies)
+      process.env.OPENCLAW_E2E_SESSION_EMAIL = 'test@example.com';
 
-      const res = await app.inject({
-        method: 'GET',
-        url: '/app/activity',
-        cookies: {
-          projects_session: sessionId,
-        },
-      });
+      try {
+        const res = await app.inject({
+          method: 'GET',
+          url: '/app/activity',
+        });
 
-      expect(res.statusCode).toBe(200);
-      expect(res.payload).toContain('app-bootstrap');
-      expect(res.payload).toContain('"activity"');
+        expect(res.statusCode).toBe(200);
+        expect(res.payload).toContain('app-bootstrap');
+        expect(res.payload).toContain('"activity"');
+      } finally {
+        delete process.env.OPENCLAW_E2E_SESSION_EMAIL;
+      }
     });
   });
 

--- a/tests/contacts_page.test.ts
+++ b/tests/contacts_page.test.ts
@@ -43,27 +43,21 @@ describe('Contacts Page', () => {
     });
 
     it('returns bootstrap data with contacts route', async () => {
-      // Create a session cookie for authentication
-      const pool2 = createTestPool();
-      const session = await pool2.query(
-        `INSERT INTO auth_session (email, expires_at)
-         VALUES ('test@example.com', now() + interval '1 hour')
-         RETURNING id::text as id`,
-      );
-      const sessionId = (session.rows[0] as { id: string }).id;
-      await pool2.end();
+      // Use E2E bypass for authentication (JWT replaced session cookies)
+      process.env.OPENCLAW_E2E_SESSION_EMAIL = 'test@example.com';
 
-      const res = await app.inject({
-        method: 'GET',
-        url: '/app/contacts',
-        cookies: {
-          projects_session: sessionId,
-        },
-      });
+      try {
+        const res = await app.inject({
+          method: 'GET',
+          url: '/app/contacts',
+        });
 
-      expect(res.statusCode).toBe(200);
-      expect(res.payload).toContain('app-bootstrap');
-      expect(res.payload).toContain('"contacts"');
+        expect(res.statusCode).toBe(200);
+        expect(res.payload).toContain('app-bootstrap');
+        expect(res.payload).toContain('"contacts"');
+      } finally {
+        delete process.env.OPENCLAW_E2E_SESSION_EMAIL;
+      }
     });
   });
 

--- a/tests/global_timeline_page.test.ts
+++ b/tests/global_timeline_page.test.ts
@@ -43,27 +43,21 @@ describe('Global Timeline Page', () => {
     });
 
     it('returns bootstrap data with timeline route', async () => {
-      // Create a session cookie for authentication
-      const pool2 = createTestPool();
-      const session = await pool2.query(
-        `INSERT INTO auth_session (email, expires_at)
-         VALUES ('test@example.com', now() + interval '1 hour')
-         RETURNING id::text as id`,
-      );
-      const sessionId = (session.rows[0] as { id: string }).id;
-      await pool2.end();
+      // Use E2E bypass for authentication (JWT replaced session cookies)
+      process.env.OPENCLAW_E2E_SESSION_EMAIL = 'test@example.com';
 
-      const res = await app.inject({
-        method: 'GET',
-        url: '/app/timeline',
-        cookies: {
-          projects_session: sessionId,
-        },
-      });
+      try {
+        const res = await app.inject({
+          method: 'GET',
+          url: '/app/timeline',
+        });
 
-      expect(res.statusCode).toBe(200);
-      expect(res.payload).toContain('app-bootstrap');
-      expect(res.payload).toContain('"timeline"');
+        expect(res.statusCode).toBe(200);
+        expect(res.payload).toContain('app-bootstrap');
+        expect(res.payload).toContain('"timeline"');
+      } finally {
+        delete process.env.OPENCLAW_E2E_SESSION_EMAIL;
+      }
     });
   });
 

--- a/tests/helpers/db.ts
+++ b/tests/helpers/db.ts
@@ -107,7 +107,6 @@ const APPLICATION_TABLES = [
   'auth_refresh_token',
   'auth_one_time_code',
   'auth_magic_link',
-  'auth_session',
 ] as const;
 
 /**


### PR DESCRIPTION
## Summary
- Adds migration 084 to `DROP TABLE auth_session`
- Removes `sessionCookieName` constant and session cookie handling from `server.ts`
- Removes `auth_session` references from test helpers and integration tests
- Updates tests to work without session-based auth

Note: `@fastify/cookie` and `COOKIE_SECRET` are still needed for the refresh token HttpOnly cookie.

Closes #1337

## Test plan
- [ ] Migration 084 drops `auth_session` table cleanly
- [ ] No remaining references to `auth_session` or `projects_session` cookie
- [ ] All integration tests pass without session auth
- [ ] Refresh token HttpOnly cookie continues to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)