### PR TITLE
[#1541] Create GitHub Environment with required reviewers for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -290,6 +290,7 @@ jobs:
     name: Publish to npm
     needs: [validate, test]
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: read
       id-token: write  # npm provenance
@@ -356,6 +357,7 @@ jobs:
     name: Publish to GitHub Packages
     needs: [validate, test]
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: read
       packages: write
@@ -398,6 +400,7 @@ jobs:
     name: Build ${{ matrix.image.name }}
     needs: [validate, test]
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: read
       packages: write

--- a/tests/workflows/release.test.ts
+++ b/tests/workflows/release.test.ts
@@ -283,6 +283,12 @@ describe('release.yml workflow', () => {
   });
 
   describe('publish jobs', () => {
+    it('should require release environment for all publish jobs', () => {
+      expect(workflow.jobs['publish-npm'].environment).toBe('release');
+      expect(workflow.jobs['publish-github-packages'].environment).toBe('release');
+      expect(workflow.jobs['publish-containers'].environment).toBe('release');
+    });
+
     it('should publish npm with provenance (id-token: write)', () => {
       expect(workflow.jobs['publish-npm'].permissions?.['id-token']).toBe('write');
     });


### PR DESCRIPTION
## Summary

- Created the `release` GitHub Environment with `troykelly` as a required reviewer
- Added `environment: release` to the `publish-npm`, `publish-github-packages`, and `publish-containers` jobs in `release.yml`
- Added tests verifying all three publish jobs use the `release` environment

This ensures that all publish steps in the release workflow require manual approval from a designated reviewer before artifacts are published to npm, GitHub Packages, or GHCR.

Closes #1541