### PR TITLE
[#1512] Fix connection pool leaks and improve error logging

### DIFF
--- a/src/api/context/graph-aware-service.ts
+++ b/src/api/context/graph-aware-service.ts
@@ -424,8 +424,8 @@ async function multiScopeMemorySearch(
         queryEmbedding = embResult.embedding;
       }
     }
-  } catch {
-    // Fall through to text search
+  } catch (err) {
+    console.warn('[GraphContext] Semantic search failed, falling back to text search:', err);
   }
 
   if (queryEmbedding) {


### PR DESCRIPTION
## Summary
- Clean up `nsPool` and `healthPool` in server `onClose` hook (were leaking on shutdown)
- Reuse shared `nsPool` in `sendAppHtml` instead of creating a new pool per page render
- Log embedding failures in graph-aware context service instead of silently swallowing

Closes #1512

## Test plan
- [x] All bootstrap, namespace, notes, notebooks, context tests pass individually
- [x] Lint passes (no new warnings)
- [x] Pre-existing failures (Docker build tests, graph context, note search) confirmed on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)