### PR TITLE
[#1826] Upgrade CodeQL Action v3 to v4

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -146,7 +146,7 @@ jobs:
           exit-code: '0'
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: 'trivy-results-${{ matrix.image.name }}.sarif'
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -609,7 +609,7 @@ jobs:
           exit-code: '0'
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@45580472a5bb82c4681c4ac726cfdb60060c2ee1 # v3
+        uses: github/codeql-action/upload-sarif@bb471cdcf4dda2c934c5b656f554d43c1434ed13 # v4
         with:
           sarif_file: 'trivy-results-${{ matrix.image.name }}.sarif'
         if: always()


### PR DESCRIPTION
## Summary

- Upgrades `github/codeql-action/upload-sarif` from v3 to v4 in both workflow files
- `containers.yml`: `@v3` → `@v4`
- `release.yml`: pinned SHA updated to v4 (`bb471cdcf4dda2c934c5b656f554d43c1434ed13`)

Closes #1826

## Test plan

- [ ] CI passes on this PR (no CodeQL-related steps to validate directly — the action is only used during container builds)
- [ ] Next release tag should show no deprecation warnings on container build jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)