### PR TITLE
[#1643] Display dynamic version in sidebar footer and settings

### DIFF
--- a/src/ui/app/vite-env.d.ts
+++ b/src/ui/app/vite-env.d.ts
@@ -1,5 +1,8 @@
 /// <reference types="vite/client" />
 
+/** Build-time version string injected by vite.config.ts `define`. */
+declare const __APP_VERSION__: string;
+
 interface ImportMetaEnv {
   /** Build-time override for the API base URL (optional). */
   readonly VITE_API_URL?: string;

--- a/src/ui/components/layout/sidebar.tsx
+++ b/src/ui/components/layout/sidebar.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Bell, Folder, Calendar, Users, Search, Settings, ChevronLeft, ChevronRight, Plus, StickyNote, Globe } from 'lucide-react';
 import { cn } from '@/ui/lib/utils';
+import { APP_VERSION } from '@/ui/lib/version';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/ui/components/ui/tooltip';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/ui/components/ui/select';
 import { ScrollArea } from '@/ui/components/ui/scroll-area';
@@ -264,6 +265,11 @@ export function Sidebar({
               <ChevronRight className="size-4" />
             </button>
           )}
+
+          {/* Version */}
+          <p data-testid="app-version" className={cn('text-center text-[10px] text-muted-foreground/50 select-none pt-1', collapsed && 'px-0')}>
+            {collapsed ? 'v' : `v${APP_VERSION}`}
+          </p>
         </div>
       </aside>
     </TooltipProvider>

--- a/src/ui/components/settings/settings-page.tsx
+++ b/src/ui/components/settings/settings-page.tsx
@@ -16,6 +16,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Separator } from '@/ui/components/ui/separator';
 import { Switch } from '@/ui/components/ui/switch';
 import { cn } from '@/ui/lib/utils';
+import { APP_VERSION } from '@/ui/lib/version';
 import { ConnectedAccountsSection } from './connected-accounts-section';
 import { EmbeddingSettingsSection } from './embedding-settings-section';
 import { InboundRoutingSection } from './inbound-routing-section';
@@ -459,7 +460,7 @@ function AboutSection() {
             <Separator />
             <div className="flex items-center justify-between">
               <span className="text-sm text-muted-foreground">Version</span>
-              <Badge variant="outline">1.0.0</Badge>
+              <Badge variant="outline">{APP_VERSION}</Badge>
             </div>
             <Separator />
             <div className="flex items-center justify-between">

--- a/src/ui/lib/version.ts
+++ b/src/ui/lib/version.ts
@@ -1,0 +1,5 @@
+/**
+ * Application version string, injected at build time by Vite's `define` config.
+ * Falls back to 'dev' when running outside the Vite pipeline (e.g. tests).
+ */
+export const APP_VERSION: string = typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : 'dev';

--- a/tests/ui/settings-page.test.tsx
+++ b/tests/ui/settings-page.test.tsx
@@ -517,7 +517,7 @@ describe('SettingsPage', () => {
 
       await waitForLoaded();
 
-      expect(screen.getByText('1.0.0')).toBeInTheDocument();
+      expect(screen.getByText('dev')).toBeInTheDocument();
     });
 
     it('shows license info', async () => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,32 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
 import path from 'node:path';
+
+function getAppVersion(): string {
+  const pkg = JSON.parse(readFileSync(path.join(__dirname, 'package.json'), 'utf-8'));
+  const version = pkg.version ?? '0.0.0';
+
+  // CI or explicit VITE_APP_VERSION override
+  if (process.env.VITE_APP_VERSION) return process.env.VITE_APP_VERSION;
+
+  // Try to get git short hash for edge/dev builds
+  try {
+    const sha = execFileSync('git', ['rev-parse', '--short', 'HEAD'], { encoding: 'utf-8' }).trim();
+    // Check if current commit is tagged (release build)
+    try {
+      const tag = execFileSync('git', ['describe', '--exact-match', '--tags', 'HEAD'], { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
+      if (tag) return tag.replace(/^v/, '');
+    } catch {
+      // Not a tagged commit — use edge format
+    }
+    return `${version}-edge+${sha}`;
+  } catch {
+    return version;
+  }
+}
 
 // Build the frontend directly into the Fastify static directory.
 // Fastify serves `/static/*` from `src/api/static/*`.
@@ -9,6 +34,9 @@ export default defineConfig({
   plugins: [react(), tailwindcss()],
   root: path.join(__dirname, 'src', 'ui', 'app'),
   base: process.env.VITE_BASE || '/static/app/',
+  define: {
+    __APP_VERSION__: JSON.stringify(getAppVersion()),
+  },
   server: {
     host: '::',
   },


### PR DESCRIPTION
## Summary
- Vite config injects `__APP_VERSION__` at build time from package.json + git state
- Tagged builds show tag version, edge/dev builds show `version-edge+sha` format
- Version appears in sidebar footer (subtle, 10px text) and settings About section
- New `src/ui/lib/version.ts` module for clean import (falls back to 'dev' in tests)
- Override via `VITE_APP_VERSION` env var for CI

Closes #1643

## Test plan
- [x] Typecheck passes
- [x] All UI tests pass (1769 tests)
- [ ] Manual test: version visible in sidebar footer
- [ ] Manual test: settings About section shows dynamic version

🤖 Generated with [Claude Code](https://claude.com/claude-code)