### PR TITLE
[#1621] Filter enabled_features to allowlist in hook normalization

### DIFF
--- a/tests/ui/connected-accounts.test.tsx
+++ b/tests/ui/connected-accounts.test.tsx
@@ -269,6 +269,22 @@ describe('useConnectedAccounts', () => {
     }
   });
 
+  it('deduplicates repeated valid features after fetch', async () => {
+    const conn = {
+      ...mockConnection,
+      enabled_features: ['contacts', 'email', 'contacts', 'email'] as unknown as OAuthConnectionSummary['enabled_features'],
+    };
+    globalThis.fetch = mockFetchSuccess([conn]) as typeof globalThis.fetch;
+
+    const { result } = renderHook(() => useConnectedAccounts());
+
+    await waitFor(() => expect(result.current.state.kind).toBe('loaded'));
+
+    if (result.current.state.kind === 'loaded') {
+      expect(result.current.state.connections[0].enabled_features).toEqual(['contacts', 'email']);
+    }
+  });
+
   it('filters unknown feature strings from replaceConnection', async () => {
     globalThis.fetch = mockFetchSuccess() as typeof globalThis.fetch;
 


### PR DESCRIPTION
## Summary

- Adds `normalizeFeatures(raw: unknown): OAuthFeature[]` helper in `use-connected-accounts.ts` — filters to the known allowlist `['contacts', 'email', 'files', 'calendar']` and drops non-string or unrecognized values
- Replaces all three `Array.isArray(x) ? x : []` normalization sites with `normalizeFeatures(x)`
- Covers: `fetchData` (GET response), `updateConnection` (PATCH response), `replaceConnection` (state-only update)

## Root cause

`enabled_features` was normalized to an array but each element was never validated. An API response returning `['contacts', 'inject_feature']` would flow through as `OAuthFeature[]` at runtime and could be PATCHed back to the server.

## Test plan

- [x] `filters unknown feature strings from enabled_features after fetch` — `['contacts', 'evil_string', 'email', 'unknown']` → `['contacts', 'email']`
- [x] `keeps all valid feature values after fetch` — all four valid values pass through unchanged
- [x] `filters unknown feature strings from updateConnection response` — PATCH response with injected string filtered
- [x] `filters unknown feature strings from replaceConnection` — state-only update path also filtered
- [x] All 34 tests in `tests/ui/connected-accounts.test.tsx` pass
- [x] Pre-existing failures unchanged

Closes #1621

🤖 Generated with [Claude Code](https://claude.com/claude-code)