### PR TITLE
[#1525] Remove deprecated user_email from entity scoping types

### DIFF
--- a/src/api/embeddings/memory-integration.ts
+++ b/src/api/embeddings/memory-integration.ts
@@ -135,8 +135,6 @@ export async function searchMemoriesSemantic(
     contact_id?: string;
     relationship_id?: string;
     project_id?: string;
-    /** @deprecated user_email column dropped from memory table in Phase 4 (Epic #1418) */
-    user_email?: string;
     tags?: string[];
     created_after?: Date;
     created_before?: Date;
@@ -201,9 +199,6 @@ export async function searchMemoriesSemantic(
     params.push(project_id);
     paramIndex++;
   }
-
-  // Epic #1418 Phase 4: user_email column dropped from memory table.
-  // Namespace scoping is handled at the route level.
 
   if (tags && tags.length > 0) {
     conditions.push(`m.tags @> $${paramIndex}`);

--- a/src/api/notebooks/types.ts
+++ b/src/api/notebooks/types.ts
@@ -8,8 +8,6 @@
 /** A notebook from the database */
 export interface Notebook {
   id: string;
-  /** @deprecated user_email column dropped from notebook table in Phase 4 (Epic #1418) */
-  user_email?: string;
   name: string;
   description: string | null;
   icon: string | null;

--- a/src/api/relationships/types.ts
+++ b/src/api/relationships/types.ts
@@ -62,8 +62,6 @@ export interface CreateRelationshipInput {
   notes?: string;
   /** Agent that created this relationship */
   created_by_agent?: string;
-  /** @deprecated user_email column dropped from relationship table in Phase 4 (Epic #1418) */
-  user_email?: string;
   /** Namespace for data partitioning (Epic #1418) */
   namespace?: string;
 }
@@ -92,8 +90,6 @@ export interface ListRelationshipsOptions {
   limit?: number;
   /** Offset for pagination */
   offset?: number;
-  /** @deprecated user_email column dropped from relationship table in Phase 4 (Epic #1418) */
-  user_email?: string;
   /** Filter by namespaces (Epic #1418) */
   queryNamespaces?: string[];
 }
@@ -156,8 +152,6 @@ export interface RelationshipSetInput {
   notes?: string;
   /** Agent performing the operation */
   created_by_agent?: string;
-  /** User email for scoping (Issue #1172) */
-  user_email?: string;
   /** Namespace for data partitioning (Epic #1418) */
   namespace?: string;
 }

--- a/src/api/search/hybrid.ts
+++ b/src/api/search/hybrid.ts
@@ -15,8 +15,6 @@ import type { MemoryEntry, MemoryType } from '../memory/types.ts';
 
 /** Options for hybrid search */
 export interface HybridSearchOptions {
-  /** @deprecated user_email column dropped from memory table in Phase 4 (Epic #1418) */
-  user_email?: string;
   /** Work item ID to filter by */
   work_item_id?: string;
   /** Contact ID to filter by */
@@ -129,8 +127,6 @@ function buildFilterConditions(options: HybridSearchOptions, startIdx: number): 
   const params: unknown[] = [];
   let idx = startIdx;
 
-  // Epic #1418 Phase 4: user_email column dropped from memory table.
-  // Namespace scoping is handled at the route level.
   if (options.work_item_id !== undefined) {
     conditions.push(`work_item_id = $${idx}`);
     params.push(options.work_item_id);

--- a/src/api/search/types.ts
+++ b/src/api/search/types.ts
@@ -16,8 +16,6 @@ export interface SearchOptions {
   date_from?: Date;
   date_to?: Date;
   semantic_weight?: number; // 0-1, weight for semantic vs text search in hybrid mode
-  /** @deprecated user_email column dropped from work_item table in Phase 4 (Epic #1418) */
-  user_email?: string;
   /** Epic #1418: namespace scoping for entity queries */
   queryNamespaces?: string[];
 }

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -677,13 +677,11 @@ export function buildServer(options: ProjectsApiOptions = {}): FastifyInstance {
     const q = req.query as Record<string, unknown> | undefined;
     if (q) {
       if ('user_email' in q) q.user_email = bound;
-      if ('user_email' in q) q.user_email = bound;
     }
 
     // Override body fields
     const b = req.body as Record<string, unknown> | undefined | null;
     if (b && typeof b === 'object') {
-      if ('user_email' in b) b.user_email = bound;
       if ('user_email' in b) b.user_email = bound;
 
       // Handle arrays that may contain per-element user_email
@@ -15654,7 +15652,6 @@ export function buildServer(options: ProjectsApiOptions = {}): FastifyInstance {
         collection?: string;
         tags?: string[];
         status?: string;
-        user_email?: string;
         limit?: number;
         offset?: number;
       };
@@ -15679,7 +15676,7 @@ export function buildServer(options: ProjectsApiOptions = {}): FastifyInstance {
           collection: body.collection,
           tags: body.tags,
           status: body.status,
-          user_email: body.user_email,
+          namespace: getStoreNamespace(req),
           limit,
           offset,
         });
@@ -15717,7 +15714,6 @@ export function buildServer(options: ProjectsApiOptions = {}): FastifyInstance {
         collection?: string;
         tags?: string[];
         status?: string;
-        user_email?: string;
         min_similarity?: number;
         limit?: number;
         offset?: number;
@@ -15749,7 +15745,7 @@ export function buildServer(options: ProjectsApiOptions = {}): FastifyInstance {
             collection: body.collection,
             tags: body.tags,
             status: body.status,
-            user_email: body.user_email,
+            namespace: getStoreNamespace(req),
             min_similarity: body.min_similarity ?? 0.3,
             limit,
             semantic_weight: semantic_weight,
@@ -15768,7 +15764,7 @@ export function buildServer(options: ProjectsApiOptions = {}): FastifyInstance {
           collection: body.collection,
           tags: body.tags,
           status: body.status,
-          user_email: body.user_email,
+          namespace: getStoreNamespace(req),
           min_similarity: body.min_similarity ?? 0.3,
           limit,
           offset,

--- a/src/api/skill-store/aggregate.ts
+++ b/src/api/skill-store/aggregate.ts
@@ -16,8 +16,6 @@ export interface AggregateParams {
   collection?: string;
   since?: string;
   until?: string;
-  /** @deprecated user_email column dropped from skill_store_item table in Phase 4 (Epic #1418) */
-  user_email?: string;
   /** Epic #1418: namespace-based scoping */
   namespace?: string;
 }

--- a/src/api/skill-store/search.ts
+++ b/src/api/skill-store/search.ts
@@ -32,8 +32,6 @@ export interface SkillStoreSearchResult {
   tags: string[];
   status: string;
   priority: number;
-  /** @deprecated user_email column dropped from skill_store_item table in Phase 4 (Epic #1418) */
-  user_email?: string | null;
   /** Epic #1418: namespace scoping */
   namespace?: string;
   created_at: string;
@@ -64,8 +62,6 @@ export interface SkillStoreSearchParams {
   collection?: string;
   tags?: string[];
   status?: string;
-  /** @deprecated user_email column dropped from skill_store_item table in Phase 4 (Epic #1418) */
-  user_email?: string;
   /** Epic #1418: namespace-based scoping */
   namespace?: string;
   limit?: number;

--- a/src/api/threads/service.ts
+++ b/src/api/threads/service.ts
@@ -286,8 +286,6 @@ export async function listThreads(pool: Pool, options: ThreadListOptions = {}): 
     paramIndex++;
   }
 
-  // Epic #1418 Phase 4: user_email column dropped from external_thread table.
-  // Namespace scoping via queryNamespaces only.
   if (options.queryNamespaces && options.queryNamespaces.length > 0) {
     whereClauses.push(`et.namespace = ANY($${paramIndex}::text[])`);
     params.push(options.queryNamespaces as unknown as string);

--- a/src/api/threads/types.ts
+++ b/src/api/threads/types.ts
@@ -70,9 +70,7 @@ export interface ThreadListOptions {
   offset?: number;
   channel?: string;
   contact_id?: string;
-  /** @deprecated user_email column dropped from external_thread table in Phase 4 (Epic #1418) */
-  user_email?: string;
-  /** Epic #1418: namespace scoping (preferred over user_email) */
+  /** Epic #1418: namespace scoping */
   queryNamespaces?: string[];
 }
 


### PR DESCRIPTION
## Summary
- Remove deprecated `user_email` fields from entity scoping type interfaces (notebooks, relationships, search, skill-store, threads, embeddings)
- Remove dead `user_email` parameters from service function signatures
- Clean up principal binding hook duplicate line in server.ts
- Replace vacuous test with meaningful namespace-scoping assertion

Closes #1525

## Changes (13 files, -78/+19 lines)
- `src/api/notebooks/types.ts` — Remove `user_email` from `Notebook`
- `src/api/relationships/types.ts` — Remove from `CreateRelationshipInput`, `ListRelationshipsOptions`, `RelationshipSetInput`
- `src/api/relationships/service.ts` — Remove dead `user_email` params from `getRelatedContacts`, `resolveContact`
- `src/api/search/types.ts` — Remove from `SearchOptions`
- `src/api/search/service.ts` — Remove from search option objects
- `src/api/search/hybrid.ts` — Remove from `HybridSearchOptions`
- `src/api/skill-store/search.ts` — Remove from `SkillStoreSearchResult`, `SkillStoreSearchParams`
- `src/api/skill-store/aggregate.ts` — Remove from `AggregateParams`
- `src/api/threads/types.ts` — Remove from `ThreadListOptions`
- `src/api/threads/service.ts` — Remove stale comment
- `src/api/embeddings/memory-integration.ts` — Remove from `searchMemoriesSemantic` options
- `src/api/server.ts` — Remove duplicate user_email binding line, use namespace for skill-store
- `src/api/search/user-scoping.test.ts` — Replace vacuous tests with namespace-scoping assertion

## Attribution fields preserved (NOT removed)
- `work_item_comment.user_email`, `notification.user_email`, `user_presence.user_email`, OAuth, geo tables

## Test plan
- [x] TypeScript compilation clean (`tsc --noEmit` — zero new errors)
- [x] `pnpm test:changed` — 135 test files passed, 2184 tests passed
- [x] `pnpm run lint` — passed
- [x] Code review — no issues found

🤖 Generated with [Claude Code](https://claude.com/claude-code)