### PR TITLE
[#1828, #1829, #1830, #1831, #1833, #1834] Omnibus: Fix plugin field mismatches, contact merge, and namespace scoping

### DIFF
--- a/packages/openclaw-plugin/src/tools/context-search.ts
+++ b/packages/openclaw-plugin/src/tools/context-search.ts
@@ -67,6 +67,8 @@ export interface ContextSearchToolOptions {
   logger: Logger;
   config: PluginConfig;
   user_id: string;
+  /** Namespace scoping for memory search (Issue #1834) */
+  namespaces?: string[];
 }
 
 /** Tool definition */
@@ -167,7 +169,7 @@ function formatResultsAsText(results: ContextSearchResultItem[]): string {
  * Creates the context_search tool.
  */
 export function createContextSearchTool(options: ContextSearchToolOptions): ContextSearchTool {
-  const { client, logger, user_id } = options;
+  const { client, logger, user_id, namespaces } = options;
 
   return {
     name: 'context_search',
@@ -214,6 +216,10 @@ export function createContextSearchTool(options: ContextSearchToolOptions): Cont
           limit: String(limit),
           user_email: user_id,
         });
+        // Namespace scoping for memory search (Issue #1834)
+        if (namespaces && namespaces.length > 0) {
+          memoryParams.set('namespaces', namespaces.join(','));
+        }
         taggedPromises.push({
           tag: 'memory',
           promise: client.get<{ results: MemoryApiResult[]; search_type: string }>(`/api/memories/search?${memoryParams.toString()}`, { user_id }),

--- a/src/api/embeddings/memory-integration.ts
+++ b/src/api/embeddings/memory-integration.ts
@@ -138,13 +138,14 @@ export async function searchMemoriesSemantic(
     tags?: string[];
     created_after?: Date;
     created_before?: Date;
+    namespaces?: string[];
   } = {},
 ): Promise<{
   results: Array<MemoryWithEmbedding & { similarity: number }>;
   search_type: 'semantic' | 'text';
   query_embedding_provider?: string;
 }> {
-  const { limit = 20, offset = 0, memory_type, work_item_id, contact_id, relationship_id, project_id, tags, created_after, created_before } = options;
+  const { limit = 20, offset = 0, memory_type, work_item_id, contact_id, relationship_id, project_id, tags, created_after, created_before, namespaces } = options;
 
   // Try to generate embedding for query
   let queryEmbedding: number[] | null = null;
@@ -203,6 +204,13 @@ export async function searchMemoriesSemantic(
   if (tags && tags.length > 0) {
     conditions.push(`m.tags @> $${paramIndex}`);
     params.push(tags);
+    paramIndex++;
+  }
+
+  // Namespace scoping (Issue #1833, #1834)
+  if (namespaces && namespaces.length > 0) {
+    conditions.push(`m.namespace = ANY($${paramIndex}::text[])`);
+    params.push(namespaces as unknown as string);
     paramIndex++;
   }
 


### PR DESCRIPTION
## Summary

Fixes 6 bugs blocking OpenClaw agent tools from functioning correctly:

- **#1828 — memory_forget rejects short IDs**: Removed `format: 'uuid'` from the JSON Schema so the gateway doesn't reject non-UUID strings before the plugin can process them
- **#1829 — contact_merge 500 error**: Fixed SQL referencing non-existent `contact_relationship` table; corrected to `relationship` with proper column names (`contact_a_id`, `contact_b_id`, `relationship_type_id`)
- **#1830 — relationship_set fails with names**: Extended `resolveContact()` to also match against `given_name || family_name` (not just `display_name`), plus added `deleted_at IS NULL` filter
- **#1831 — contact_get shows "undefined"**: Fixed `contact.name` → `contact.display_name` with `given_name`/`family_name` fallback; fixed `namespace_members` using `role`/`is_default` → `access`/`is_home`
- **#1833 — memory search ignores namespace**: Added `namespaces` query parameter parsing in memory search endpoint and namespace filtering in `searchMemoriesSemantic()`
- **#1834 — context_search ignores namespace**: Passed recall namespaces from `context_search` handler through to the memory search API call

## Files Changed

| File | Changes |
|------|---------|
| `packages/openclaw-plugin/src/register-openclaw.ts` | #1828 schema fix, #1831 field mappings, #1834 namespace passthrough |
| `packages/openclaw-plugin/src/tools/context-search.ts` | #1834 namespace support in tool options and memory search URL |
| `src/api/embeddings/memory-integration.ts` | #1833 namespace filter in `searchMemoriesSemantic()` |
| `src/api/relationships/service.ts` | #1830 extended name matching in `resolveContact()` |
| `src/api/server.ts` | #1829 contact merge SQL fix, #1833 namespace query param parsing |

## Test plan

- [x] `pnpm run build` — TypeScript compiles clean
- [x] `pnpm exec vitest run` — 510 test files, 9443 tests pass, 0 failures

Closes #1828
Closes #1829
Closes #1830
Closes #1831
Closes #1833
Closes #1834

🤖 Generated with [Claude Code](https://claude.com/claude-code)