### PR TITLE
[#1559] Update snapshots in validate job after version bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,6 +144,15 @@ jobs:
           # Update lockfile to reflect new versions
           pnpm install --lockfile-only
 
+      - name: Update test snapshots for new version
+        run: |
+          set -euo pipefail
+          # Install dependencies so we can build and run snapshot tests.
+          # The lockfile was just updated by the bump step above.
+          pnpm install --frozen-lockfile
+          pnpm --filter @troykelly/openclaw-projects run build
+          pnpm exec vitest run packages/openclaw-plugin/tests/schema-snapshots.test.ts -u
+
       - name: Commit version bump to main
         env:
           RELEASE_VERSION: ${{ steps.version.outputs.version }}
@@ -165,6 +174,7 @@ jobs:
             package.json \
             packages/openclaw-plugin/package.json \
             packages/openclaw-plugin/openclaw.plugin.json \
+            packages/openclaw-plugin/tests/__snapshots__/schema-snapshots.test.ts.snap \
             pnpm-lock.yaml
 
           git commit -m "chore(release): v${FILE_VERSION} [skip ci]"
@@ -183,6 +193,7 @@ jobs:
             package.json
             packages/openclaw-plugin/package.json
             packages/openclaw-plugin/openclaw.plugin.json
+            packages/openclaw-plugin/tests/__snapshots__/schema-snapshots.test.ts.snap
             pnpm-lock.yaml
           if-no-files-found: error
           retention-days: 3


### PR DESCRIPTION
## Summary

- Adds a step in the `validate` job to build the plugin and update test snapshots after bumping version numbers
- Includes the snapshot file in the version bump commit pushed to main
- Includes the snapshot file in the artifact upload for publish jobs

Without this fix, publish jobs fail because the schema snapshot expects the old version but `openclaw.plugin.json` (overlaid by the artifact) has the new version.

Closes #1559

## Test plan

- [ ] CI passes on this PR (workflow YAML is valid)
- [ ] Push `v0.0.22` tag after merge to verify the full release pipeline succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)