### PR TITLE
[#2045] Phase 3: Fix test coverage gaps for plugin-SDK interface

### DIFF
--- a/packages/openclaw-plugin/tests/gateway/README.md
+++ b/packages/openclaw-plugin/tests/gateway/README.md
@@ -62,7 +62,7 @@ These tests validate the openclaw-projects plugin at the Gateway integration lev
 
 ## Architecture
 
-Tests import the real Gateway loader directly from the gateway source at `.local/openclaw-gateway/`. The `vitest.config.ts` sets up path aliases:
+Most tests import the real Gateway loader directly from the gateway source at `.local/openclaw-gateway/`. The `vitest.config.ts` sets up path aliases:
 
 ```
 openclaw-gateway/plugins/loader -> .local/openclaw-gateway/src/plugins/loader.ts
@@ -76,10 +76,23 @@ This approach:
 - Is resilient to bundle hash changes in the openclaw npm package
 - Requires the gateway source (available in dev via `.local/openclaw-gateway`)
 
+### Tests that always run (no gateway source needed) (#2043)
+
+| Test | Why it doesn't need gateway source |
+|------|-------------------------------------|
+| `manifest-validation.test.ts` | Only reads local `openclaw.plugin.json` |
+| `plugin-exports.test.ts` | Only imports from `dist/index.js` |
+
+### Tests that require gateway source
+
+All other tests import `loadOpenClawPlugins` or `createHookRunner` from internal
+gateway paths that are NOT part of the openclaw npm package. These are skipped in
+CI with a console warning when `.local/openclaw-gateway` is absent.
+
 ## Running Tests
 
 ```bash
-# Run gateway tests
+# Run gateway tests (only non-gateway-source tests run without .local/openclaw-gateway)
 pnpm test tests/gateway
 
 # Run full test suite
@@ -91,6 +104,6 @@ pnpm run build
 
 ## Prerequisites
 
-- Gateway source symlinked at `.local/openclaw-gateway/`
-- Plugin built (`pnpm run build`) for export verification tests
 - `node_modules` installed via `pnpm install`
+- Plugin built (`pnpm run build`) for export verification tests
+- **Optional**: Gateway source symlinked at `.local/openclaw-gateway/` for full test coverage

--- a/packages/openclaw-plugin/tests/gateway/manifest-validation.test.ts
+++ b/packages/openclaw-plugin/tests/gateway/manifest-validation.test.ts
@@ -2,8 +2,9 @@
  * Gateway Integration Tests: Manifest Validation
  * Tests plugin manifest structure and validity.
  *
- * NOTE: Full loader integration tests are blocked pending openclaw Gateway config documentation.
- * See follow-up issue for full loader integration tests.
+ * This test does NOT require the gateway source at .local/openclaw-gateway —
+ * it only reads local filesystem files (openclaw.plugin.json). It always runs,
+ * including in CI. (#2043)
  */
 
 import { describe, it, expect } from 'vitest';

--- a/packages/openclaw-plugin/tests/gateway/plugin-exports.test.ts
+++ b/packages/openclaw-plugin/tests/gateway/plugin-exports.test.ts
@@ -1,6 +1,10 @@
 /**
  * Gateway Integration Tests: Plugin Exports
  * Tests that the plugin exports the expected structure.
+ *
+ * This test does NOT require the gateway source at .local/openclaw-gateway —
+ * it imports from the built dist/ output and the shared setup.ts constants.
+ * It always runs, including in CI (requires `pnpm run build` first). (#2043)
  */
 
 import { describe, it, expect } from 'vitest';

--- a/packages/openclaw-plugin/tests/gateway/plugin-loading.test.ts
+++ b/packages/openclaw-plugin/tests/gateway/plugin-loading.test.ts
@@ -2,8 +2,9 @@
  * Gateway Integration Tests: Plugin Loading
  * Tests plugin discovery, loading, and status reporting via the real Gateway loader.
  *
- * Uses loadOpenClawPlugins() from the gateway source to validate our plugin
- * integrates correctly with the Gateway's plugin discovery and loading pipeline.
+ * REQUIRES gateway source at .local/openclaw-gateway — imports loadOpenClawPlugins()
+ * which is an internal gateway function not exported via the openclaw npm package.
+ * Skipped in CI when gateway source is absent (see vitest.config.ts). (#2043)
  */
 
 import { describe, it, expect } from 'vitest';

--- a/packages/openclaw-plugin/tests/sdk-type-compatibility.test.ts
+++ b/packages/openclaw-plugin/tests/sdk-type-compatibility.test.ts
@@ -66,9 +66,14 @@ import type {
 type SdkOnMethod = NonNullable<SdkOpenClawPluginApi['on']>;
 type SdkHookNameParam = Parameters<SdkOnMethod>[0];
 
-// Every local PluginHookName value should be assignable to the SDK's parameter type
+// Bidirectional hook name compatibility (#2038):
+// 1. Every local PluginHookName value must be assignable to the SDK's parameter type
 const _localToSdk: SdkHookNameParam = '' as PluginHookName;
 void _localToSdk;
+// 2. Every SDK hook name must be assignable to our local PluginHookName
+// If the SDK adds a new hook that we haven't defined locally, this will produce a type error.
+const _sdkToLocal: PluginHookName = '' as SdkHookNameParam;
+void _sdkToLocal;
 
 describe('SDK Type Compatibility', () => {
   describe('PluginHookName', () => {

--- a/packages/openclaw-plugin/vitest.config.ts
+++ b/packages/openclaw-plugin/vitest.config.ts
@@ -18,10 +18,40 @@ const __dirname = path.dirname(__filename);
  * - Full TypeScript support via vitest's built-in transpilation
  * - Resilience to bundle hash changes
  *
- * When the gateway source is NOT available, gateway tests are skipped.
+ * When the gateway source is NOT available, tests that import gateway internals
+ * are skipped. Tests that only use local files or the published SDK (e.g.
+ * manifest-validation, plugin-exports) always run. (#2043)
  */
 const gatewayRoot = path.resolve(__dirname, '../../.local/openclaw-gateway');
 const hasGateway = fs.existsSync(gatewayRoot);
+
+/**
+ * Gateway test files that require the gateway source tree at .local/openclaw-gateway.
+ * These import internal gateway functions (loadOpenClawPlugins, createHookRunner)
+ * that are NOT part of the openclaw npm package's public API.
+ *
+ * Tests NOT listed here (manifest-validation, plugin-exports) use only local
+ * filesystem reads or the built dist/ output and always run, including in CI. (#2043)
+ */
+const gatewaySourceRequiredTests = [
+  'tests/gateway/plugin-loading.test.ts',
+  'tests/gateway/config-validation.test.ts',
+  'tests/gateway/tool-registration.test.ts',
+  'tests/gateway/tool-resolution.test.ts',
+  'tests/gateway/hook-registration.test.ts',
+  'tests/gateway/hook-invocation.test.ts',
+  'tests/gateway/service-registration.test.ts',
+  'tests/gateway/cli-registration.test.ts',
+];
+
+if (!hasGateway) {
+  console.warn(
+    `[openclaw-plugin] Gateway source not found at ${gatewayRoot}. ` +
+      `Skipping ${gatewaySourceRequiredTests.length} gateway integration tests that require ` +
+      `internal gateway imports (loadOpenClawPlugins, createHookRunner). ` +
+      `To run all tests, symlink the gateway source to .local/openclaw-gateway. (#2043)`,
+  );
+}
 
 export default defineConfig({
   resolve: {
@@ -40,8 +70,10 @@ export default defineConfig({
   test: {
     include: ['tests/**/*.test.ts'],
     exclude: [
-      // Skip gateway integration tests when gateway source is not available
-      ...(hasGateway ? [] : ['tests/gateway/**/*.test.ts']),
+      // Only skip gateway tests that import internal gateway functions.
+      // Tests that use local files or built output (manifest-validation,
+      // plugin-exports) always run, even without gateway source. (#2043)
+      ...(hasGateway ? [] : gatewaySourceRequiredTests),
     ],
     globals: false,
     coverage: {


### PR DESCRIPTION
## Summary

Omnibus PR for Epic #2045 Phase 3, covering two test coverage issues:

- **#2038**: The `sdk-type-compatibility` test hardcoded a stale hook count of 14 (already fixed by Phase 1 to 24). This PR adds a **bidirectional compile-time type check** (`_sdkToLocal`) ensuring that if the SDK adds new hooks we haven't defined locally, TypeScript will produce a compile error — catching drift in both directions.

- **#2043**: All 10 gateway integration tests were silently excluded when `.local/openclaw-gateway` was absent (which includes CI). Analysis showed that 2 tests (`manifest-validation`, `plugin-exports`) don't need gateway source at all. This PR:
  - Narrows the exclusion to only the 8 tests that import internal gateway functions
  - `manifest-validation.test.ts` (4 tests) and `plugin-exports.test.ts` (5 tests) now always run, including in CI
  - Adds a `console.warn` when tests are skipped, making it visible in CI logs
  - Documents in each test file and README which tests need gateway source and why

## Changes

| File | Change |
|------|--------|
| `tests/sdk-type-compatibility.test.ts` | Add `_sdkToLocal` bidirectional compile-time check |
| `vitest.config.ts` | Narrow gateway exclusion to 8 specific files; add skip warning |
| `tests/gateway/manifest-validation.test.ts` | Update doc comment (no gateway required) |
| `tests/gateway/plugin-exports.test.ts` | Update doc comment (no gateway required) |
| `tests/gateway/plugin-loading.test.ts` | Update doc comment (gateway required, why) |
| `tests/gateway/README.md` | Document which tests need gateway source |

## Test plan

- [x] `pnpm run build` passes (typecheck including bidirectional hook check)
- [x] Plugin tests pass: 61 files, 1966 tests, 0 new failures
- [x] Unit tests pass: 249 files, 3860 tests (pre-existing inline-edit unhandled rejection unrelated)
- [x] `manifest-validation.test.ts` and `plugin-exports.test.ts` now run without gateway source
- [x] Warning message prints when gateway tests are skipped

Closes #2038
Closes #2043

🤖 Generated with [Claude Code](https://claude.com/claude-code)