### PR TITLE
[#1554] Add artifact overlay verification to publish jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,12 +100,14 @@ jobs:
           # Refuse to release from commits not on the protected main branch.
           # This prevents supply-chain attacks where a tag is pushed pointing
           # to an unreviewed commit (e.g., a feature branch or detached HEAD).
+          echo "Tag commit: ${TAG_COMMIT}"
+          echo "Main HEAD:  $(git rev-parse HEAD)"
           if ! git merge-base --is-ancestor "${TAG_COMMIT}" HEAD; then
-            echo "::error::Tag commit ${TAG_COMMIT} is not an ancestor of main. Refusing to release."
+            echo "::error::Tag commit ${TAG_COMMIT} is not an ancestor of main (HEAD=$(git rev-parse HEAD)). Refusing to release."
             echo "::error::Tags must point to commits that are on the main branch."
             exit 1
           fi
-          echo "Verified: tag commit ${TAG_COMMIT} is on main"
+          echo "Verified: tag commit ${TAG_COMMIT} is an ancestor of main HEAD"
 
       - name: Bump version in all package files
         env:
@@ -331,6 +333,19 @@ jobs:
         with:
           name: version-bumped-files
 
+      - name: Verify artifact overlay
+        env:
+          EXPECTED_VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          set -euo pipefail
+          EXPECTED="${EXPECTED_VERSION%%+*}"
+          ACTUAL=$(node -e "console.log(require('./packages/openclaw-plugin/package.json').version)")
+          if [ "${ACTUAL}" != "${EXPECTED}" ]; then
+            echo "::error::Artifact overlay failed: plugin package.json has version ${ACTUAL}, expected ${EXPECTED}"
+            exit 1
+          fi
+          echo "Artifact verified: plugin version is ${ACTUAL}"
+
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
@@ -402,6 +417,19 @@ jobs:
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: version-bumped-files
+
+      - name: Verify artifact overlay
+        env:
+          EXPECTED_VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          set -euo pipefail
+          EXPECTED="${EXPECTED_VERSION%%+*}"
+          ACTUAL=$(node -e "console.log(require('./packages/openclaw-plugin/package.json').version)")
+          if [ "${ACTUAL}" != "${EXPECTED}" ]; then
+            echo "::error::Artifact overlay failed: plugin package.json has version ${ACTUAL}, expected ${EXPECTED}"
+            exit 1
+          fi
+          echo "Artifact verified: plugin version is ${ACTUAL}"
 
       - name: Setup Node.js for GitHub Packages
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4


### PR DESCRIPTION
## Summary

- Add version verification step after artifact download in both publish jobs — asserts plugin `package.json` version matches `needs.validate.outputs.version`
- If artifact overlay failed (wrong paths, v4 behavior change, etc.), this catches it before publish with a clear error
- Add diagnostic output to tag provenance check (prints both tag commit SHA and main HEAD SHA)

## Context

Follow-up hardening for #1554 and #1556. These verification steps turn the two identified uncertainties into loud, safe failures instead of silent misbehavior.

## Test plan

- [ ] CI passes (the verification steps run against checked-out code where version already matches — they validate the mechanism works)
- [ ] On actual release, verification confirms artifact overlay succeeded before publish

Closes #1554

🤖 Generated with [Claude Code](https://claude.com/claude-code)