### PR TITLE
[#1822] Fix DNS rebinding SSRF in legacy geolocation providers

### DIFF
--- a/src/api/geolocation/types.ts
+++ b/src/api/geolocation/types.ts
@@ -69,7 +69,7 @@ export interface Connection {
 /** The plugin interface all geolocation providers must implement. */
 export interface GeoProviderPlugin {
   type: GeoProviderType;
-  validateConfig(config: unknown): Result<ProviderConfig, ValidationError[]>;
+  validateConfig(config: unknown): Result<ProviderConfig, ValidationError[]> | Promise<Result<ProviderConfig, ValidationError[]>>;
   verify(config: ProviderConfig, credentials: string): Promise<VerifyResult>;
   discoverEntities(config: ProviderConfig, credentials: string): Promise<EntityInfo[]>;
   connect(

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -19272,7 +19272,7 @@ export function buildServer(options: ProjectsApiOptions = {}): FastifyInstance {
     const { getProvider: getRegistryPlugin } = await import('./geolocation/registry.ts');
     const plugin = getRegistryPlugin(providerType as 'home_assistant' | 'mqtt' | 'webhook');
     if (plugin) {
-      const validation = plugin.validateConfig(config);
+      const validation = await plugin.validateConfig(config);
       if (!validation.ok) {
         return reply.code(400).send({ error: 'Invalid config', details: validation.error });
       }
@@ -19439,7 +19439,7 @@ export function buildServer(options: ProjectsApiOptions = {}): FastifyInstance {
         const { getProvider: getRegistryPlugin } = await import('./geolocation/registry.ts');
         const plugin = getRegistryPlugin(existing.provider_type);
         if (plugin) {
-          const validation = plugin.validateConfig(body.config);
+          const validation = await plugin.validateConfig(body.config);
           if (!validation.ok) {
             return reply.code(400).send({ error: 'Invalid config', details: validation.error });
           }


### PR DESCRIPTION
## Summary

- Replace sync `validateOutboundUrl`/`validateOutboundHost` with DNS-resolving async variants (`resolveAndValidateOutbound*`) in home-assistant.ts and mqtt-provider.ts
- Prevents DNS rebinding attacks where an attacker-controlled hostname passes the literal hostname check but resolves to a private IP at runtime
- `GeoProviderPlugin.validateConfig` interface updated to accept `Result | Promise<Result>` (backward compatible — sync implementations still work)
- 4 new DNS rebinding test cases (2 per provider), all 143 geolocation tests pass

Closes #1822

## Test plan

- [x] `pnpm run build` — clean typecheck
- [x] Home Assistant provider tests pass (24 tests including 2 new DNS rebinding cases)
- [x] MQTT provider tests pass (87 tests including 2 new DNS rebinding cases)
- [x] Webhook provider tests pass (85 tests, unaffected — no outbound URL validation)
- [x] Network guard tests pass (16 tests)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)