### PR TITLE
[#1591] Fix Settings page TypeError crash on .length access

### DIFF
--- a/src/ui/components/settings/connected-accounts-section.tsx
+++ b/src/ui/components/settings/connected-accounts-section.tsx
@@ -116,7 +116,7 @@ function ConnectionEditForm({ connection, onSave, onCancel, isSaving }: Connecti
   const [form, setForm] = useState<EditFormState>({
     label: connection.label,
     permission_level: connection.permission_level,
-    enabled_features: [...connection.enabled_features],
+    enabled_features: [...(connection.enabled_features ?? [])],
   });
 
   const toggleFeature = useCallback((feature: OAuthFeature) => {
@@ -260,8 +260,8 @@ function ConnectionCard({ connection, onUpdate, onDelete, isUpdating }: Connecti
             <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
               <span>{formatPermission(connection.permission_level)}</span>
               <span className="text-border">|</span>
-              {connection.enabled_features.length > 0 ? (
-                connection.enabled_features.map((f) => (
+              {(connection.enabled_features ?? []).length > 0 ? (
+                (connection.enabled_features ?? []).map((f) => (
                   <Badge key={f} variant="outline" className="text-xs">
                     {formatFeature(f)}
                   </Badge>
@@ -457,7 +457,8 @@ export function ConnectedAccountsSection() {
     );
   }
 
-  const { connections, providers } = state;
+  const connections = state.connections ?? [];
+  const providers = state.providers ?? [];
 
   return (
     <Card data-testid="connected-accounts-card">

--- a/src/ui/components/settings/connection-manage-panel.tsx
+++ b/src/ui/components/settings/connection-manage-panel.tsx
@@ -72,7 +72,7 @@ export function ConnectionManagePanel({
   const [label, setLabel] = useState(connection.label);
   const [is_active, setIsActive] = useState(connection.is_active);
   const [permission_level, setPermissionLevel] = useState<OAuthPermissionLevel>(connection.permission_level);
-  const [enabled_features, setEnabledFeatures] = useState<OAuthFeature[]>([...connection.enabled_features]);
+  const [enabled_features, setEnabledFeatures] = useState<OAuthFeature[]>([...(connection.enabled_features ?? [])]);
   const [sync_status, setSyncStatus] = useState<Record<string, FeatureSyncInfo | undefined>>(
     connection.sync_status as Record<string, FeatureSyncInfo | undefined>,
   );
@@ -101,7 +101,7 @@ export function ConnectionManagePanel({
         setLabel(connection.label);
         setIsActive(connection.is_active);
         setPermissionLevel(connection.permission_level);
-        setEnabledFeatures([...connection.enabled_features]);
+        setEnabledFeatures([...(connection.enabled_features ?? [])]);
         return null;
       } finally {
         setIsSaving(false);

--- a/src/ui/components/settings/sync-status-display.tsx
+++ b/src/ui/components/settings/sync-status-display.tsx
@@ -56,7 +56,7 @@ export function SyncStatusDisplay({
   sync_status,
   onSyncNow,
 }: SyncStatusDisplayProps) {
-  if (enabled_features.length === 0) {
+  if (!enabled_features || enabled_features.length === 0) {
     return null;
   }
 

--- a/src/ui/components/settings/use-connected-accounts.ts
+++ b/src/ui/components/settings/use-connected-accounts.ts
@@ -22,8 +22,11 @@ export function useConnectedAccounts() {
     ]);
 
     return {
-      connections: connectionsRes.connections,
-      providers: [...providersRes.providers, ...providersRes.unconfigured],
+      connections: Array.isArray(connectionsRes?.connections) ? connectionsRes.connections : [],
+      providers: [
+        ...(Array.isArray(providersRes?.providers) ? providersRes.providers : []),
+        ...(Array.isArray(providersRes?.unconfigured) ? providersRes.unconfigured : []),
+      ],
     };
   }, []);
 

--- a/tests/ui/settings/settings-length-guards.test.tsx
+++ b/tests/ui/settings/settings-length-guards.test.tsx
@@ -1,0 +1,128 @@
+/**
+ * Tests that settings components handle undefined/null arrays gracefully
+ * instead of crashing with "Cannot read properties of undefined (reading 'length')".
+ *
+ * Covers #1591.
+ *
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import * as React from 'react';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+// Mock apiClient before importing components that use it
+vi.mock('@/ui/lib/api-client', () => ({
+  apiClient: {
+    get: vi.fn(),
+    post: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+// Mock auth-manager (needed by api-client internals)
+vi.mock('@/ui/lib/auth-manager', () => ({
+  getAccessToken: vi.fn(() => 'test-token'),
+  clearAccessToken: vi.fn(),
+  refreshAccessToken: vi.fn(),
+}));
+
+// Mock api-config
+vi.mock('@/ui/lib/api-config', () => ({
+  getApiBaseUrl: vi.fn(() => 'http://localhost:3000'),
+}));
+
+import { apiClient } from '@/ui/lib/api-client';
+import { ConnectedAccountsSection } from '@/ui/components/settings/connected-accounts-section';
+import { SyncStatusDisplay } from '@/ui/components/settings/sync-status-display';
+import type { OAuthFeature } from '@/ui/components/settings/types';
+
+const mockedApiClient = vi.mocked(apiClient);
+
+// ---------------------------------------------------------------------------
+// Tests: useConnectedAccounts fetchData guard
+// ---------------------------------------------------------------------------
+
+describe('ConnectedAccountsSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders without crash when API returns undefined connections/providers', async () => {
+    // Simulate API returning objects without the expected array fields
+    mockedApiClient.get.mockImplementation(async (path: string) => {
+      if (path.includes('/connections')) {
+        // Missing `connections` field entirely
+        return {} as never;
+      }
+      if (path.includes('/providers')) {
+        // Missing `providers` and `unconfigured` fields
+        return {} as never;
+      }
+      return {} as never;
+    });
+
+    // Should NOT throw "Cannot read properties of undefined (reading 'length')"
+    expect(() => render(<ConnectedAccountsSection />)).not.toThrow();
+
+    // Initially shows loading state
+    expect(screen.getByText('Loading connected accounts...')).toBeTruthy();
+  });
+
+  it('renders without crash when API returns null for array fields', async () => {
+    mockedApiClient.get.mockImplementation(async (path: string) => {
+      if (path.includes('/connections')) {
+        return { connections: null } as never;
+      }
+      if (path.includes('/providers')) {
+        return { providers: null, unconfigured: null } as never;
+      }
+      return {} as never;
+    });
+
+    expect(() => render(<ConnectedAccountsSection />)).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: SyncStatusDisplay guard for undefined enabled_features
+// ---------------------------------------------------------------------------
+
+describe('SyncStatusDisplay', () => {
+  it('returns null when enabled_features is undefined', () => {
+    const { container } = render(
+      <SyncStatusDisplay
+        enabled_features={undefined as unknown as OAuthFeature[]}
+        sync_status={{}}
+        onSyncNow={vi.fn()}
+      />,
+    );
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('returns null when enabled_features is an empty array', () => {
+    const { container } = render(
+      <SyncStatusDisplay
+        enabled_features={[]}
+        sync_status={{}}
+        onSyncNow={vi.fn()}
+      />,
+    );
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders sync status for valid features', () => {
+    render(
+      <SyncStatusDisplay
+        enabled_features={['contacts']}
+        sync_status={{}}
+        onSyncNow={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('Contacts')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- Add defensive null/undefined guards on all `.length` accesses in settings components
- Add runtime array validation in `useConnectedAccounts` hook's `fetchData`
- Ensure settings page renders gracefully when API returns unexpected data shapes
- Add test coverage for undefined/null array handling in settings components

Closes #1591

## Test plan
- [x] Settings page renders without crash when API returns expected data
- [x] Settings page handles gracefully when API returns missing/null fields
- [x] All existing tests pass (179 tests across 9 files)
- [x] TypeScript compilation succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)