### PR TITLE
[#1428] Gateway per-agent namespace config

### DIFF
--- a/packages/openclaw-plugin/openclaw.plugin.json
+++ b/packages/openclaw-plugin/openclaw.plugin.json
@@ -106,7 +106,7 @@
         "type": "string",
         "enum": ["agent", "identity", "session"],
         "default": "agent",
-        "description": "How to scope user memories"
+        "description": "@deprecated — replaced by namespace config. Kept for backward compatibility."
       },
       "maxRecallMemories": {
         "type": "integer",
@@ -157,10 +157,35 @@
         "description": "PromptGuard-2 classifier URL for multilingual injection detection (e.g., http://prompt-guard:8190)"
       },
       "namespace": {
-        "type": "string",
-        "pattern": "^[a-z0-9][a-z0-9._-]*$",
-        "maxLength": 63,
-        "description": "Default namespace for data scoping (e.g., 'personal', 'team-alpha')"
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "default": {
+                "type": "string",
+                "pattern": "^[a-z0-9][a-z0-9._-]*$",
+                "maxLength": 63,
+                "description": "Namespace for store/create when none specified"
+              },
+              "recall": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "pattern": "^[a-z0-9][a-z0-9._-]*$",
+                  "maxLength": 63
+                },
+                "description": "Namespaces to search when none specified"
+              }
+            }
+          },
+          {
+            "type": "string",
+            "pattern": "^[a-z0-9][a-z0-9._-]*$",
+            "maxLength": 63,
+            "description": "Shorthand: string treated as { default: value }"
+          }
+        ],
+        "description": "Namespace configuration for data scoping"
       }
     },
     "additionalProperties": false,
@@ -270,8 +295,8 @@
       "group": "Memory"
     },
     "userScoping": {
-      "label": "User Scoping",
-      "help": "How to isolate memories between users",
+      "label": "User Scoping (deprecated)",
+      "help": "Deprecated — replaced by namespace config",
       "group": "Memory"
     },
     "maxRecallMemories": {
@@ -319,8 +344,7 @@
     },
     "namespace": {
       "label": "Namespace",
-      "placeholder": "default",
-      "help": "Default namespace for data scoping. All data operations will be scoped to this namespace.",
+      "help": "Namespace config for data scoping. Can be a string (shorthand for default) or { default, recall[] }.",
       "group": "Advanced"
     }
   }

--- a/packages/openclaw-plugin/src/api-client.ts
+++ b/packages/openclaw-plugin/src/api-client.ts
@@ -28,8 +28,6 @@ export interface RequestOptions {
   timeout?: number;
   /** Mark request as coming from an agent (adds X-OpenClaw-Agent header) */
   isAgent?: boolean;
-  /** Override namespace for this request (defaults to config.namespace) */
-  namespace?: string;
 }
 
 /** API client options */
@@ -98,8 +96,6 @@ export class ApiClient {
   private readonly logger: Logger;
   private readonly timeout: number;
   private readonly maxRetries: number;
-  private readonly namespace: string | undefined;
-
   constructor(options: ApiClientOptions) {
     // Ensure URL doesn't have trailing slash
     this.baseUrl = options.config.apiUrl.replace(/\/$/, '');
@@ -107,7 +103,6 @@ export class ApiClient {
     this.logger = options.logger ?? createLogger('api-client');
     this.timeout = options.config.timeout;
     this.maxRetries = options.config.maxRetries;
-    this.namespace = options.config.namespace;
   }
 
   /**
@@ -205,12 +200,6 @@ export class ApiClient {
 
       if (options?.user_id) {
         headers['X-Agent-Id'] = options.user_id;
-      }
-
-      // Namespace scoping: per-request override or config default (Issue #1428)
-      const ns = options?.namespace ?? this.namespace;
-      if (ns) {
-        headers['X-Namespace'] = ns;
       }
 
       // Mark request as coming from an agent for privacy filtering

--- a/packages/openclaw-plugin/src/cli.ts
+++ b/packages/openclaw-plugin/src/cli.ts
@@ -124,7 +124,7 @@ export function createUsersCommand(ctx: CliContext): () => Promise<CommandResult
   return async (): Promise<CommandResult<UsersData>> => {
     logger.info('CLI users command invoked', { user_id });
 
-    const scopingMode = config.userScoping;
+    const scopingMode = config.userScoping ?? 'agent';
     const description = SCOPING_DESCRIPTIONS[scopingMode] ?? 'Unknown scoping mode';
 
     return {

--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -136,7 +136,7 @@ function createPluginInstance(config: PluginConfig, logger: Logger, runtime: unk
       agentId: context.agent.agentId,
       sessionKey: context.session.sessionId,
     },
-    config.userScoping,
+    config.userScoping ?? 'agent',
   );
 
   // Create tools
@@ -308,7 +308,7 @@ export const plugin = {
 };
 
 // Re-export types and utilities
-export type { PluginConfig, RawPluginConfig } from './config.js';
+export type { PluginConfig, RawPluginConfig, NamespaceConfig } from './config.js';
 export {
   validateConfig,
   safeValidateConfig,
@@ -317,6 +317,7 @@ export {
   resolveConfigSecrets,
   resolveConfigSecretsSync,
   redactConfig,
+  resolveNamespaceConfig,
 } from './config.js';
 export type { SecretConfig } from './secrets.js';
 export { resolveSecret, resolveSecretSync, resolveSecrets, clearSecretCache, clearCachedSecret } from './secrets.js';

--- a/packages/openclaw-plugin/tests/__snapshots__/schema-snapshots.test.ts.snap
+++ b/packages/openclaw-plugin/tests/__snapshots__/schema-snapshots.test.ts.snap
@@ -108,10 +108,35 @@ exports[`Schema Snapshots > Manifest configSchema > configSchema should match sn
       "type": "number",
     },
     "namespace": {
-      "description": "Default namespace for data scoping (e.g., 'personal', 'team-alpha')",
-      "maxLength": 63,
-      "pattern": "^[a-z0-9][a-z0-9._-]*$",
-      "type": "string",
+      "description": "Namespace configuration for data scoping",
+      "oneOf": [
+        {
+          "properties": {
+            "default": {
+              "description": "Namespace for store/create when none specified",
+              "maxLength": 63,
+              "pattern": "^[a-z0-9][a-z0-9._-]*$",
+              "type": "string",
+            },
+            "recall": {
+              "description": "Namespaces to search when none specified",
+              "items": {
+                "maxLength": 63,
+                "pattern": "^[a-z0-9][a-z0-9._-]*$",
+                "type": "string",
+              },
+              "type": "array",
+            },
+          },
+          "type": "object",
+        },
+        {
+          "description": "Shorthand: string treated as { default: value }",
+          "maxLength": 63,
+          "pattern": "^[a-z0-9][a-z0-9._-]*$",
+          "type": "string",
+        },
+      ],
     },
     "nominatimUrl": {
       "description": "Nominatim reverse geocoding URL (e.g., http://nominatim:8080)",
@@ -200,7 +225,7 @@ exports[`Schema Snapshots > Manifest configSchema > configSchema should match sn
     },
     "userScoping": {
       "default": "agent",
-      "description": "How to scope user memories",
+      "description": "@deprecated — replaced by namespace config. Kept for backward compatibility.",
       "enum": [
         "agent",
         "identity",
@@ -290,9 +315,8 @@ exports[`Schema Snapshots > Manifest configSchema > manifest uiHints should matc
   },
   "namespace": {
     "group": "Advanced",
-    "help": "Default namespace for data scoping. All data operations will be scoped to this namespace.",
+    "help": "Namespace config for data scoping. Can be a string (shorthand for default) or { default, recall[] }.",
     "label": "Namespace",
-    "placeholder": "default",
   },
   "nominatimUrl": {
     "group": "Advanced",
@@ -384,8 +408,8 @@ exports[`Schema Snapshots > Manifest configSchema > manifest uiHints should matc
   },
   "userScoping": {
     "group": "Memory",
-    "help": "How to isolate memories between users",
-    "label": "User Scoping",
+    "help": "Deprecated — replaced by namespace config",
+    "label": "User Scoping (deprecated)",
   },
 }
 `;

--- a/packages/openclaw-plugin/tests/config.test.ts
+++ b/packages/openclaw-plugin/tests/config.test.ts
@@ -115,12 +115,12 @@ describe('Config Schema', () => {
       expect(config.autoCapture).toBe(true);
     });
 
-    it('should set userScoping to "agent" by default', () => {
+    it('should leave userScoping undefined by default (deprecated, Issue #1428)', () => {
       const config = validateConfig({
         apiUrl: 'https://example.com',
         apiKey: 'test-key',
       });
-      expect(config.userScoping).toBe('agent');
+      expect(config.userScoping).toBeUndefined();
     });
 
     it('should set maxRecallMemories to 5 by default', () => {

--- a/packages/openclaw-plugin/tests/integration.test.ts
+++ b/packages/openclaw-plugin/tests/integration.test.ts
@@ -175,7 +175,7 @@ describe('Integration Tests', () => {
 
       expect(instance.config.autoRecall).toBe(true);
       expect(instance.config.autoCapture).toBe(true);
-      expect(instance.config.userScoping).toBe('agent');
+      expect(instance.config.userScoping).toBeUndefined(); // deprecated (Issue #1428)
       expect(instance.config.maxRecallMemories).toBe(5);
       expect(instance.config.minRecallScore).toBe(0.7);
     });

--- a/packages/openclaw-plugin/tests/namespace.test.ts
+++ b/packages/openclaw-plugin/tests/namespace.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Tests for namespace configuration (Issue #1428).
+ *
+ * Validates:
+ * - Config schema accepts namespace as object or string
+ * - resolveNamespaceConfig applies fallback logic
+ * - Tool schemas include namespace/namespaces params
+ * - Tool handlers pass namespace to API calls
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  validateConfig,
+  safeValidateRawConfig,
+  resolveNamespaceConfig,
+  type PluginConfig,
+} from '../src/config.js';
+
+describe('Namespace Configuration (Issue #1428)', () => {
+  describe('resolveNamespaceConfig', () => {
+    it('should use explicit default and recall from config', () => {
+      const result = resolveNamespaceConfig(
+        { default: 'arthouse', recall: ['arthouse', 'shared'] },
+        'some-agent',
+      );
+      expect(result.default).toBe('arthouse');
+      expect(result.recall).toEqual(['arthouse', 'shared']);
+    });
+
+    it('should default recall to [default] when recall not specified', () => {
+      const result = resolveNamespaceConfig(
+        { default: 'arthouse' },
+        'some-agent',
+      );
+      expect(result.default).toBe('arthouse');
+      expect(result.recall).toEqual(['arthouse']);
+    });
+
+    it('should fall back to agent ID as namespace when no config', () => {
+      const result = resolveNamespaceConfig(undefined, 'arthouse');
+      expect(result.default).toBe('arthouse');
+      expect(result.recall).toEqual(['arthouse']);
+    });
+
+    it('should fall back to "default" when agent ID has invalid chars', () => {
+      const result = resolveNamespaceConfig(undefined, 'Agent With Spaces');
+      expect(result.default).toBe('default');
+      expect(result.recall).toEqual(['default']);
+    });
+
+    it('should fall back to "default" when agent ID starts with hyphen', () => {
+      const result = resolveNamespaceConfig(undefined, '-invalid');
+      expect(result.default).toBe('default');
+      expect(result.recall).toEqual(['default']);
+    });
+
+    it('should accept agent ID with dots, hyphens, underscores', () => {
+      const result = resolveNamespaceConfig(undefined, 'my-agent.v2_test');
+      expect(result.default).toBe('my-agent.v2_test');
+      expect(result.recall).toEqual(['my-agent.v2_test']);
+    });
+
+    it('should accept agent ID starting with digit', () => {
+      const result = resolveNamespaceConfig(undefined, '42agent');
+      expect(result.default).toBe('42agent');
+      expect(result.recall).toEqual(['42agent']);
+    });
+
+    it('should use explicit recall even when default is from agent ID fallback', () => {
+      const result = resolveNamespaceConfig(
+        { recall: ['ns1', 'ns2'] },
+        'arthouse',
+      );
+      // No explicit default, so falls back to agent ID
+      expect(result.default).toBe('arthouse');
+      expect(result.recall).toEqual(['ns1', 'ns2']);
+    });
+  });
+
+  describe('Config schema', () => {
+    it('should accept namespace as object with default and recall', () => {
+      const result = safeValidateRawConfig({
+        apiUrl: 'https://example.com',
+        apiKey: 'test-key',
+        namespace: {
+          default: 'arthouse',
+          recall: ['arthouse', 'shared'],
+        },
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.namespace).toEqual({
+          default: 'arthouse',
+          recall: ['arthouse', 'shared'],
+        });
+      }
+    });
+
+    it('should accept namespace as bare string (backward compat)', () => {
+      const result = safeValidateRawConfig({
+        apiUrl: 'https://example.com',
+        apiKey: 'test-key',
+        namespace: 'personal',
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        // String is transformed to { default: value }
+        expect(result.data.namespace).toEqual({ default: 'personal' });
+      }
+    });
+
+    it('should accept config without namespace (undefined)', () => {
+      const result = safeValidateRawConfig({
+        apiUrl: 'https://example.com',
+        apiKey: 'test-key',
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.namespace).toBeUndefined();
+      }
+    });
+
+    it('should reject invalid namespace pattern', () => {
+      const result = safeValidateRawConfig({
+        apiUrl: 'https://example.com',
+        apiKey: 'test-key',
+        namespace: 'UPPERCASE',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('should reject namespace with spaces', () => {
+      const result = safeValidateRawConfig({
+        apiUrl: 'https://example.com',
+        apiKey: 'test-key',
+        namespace: 'has spaces',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('should reject namespace object with invalid default pattern', () => {
+      const result = safeValidateRawConfig({
+        apiUrl: 'https://example.com',
+        apiKey: 'test-key',
+        namespace: { default: 'INVALID' },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('should reject namespace object with invalid recall entry', () => {
+      const result = safeValidateRawConfig({
+        apiUrl: 'https://example.com',
+        apiKey: 'test-key',
+        namespace: { default: 'valid', recall: ['also-valid', 'NOT VALID'] },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('should accept userScoping as optional (deprecated)', () => {
+      const result = safeValidateRawConfig({
+        apiUrl: 'https://example.com',
+        apiKey: 'test-key',
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.userScoping).toBeUndefined();
+      }
+    });
+
+    it('should still accept userScoping for backward compat', () => {
+      const result = safeValidateRawConfig({
+        apiUrl: 'https://example.com',
+        apiKey: 'test-key',
+        userScoping: 'session',
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.userScoping).toBe('session');
+      }
+    });
+  });
+
+  describe('Resolved config schema', () => {
+    it('should accept namespace object in resolved config', () => {
+      const config = validateConfig({
+        apiUrl: 'https://example.com',
+        apiKey: 'test-key',
+        namespace: { default: 'personal', recall: ['personal', 'shared'] },
+      });
+      expect(config.namespace).toEqual({
+        default: 'personal',
+        recall: ['personal', 'shared'],
+      });
+    });
+
+    it('should accept undefined namespace in resolved config', () => {
+      const config = validateConfig({
+        apiUrl: 'https://example.com',
+        apiKey: 'test-key',
+      });
+      expect(config.namespace).toBeUndefined();
+    });
+
+    it('should make userScoping optional in resolved config', () => {
+      const config = validateConfig({
+        apiUrl: 'https://example.com',
+        apiKey: 'test-key',
+      });
+      expect(config.userScoping).toBeUndefined();
+    });
+  });
+});
+
+describe('Tool schema namespace properties', () => {
+  // Import the schemas export from register-openclaw
+  // We can't directly test the internal schemas, but we can test via the
+  // exported schemas object
+  it('should export schemas with namespace/namespaces properties', async () => {
+    const { schemas } = await import('../src/register-openclaw.js');
+    // memory_recall should have namespaces (query tool)
+    expect(schemas.memoryRecall.properties?.namespaces).toBeDefined();
+    expect(schemas.memoryRecall.properties?.namespaces?.type).toBe('array');
+
+    // memory_store should have namespace (store tool)
+    expect(schemas.memoryStore.properties?.namespace).toBeDefined();
+    expect(schemas.memoryStore.properties?.namespace?.type).toBe('string');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1428

Replaces header-based namespace scoping with per-tool namespace parameters in the OpenClaw gateway plugin. Each tool now accepts an optional `namespace` (for store/create operations) or `namespaces` (for recall/list operations) parameter, falling back to the agent's configured defaults.

### Key changes:

- **Config schema**: `namespace` field now accepts either an object `{default, recall}` or a bare string (backward compat). Added `resolveNamespaceConfig()` for fallback logic (agent ID as namespace if valid pattern, else `'default'`).
- **API client**: Removed `X-Namespace` header injection — namespace now passed as body/query param by individual tool handlers.
- **Tool schemas**: Added `namespace`/`namespaces` optional params to all tools via `withNamespace()`/`withNamespaces()` JSON schema wrappers.
- **Tool handlers**: Updated all handlers with `getStoreNamespace()`/`getRecallNamespaces()` helpers that read params or fall back to resolved config.
- **Backward compat**: `userScoping` config field deprecated but still accepted (now optional). Bare string `namespace: "foo"` transforms to `{default: "foo"}`.

### Test results:

- 1582 passed, 107 skipped, 2 failed (pre-existing on `main` — `tool-registration.test.ts` expects 33 tools but 44 are registered)
- 21 new namespace-specific tests in `namespace.test.ts`
- Lint and TypeScript type check pass clean

## Test plan

- [x] `namespace.test.ts` — 21 tests for config resolution, schema validation, tool schema properties
- [x] `config.test.ts` — 81 tests pass (updated deprecated `userScoping` default assertion)
- [x] `integration.test.ts` — updated `userScoping` assertion for deprecation
- [x] `register-openclaw.test.ts` — all pass with namespace-enriched schemas
- [x] `schema-snapshots.test.ts` — snapshots regenerated with new namespace/manifest changes
- [x] Full suite: 1582/1691 pass (2 pre-existing failures on `main`)
- [x] Lint clean
- [x] TypeScript type check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)