### PR TITLE
[#1355] Fix OAuth authorize endpoint to redirect instead of returning JSON

### DIFF
--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -11789,12 +11789,13 @@ export function buildServer(options: ProjectsApiOptions = {}): FastifyInstance {
     });
   });
 
-  // GET /api/oauth/authorize/:provider - Get OAuth authorization URL
+  // GET /api/oauth/authorize/:provider - Redirect to OAuth provider
   // Accepts optional query params:
   //   scopes: comma-separated raw scope strings (legacy)
   //   features: comma-separated feature names (contacts,email,files,calendar)
   //   permissionLevel: 'read' or 'read_write' (default: 'read')
   // When features are provided, scopes are computed from the feature-to-scope map.
+  // Returns a 302 redirect to the provider's authorization URL.
   app.get('/api/oauth/authorize/:provider', async (req, reply) => {
     const params = req.params as { provider: string };
     const query = req.query as { scopes?: string; features?: string; permissionLevel?: string };
@@ -11843,12 +11844,7 @@ export function buildServer(options: ProjectsApiOptions = {}): FastifyInstance {
         permissionLevel,
       });
 
-      return reply.send({
-        authUrl: authResult.url,
-        state: authResult.state,
-        provider: authResult.provider,
-        scopes: authResult.scopes,
-      });
+      return reply.redirect(authResult.url);
     } catch (error) {
       if (error instanceof ProviderNotConfiguredError) {
         return reply.code(503).send({

--- a/tests/email_calendar_sync_api.test.ts
+++ b/tests/email_calendar_sync_api.test.ts
@@ -71,27 +71,26 @@ describe('Email & Calendar Sync API', () => {
     });
 
     describe('GET /api/oauth/authorize/:provider', () => {
-      it('returns authorization URL for google', async () => {
+      it('redirects to authorization URL for google', async () => {
         const response = await app.inject({
           method: 'GET',
           url: '/api/oauth/authorize/google?userEmail=user@example.com&scopes=email,calendar',
         });
 
-        expect(response.statusCode).toBe(200);
-        const body = response.json();
-        expect(body.authUrl).toBeDefined();
-        expect(body.state).toBeDefined();
+        expect(response.statusCode).toBe(302);
+        const location = response.headers.location as string;
+        expect(location).toContain('accounts.google.com');
       });
 
-      it('returns authorization URL for microsoft', async () => {
+      it('redirects to authorization URL for microsoft', async () => {
         const response = await app.inject({
           method: 'GET',
           url: '/api/oauth/authorize/microsoft?userEmail=user@example.com&scopes=email,calendar',
         });
 
-        expect(response.statusCode).toBe(200);
-        const body = response.json();
-        expect(body.authUrl).toBeDefined();
+        expect(response.statusCode).toBe(302);
+        const location = response.headers.location as string;
+        expect(location).toContain('login.microsoftonline.com');
       });
 
       it('returns 400 for unknown provider', async () => {

--- a/tests/oauth/api.test.ts
+++ b/tests/oauth/api.test.ts
@@ -90,7 +90,7 @@ describe('OAuth API Endpoints', () => {
       expect(body.error).toContain('not configured');
     });
 
-    it('returns authorization URL when configured', async () => {
+    it('redirects to authorization URL when configured', async () => {
       process.env.MS365_CLIENT_ID = 'test-client-id';
       process.env.MS365_CLIENT_SECRET = 'test-client-secret';
 
@@ -102,11 +102,9 @@ describe('OAuth API Endpoints', () => {
         url: '/api/oauth/authorize/microsoft',
       });
 
-      expect(response.statusCode).toBe(200);
-      const body = response.json();
-      expect(body.authUrl).toContain('login.microsoftonline.com');
-      expect(body.state).toBeTruthy();
-      expect(body.provider).toBe('microsoft');
+      expect(response.statusCode).toBe(302);
+      const location = response.headers.location as string;
+      expect(location).toContain('login.microsoftonline.com');
     });
 
     it('returns error for invalid provider', async () => {


### PR DESCRIPTION
## Summary
- Changed `GET /api/oauth/authorize/:provider` to return a **302 redirect** to the provider's authorization URL instead of a JSON response containing `{ authUrl, state, provider, scopes }`
- The frontend (`connected-accounts-section.tsx`) uses `<a href=...>` tags to navigate to this endpoint, which requires a browser redirect for the OAuth flow to work
- Updated unit tests (`tests/oauth/api.test.ts`), integration tests (`tests/email_calendar_sync_api.test.ts`), and E2E tests (`packages/openclaw-plugin/tests/e2e/oauth.test.ts`) to expect 302 redirects

## Root Cause
The endpoint was designed as a JSON API but consumed by the frontend as a browser navigation link. PR #1399 (issue #1335) fixed the **callback** side (post-auth redirect with one-time code exchange) but did not address the **authorize** side.

## Test plan
- [x] `tests/oauth/api.test.ts` — "redirects to authorization URL when configured" passes
- [x] `tests/email_calendar_sync_api.test.ts` — "redirects to authorization URL for google/microsoft" passes
- [x] `packages/openclaw-plugin/tests/e2e/oauth.test.ts` — updated to use `redirect: 'manual'` and assert Location header
- [x] Lint passes (no new errors)

Closes #1355

🤖 Generated with [Claude Code](https://claude.com/claude-code)