### PR TITLE
[#1481] Phase 4 cleanup: drop user_email columns, deprecate sharing tables

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@troykelly/openclaw-projects-server",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "private": true,
   "description": "Postgres-backed project + task management system",
   "type": "module",

--- a/packages/openclaw-plugin/openclaw.plugin.json
+++ b/packages/openclaw-plugin/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "openclaw-projects",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "name": "OpenClaw Projects Plugin",
   "description": "Memory provider with projects, todos, and contacts integration",
   "kind": "memory",

--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@troykelly/openclaw-projects",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "OpenClaw memory plugin with projects, todos, and contacts integration",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/openclaw-plugin/tests/__snapshots__/schema-snapshots.test.ts.snap
+++ b/packages/openclaw-plugin/tests/__snapshots__/schema-snapshots.test.ts.snap
@@ -250,7 +250,7 @@ exports[`Schema Snapshots > Manifest configSchema > full manifest structure (exc
   "skills": [
     "skills",
   ],
-  "version": "0.0.18",
+  "version": "0.0.19",
 }
 `;
 

--- a/src/api/memory/service.ts
+++ b/src/api/memory/service.ts
@@ -488,11 +488,11 @@ export async function listMemories(pool: Pool, options: ListMemoriesOptions = {}
 }
 
 /**
- * Gets global memories for a user (no work_item_id, contact_id, or relationship_id).
+ * Gets global memories (no work_item_id, contact_id, or relationship_id).
+ * Epic #1418 Phase 4: namespace-based scoping (user_email parameter removed).
  */
 export async function getGlobalMemories(
   pool: Pool,
-  _user_email: string,
   options: { memory_type?: MemoryType; limit?: number; offset?: number; queryNamespaces?: string[] } = {},
 ): Promise<ListMemoriesResult> {
   const conditions: string[] = [

--- a/src/api/memory/types.ts
+++ b/src/api/memory/types.ts
@@ -14,8 +14,6 @@ export type MemoryType = 'preference' | 'fact' | 'note' | 'decision' | 'context'
 
 /** Memory scoping options */
 export interface MemoryScope {
-  /** User email for global scope */
-  user_email?: string;
   /** Work item ID for work item scope */
   work_item_id?: string;
   /** Contact ID for contact scope */
@@ -130,7 +128,7 @@ export interface ListMemoriesOptions extends MemoryScope {
   created_before?: Date;
   limit?: number;
   offset?: number;
-  /** Epic #1418: namespace scoping (preferred over user_email) */
+  /** Epic #1418: namespace scoping */
   queryNamespaces?: string[];
 }
 
@@ -159,6 +157,6 @@ export interface SearchMemoriesOptions extends MemoryScope {
   limit?: number;
   offset?: number;
   min_similarity?: number;
-  /** Epic #1418: namespace scoping (preferred over user_email) */
+  /** Epic #1418: namespace scoping */
   queryNamespaces?: string[];
 }

--- a/src/api/notes/types.ts
+++ b/src/api/notes/types.ts
@@ -15,8 +15,6 @@ export type EmbeddingStatus = 'pending' | 'complete' | 'failed' | 'skipped';
 export interface Note {
   id: string;
   notebook_id: string | null;
-  /** @deprecated user_email column dropped from note table in Phase 4 (Epic #1418) */
-  user_email?: string;
   title: string;
   content: string;
   summary: string | null;
@@ -71,7 +69,7 @@ export interface ListNotesOptions {
   offset?: number;
   sort_by?: 'created_at' | 'updated_at' | 'title';
   sort_order?: 'asc' | 'desc';
-  /** Epic #1418: namespace scoping (preferred over user_email) */
+  /** Epic #1418: namespace scoping */
   queryNamespaces?: string[];
 }
 

--- a/tests/memory/service.test.ts
+++ b/tests/memory/service.test.ts
@@ -49,9 +49,8 @@ describe('Memory Service', () => {
   });
 
   describe('createMemory', () => {
-    it('creates a global memory with user email only', async () => {
+    it('creates a global memory', async () => {
       const memory = await createMemory(pool, {
-        user_email: 'test@example.com',
         title: 'Test preference',
         content: 'User prefers dark mode',
         memory_type: 'preference',
@@ -78,7 +77,6 @@ describe('Memory Service', () => {
       const work_item_id = (workItemResult.rows[0] as { id: string }).id;
 
       const memory = await createMemory(pool, {
-        user_email: 'test@example.com',
         work_item_id,
         title: 'Tech decision',
         content: 'Chose PostgreSQL for ACID compliance',
@@ -99,7 +97,6 @@ describe('Memory Service', () => {
       const contact_id = (contactResult.rows[0] as { id: string }).id;
 
       const memory = await createMemory(pool, {
-        user_email: 'test@example.com',
         contact_id,
         title: 'Contact preference',
         content: 'John prefers email communication',
@@ -112,7 +109,6 @@ describe('Memory Service', () => {
 
     it('creates a memory with full attribution', async () => {
       const memory = await createMemory(pool, {
-        user_email: 'test@example.com',
         title: 'Agent note',
         content: 'User mentioned they like pizza',
         memory_type: 'fact',
@@ -127,7 +123,6 @@ describe('Memory Service', () => {
 
     it('creates a memory with custom importance and confidence', async () => {
       const memory = await createMemory(pool, {
-        user_email: 'test@example.com',
         title: 'Important fact',
         content: 'User is allergic to peanuts',
         memory_type: 'fact',
@@ -143,7 +138,6 @@ describe('Memory Service', () => {
       const expires_at = new Date(Date.now() + 3600000); // 1 hour from now
 
       const memory = await createMemory(pool, {
-        user_email: 'test@example.com',
         title: 'Temporary context',
         content: 'Currently in a meeting',
         memory_type: 'context',
@@ -157,7 +151,6 @@ describe('Memory Service', () => {
     it('throws on invalid memory type', async () => {
       await expect(
         createMemory(pool, {
-          user_email: 'test@example.com',
           title: 'Test',
           content: 'Test',
           memory_type: 'invalid' as any,
@@ -167,7 +160,6 @@ describe('Memory Service', () => {
 
     it('normalizes 0-1 float importance to 1-10 integer scale', async () => {
       const memory = await createMemory(pool, {
-        user_email: 'test@example.com',
         title: 'Float importance test',
         content: 'Testing 0.7 importance',
         memory_type: 'fact',
@@ -179,7 +171,6 @@ describe('Memory Service', () => {
 
     it('normalizes importance 0.0 to 1', async () => {
       const memory = await createMemory(pool, {
-        user_email: 'test@example.com',
         title: 'Min importance',
         content: 'Testing 0.0 importance',
         memory_type: 'fact',
@@ -191,7 +182,6 @@ describe('Memory Service', () => {
 
     it('normalizes importance 1.0 to 10', async () => {
       const memory = await createMemory(pool, {
-        user_email: 'test@example.com',
         title: 'Max importance',
         content: 'Testing 1.0 importance',
         memory_type: 'fact',
@@ -203,7 +193,6 @@ describe('Memory Service', () => {
 
     it('passes through 1-10 integer importance unchanged', async () => {
       const memory = await createMemory(pool, {
-        user_email: 'test@example.com',
         title: 'Integer importance',
         content: 'Testing integer 8',
         memory_type: 'fact',
@@ -216,7 +205,6 @@ describe('Memory Service', () => {
     it('rejects importance outside valid ranges', async () => {
       await expect(
         createMemory(pool, {
-          user_email: 'test@example.com',
           title: 'Bad importance',
           content: 'Testing invalid importance',
           memory_type: 'fact',
@@ -226,7 +214,6 @@ describe('Memory Service', () => {
 
       await expect(
         createMemory(pool, {
-          user_email: 'test@example.com',
           title: 'Bad importance',
           content: 'Testing negative importance',
           memory_type: 'fact',
@@ -239,7 +226,6 @@ describe('Memory Service', () => {
   describe('getMemory', () => {
     it('returns a memory by ID', async () => {
       const created = await createMemory(pool, {
-        user_email: 'test@example.com',
         title: 'Test memory',
         content: 'Test content',
       });
@@ -260,7 +246,6 @@ describe('Memory Service', () => {
   describe('updateMemory', () => {
     it('updates memory title and content', async () => {
       const created = await createMemory(pool, {
-        user_email: 'test@example.com',
         title: 'Original title',
         content: 'Original content',
       });
@@ -277,7 +262,6 @@ describe('Memory Service', () => {
 
     it('updates memory type', async () => {
       const created = await createMemory(pool, {
-        user_email: 'test@example.com',
         title: 'Test',
         content: 'Test',
         memory_type: 'note',
@@ -292,7 +276,6 @@ describe('Memory Service', () => {
 
     it('updates importance and confidence', async () => {
       const created = await createMemory(pool, {
-        user_email: 'test@example.com',
         title: 'Test',
         content: 'Test',
       });
@@ -315,7 +298,6 @@ describe('Memory Service', () => {
 
     it('throws on invalid importance', async () => {
       const created = await createMemory(pool, {
-        user_email: 'test@example.com',
         title: 'Test',
         content: 'Test',
       });
@@ -325,7 +307,6 @@ describe('Memory Service', () => {
 
     it('throws on invalid confidence', async () => {
       const created = await createMemory(pool, {
-        user_email: 'test@example.com',
         title: 'Test',
         content: 'Test',
       });
@@ -337,7 +318,6 @@ describe('Memory Service', () => {
   describe('deleteMemory', () => {
     it('deletes a memory', async () => {
       const created = await createMemory(pool, {
-        user_email: 'test@example.com',
         title: 'To be deleted',
         content: 'Test',
       });
@@ -388,7 +368,6 @@ describe('Memory Service', () => {
 
     it('excludes expired memories by default', async () => {
       await createMemory(pool, {
-        user_email: 'test@example.com',
         title: 'Active',
         content: 'Not expired',
       });
@@ -433,10 +412,9 @@ describe('Memory Service', () => {
   });
 
   describe('getGlobalMemories', () => {
-    it('returns only global memories for a user', async () => {
+    it('returns only global memories (namespace-scoped)', async () => {
       // Global memory (no work_item_id or contact_id)
       await createMemory(pool, {
-        user_email: 'test@example.com',
         title: 'Global preference',
         content: 'Dark mode',
         memory_type: 'preference',
@@ -449,13 +427,12 @@ describe('Memory Service', () => {
          RETURNING id::text as id`,
       );
       await createMemory(pool, {
-        user_email: 'test@example.com',
         work_item_id: (workItemResult.rows[0] as { id: string }).id,
         title: 'Work item memory',
         content: 'Scoped to work item',
       });
 
-      const result = await getGlobalMemories(pool, 'test@example.com');
+      const result = await getGlobalMemories(pool);
 
       expect(result.memories.length).toBe(1);
       expect(result.memories[0].title).toBe('Global preference');
@@ -465,14 +442,12 @@ describe('Memory Service', () => {
   describe('supersedeMemory', () => {
     it('creates new memory and marks old as superseded', async () => {
       const oldMemory = await createMemory(pool, {
-        user_email: 'test@example.com',
         title: 'Old fact',
         content: 'Outdated information',
         memory_type: 'fact',
       });
 
       const newMemory = await supersedeMemory(pool, oldMemory.id, {
-        user_email: 'test@example.com',
         title: 'New fact',
         content: 'Updated information',
         memory_type: 'fact',
@@ -490,7 +465,6 @@ describe('Memory Service', () => {
     it('deletes expired memories', async () => {
       // Create active memory
       await createMemory(pool, {
-        user_email: 'test@example.com',
         title: 'Active',
         content: 'Still valid',
       });
@@ -516,14 +490,12 @@ describe('Memory Service', () => {
     it('searches memories using semantic search when embeddings configured', async () => {
       // Create memories with embeddings populated
       const memory = await createMemory(pool, {
-        user_email: 'test@example.com',
         title: 'Pizza preference',
         content: 'User loves pepperoni pizza',
         memory_type: 'preference',
       });
 
       await createMemory(pool, {
-        user_email: 'test@example.com',
         title: 'Coffee preference',
         content: 'User drinks black coffee',
         memory_type: 'preference',
@@ -544,7 +516,6 @@ describe('Memory Service', () => {
     it('falls back to text search when no embeddings match', async () => {
       // Create memories without populating embeddings
       await createMemory(pool, {
-        user_email: 'test@example.com',
         title: 'Pizza preference',
         content: 'User loves pepperoni pizza',
         memory_type: 'preference',
@@ -561,14 +532,12 @@ describe('Memory Service', () => {
 
     it('filters search by memory type', async () => {
       const pref = await createMemory(pool, {
-        user_email: 'test@example.com',
         title: 'Pizza preference',
         content: 'User loves pizza',
         memory_type: 'preference',
       });
 
       const fact = await createMemory(pool, {
-        user_email: 'test@example.com',
         title: 'Pizza fact',
         content: 'Pizza originated in Italy',
         memory_type: 'fact',

--- a/tests/memory_project_scope.test.ts
+++ b/tests/memory_project_scope.test.ts
@@ -91,7 +91,6 @@ describe('Memory Project Scope (Issue #1273)', () => {
       const project_id = await createTestProject();
 
       const memory = await createMemory(pool, {
-        user_email: 'test@example.com',
         title: 'Deployment config',
         content: 'Uses Docker Compose for staging',
         memory_type: 'fact',
@@ -118,7 +117,6 @@ describe('Memory Project Scope (Issue #1273)', () => {
 
     it('creates a memory without project_id (backward compatible)', async () => {
       const memory = await createMemory(pool, {
-        user_email: 'test@example.com',
         title: 'Global note',
         content: 'No project scope',
       });
@@ -175,13 +173,11 @@ describe('Memory Project Scope (Issue #1273)', () => {
       const unscoped = await createMemory(pool, {
         title: 'Global memory',
         content: 'Same text in both scopes',
-        user_email: 'test@example.com',
       });
 
       const scoped = await createMemory(pool, {
         title: 'Project memory',
         content: 'Same text in both scopes',
-        user_email: 'test@example.com',
         project_id,
       });
 
@@ -238,14 +234,12 @@ describe('Memory Project Scope (Issue #1273)', () => {
       const project_id = await createTestProject();
 
       await createMemory(pool, {
-        user_email: 'user@example.com',
         title: 'Project preference',
         content: 'Use TypeScript strict mode',
         memory_type: 'preference',
         project_id,
       });
       await createMemory(pool, {
-        user_email: 'user@example.com',
         title: 'Project fact',
         content: 'Uses Fastify framework',
         memory_type: 'fact',
@@ -269,13 +263,11 @@ describe('Memory Project Scope (Issue #1273)', () => {
       const project_id = await createTestProject();
 
       await createMemory(pool, {
-        user_email: 'user@example.com',
         title: 'Global preference',
         content: 'Prefers dark mode',
         memory_type: 'preference',
       });
       await createMemory(pool, {
-        user_email: 'user@example.com',
         title: 'Project-scoped preference',
         content: 'Prefers tabs over spaces',
         memory_type: 'preference',
@@ -368,7 +360,6 @@ describe('Memory Project Scope (Issue #1273)', () => {
           title: 'API project memory',
           content: 'Created via API with project scope',
           memory_type: 'fact',
-          user_email: 'test@example.com',
           project_id: project_id,
         },
       });
@@ -386,7 +377,6 @@ describe('Memory Project Scope (Issue #1273)', () => {
           title: 'No project scope',
           content: 'Backward compatible',
           memory_type: 'note',
-          user_email: 'test@example.com',
         },
       });
 

--- a/tests/memory_relationship_scope.test.ts
+++ b/tests/memory_relationship_scope.test.ts
@@ -130,7 +130,6 @@ describe('Memory Relationship Scope (Issue #493)', () => {
       const { relationship_id } = await createTestRelationship();
 
       const memory = await createMemory(pool, {
-        user_email: 'test@example.com',
         title: 'Anniversary date',
         content: 'Troy and Alex anniversary is March 15',
         memory_type: 'fact',
@@ -157,7 +156,6 @@ describe('Memory Relationship Scope (Issue #493)', () => {
 
     it('creates a memory without relationship_id (backward compatible)', async () => {
       const memory = await createMemory(pool, {
-        user_email: 'test@example.com',
         title: 'Simple note',
         content: 'No relationship scope',
       });
@@ -227,14 +225,12 @@ describe('Memory Relationship Scope (Issue #493)', () => {
       const { relationship_id } = await createTestRelationship();
 
       await createMemory(pool, {
-        user_email: 'user1@example.com',
         title: 'Preference about relationship',
         content: 'Prefers weekly catch-ups',
         memory_type: 'preference',
         relationship_id,
       });
       await createMemory(pool, {
-        user_email: 'user1@example.com',
         title: 'Fact about relationship',
         content: 'Met in 2020',
         memory_type: 'fact',
@@ -332,7 +328,6 @@ describe('Memory Relationship Scope (Issue #493)', () => {
           title: 'API relationship memory',
           content: 'Created via API with relationship scope',
           memory_type: 'fact',
-          user_email: 'test@example.com',
           relationship_id: relationship_id,
         },
       });
@@ -350,7 +345,6 @@ describe('Memory Relationship Scope (Issue #493)', () => {
           title: 'No relationship scope',
           content: 'Backward compatible',
           memory_type: 'note',
-          user_email: 'test@example.com',
         },
       });
 

--- a/tests/memory_tags.test.ts
+++ b/tests/memory_tags.test.ts
@@ -68,7 +68,6 @@ describe('Memory Tags (Issue #492)', () => {
   describe('createMemory with tags', () => {
     it('creates a memory with tags', async () => {
       const memory = await createMemory(pool, {
-        user_email: 'test@example.com',
         title: 'Music preference',
         content: 'User likes lo-fi beats while working',
         memory_type: 'preference',
@@ -80,7 +79,6 @@ describe('Memory Tags (Issue #492)', () => {
 
     it('creates a memory with empty tags', async () => {
       const memory = await createMemory(pool, {
-        user_email: 'test@example.com',
         title: 'Simple note',
         content: 'A memory without tags',
       });
@@ -90,7 +88,6 @@ describe('Memory Tags (Issue #492)', () => {
 
     it('creates a memory without specifying tags (defaults to empty array)', async () => {
       const memory = await createMemory(pool, {
-        user_email: 'test@example.com',
         title: 'Default tags test',
         content: 'Tags should default to empty array',
       });
@@ -104,7 +101,6 @@ describe('Memory Tags (Issue #492)', () => {
   describe('getMemory returns tags', () => {
     it('returns tags when retrieving a memory', async () => {
       const created = await createMemory(pool, {
-        user_email: 'test@example.com',
         title: 'Tagged memory',
         content: 'Has tags',
         tags: ['important', 'food'],
@@ -121,7 +117,6 @@ describe('Memory Tags (Issue #492)', () => {
   describe('updateMemory with tags', () => {
     it('updates tags on an existing memory', async () => {
       const created = await createMemory(pool, {
-        user_email: 'test@example.com',
         title: 'Updatable',
         content: 'Will update tags',
         tags: ['original'],
@@ -136,7 +131,6 @@ describe('Memory Tags (Issue #492)', () => {
 
     it('clears tags by setting empty array', async () => {
       const created = await createMemory(pool, {
-        user_email: 'test@example.com',
         title: 'Tags to clear',
         content: 'Will clear tags',
         tags: ['a', 'b', 'c'],
@@ -155,13 +149,11 @@ describe('Memory Tags (Issue #492)', () => {
   describe('listMemories tag filtering', () => {
     it('filters memories by a single tag', async () => {
       await createMemory(pool, {
-        user_email: 'test@example.com',
         title: 'Music pref',
         content: 'Likes jazz',
         tags: ['music', 'jazz'],
       });
       await createMemory(pool, {
-        user_email: 'test@example.com',
         title: 'Food pref',
         content: 'Likes sushi',
         tags: ['food', 'sushi'],
@@ -175,13 +167,11 @@ describe('Memory Tags (Issue #492)', () => {
 
     it('filters memories by multiple tags (AND semantics - contains all)', async () => {
       await createMemory(pool, {
-        user_email: 'test@example.com',
         title: 'Jazz at work',
         content: 'Likes jazz while coding',
         tags: ['music', 'work', 'jazz'],
       });
       await createMemory(pool, {
-        user_email: 'test@example.com',
         title: 'Rock at gym',
         content: 'Likes rock at the gym',
         tags: ['music', 'exercise', 'rock'],
@@ -228,14 +218,12 @@ describe('Memory Tags (Issue #492)', () => {
   describe('searchMemories with tag filtering', () => {
     it('combines tag filter with text search', async () => {
       await createMemory(pool, {
-        user_email: 'test@example.com',
         title: 'Piano music preference',
         content: 'User loves piano music for focus work',
         memory_type: 'preference',
         tags: ['music', 'focus'],
       });
       await createMemory(pool, {
-        user_email: 'test@example.com',
         title: 'Coffee preference',
         content: 'User drinks black coffee for focus',
         memory_type: 'preference',
@@ -256,7 +244,6 @@ describe('Memory Tags (Issue #492)', () => {
   describe('search_vector trigger', () => {
     it('includes tags in full-text search vector', async () => {
       const memory = await createMemory(pool, {
-        user_email: 'test@example.com',
         title: 'Simple note',
         content: 'A basic memory entry',
         tags: ['uniquetagname'],
@@ -285,7 +272,6 @@ describe('Memory Tags (Issue #492)', () => {
           title: 'Tagged via API',
           content: 'Testing tag support',
           memory_type: 'preference',
-          user_email: 'test@example.com',
           tags: ['api-test', 'music'],
         },
       });

--- a/tests/unified_memory_api.test.ts
+++ b/tests/unified_memory_api.test.ts
@@ -267,14 +267,14 @@ describe('Unified Memory API (Issue #209)', () => {
       expect(body.memories[0].title).toBe('Global');
     });
 
-    it('returns 400 when user_email is missing', async () => {
+    it('returns 200 without user_email (namespace scoping only)', async () => {
       const res = await app.inject({
         method: 'GET',
         url: '/api/memories/global',
       });
 
-      expect(res.statusCode).toBe(400);
-      expect(res.json().error).toContain('user_email');
+      // Epic #1418 Phase 4: user_email no longer required for memory routes
+      expect(res.statusCode).toBe(200);
     });
   });
 

--- a/tests/user_email_scoping.test.ts
+++ b/tests/user_email_scoping.test.ts
@@ -6,13 +6,13 @@ import { buildServer } from '../src/api/server.ts';
 
 /**
  * Tests for namespace-based scoping on work_item, contact, and relationship tables.
- * Epic #1418 replaced user_email scoping (Issue #1172) with namespace scoping.
+ * Epic #1418 Phase 4: user_email columns dropped, namespace is the sole scoping mechanism.
  *
  * Verifies:
  * 1. Items created via API are assigned a namespace (defaults to 'default')
- * 2. user_email query params are accepted but do NOT affect scoping
+ * 2. user_email columns no longer exist in entity tables
  * 3. All items in the same namespace are visible to all queries in that namespace
- * 4. CRUD operations work regardless of user_email params
+ * 4. CRUD operations work with namespace-only scoping
  */
 describe('Namespace scoping (Epic #1418, replaces user_email scoping #1172)', () => {
   const app = buildServer();


### PR DESCRIPTION
## Summary

Closes #1481

Epic #1418 Phase 4 cleanup: removes `user_email` from the API contract for entity routes where namespace is now the sole scoping mechanism.

- Removed `user_email` from ~50 entity route query/body type declarations in `server.ts`
- Removed `user_email` from `MemoryScope` interface and `getGlobalMemories()` function signature
- Removed deprecated `user_email` field from `Note` interface (column dropped in migration 091)
- Updated memory and scoping tests to remove `user_email` parameters
- Bumped version 0.0.18 -> 0.0.19

### What was kept
`user_email` is retained in routes where it serves **identity/attribution** (not data scoping):
- Notification routes (user-specific delivery)
- Comment/reaction routes (author identity)
- Presence routes (who is viewing/editing)
- Note/notebook routes (access control via `user_can_access_note()`)
- OAuth, calendar, geo, webhook, dev session routes

### Migration 091
The database migration (`091_drop_user_email_scoping.up.sql`) already exists and handles:
- Dropping `user_email` columns from 14 entity tables
- Recreating views without `user_email`
- Updating `user_can_access_note()` to use `namespace_grant`
- Adding deprecation comments on sharing tables

## Test plan
- [x] Memory service tests pass (34 tests)
- [x] Namespace scoping tests pass (15 tests)
- [x] Unified memory API tests pass (17 tests)
- [x] Memory tags, relationship scope, project scope tests pass (100+ tests)
- [x] Entity links and skill store tests pass
- [x] TypeScript compilation clean (no new errors)
- [x] Lint clean (no new errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)