### PR TITLE
[#1336] Update E2E tests for JWT authentication

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -69,6 +69,8 @@ services:
       PGPASSWORD: openclaw_test
       PGDATABASE: openclaw_test
       OPENCLAW_PROJECTS_AUTH_DISABLED: "true"
+      OPENCLAW_E2E_SESSION_EMAIL: "e2e-test@example.com"
+      JWT_SECRET: "e2e-test-jwt-secret-at-least-32-bytes-long!!"
       NODE_ENV: test
       PORT: 3001
     ports:

--- a/packages/openclaw-plugin/tests/e2e/oauth.test.ts
+++ b/packages/openclaw-plugin/tests/e2e/oauth.test.ts
@@ -10,16 +10,22 @@
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { createE2EContext, areE2EServicesAvailable, cleanupResources, type E2ETestContext } from './setup.js';
+import { createE2EContext, areE2EServicesAvailable, cleanupResources, signTestJwt, type E2ETestContext } from './setup.js';
 
 const RUN_E2E = process.env.RUN_E2E === 'true';
 
 /**
  * Raw fetch helper that returns the Response (not parsed JSON) so tests
  * can assert on status codes and error payloads.
+ * Automatically attaches a JWT Bearer token.
  */
 async function rawFetch(baseUrl: string, path: string, options?: RequestInit): Promise<Response> {
-  return fetch(`${baseUrl}${path}`, options);
+  const token = await signTestJwt();
+  const headers = new Headers(options?.headers);
+  if (!headers.has('Authorization')) {
+    headers.set('Authorization', `Bearer ${token}`);
+  }
+  return fetch(`${baseUrl}${path}`, { ...options, headers });
 }
 
 // ────────────────────────────────────────────────────────────────────────────

--- a/packages/openclaw-plugin/tests/e2e/user-email-scoping.e2e.test.ts
+++ b/packages/openclaw-plugin/tests/e2e/user-email-scoping.e2e.test.ts
@@ -10,7 +10,7 @@
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { defaultConfig, waitForService, type E2EConfig } from './setup.js';
+import { defaultConfig, waitForService, signTestJwt, type E2EConfig } from './setup.js';
 
 const RUN_E2E = process.env.RUN_E2E === 'true';
 
@@ -21,35 +21,47 @@ const USER_B = 'e2e-user-b@test.openclaw.local';
 /**
  * Minimal fetch wrapper that returns the raw Response so callers
  * can assert on status codes (404, 204, etc.) directly.
+ * Automatically attaches a JWT Bearer token to every request.
  */
 function createRawClient(baseUrl: string) {
   return {
     async get(path: string): Promise<Response> {
-      return fetch(`${baseUrl}${path}`, { method: 'GET' });
+      const token = await signTestJwt();
+      return fetch(`${baseUrl}${path}`, {
+        method: 'GET',
+        headers: { 'Authorization': `Bearer ${token}` },
+      });
     },
     async post(path: string, body: unknown): Promise<Response> {
+      const token = await signTestJwt();
       return fetch(`${baseUrl}${path}`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
         body: JSON.stringify(body),
       });
     },
     async put(path: string, body: unknown): Promise<Response> {
+      const token = await signTestJwt();
       return fetch(`${baseUrl}${path}`, {
         method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
         body: JSON.stringify(body),
       });
     },
     async patch(path: string, body: unknown): Promise<Response> {
+      const token = await signTestJwt();
       return fetch(`${baseUrl}${path}`, {
         method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
         body: JSON.stringify(body),
       });
     },
     async delete(path: string): Promise<Response> {
-      return fetch(`${baseUrl}${path}`, { method: 'DELETE' });
+      const token = await signTestJwt();
+      return fetch(`${baseUrl}${path}`, {
+        method: 'DELETE',
+        headers: { 'Authorization': `Bearer ${token}` },
+      });
     },
   };
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -32,6 +32,7 @@ export default defineConfig({
     env: {
       OPENCLAW_PROJECTS_AUTH_DISABLED: 'true',
       OPENCLAW_E2E_SESSION_EMAIL: 'e2e-test@example.com',
+      JWT_SECRET: 'e2e-test-jwt-secret-at-least-32-bytes-long!!',
       RATE_LIMIT_DISABLED: 'true',
       PORT: '3000',
     },


### PR DESCRIPTION
## Summary

- Updated E2E API test client (`setup.ts`) to send `Authorization: Bearer` header on every request
- Added `signTestJwt()` helper that generates valid HS256 JWTs matching the backend's token format
- Updated `docker-compose.test.yml` with `JWT_SECRET` and `OPENCLAW_E2E_SESSION_EMAIL` env vars
- Updated `playwright.config.ts` with `JWT_SECRET` for browser test server
- Updated `oauth.test.ts` and `user-email-scoping.e2e.test.ts` raw fetch helpers to include Bearer auth
- No session cookie references remain in test code

The E2E bypass (`OPENCLAW_PROJECTS_AUTH_DISABLED` + `OPENCLAW_E2E_SESSION_EMAIL`) continues to work as a fallback for Playwright browser tests, while API-level E2E tests now authenticate via JWT Bearer tokens.

Closes #1336

## Test plan

- [x] `pnpm run lint` passes (warnings only, no errors)
- [x] `pnpm test:unit` passes (5 pre-existing failures unrelated to this change)
- [ ] `pnpm run test:e2e` passes with Docker services (requires CI)
- [x] No `projects_session` cookie references in test code
- [x] JWT generation uses same HS256/kid format as `src/api/auth/jwt.ts`