### PR TITLE
[#1401] Document PUBLIC_BASE_URL breaking change in compose files

### DIFF
--- a/docker-compose.full.yml
+++ b/docker-compose.full.yml
@@ -351,6 +351,10 @@ services:
       NODE_ENV: production
       HOST: "::"
       PORT: 3001
+      # PUBLIC_BASE_URL is the app/root domain where the SPA is served, NOT the
+      # API subdomain. The API URL is derived automatically as api.${DOMAIN} by
+      # deriveApiUrl() in server.ts. Changed from https://api.${DOMAIN} in
+      # v0.0.56 (#1328). See docs/deployment.md "Breaking Changes".
       PUBLIC_BASE_URL: https://${DOMAIN:?DOMAIN is required}
       COOKIE_SECRET: ${COOKIE_SECRET:?COOKIE_SECRET is required}
       # JWT signing (required for production auth)

--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -384,6 +384,11 @@ services:
       # Port 3001 (not 3000) to avoid conflicts with Traefik service labels.
       # ModSecurity and nginx proxy both use this port.
       PORT: 3001
+      # PUBLIC_BASE_URL is the app/root domain where the SPA is served, NOT the
+      # API subdomain. The API URL is derived automatically as api.${DOMAIN} by
+      # deriveApiUrl() in server.ts. Magic links, share URLs, CORS, and CSP all
+      # use this value. Changed from https://api.${DOMAIN} in v0.0.56 (#1328).
+      # See docs/deployment.md "Breaking Changes" for migration notes.
       PUBLIC_BASE_URL: https://${DOMAIN:?DOMAIN is required}
       COOKIE_SECRET: ${COOKIE_SECRET:?COOKIE_SECRET is required}
       # JWT signing (required for production auth)


### PR DESCRIPTION
## Summary

- Add inline comments in `docker-compose.traefik.yml` and `docker-compose.full.yml` explaining that `PUBLIC_BASE_URL` is the app/root domain (not the API subdomain), and the API URL is derived automatically as `api.${DOMAIN}`
- Add a **Breaking Changes** section to `docs/deployment.md` with migration guidance for existing Traefik deployments
- Link to the originating change (#1328) and the JWT auth epic (#1322)

The compose file change was intentional — `PUBLIC_BASE_URL` was standardized to mean the app domain where the SPA is served. The API URL (`https://api.${DOMAIN}`) is derived automatically by `deriveApiUrl()` in `server.ts`. The Traefik routing (api.DOMAIN -> ModSecurity -> API, DOMAIN -> frontend) is unchanged and correct.

Closes #1401

## Test plan

- [x] `tests/sharing-base-url.test.ts` — 4 tests pass (PUBLIC_BASE_URL usage in sharing modules)
- [x] `tests/derive-api-url.test.ts` — 6 tests pass (API URL derivation from PUBLIC_BASE_URL)
- [x] `tests/csp_headers.test.ts` — 12 tests pass (CSP connect-src includes api subdomain)
- [x] `tests/docker/basic-compose.test.ts` — 57 tests pass (compose file validation)
- [x] Lint passes (warnings only, no errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)