### PR TITLE
[#1400] Add JWT_SECRET to production Docker Compose files

### DIFF
--- a/docker-compose.full.yml
+++ b/docker-compose.full.yml
@@ -353,6 +353,9 @@ services:
       PORT: 3001
       PUBLIC_BASE_URL: https://${DOMAIN:?DOMAIN is required}
       COOKIE_SECRET: ${COOKIE_SECRET:?COOKIE_SECRET is required}
+      # JWT signing (required for production auth)
+      JWT_SECRET: ${JWT_SECRET:-}
+      JWT_SECRET_PREVIOUS: ${JWT_SECRET_PREVIOUS:-}
       PGHOST: db
       PGPORT: 5432
       PGUSER: ${POSTGRES_USER:-openclaw}
@@ -456,6 +459,9 @@ services:
       PGDATABASE: ${POSTGRES_DB:-openclaw}
       OPENCLAW_GATEWAY_URL: http://openclaw-gateway:18789
       OPENCLAW_API_TOKEN: ${OPENCLAW_API_TOKEN:-}
+      # JWT signing (required when worker verifies tokens)
+      JWT_SECRET: ${JWT_SECRET:-}
+      JWT_SECRET_PREVIOUS: ${JWT_SECRET_PREVIOUS:-}
       EMBEDDING_PROVIDER: ${EMBEDDING_PROVIDER:-}
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       OPENAI_API_KEY_FILE: ${OPENAI_API_KEY_FILE:-}

--- a/docker-compose.quickstart.yml
+++ b/docker-compose.quickstart.yml
@@ -126,6 +126,7 @@ services:
       PUBLIC_BASE_URL: ${PUBLIC_BASE_URL:-http://localhost:3000}
       COOKIE_SECRET: ${COOKIE_SECRET:?Set COOKIE_SECRET in .env or run ./scripts/setup.sh}
       JWT_SECRET: ${JWT_SECRET:-}
+      JWT_SECRET_PREVIOUS: ${JWT_SECRET_PREVIOUS:-}
       # Database
       PGHOST: db
       PGPORT: 5432
@@ -220,6 +221,9 @@ services:
       PGUSER: ${POSTGRES_USER:-openclaw}
       PGPASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
       PGDATABASE: ${POSTGRES_DB:-openclaw}
+      # JWT signing (required when worker verifies tokens)
+      JWT_SECRET: ${JWT_SECRET:-}
+      JWT_SECRET_PREVIOUS: ${JWT_SECRET_PREVIOUS:-}
       # Optional — embedding (semantic search)
       EMBEDDING_PROVIDER: ${EMBEDDING_PROVIDER:-}
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}

--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -386,6 +386,9 @@ services:
       PORT: 3001
       PUBLIC_BASE_URL: https://${DOMAIN:?DOMAIN is required}
       COOKIE_SECRET: ${COOKIE_SECRET:?COOKIE_SECRET is required}
+      # JWT signing (required for production auth)
+      JWT_SECRET: ${JWT_SECRET:-}
+      JWT_SECRET_PREVIOUS: ${JWT_SECRET_PREVIOUS:-}
       # Database connection
       PGHOST: db
       PGPORT: 5432
@@ -507,6 +510,9 @@ services:
       PGDATABASE: ${POSTGRES_DB:-openclaw}
       OPENCLAW_GATEWAY_URL: ${OPENCLAW_GATEWAY_URL:-}
       OPENCLAW_API_TOKEN: ${OPENCLAW_API_TOKEN:-}
+      # JWT signing (required when worker verifies tokens)
+      JWT_SECRET: ${JWT_SECRET:-}
+      JWT_SECRET_PREVIOUS: ${JWT_SECRET_PREVIOUS:-}
       EMBEDDING_PROVIDER: ${EMBEDDING_PROVIDER:-}
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       OPENAI_API_KEY_FILE: ${OPENAI_API_KEY_FILE:-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -152,6 +152,9 @@ services:
       PORT: 3000
       PUBLIC_BASE_URL: ${PUBLIC_BASE_URL:-http://localhost:3000}
       COOKIE_SECRET: ${COOKIE_SECRET:?COOKIE_SECRET is required}
+      # JWT signing (required for production auth)
+      JWT_SECRET: ${JWT_SECRET:-}
+      JWT_SECRET_PREVIOUS: ${JWT_SECRET_PREVIOUS:-}
       # Database connection
       PGHOST: db
       PGPORT: 5432
@@ -260,6 +263,9 @@ services:
       PGDATABASE: ${POSTGRES_DB:-openclaw}
       OPENCLAW_GATEWAY_URL: ${OPENCLAW_GATEWAY_URL:-}
       OPENCLAW_API_TOKEN: ${OPENCLAW_API_TOKEN:-}
+      # JWT signing (required when worker verifies tokens)
+      JWT_SECRET: ${JWT_SECRET:-}
+      JWT_SECRET_PREVIOUS: ${JWT_SECRET_PREVIOUS:-}
       EMBEDDING_PROVIDER: ${EMBEDDING_PROVIDER:-}
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       OPENAI_API_KEY_FILE: ${OPENAI_API_KEY_FILE:-}


### PR DESCRIPTION
## Summary
- Added `JWT_SECRET: ${JWT_SECRET:-}` and `JWT_SECRET_PREVIOUS: ${JWT_SECRET_PREVIOUS:-}` to **api** and **worker** services in all Docker Compose files:
  - `docker-compose.yml` (basic production)
  - `docker-compose.traefik.yml` (Traefik production)
  - `docker-compose.full.yml` (full-stack production)
  - `docker-compose.quickstart.yml` (added `JWT_SECRET_PREVIOUS` to api, both vars to worker)

Without these environment variables, containers cannot sign or verify JWTs via `src/api/auth/jwt.ts`, breaking authentication in production deployments. The quickstart file already had `JWT_SECRET` in the api service but was missing the previous-key rotation support and worker coverage.

Closes #1400

## Test plan
- [x] Verified all 4 compose files contain `JWT_SECRET` and `JWT_SECRET_PREVIOUS` in both `api` and `worker` services
- [x] Validated YAML structure parses correctly
- [x] `.env.example` already documents both variables (lines 319-324)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)