### PR TITLE
[#1760] Fix 404 for non-default namespace by-ID operations

### DIFF
--- a/packages/openclaw-plugin/src/api-client.ts
+++ b/packages/openclaw-plugin/src/api-client.ts
@@ -26,6 +26,8 @@ export interface RequestOptions {
   user_id?: string;
   /** User email for identity resolution (e.g. namespace grant creation) (#1567) */
   user_email?: string;
+  /** Target namespace for the request (adds X-Namespace header) (#1760) */
+  namespace?: string;
   /** Custom timeout (overrides config) */
   timeout?: number;
   /** Mark request as coming from an agent (adds X-OpenClaw-Agent header) */
@@ -206,6 +208,11 @@ export class ApiClient {
 
       if (options?.user_email) {
         headers['X-User-Email'] = options.user_email;
+      }
+
+      // Namespace scoping — ensures by-ID operations target the correct namespace (#1760)
+      if (options?.namespace) {
+        headers['X-Namespace'] = options.namespace;
       }
 
       // Mark request as coming from an agent for privacy filtering

--- a/packages/openclaw-plugin/tests/api-client.test.ts
+++ b/packages/openclaw-plugin/tests/api-client.test.ts
@@ -141,6 +141,61 @@ describe('ApiClient', () => {
       expect(callHeaders['X-User-Email']).toBeUndefined();
     });
 
+    it('should include X-Namespace header when namespace provided (#1760)', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({}),
+      });
+
+      const client = createApiClient({ config: defaultConfig, logger: mockLogger });
+      await client.get('/test', { user_id: 'acme', namespace: 'acme' });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'X-Agent-Id': 'acme',
+            'X-Namespace': 'acme',
+          }),
+        }),
+      );
+    });
+
+    it('should not include X-Namespace header when namespace is absent (#1760)', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({}),
+      });
+
+      const client = createApiClient({ config: defaultConfig, logger: mockLogger });
+      await client.get('/test', { user_id: 'troy' });
+
+      const callHeaders = mockFetch.mock.calls[0][1].headers as Record<string, string>;
+      expect(callHeaders['X-Namespace']).toBeUndefined();
+    });
+
+    it('should include X-Namespace header on PATCH requests (#1760)', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({}),
+      });
+
+      const client = createApiClient({ config: defaultConfig, logger: mockLogger });
+      await client.patch('/api/work-items/123/status', { status: 'completed' }, { user_id: 'acme', namespace: 'acme' });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'X-Namespace': 'acme',
+          }),
+        }),
+      );
+    });
+
     it('should include Content-Type header', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,


### PR DESCRIPTION
## Summary

- Plugin API client now sends `X-Namespace` header for by-ID operations (GET/PATCH/DELETE on specific items), fixing 404s when accessing work items, contacts, or memories in non-default namespaces
- Added `namespace` field to `RequestOptions` and `reqOptsScoped()` helper that includes the resolved default namespace from plugin state
- Carefully scoped: only by-ID operations use the namespace header; list/search/create operations are unchanged (they already pass namespace via body/query params, and the middleware checks headers first which would override explicit values)

**Affected operations:** `project_get`, `todo_complete`, `contact_get`, `contact_update`, `contact_tag`, `contact_untag`, `contact_relationships`, `memory_forget` (by ID and search-then-delete)

Closes #1760

## Test plan

- [x] Added 3 unit tests for `X-Namespace` header behavior (present when set, absent when unset, works on PATCH)
- [x] All 1599 plugin tests pass
- [x] Typecheck passes (`pnpm run build`)
- [x] Codex review completed — addressed high-priority feedback about header precedence by scoping to by-ID operations only

🤖 Generated with [Claude Code](https://claude.com/claude-code)