### PR TITLE
[#1542] Implement draft-then-undraft release pattern for partial failure resilience

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -593,12 +593,13 @@ jobs:
           | prompt-guard | \`docker pull ghcr.io/troykelly/openclaw-projects-prompt-guard:${RELEASE_VERSION}\` |
           BODYEOF
 
-      - name: Create GitHub Release
+      - name: Create GitHub Release (draft)
+        id: create_release
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2
         with:
           tag_name: ${{ needs.validate.outputs.tag }}
           name: v${{ needs.validate.outputs.version }}
-          draft: false
+          draft: true
           prerelease: ${{ needs.validate.outputs.prerelease == 'true' }}
           generate_release_notes: true
           body_path: release/RELEASE_BODY.md
@@ -608,3 +609,11 @@ jobs:
             release/docker-compose.quickstart.yml
             release/docker-compose.full.yml
             release/openclaw-projects-${{ needs.validate.outputs.version }}.tar.gz
+
+      - name: Undraft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.validate.outputs.tag }}
+        run: |
+          set -euo pipefail
+          gh release edit "${RELEASE_TAG}" --draft=false


### PR DESCRIPTION
## Summary

Implements the draft-then-undraft release pattern for the unified release workflow (#1538). This ensures that if any artifact upload fails during the GitHub Release creation step, the release remains as a draft rather than being published in an incomplete state.

Closes #1542

## Changes

### `.github/workflows/release.yml`
- Changed `softprops/action-gh-release` to create releases with `draft: true` (was `draft: false`)
- Added `id: create_release` to the release step for output referencing
- Added a new "Undraft release" step that runs `gh release edit --draft=false` after successful artifact upload
- The undraft step uses env vars for the tag (safe from injection) and only runs on success (default step condition)

### `tests/workflows/release.test.ts` (new)
- 26 tests validating the full release workflow structure
- Draft-then-undraft pattern tests verify:
  - Release is created with `draft: true`
  - SHA-pinned action reference is maintained
  - Release step has an `id` for output referencing
  - Undraft step exists after the release creation step
  - Undraft uses `gh release edit` (GitHub CLI)
  - Undraft references the release tag
  - Undraft does NOT run on `failure()` or `always()` (ensuring drafts stay on failure)

## Partial Failure Recovery

If the release step fails (e.g., artifact upload error):
1. The release stays as a **draft** on GitHub
2. The "Undraft release" step is skipped (default `if: success()` behavior)
3. Manual recovery: fix the issue, then either:
   - Re-run the failed workflow job
   - Manually upload missing artifacts and undraft via `gh release edit vX.Y.Z --draft=false`

## Test Results

```
tests/workflows/release.test.ts (26 tests) - all passing
```