### PR TITLE
[#2045] Phase 1: Align foundation types with OpenClaw SDK 2026.3.1

### DIFF
--- a/packages/openclaw-plugin/src/types/openclaw-api.ts
+++ b/packages/openclaw-plugin/src/types/openclaw-api.ts
@@ -47,11 +47,39 @@ export interface JSONSchemaProperty {
   additionalProperties?: JSONSchemaProperty | boolean;
 }
 
-/** Tool execution context */
+/**
+ * Tool execution context.
+ *
+ * Maps to the SDK's OpenClawPluginToolContext with our additional user_id
+ * and requestId fields for internal use. (#2039)
+ */
 export interface ToolContext {
-  user_id?: string;
+  /** OpenClaw config object (opaque to our plugin) */
+  config?: Record<string, unknown>;
+  /** Workspace directory for the current agent */
+  workspaceDir?: string;
+  /** Agent-specific directory */
+  agentDir?: string;
+  /** Agent identifier */
   agentId?: string;
+  /** Session key */
+  sessionKey?: string;
+  /** Message channel (e.g., "telegram", "discord") */
+  messageChannel?: string;
+  /** Agent account identifier */
+  agentAccountId?: string;
+  /** Trusted sender id from inbound context (runtime-provided, not tool args). (#2039) */
+  requesterSenderId?: string;
+  /** Whether the trusted sender is an owner. (#2039) */
+  senderIsOwner?: boolean;
+  /** Whether the tool is running in a sandbox */
+  sandboxed?: boolean;
+  // ── Fields specific to our plugin (not in SDK's OpenClawPluginToolContext) ──
+  /** Internal user identifier for scoping */
+  user_id?: string;
+  /** Session identifier */
   sessionId?: string;
+  /** Request identifier */
   requestId?: string;
 }
 
@@ -125,20 +153,32 @@ export interface ToolDefinition {
 /**
  * Hook names using the actual OpenClaw snake_case convention.
  * Preferred over legacy camelCase names.
+ *
+ * All 24 hook names from the SDK 2026.3.1 contract. (#2030)
  */
 export type PluginHookName =
+  | 'before_model_resolve'
+  | 'before_prompt_build'
   | 'before_agent_start'
+  | 'llm_input'
+  | 'llm_output'
   | 'agent_end'
   | 'before_compaction'
   | 'after_compaction'
+  | 'before_reset'
   | 'message_received'
   | 'message_sending'
   | 'message_sent'
   | 'before_tool_call'
   | 'after_tool_call'
   | 'tool_result_persist'
+  | 'before_message_write'
   | 'session_start'
   | 'session_end'
+  | 'subagent_spawning'
+  | 'subagent_delivery_target'
+  | 'subagent_spawned'
+  | 'subagent_ended'
   | 'gateway_start'
   | 'gateway_stop';
 
@@ -150,20 +190,32 @@ export interface PluginHookBeforeAgentStartEvent {
   messages?: unknown[];
 }
 
-/** Context passed as second argument to hook handlers */
+/** Context passed as second argument to hook handlers (#2035) */
 export interface PluginHookAgentContext {
   agentId?: string;
   sessionKey?: string;
+  /** Session identifier. Added in SDK 2026.3.1. (#2035) */
+  sessionId?: string;
   workspaceDir?: string;
   messageProvider?: string;
 }
 
-/** Return value from before_agent_start hook */
+/**
+ * Return value from before_agent_start hook.
+ *
+ * In the SDK this is defined as:
+ *   PluginHookBeforePromptBuildResult & PluginHookBeforeModelResolveResult
+ * which adds modelOverride and providerOverride. (#2033)
+ */
 export interface PluginHookBeforeAgentStartResult {
   /** Append to the system prompt */
   systemPrompt?: string;
   /** Prepend to conversation context */
   prependContext?: string;
+  /** Override the model for this agent run. E.g. "llama3.3:8b" (#2033) */
+  modelOverride?: string;
+  /** Override the provider for this agent run. E.g. "ollama" (#2033) */
+  providerOverride?: string;
 }
 
 /** Event payload for message_received hook (Issue #1223) */
@@ -210,7 +262,13 @@ export type HookEvent =
 /** Legacy hook handler function */
 export type HookHandler<T = unknown> = (event: T) => Promise<T | null | undefined>;
 
-/** CLI registration callback */
+/**
+ * CLI registration context.
+ *
+ * Aligned with the SDK's OpenClawPluginCliContext. (#2037)
+ * The SDK uses `Commander.Command` for program and `OpenClawConfig` for config;
+ * we use simplified types to avoid pulling in those dependencies.
+ */
 export interface CliRegistrationContext {
   /** Commander program instance */
   program: {
@@ -221,40 +279,94 @@ export interface CliRegistrationContext {
       };
     };
   };
+  /** OpenClaw gateway configuration (opaque to our plugin) */
+  config?: Record<string, unknown>;
+  /** Workspace directory */
+  workspaceDir?: string;
+  /** Logger instance */
+  logger?: {
+    debug?: (message: string) => void;
+    info: (message: string) => void;
+    warn: (message: string) => void;
+    error: (message: string) => void;
+  };
 }
 
-export type CliRegistrationCallback = (context: CliRegistrationContext) => void;
+/**
+ * CLI registration callback.
+ *
+ * Aligned with SDK's OpenClawPluginCliRegistrar: may return void or Promise<void>. (#2037)
+ */
+export type CliRegistrationCallback = (context: CliRegistrationContext) => void | Promise<void>;
 
-/** Service definition for background processes */
+/**
+ * Service definition for background processes.
+ *
+ * Aligned with the SDK's OpenClawPluginService type. (#2036)
+ * The SDK uses OpenClawPluginServiceContext for the ctx parameter;
+ * we use Record<string, unknown> to avoid pulling in OpenClawConfig.
+ */
 export interface ServiceDefinition {
   /** Unique service ID */
   id: string;
   /** Called when plugin starts */
-  start: (ctx?: Record<string, unknown>) => Promise<void>;
-  /** Called when plugin stops */
-  stop: (ctx?: Record<string, unknown>) => Promise<void>;
+  start: (ctx?: Record<string, unknown>) => void | Promise<void>;
+  /** Called when plugin stops (optional per SDK contract) (#2036) */
+  stop?: (ctx?: Record<string, unknown>) => void | Promise<void>;
 }
 
-/** OpenClaw Plugin API provided to plugins */
+/**
+ * OpenClaw Plugin API provided to plugins.
+ *
+ * Aligned with the SDK's OpenClawPluginApi type. (#2034)
+ * Where the SDK uses concrete types (OpenClawConfig, AnyAgentTool, Commander.Command),
+ * we use simplified equivalents to avoid pulling in those dependencies.
+ */
 export interface OpenClawPluginApi {
+  // ── Identity fields (from SDK) (#2034) ────────────────────────────────────
+
+  /** Plugin ID */
+  id: string;
+
+  /** Plugin display name */
+  name: string;
+
+  /** Plugin version (optional) */
+  version?: string;
+
+  /** Plugin description (optional) */
+  description?: string;
+
+  /** Plugin source/origin (e.g., "bundled", "global", "workspace") */
+  source: string;
+
+  // ── Configuration ─────────────────────────────────────────────────────────
+
   /** Full OpenClaw gateway configuration */
   config: Record<string, unknown>;
 
   /** Plugin-specific configuration from plugins.entries.<id>.config */
   pluginConfig?: Record<string, unknown>;
 
+  // ── Runtime ───────────────────────────────────────────────────────────────
+
   /** Logger instance */
   logger: Logger;
 
-  /** Plugin ID */
-  pluginId: string;
+  /**
+   * Plugin runtime utilities.
+   * The SDK exposes this as PluginRuntime with agent, tts, etc.
+   * We use Record<string, unknown> to avoid the full dependency. (#2034)
+   */
+  runtime: Record<string, unknown>;
 
-  /** Runtime utilities */
-  runtime?: {
-    tts?: {
-      textToSpeechTelephony: (text: string, options?: { voice?: string }) => Promise<{ pcm: Buffer; sampleRate: number }>;
-    };
-  };
+  // ── Legacy alias (retained for backward compat within our plugin) ─────────
+  /**
+   * @deprecated Use `id` instead. Kept for backward compatibility.
+   */
+  pluginId?: string;
+
+  // ── Registration methods ──────────────────────────────────────────────────
 
   /**
    * Register a tool with the OpenClaw Gateway.
@@ -271,7 +383,7 @@ export interface OpenClawPluginApi {
    *   return { prependContext: 'some context' }
    * })
    */
-  on?: <K extends PluginHookName>(hookName: K, handler: (...args: unknown[]) => unknown, opts?: { priority?: number }) => void;
+  on: <K extends PluginHookName>(hookName: K, handler: (...args: unknown[]) => unknown, opts?: { priority?: number }) => void;
 
   /**
    * Register a lifecycle hook (legacy method).
@@ -279,13 +391,28 @@ export interface OpenClawPluginApi {
    *
    * @deprecated Use api.on() for modern hook registration with proper typing.
    */
-  registerHook: <T = unknown>(event: HookEvent, handler: HookHandler<T>) => void;
+  registerHook: <T = unknown>(event: HookEvent | string | string[], handler: HookHandler<T>) => void;
+
+  /**
+   * Register an HTTP handler for custom request processing. (#2034)
+   */
+  registerHttpHandler: (handler: (req: unknown, res: unknown) => Promise<boolean> | boolean) => void;
+
+  /**
+   * Register an HTTP route handler at a specific path. (#2034)
+   */
+  registerHttpRoute: (params: { path: string; handler: (req: unknown, res: unknown) => Promise<void> | void }) => void;
+
+  /**
+   * Register a messaging channel plugin. (#2034)
+   */
+  registerChannel: (registration: Record<string, unknown>) => void;
 
   /**
    * Register CLI commands.
    * Commands are available via `openclaw <plugin-id> <command>`.
    */
-  registerCli: (callback: CliRegistrationCallback) => void;
+  registerCli: (callback: CliRegistrationCallback, opts?: { commands?: string[] }) => void;
 
   /**
    * Register a background service.
@@ -298,6 +425,22 @@ export interface OpenClawPluginApi {
    * Methods are exposed as `pluginId.methodName`.
    */
   registerGatewayMethod: <T = unknown, R = unknown>(methodName: string, handler: (params: T) => Promise<R>) => void;
+
+  /**
+   * Register a model provider plugin. (#2034)
+   */
+  registerProvider: (provider: Record<string, unknown>) => void;
+
+  /**
+   * Register a custom command that bypasses the LLM agent. (#2034)
+   * Plugin commands are processed before built-in commands and before agent invocation.
+   */
+  registerCommand: (command: Record<string, unknown>) => void;
+
+  /**
+   * Resolve a relative path against the plugin's context. (#2034)
+   */
+  resolvePath: (input: string) => string;
 }
 
 /** Plugin initialization function signature */

--- a/packages/openclaw-plugin/tests/sdk-type-compatibility.test.ts
+++ b/packages/openclaw-plugin/tests/sdk-type-compatibility.test.ts
@@ -14,7 +14,8 @@
  *
  * Types kept local (and why):
  *   - JSONSchema, JSONSchemaProperty: Generic JSON Schema, no SDK equivalent
- *   - ToolContext, ToolResult: Our internal tool execution types
+ *   - ToolContext: Our internal tool execution type (maps to SDK's OpenClawPluginToolContext)
+ *   - ToolResult: Our internal tool execution result
  *   - AgentToolResult: SDK uses (TextContent | ImageContent)[], we use {type:'text',text:string}[]
  *   - AgentToolExecute: Depends on our AgentToolResult
  *   - ToolDefinition: SDK uses AnyAgentTool (TypeBox), we use plain JSON Schema
@@ -29,7 +30,7 @@
  *   - ServiceDefinition: Simplified service definition
  *   - PluginInitializer, PluginDefinition, OpenClawPluginAPI: Plugin definitions
  *
- * Part of #885.
+ * Part of #885. Updated for Epic #2045.
  */
 
 import { describe, expect, it } from 'vitest';
@@ -41,6 +42,8 @@ import type {
   PluginHookBeforeAgentStartResult,
   PluginHookAgentEndEvent,
   OpenClawPluginApi,
+  ToolContext,
+  ServiceDefinition,
 } from '../src/types/openclaw-api.js';
 
 // ── Compile-time type compatibility checks ────────────────────────────────────
@@ -64,25 +67,35 @@ void _localToSdk;
 
 describe('SDK Type Compatibility', () => {
   describe('PluginHookName', () => {
-    it('should include all expected hook names', () => {
+    it('should include all 24 SDK hook names', () => {
+      // All 24 hook names from the SDK's PluginHookName union (#2030)
       const expectedHooks: PluginHookName[] = [
+        'before_model_resolve',
+        'before_prompt_build',
         'before_agent_start',
+        'llm_input',
+        'llm_output',
         'agent_end',
         'before_compaction',
         'after_compaction',
+        'before_reset',
         'message_received',
         'message_sending',
         'message_sent',
         'before_tool_call',
         'after_tool_call',
         'tool_result_persist',
+        'before_message_write',
         'session_start',
         'session_end',
+        'subagent_spawning',
+        'subagent_delivery_target',
+        'subagent_spawned',
+        'subagent_ended',
         'gateway_start',
         'gateway_stop',
       ];
-      // This ensures our type covers all 14 hooks
-      expect(expectedHooks).toHaveLength(14);
+      expect(expectedHooks).toHaveLength(24);
     });
 
     it('should match the SDK hook names at runtime', () => {
@@ -95,15 +108,17 @@ describe('SDK Type Compatibility', () => {
   });
 
   describe('PluginHookAgentContext', () => {
-    it('should have the expected shape', () => {
+    it('should have the expected shape including sessionId (#2035)', () => {
       const ctx: PluginHookAgentContext = {
         agentId: 'test-agent',
         sessionKey: 'test-session',
+        sessionId: 'test-session-id',
         workspaceDir: '/tmp/workspace',
         messageProvider: 'test-provider',
       };
       expect(ctx.agentId).toBe('test-agent');
       expect(ctx.sessionKey).toBe('test-session');
+      expect(ctx.sessionId).toBe('test-session-id');
       expect(ctx.workspaceDir).toBe('/tmp/workspace');
       expect(ctx.messageProvider).toBe('test-provider');
     });
@@ -111,6 +126,7 @@ describe('SDK Type Compatibility', () => {
     it('should allow all optional fields', () => {
       const ctx: PluginHookAgentContext = {};
       expect(ctx.agentId).toBeUndefined();
+      expect(ctx.sessionId).toBeUndefined();
     });
   });
 
@@ -133,6 +149,16 @@ describe('SDK Type Compatibility', () => {
       };
       expect(result.systemPrompt).toBe('You are a helpful assistant');
       expect(result.prependContext).toBe('User preferences loaded');
+    });
+
+    it('should support modelOverride and providerOverride (#2033)', () => {
+      const result: PluginHookBeforeAgentStartResult = {
+        systemPrompt: 'System prompt',
+        modelOverride: 'llama3.3:8b',
+        providerOverride: 'ollama',
+      };
+      expect(result.modelOverride).toBe('llama3.3:8b');
+      expect(result.providerOverride).toBe('ollama');
     });
   });
 
@@ -158,6 +184,57 @@ describe('SDK Type Compatibility', () => {
     });
   });
 
+  describe('ToolContext', () => {
+    it('should include requesterSenderId and senderIsOwner (#2039)', () => {
+      const ctx: ToolContext = {
+        user_id: 'user-1',
+        agentId: 'agent-1',
+        sessionId: 'session-1',
+        requestId: 'req-1',
+        requesterSenderId: 'sender-123',
+        senderIsOwner: true,
+      };
+      expect(ctx.requesterSenderId).toBe('sender-123');
+      expect(ctx.senderIsOwner).toBe(true);
+    });
+
+    it('should include workspaceDir, agentDir, messageChannel, agentAccountId, sandboxed', () => {
+      const ctx: ToolContext = {
+        workspaceDir: '/tmp/workspace',
+        agentDir: '/tmp/agent',
+        messageChannel: 'telegram',
+        agentAccountId: 'acct-1',
+        sandboxed: true,
+      };
+      expect(ctx.workspaceDir).toBe('/tmp/workspace');
+      expect(ctx.agentDir).toBe('/tmp/agent');
+      expect(ctx.messageChannel).toBe('telegram');
+      expect(ctx.agentAccountId).toBe('acct-1');
+      expect(ctx.sandboxed).toBe(true);
+    });
+  });
+
+  describe('ServiceDefinition', () => {
+    it('should allow stop to be optional (#2036)', () => {
+      const service: ServiceDefinition = {
+        id: 'test-service',
+        start: async () => {},
+      };
+      expect(service.id).toBe('test-service');
+      expect(service.stop).toBeUndefined();
+    });
+
+    it('should accept start/stop returning void or Promise<void> (#2036)', () => {
+      const service: ServiceDefinition = {
+        id: 'test-service',
+        start: () => {},
+        stop: () => {},
+      };
+      expect(service.id).toBe('test-service');
+      expect(service.stop).toBeDefined();
+    });
+  });
+
   describe('OpenClawPluginApi', () => {
     it('should define the same method names as the SDK', () => {
       // Verify that both our API and the SDK share key method names.
@@ -166,19 +243,39 @@ describe('SDK Type Compatibility', () => {
       type LocalMethods = keyof OpenClawPluginApi;
       type SdkMethods = keyof SdkOpenClawPluginApi;
 
-      // Methods that both our type and the SDK should have
+      // Methods that both our type and the SDK should have (#2034)
       const sharedMethods: Array<LocalMethods & SdkMethods> = [
         'registerTool',
         'registerHook',
         'registerCli',
         'registerService',
         'registerGatewayMethod',
+        'registerHttpHandler',
+        'registerHttpRoute',
+        'registerChannel',
+        'registerProvider',
+        'registerCommand',
+        'resolvePath',
         'on',
         'config',
         'logger',
+        'id',
+        'name',
+        'source',
+        'runtime',
+        'pluginConfig',
       ];
 
-      expect(sharedMethods.length).toBeGreaterThanOrEqual(8);
+      expect(sharedMethods.length).toBeGreaterThanOrEqual(19);
+    });
+
+    it('should include version and description fields (#2034)', () => {
+      // Compile-time check: these optional fields must exist on our type
+      const api = {} as OpenClawPluginApi;
+      // TypeScript will error if these don't exist
+      void api.version;
+      void api.description;
+      expect(true).toBe(true);
     });
   });
 

--- a/tests/openclaw-contract/hook-contract.test.ts
+++ b/tests/openclaw-contract/hook-contract.test.ts
@@ -104,11 +104,11 @@ describe('OpenClaw Hook Contract Validation', () => {
       expect(content).toContain('OpenClawPluginAPI');
     });
 
-    it('should identify missing api.on method', () => {
+    it('should include api.on method aligned with SDK (#2034)', () => {
       const content = readFileSync(typesPath, 'utf-8');
-      // Our type doesn't have the `on` method for modern hook registration
-      // The actual OpenClaw API has: on: <K extends PluginHookName>(hookName: K, ...) => void
-      expect(content).not.toContain('on: <K extends PluginHookName>');
+      // Our type now includes the `on` method for modern hook registration,
+      // aligned with the SDK's OpenClawPluginApi type.
+      expect(content).toContain('on: <K extends PluginHookName>');
     });
   });
 


### PR DESCRIPTION
## Summary

Omnibus PR aligning all foundation types in `packages/openclaw-plugin/src/types/openclaw-api.ts` with the OpenClaw SDK 2026.3.1 contract. This is Phase 1 of Epic #2045.

### Issues resolved

- Closes #2030 — `PluginHookName` expanded from 14 to all 24 SDK hook names
- Closes #2033 — `PluginHookBeforeAgentStartResult` now includes `modelOverride` and `providerOverride`
- Closes #2034 — `OpenClawPluginApi` aligned with SDK (added `id`, `name`, `version`, `description`, `source`, `runtime`, `registerHttpHandler`, `registerHttpRoute`, `registerChannel`, `registerProvider`, `registerCommand`, `resolvePath`; `on` now required)
- Closes #2035 — `PluginHookAgentContext` now includes `sessionId`
- Closes #2036 — `ServiceDefinition.stop` made optional, `start`/`stop` return `void | Promise<void>`
- Closes #2037 — `CliRegistrationCallback` may return `void | Promise<void>`, `CliRegistrationContext` now includes `config`, `workspaceDir`, `logger`
- Closes #2039 — `ToolContext` expanded with `requesterSenderId`, `senderIsOwner`, `workspaceDir`, `agentDir`, `messageChannel`, `agentAccountId`, `sandboxed`
- Closes #2040 — Investigated `uiHints.group`: JSON-level convention consumed by Gateway UI, no TypeScript type change needed

### Approach

All local types in `openclaw-api.ts` were compared field-by-field against the SDK's `plugins/types.d.ts` and aligned. Where the SDK uses concrete types we don't depend on (e.g., `OpenClawConfig`, `AnyAgentTool`, `Commander.Command`), we use simplified equivalents (`Record<string, unknown>`, etc.) to avoid pulling in those dependencies.

### Tests

- Updated `sdk-type-compatibility.test.ts` with assertions for all new fields and the full 24-hook union
- Updated `hook-contract.test.ts` to reflect that `api.on` is now a required method
- All 249 test files pass (3860 tests)
- Typecheck (`pnpm run build`) passes

## Test plan

- [x] `pnpm run build` passes (typecheck)
- [x] `pnpm test:unit` passes (all 249 files, 3860 tests)
- [ ] CI pipeline green
- [ ] Codex review pass