### PR TITLE
[#1415][#1416] Use Fastify trusted IP and hostname in webhook middleware

### DIFF
--- a/src/api/webhooks/ip-whitelist.ts
+++ b/src/api/webhooks/ip-whitelist.ts
@@ -172,23 +172,17 @@ export function parseIPWhitelist(value: string | undefined | null): string[] {
 }
 
 /**
- * Get the client IP address from a request, handling X-Forwarded-For.
+ * Get the client IP address from a request.
+ *
+ * With `trustProxy: true`, Fastify already resolves the real client IP
+ * from X-Forwarded-For into `request.ip`. Manual header parsing is
+ * redundant and could be spoofed if the upstream proxy appends rather
+ * than replaces the XFF header. See #1415.
  *
  * @param request - Fastify request
  * @returns Client IP address
  */
 export function getClientIP(request: FastifyRequest): string {
-  // Check X-Forwarded-For header (set by proxies/load balancers)
-  const forwardedFor = request.headers['x-forwarded-for'] as string | undefined;
-
-  if (forwardedFor) {
-    // X-Forwarded-For can contain multiple IPs: client, proxy1, proxy2, ...
-    // The first IP is the original client
-    const firstIP = forwardedFor.split(',')[0].trim();
-    if (firstIP) return firstIP;
-  }
-
-  // Fall back to direct request IP
   return request.ip;
 }
 

--- a/src/api/webhooks/verification.ts
+++ b/src/api/webhooks/verification.ts
@@ -162,10 +162,15 @@ export function verifyHmacSha256(request: FastifyRequest, secretEnvVar: string, 
 
 /**
  * Get the full URL from a Fastify request.
+ *
+ * Uses `request.host` (which respects trustProxy settings and includes
+ * the port) instead of the raw Host header. In multi-proxy setups the
+ * Host header may be rewritten, while Fastify resolves the trusted host
+ * from X-Forwarded-Host when trustProxy is enabled. See #1416.
  */
 function getFullUrl(request: FastifyRequest): string {
   const protocol = request.protocol || 'https';
-  const host = request.headers['host'] || request.hostname;
+  const host = request.host;
   const url = request.url;
   return `${protocol}://${host}${url}`;
 }


### PR DESCRIPTION
## Summary

- **#1415**: Replace manual `X-Forwarded-For` parsing in `getClientIP()` with Fastify's trusted `request.ip` — with `trustProxy: true`, Fastify already resolves the real client IP, making raw header parsing redundant and potentially spoofable.
- **#1416**: Replace raw `request.headers['host']` in `getFullUrl()` with Fastify's trusted `request.host` — respects `trustProxy` settings (including `X-Forwarded-Host`) and preserves the port, preventing signature failures in multi-proxy setups.

Closes #1415
Closes #1416

## Test plan

- [x] Updated `getClientIP` unit tests to verify it delegates to `request.ip` (no XFF parsing)
- [x] Updated middleware test to simulate Fastify's trustProxy-resolved `request.ip`
- [x] Added unit test for multi-proxy hostname scenario (raw Host header differs from trusted hostname)
- [x] Verified all 74 tests pass across 3 test files (unit + integration)
- [x] Integration test with real Fastify `inject()` confirms trustProxy works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)