### PR TITLE
[#2064] Add OpenAPI spec and agent-facing docs for Cloudflare email webhook

### DIFF
--- a/docs/api/messaging.md
+++ b/docs/api/messaging.md
@@ -362,3 +362,212 @@ Authorization: Bearer your-api-token
 Webhook endpoints verify signatures:
 - **Twilio**: X-Twilio-Signature header validation
 - **Postmark**: Basic auth or API token validation
+- **Cloudflare Email**: X-Cloudflare-Email-Secret shared secret (see below)
+
+---
+
+## Cloudflare Email Inbound Webhook
+
+### Overview
+
+The Cloudflare Email integration receives inbound emails via a [Cloudflare Email Worker](https://developers.cloudflare.com/email-routing/email-workers/) that parses the MIME message and POSTs a JSON payload to this endpoint.
+
+**Flow:**
+```
+Inbound email → Cloudflare Email Routing → Email Worker → POST /cloudflare/email → openclaw-projects
+```
+
+A reference Worker implementation is provided in [`examples/cloudflare-email-worker/`](../../examples/cloudflare-email-worker/README.md).
+
+### Receive Inbound Email
+
+**POST** `/cloudflare/email`
+
+Receives a parsed email from the Cloudflare Worker, creates or matches the sender contact, threads the email, stores the message, and returns a triage decision.
+
+**Authentication:**
+
+This endpoint does NOT use Bearer token auth. Instead, the Worker authenticates via a shared secret header:
+
+```bash
+X-Cloudflare-Email-Secret: your-shared-secret
+```
+
+The secret must match the `CLOUDFLARE_EMAIL_SECRET` environment variable. Comparison is timing-safe.
+
+**Request Body:**
+```json
+{
+  "from": "sender@example.com",
+  "to": "support@myapp.com",
+  "subject": "Question about my order",
+  "text_body": "Hi, I have a question about order #12345.",
+  "html_body": "<p>Hi, I have a question about order #12345.</p>",
+  "headers": {
+    "message-id": "<unique-id-123@example.com>",
+    "in-reply-to": "<previous-id-456@example.com>",
+    "references": "<original-id-789@example.com>"
+  },
+  "timestamp": "2026-03-03T12:00:00.000Z"
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `from` | string | Yes | Sender email address |
+| `to` | string | Yes | Recipient email address (used for route resolution) |
+| `subject` | string | Yes | Email subject line |
+| `text_body` | string | No | Plain text body from MIME |
+| `html_body` | string | No | HTML body from MIME |
+| `headers` | object | Yes | Email headers (see below) |
+| `headers.message-id` | string | No | RFC 5322 Message-ID (used for deduplication and threading) |
+| `headers.in-reply-to` | string | No | In-Reply-To header (links replies to parent messages) |
+| `headers.references` | string | No | References header (full thread chain) |
+| `raw` | string | No | Full raw MIME message (optional, for debugging) |
+| `timestamp` | string | Yes | ISO 8601 timestamp (must be within 5 minutes for replay protection) |
+
+**Response (200 OK):**
+
+The response always includes a triage `action` field that the Worker uses to decide whether to accept or reject the email at the SMTP level.
+
+**Accept response** (route found):
+```json
+{
+  "success": true,
+  "action": "accept",
+  "receipt_id": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+  "contact_id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
+  "thread_id": "b2c3d4e5-6789-01ab-cdef-2345678901bc",
+  "message_id": "c3d4e5f6-7890-12ab-cdef-3456789012cd"
+}
+```
+
+**Reject response** (no route configured):
+```json
+{
+  "success": true,
+  "action": "reject",
+  "reject_reason": "No agent configured for support@myapp.com",
+  "receipt_id": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+  "contact_id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
+  "thread_id": "b2c3d4e5-6789-01ab-cdef-2345678901bc",
+  "message_id": "c3d4e5f6-7890-12ab-cdef-3456789012cd"
+}
+```
+
+**Accept with auto-reply:**
+```json
+{
+  "success": true,
+  "action": "accept",
+  "receipt_id": "...",
+  "contact_id": "...",
+  "thread_id": "...",
+  "message_id": "...",
+  "auto_reply": {
+    "subject": "Re: Question about my order",
+    "text_body": "Thank you for your message. An agent will respond shortly.",
+    "html_body": "<p>Thank you for your message. An agent will respond shortly.</p>"
+  }
+}
+```
+
+When `auto_reply` is present, the Worker constructs a MIME reply and sends it back to the sender via `message.reply()`.
+
+**Error Responses:**
+- `400 Bad Request` — Missing required fields, invalid timestamp, or stale timestamp (>5 min old)
+- `401 Unauthorized` — Missing or invalid `X-Cloudflare-Email-Secret` header
+- `500 Internal Server Error` — Server-side error
+
+**Example:**
+```bash
+curl -X POST https://api.example.com/cloudflare/email \
+  -H "X-Cloudflare-Email-Secret: $CLOUDFLARE_EMAIL_SECRET" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "from": "sender@example.com",
+    "to": "support@myapp.com",
+    "subject": "Hello",
+    "text_body": "This is a test email.",
+    "headers": {
+      "message-id": "<test-123@example.com>"
+    },
+    "timestamp": "2026-03-03T12:00:00.000Z"
+  }'
+```
+
+### Triage and Route Resolution
+
+When an email arrives, the API resolves a route to decide which agent handles it:
+
+1. **Inbound destination lookup** — Checks the `inbound_destination` table for a row matching the recipient address and `email` channel type
+2. **Channel default fallback** — If no destination match, checks the `channel_default` table for an email channel default
+3. **No route** — If neither exists, returns `action: "reject"`
+
+**To configure email routing:**
+
+Use the [Inbound Destinations API](/inbound-destinations) to create a destination:
+
+```bash
+# Create an inbound destination for email
+curl -X PUT https://api.example.com/inbound-destinations/{id} \
+  -H "Authorization: Bearer $API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "channel_type": "email",
+    "destination_value": "support@myapp.com",
+    "agent_id": "agent-assistant-v2",
+    "is_active": true
+  }'
+```
+
+Or set a channel default so ALL email is routed to an agent:
+
+```bash
+curl -X PUT https://api.example.com/channel-defaults/email \
+  -H "Authorization: Bearer $API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "agent_id": "agent-assistant-v2"
+  }'
+```
+
+### Email Threading
+
+Emails are automatically threaded using RFC 5322 headers:
+
+| Header | Purpose |
+|--------|---------|
+| `Message-ID` | Unique identifier for each email. Used as the external message key for deduplication. |
+| `In-Reply-To` | Links a reply to its parent message. Used to find existing threads. |
+| `References` | Full chain of Message-IDs in the thread. Used as fallback for thread resolution. |
+
+**Thread key derivation:**
+- If `In-Reply-To` is present → thread key derived from the referenced message
+- If `References` is present → thread key derived from the first reference
+- Otherwise → new thread created from the Message-ID
+
+Duplicate messages (same Message-ID + thread) are upserted, not duplicated.
+
+### Contact Creation
+
+When an email arrives from an unknown sender:
+1. A new `contact` record is created with the email address as the display name
+2. A `contact_endpoint` is created with type `email` and the normalized sender address
+3. Subsequent emails from the same address reuse the existing contact
+
+### Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `CLOUDFLARE_EMAIL_SECRET` | Yes | Shared secret for authenticating the Worker |
+| `CLOUDFLARE_EMAIL_SECRET_FILE` | No | Alternative: path to a file containing the secret |
+
+### Worker Deployment
+
+See the reference Cloudflare Email Worker implementation in [`examples/cloudflare-email-worker/`](../../examples/cloudflare-email-worker/README.md) for:
+- Complete Worker source code with MIME parsing via `postal-mime`
+- Triage-based rejection via `message.setReject()`
+- Auto-reply via `message.reply()`
+- Retry logic for transient failures
+- `wrangler.jsonc` deployment configuration

--- a/src/api/openapi/index.ts
+++ b/src/api/openapi/index.ts
@@ -30,6 +30,7 @@ import { webhooksNotificationsPaths } from './paths/webhooks-notifications.ts';
 import { analyticsPaths } from './paths/analytics.ts';
 import { oauthDriveSyncPaths } from './paths/oauth-drive-sync.ts';
 import { emailPaths } from './paths/email.ts';
+import { cloudflareEmailPaths } from './paths/cloudflare-email.ts';
 import { calendarPaths } from './paths/calendar.ts';
 import { geolocationPaths } from './paths/geolocation.ts';
 import { contextsPaths } from './paths/contexts.ts';
@@ -95,6 +96,7 @@ function allDomainModules(): OpenApiDomainModule[] {
     analyticsPaths(),
     oauthDriveSyncPaths(),
     emailPaths(),
+    cloudflareEmailPaths(),
     calendarPaths(),
     geolocationPaths(),
     contextsPaths(),

--- a/src/api/openapi/paths/cloudflare-email.ts
+++ b/src/api/openapi/paths/cloudflare-email.ts
@@ -1,0 +1,243 @@
+/**
+ * OpenAPI path definitions for the Cloudflare Email inbound webhook.
+ * Route: POST /cloudflare/email
+ *
+ * This endpoint receives parsed email payloads from a Cloudflare Email Worker.
+ * It is NOT authenticated via Bearer token — it uses a shared secret header
+ * (X-Cloudflare-Email-Secret) for verification.
+ *
+ * Part of Issue #210, #2061, #2062.
+ */
+import type { OpenApiDomainModule } from '../types.ts';
+import { errorResponses, jsonBody, jsonResponse } from '../helpers.ts';
+
+export function cloudflareEmailPaths(): OpenApiDomainModule {
+  return {
+    tags: [
+      {
+        name: 'CloudflareEmail',
+        description:
+          'Inbound email webhook for Cloudflare Email Workers. ' +
+          'Receives parsed email payloads, creates contacts and threads, ' +
+          'and returns a triage decision (accept/reject) that the Worker ' +
+          'uses to control SMTP-level acceptance.',
+      },
+    ],
+    schemas: {
+      CloudflareEmailPayload: {
+        type: 'object',
+        required: ['from', 'to', 'subject', 'headers', 'timestamp'],
+        properties: {
+          from: {
+            type: 'string',
+            description: 'Sender email address (from MIME From header or envelope)',
+            example: 'sender@example.com',
+          },
+          to: {
+            type: 'string',
+            description: 'Recipient email address (envelope recipient)',
+            example: 'support@myapp.com',
+          },
+          subject: {
+            type: 'string',
+            description: 'Email subject line',
+            example: 'Question about my order',
+          },
+          text_body: {
+            type: 'string',
+            nullable: true,
+            description: 'Plain text body extracted from MIME. Falls back to stripped HTML if absent.',
+            example: 'Hi, I have a question about order #12345.',
+          },
+          html_body: {
+            type: 'string',
+            nullable: true,
+            description: 'HTML body extracted from MIME.',
+            example: '<p>Hi, I have a question about order #12345.</p>',
+          },
+          headers: {
+            $ref: '#/components/schemas/CloudflareEmailHeaders',
+          },
+          raw: {
+            type: 'string',
+            nullable: true,
+            description:
+              'Full raw MIME message (optional). Only included when the Worker has INCLUDE_RAW_MIME=true. ' +
+              'Useful for debugging but increases payload size significantly.',
+          },
+          timestamp: {
+            type: 'string',
+            format: 'date-time',
+            description:
+              'ISO 8601 timestamp when the Worker processed the email. ' +
+              'Used for replay protection — payloads older than 5 minutes are rejected.',
+            example: '2026-03-03T12:00:00.000Z',
+          },
+        },
+      },
+      CloudflareEmailHeaders: {
+        type: 'object',
+        description:
+          'Email headers extracted by the Cloudflare Worker. ' +
+          'Used for threading (Message-ID, In-Reply-To, References) and metadata.',
+        properties: {
+          'message-id': {
+            type: 'string',
+            description: 'RFC 5322 Message-ID header. Used as the external message key for deduplication.',
+            example: '<unique-id-123@example.com>',
+          },
+          'in-reply-to': {
+            type: 'string',
+            nullable: true,
+            description: 'In-Reply-To header. Links this email to the message it replies to, enabling threading.',
+            example: '<original-id-456@example.com>',
+          },
+          references: {
+            type: 'string',
+            nullable: true,
+            description: 'References header. Space-separated list of Message-IDs in the thread chain.',
+            example: '<original-id-456@example.com> <reply-id-789@example.com>',
+          },
+        },
+        additionalProperties: {
+          type: 'string',
+          description: 'Additional headers the Worker may include (date, list-id, etc.)',
+        },
+      },
+      CloudflareEmailWebhookResponse: {
+        type: 'object',
+        required: ['success', 'action'],
+        description:
+          'Webhook response controlling the Worker triage decision. ' +
+          'The Worker inspects `action` to decide whether to accept or reject the email at the SMTP level.',
+        properties: {
+          success: {
+            type: 'boolean',
+            description: 'Whether the webhook processed the payload successfully',
+            example: true,
+          },
+          action: {
+            type: 'string',
+            enum: ['accept', 'reject'],
+            description:
+              'Triage decision. "accept" means the email is routed to an agent. ' +
+              '"reject" signals the Worker to return an SMTP 550 bounce via message.setReject().',
+            example: 'accept',
+          },
+          reject_reason: {
+            type: 'string',
+            nullable: true,
+            description: 'Human-readable reason when action is "reject". Sent as the SMTP rejection reason.',
+            example: 'No agent configured for this address',
+          },
+          receipt_id: {
+            type: 'string',
+            format: 'uuid',
+            nullable: true,
+            description: 'Database ID of the stored message (present on both accept and reject)',
+            example: 'd290f1ee-6c54-4b01-90e6-d701748f0851',
+          },
+          contact_id: {
+            type: 'string',
+            format: 'uuid',
+            nullable: true,
+            description: 'Database ID of the sender contact (created or matched)',
+            example: 'a1b2c3d4-5678-90ab-cdef-1234567890ab',
+          },
+          thread_id: {
+            type: 'string',
+            format: 'uuid',
+            nullable: true,
+            description: 'Database ID of the email thread',
+            example: 'b2c3d4e5-6789-01ab-cdef-2345678901bc',
+          },
+          message_id: {
+            type: 'string',
+            format: 'uuid',
+            nullable: true,
+            description: 'Database ID of the stored email message',
+            example: 'c3d4e5f6-7890-12ab-cdef-3456789012cd',
+          },
+          auto_reply: {
+            $ref: '#/components/schemas/CloudflareEmailAutoReply',
+          },
+        },
+      },
+      CloudflareEmailAutoReply: {
+        type: 'object',
+        nullable: true,
+        required: ['subject', 'text_body'],
+        description:
+          'Optional auto-reply content. When present, the Worker constructs a MIME reply ' +
+          'and sends it back to the sender via message.reply(). Only included when action is "accept".',
+        properties: {
+          subject: {
+            type: 'string',
+            description: 'Subject line for the reply (typically "Re: <original subject>")',
+            example: 'Re: Question about my order',
+          },
+          text_body: {
+            type: 'string',
+            description: 'Plain text body of the auto-reply',
+            example: 'Thank you for your message. An agent will respond shortly.',
+          },
+          html_body: {
+            type: 'string',
+            nullable: true,
+            description: 'HTML body of the auto-reply (optional)',
+            example: '<p>Thank you for your message. An agent will respond shortly.</p>',
+          },
+        },
+      },
+    },
+    paths: {
+      '/cloudflare/email': {
+        post: {
+          operationId: 'receiveCloudflareEmail',
+          summary: 'Receive inbound email from Cloudflare Email Worker',
+          description:
+            'Webhook endpoint for Cloudflare Email Workers. Receives a parsed email payload, ' +
+            'creates or matches the sender contact, threads the email using Message-ID/In-Reply-To/References, ' +
+            'stores the message, and returns a triage decision.\n\n' +
+            '**Authentication:** Uses `X-Cloudflare-Email-Secret` shared secret header (NOT Bearer token). ' +
+            'The secret is compared using timing-safe comparison.\n\n' +
+            '**Triage flow:**\n' +
+            '1. Email is always stored (contact, thread, message created)\n' +
+            '2. Route resolver checks `inbound_destination` for the recipient address\n' +
+            '3. Falls back to `channel_default` for the email channel\n' +
+            '4. If a route is found → `action: "accept"`, webhook dispatched to agent\n' +
+            '5. If no route → `action: "reject"`, Worker bounces the email via SMTP 550\n\n' +
+            '**Threading:** Emails are grouped into threads using the Message-ID header as the external key. ' +
+            'Replies are linked to existing threads via the In-Reply-To and References headers.\n\n' +
+            '**Idempotency:** Duplicate messages (same Message-ID + thread) are upserted, not duplicated.\n\n' +
+            '**Replay protection:** Payloads with timestamps older than 5 minutes are rejected (400).\n\n' +
+            'See `examples/cloudflare-email-worker/` for the reference Worker implementation.',
+          tags: ['CloudflareEmail'],
+          security: [], // Not using Bearer auth
+          parameters: [
+            {
+              name: 'X-Cloudflare-Email-Secret',
+              in: 'header',
+              required: true,
+              description:
+                'Shared secret for authenticating the Cloudflare Worker. ' +
+                'Must match the CLOUDFLARE_EMAIL_SECRET environment variable.',
+              schema: { type: 'string' },
+              example: 'your-shared-secret-here',
+            },
+          ],
+          requestBody: jsonBody({
+            $ref: '#/components/schemas/CloudflareEmailPayload',
+          }),
+          responses: {
+            '200': jsonResponse(
+              'Email processed — check `action` field for triage decision',
+              { $ref: '#/components/schemas/CloudflareEmailWebhookResponse' },
+            ),
+            ...errorResponses(400, 401, 500),
+          },
+        },
+      },
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- Adds `cloudflare-email.ts` OpenAPI path module defining `POST /cloudflare/email` with full request/response schemas (`CloudflareEmailPayload`, `CloudflareEmailHeaders`, `CloudflareEmailWebhookResponse`, `CloudflareEmailAutoReply`)
- Registers the new domain module in the OpenAPI assembler so agents can discover the endpoint via `/openapi.json`
- Adds comprehensive Cloudflare Email section to `docs/api/messaging.md` covering:
  - Webhook endpoint contract with request/response examples
  - Triage flow and route resolution (inbound_destination → channel_default → reject)
  - Email threading via Message-ID / In-Reply-To / References
  - Contact creation behavior
  - Auto-reply response format
  - Environment variable reference
  - Links to Worker example

Closes #2064

## Test plan

- [x] `pnpm run build` — typecheck passes
- [x] `pnpm exec vitest run tests/cloudflare-email/` — 15/15 integration tests pass
- [ ] Verify `/openapi.json` includes CloudflareEmail tag and `/cloudflare/email` path at runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)