### PR TITLE
[#1641] Add defensive guards against undefined .length in settings

### DIFF
--- a/src/ui/components/settings/embedding-settings-section.tsx
+++ b/src/ui/components/settings/embedding-settings-section.tsx
@@ -327,7 +327,8 @@ export function EmbeddingSettingsSection() {
     );
   }
 
-  const { provider, available_providers, budget, usage } = state.data;
+  const { provider, budget, usage } = state.data;
+  const available_providers = Array.isArray(state.data.available_providers) ? state.data.available_providers : [];
 
   return (
     <>

--- a/src/ui/components/settings/inbound-routing-section.tsx
+++ b/src/ui/components/settings/inbound-routing-section.tsx
@@ -95,9 +95,10 @@ function ChannelDefaultsSection() {
   const fetchDefaults = useCallback(async () => {
     try {
       const data = await apiClient.get<ChannelDefault[]>('/api/channel-defaults');
-      setDefaults(data);
+      const items = Array.isArray(data) ? data : [];
+      setDefaults(items);
       const values: Record<string, { agent_id: string }> = {};
-      for (const d of data) {
+      for (const d of items) {
         values[d.channel_type] = { agent_id: d.agent_id };
       }
       setEditValues(values);
@@ -214,7 +215,7 @@ function InboundDestinationsSection() {
       const data = await apiClient.get<{ items: InboundDestination[]; total: number }>(
         '/api/inbound-destinations?limit=100&include_inactive=true',
       );
-      setDestinations(data.items);
+      setDestinations(Array.isArray(data.items) ? data.items : []);
     } catch {
       // Handle error
     } finally {
@@ -360,7 +361,7 @@ function PromptTemplatesSection() {
       const data = await apiClient.get<{ items: PromptTemplate[]; total: number }>(
         '/api/prompt-templates?limit=100&include_inactive=true',
       );
-      setTemplates(data.items);
+      setTemplates(Array.isArray(data.items) ? data.items : []);
     } catch {
       // Handle error
     } finally {

--- a/src/ui/components/settings/location-section.tsx
+++ b/src/ui/components/settings/location-section.tsx
@@ -324,7 +324,7 @@ function ProviderCard({ provider, onDelete, onVerify, isSubmitting }: ProviderCa
             )}
             <span>{verifyResult.message}</span>
           </div>
-          {verifyResult.success && verifyResult.entities.length > 0 && (
+          {verifyResult.success && verifyResult.entities && verifyResult.entities.length > 0 && (
             <div className="mt-2 flex flex-wrap gap-1">
               {verifyResult.entities.map((entity) => (
                 <Badge key={entity.id} variant="outline" className="text-xs">


### PR DESCRIPTION
## Summary
- Guard all API-sourced array data in settings subsections with `Array.isArray` checks
- Prevents `TypeError: Cannot read properties of undefined (reading 'length')` when API returns unexpected shapes
- Fixes: location-section entities, inbound-routing items/templates/defaults, embedding providers

Closes #1641

## Test plan
- [x] Typecheck passes
- [x] All UI tests pass (1769 tests)
- [ ] Manual test: settings page loads without crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)