### PR TITLE
[#1974] Support all SSH key types for enrollment host key

### DIFF
--- a/src/tmux-worker/config.ts
+++ b/src/tmux-worker/config.ts
@@ -23,6 +23,8 @@ export interface TmuxWorkerConfig {
   grpcTlsCa: string;
   /** Path to persist the SSH enrollment host key. Empty = ephemeral. */
   enrollmentSshHostKeyPath: string;
+  /** SSH host key type to generate: ed25519 (default), ecdsa, or rsa. */
+  enrollmentSshHostKeyType: string;
 }
 
 /**
@@ -51,6 +53,7 @@ export function loadConfig(): TmuxWorkerConfig {
   const grpcTlsKey = process.env.GRPC_TLS_KEY ?? '';
   const grpcTlsCa = process.env.GRPC_TLS_CA ?? '';
   const enrollmentSshHostKeyPath = process.env.ENROLLMENT_SSH_HOST_KEY_PATH ?? '';
+  const enrollmentSshHostKeyType = process.env.ENROLLMENT_SSH_HOST_KEY_TYPE ?? 'ed25519';
 
   return {
     grpcPort,
@@ -63,6 +66,7 @@ export function loadConfig(): TmuxWorkerConfig {
     grpcTlsKey,
     grpcTlsCa,
     enrollmentSshHostKeyPath,
+    enrollmentSshHostKeyType,
   };
 }
 


### PR DESCRIPTION
## Summary

- Uses `ssh-keygen` for host key generation instead of Node `crypto.generateKeyPairSync`, supporting **all key types** (Ed25519, ECDSA, RSA) in OpenSSH format that ssh2 v1.17+ can parse
- Defaults to **Ed25519** (modern, fast, small keys) instead of the RSA-2048 band-aid from #1966
- Falls back to RSA-4096 via Node crypto when `ssh-keygen` is unavailable (dev environments without `openssh-client`)
- Adds `ENROLLMENT_SSH_HOST_KEY_TYPE` env var (default: `ed25519`, options: `ecdsa`, `rsa`)
- Loading existing keys from disk accepts any format ssh2 supports (OpenSSH, PEM, PuTTY)

## Verification

- Typecheck passes
- 15 unit tests pass: Ed25519/ECDSA/RSA generation, ssh2 parsing, fallback, load-or-generate variants
- Docker container builds, starts with `Generated ed25519 SSH enrollment host key (ephemeral)`
- Health check returns OK
- `ssh-keyscan` confirms server presents `ssh-ed25519` host key
- gRPC e2e: GetWorkerStatus, CreateSession, SendCommand all pass

## Test plan

- [x] `pnpm run build` passes
- [x] `pnpm exec vitest run src/tmux-worker/ssh2-esm-import.test.ts` — 15/15 pass
- [x] Docker image builds
- [x] Container starts with Ed25519 host key
- [x] `ssh-keyscan` shows `ssh-ed25519` key type
- [x] Health check OK
- [x] gRPC service functional

Closes #1974

🤖 Generated with [Claude Code](https://claude.com/claude-code)