### PR TITLE
[#2065] Security hardening for Cloudflare email triage and auto-reply

### DIFF
--- a/examples/cloudflare-email-worker/src/__tests__/index.test.ts
+++ b/examples/cloudflare-email-worker/src/__tests__/index.test.ts
@@ -6,6 +6,9 @@ import {
   extractHeaders,
   buildPayload,
   buildReplyMime,
+  sanitizeHeaderValue,
+  isAutomatedSender,
+  hasAutoSubmittedHeader,
   postWebhook,
   DEFAULT_MAX_RAW_BYTES,
   WEBHOOK_PATH,
@@ -629,7 +632,7 @@ describe("webhook response triage", () => {
     const response: WebhookResponse = {
       success: true,
       action: "reject",
-      reject_reason: "No agent configured for support@myapp.com",
+      reject_reason: "No agent configured for this address",
       receipt_id: "m1",
       contact_id: "c1",
       thread_id: "t1",
@@ -656,5 +659,122 @@ describe("webhook response triage", () => {
     expect(response.action).toBe("accept");
     expect(response.auto_reply?.subject).toBe("Re: Your inquiry");
     expect(response.auto_reply?.text_body).toContain("received");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Security hardening (#2065)
+// ---------------------------------------------------------------------------
+
+describe("sanitizeHeaderValue", () => {
+  it("strips CR and LF from header values", () => {
+    expect(sanitizeHeaderValue("Normal Subject")).toBe("Normal Subject");
+    expect(sanitizeHeaderValue("Evil\r\nBcc: attacker@evil.com")).toBe(
+      "EvilBcc: attacker@evil.com",
+    );
+    expect(sanitizeHeaderValue("Has\nnewline")).toBe("Hasnewline");
+    expect(sanitizeHeaderValue("Has\rreturn")).toBe("Hasreturn");
+  });
+
+  it("handles empty strings", () => {
+    expect(sanitizeHeaderValue("")).toBe("");
+  });
+});
+
+describe("isAutomatedSender", () => {
+  it("detects common automated sender prefixes", () => {
+    expect(isAutomatedSender("noreply@example.com")).toBe(true);
+    expect(isAutomatedSender("no-reply@example.com")).toBe(true);
+    expect(isAutomatedSender("NOREPLY@EXAMPLE.COM")).toBe(true);
+    expect(isAutomatedSender("mailer-daemon@example.com")).toBe(true);
+    expect(isAutomatedSender("postmaster@example.com")).toBe(true);
+    expect(isAutomatedSender("auto-confirm@example.com")).toBe(true);
+    expect(isAutomatedSender("bounce+abc@example.com")).toBe(true);
+  });
+
+  it("allows normal senders", () => {
+    expect(isAutomatedSender("alice@example.com")).toBe(false);
+    expect(isAutomatedSender("support@example.com")).toBe(false);
+    expect(isAutomatedSender("reply@example.com")).toBe(false);
+  });
+});
+
+describe("hasAutoSubmittedHeader", () => {
+  function makeHeaders(map: Record<string, string>): ForwardableEmailMessage["headers"] {
+    return {
+      get(key: string) {
+        return map[key.toLowerCase()] ?? null;
+      },
+    } as ForwardableEmailMessage["headers"];
+  }
+
+  it("detects Auto-Submitted header", () => {
+    expect(hasAutoSubmittedHeader(makeHeaders({ "auto-submitted": "auto-replied" }))).toBe(true);
+    expect(hasAutoSubmittedHeader(makeHeaders({ "auto-submitted": "auto-generated" }))).toBe(true);
+  });
+
+  it("allows Auto-Submitted: no", () => {
+    expect(hasAutoSubmittedHeader(makeHeaders({ "auto-submitted": "no" }))).toBe(false);
+  });
+
+  it("detects Precedence header", () => {
+    expect(hasAutoSubmittedHeader(makeHeaders({ precedence: "bulk" }))).toBe(true);
+    expect(hasAutoSubmittedHeader(makeHeaders({ precedence: "junk" }))).toBe(true);
+    expect(hasAutoSubmittedHeader(makeHeaders({ precedence: "list" }))).toBe(true);
+  });
+
+  it("allows when no auto-submit headers present", () => {
+    expect(hasAutoSubmittedHeader(makeHeaders({}))).toBe(false);
+  });
+});
+
+describe("buildReplyMime security (#2065)", () => {
+  it("includes Auto-Submitted and Precedence headers", async () => {
+    const stream = buildReplyMime(
+      "support@myapp.com",
+      "sender@example.com",
+      "Re: Hello",
+      "Thanks!",
+      undefined,
+      undefined,
+    );
+    const bytes = await streamToUint8Array(stream);
+    const raw = new TextDecoder().decode(bytes);
+
+    expect(raw).toContain("Auto-Submitted: auto-replied");
+    expect(raw).toContain("Precedence: bulk");
+  });
+
+  it("sanitizes subject containing CRLF injection", async () => {
+    const stream = buildReplyMime(
+      "support@myapp.com",
+      "sender@example.com",
+      "Evil\r\nBcc: attacker@evil.com\r\nSubject: Injected",
+      "Body text",
+      undefined,
+      undefined,
+    );
+    const bytes = await streamToUint8Array(stream);
+    const raw = new TextDecoder().decode(bytes);
+
+    // The injected Bcc header should NOT appear as a separate header
+    expect(raw).not.toContain("\r\nBcc:");
+    expect(raw).toContain("Subject: EvilBcc: attacker@evil.comSubject: Injected");
+  });
+
+  it("sanitizes In-Reply-To containing CRLF injection", async () => {
+    const stream = buildReplyMime(
+      "support@myapp.com",
+      "sender@example.com",
+      "Re: Test",
+      "Body",
+      undefined,
+      "<msg@test>\r\nBcc: attacker@evil.com",
+    );
+    const bytes = await streamToUint8Array(stream);
+    const raw = new TextDecoder().decode(bytes);
+
+    expect(raw).not.toContain("\r\nBcc:");
+    expect(raw).toContain("In-Reply-To: <msg@test>Bcc: attacker@evil.com");
   });
 });

--- a/examples/cloudflare-email-worker/src/index.ts
+++ b/examples/cloudflare-email-worker/src/index.ts
@@ -278,9 +278,58 @@ export async function postWebhook(
 }
 
 /**
+ * Strip CR and LF characters from a header value to prevent MIME header injection.
+ * A malicious subject like "Foo\r\nBcc: evil@attacker.com" would otherwise inject headers.
+ */
+export function sanitizeHeaderValue(value: string): string {
+  return value.replace(/[\r\n]/g, "");
+}
+
+/**
+ * Check whether an email address belongs to an automated sender.
+ * Auto-replies to these addresses risk creating infinite mail loops.
+ */
+export function isAutomatedSender(address: string): boolean {
+  const lower = address.toLowerCase();
+  const automatedPrefixes = [
+    "noreply@",
+    "no-reply@",
+    "mailer-daemon@",
+    "postmaster@",
+    "auto-",
+    "bounce",
+  ];
+  return automatedPrefixes.some((prefix) => lower.startsWith(prefix));
+}
+
+/**
+ * Check whether an email's headers indicate it is an automated message.
+ * RFC 3834 Auto-Submitted header and Precedence header are checked.
+ */
+export function hasAutoSubmittedHeader(
+  headers: ForwardableEmailMessage["headers"],
+): boolean {
+  const autoSubmitted = headers.get("Auto-Submitted");
+  if (autoSubmitted && autoSubmitted.toLowerCase() !== "no") {
+    return true;
+  }
+  const precedence = headers.get("Precedence");
+  if (
+    precedence &&
+    ["bulk", "junk", "list", "auto_reply"].includes(precedence.toLowerCase())
+  ) {
+    return true;
+  }
+  return false;
+}
+
+/**
  * Build a minimal RFC 5322 MIME message for use with message.reply().
  *
- * The reply includes In-Reply-To and References headers for proper threading.
+ * The reply includes In-Reply-To and References headers for proper threading,
+ * plus Auto-Submitted and Precedence headers to prevent mail loops (RFC 3834).
+ *
+ * All header values are sanitized to prevent MIME header injection.
  */
 export function buildReplyMime(
   from: string,
@@ -297,16 +346,19 @@ export function buildReplyMime(
     : "text/plain; charset=utf-8";
 
   const lines: string[] = [
-    `From: ${from}`,
-    `To: ${to}`,
-    `Subject: ${subject}`,
+    `From: ${sanitizeHeaderValue(from)}`,
+    `To: ${sanitizeHeaderValue(to)}`,
+    `Subject: ${sanitizeHeaderValue(subject)}`,
     `MIME-Version: 1.0`,
     `Date: ${new Date().toUTCString()}`,
+    `Auto-Submitted: auto-replied`,
+    `Precedence: bulk`,
   ];
 
   if (inReplyToMessageId) {
-    lines.push(`In-Reply-To: ${inReplyToMessageId}`);
-    lines.push(`References: ${inReplyToMessageId}`);
+    const safeMessageId = sanitizeHeaderValue(inReplyToMessageId);
+    lines.push(`In-Reply-To: ${safeMessageId}`);
+    lines.push(`References: ${safeMessageId}`);
   }
 
   lines.push(`Content-Type: ${contentType}`);
@@ -466,26 +518,37 @@ export default {
 
     // -----------------------------------------------------------------------
     // 7. Auto-reply if the API included one (#2062)
+    //    Skip for automated senders to prevent mail loops (RFC 3834, #2065)
     // -----------------------------------------------------------------------
     if (webhookResult?.auto_reply) {
-      try {
-        const { auto_reply } = webhookResult;
-        const replyMime = buildReplyMime(
-          message.to,     // Reply from the receiving address
-          message.from,   // Reply to the original sender
-          auto_reply.subject,
-          auto_reply.text_body,
-          auto_reply.html_body,
-          message.headers.get("Message-ID") ?? undefined,
+      const skipAutoReply =
+        isAutomatedSender(message.from) ||
+        hasAutoSubmittedHeader(message.headers);
+
+      if (skipAutoReply) {
+        console.log(
+          `${logPrefix} Skipping auto-reply: sender is automated`,
         );
-        // EmailMessage is a Workers-only runtime class from cloudflare:email
-        const { EmailMessage } = await import("cloudflare:email");
-        const replyMessage = new EmailMessage(message.to, message.from, replyMime);
-        await message.reply(replyMessage);
-        console.log(`${logPrefix} Auto-reply sent`);
-      } catch (replyErr) {
-        // Reply failures are non-fatal (DMARC check may fail, etc.)
-        console.warn(`${logPrefix} Auto-reply failed: ${replyErr}`);
+      } else {
+        try {
+          const { auto_reply } = webhookResult;
+          const replyMime = buildReplyMime(
+            message.to,     // Reply from the receiving address
+            message.from,   // Reply to the original sender
+            auto_reply.subject,
+            auto_reply.text_body,
+            auto_reply.html_body,
+            message.headers.get("Message-ID") ?? undefined,
+          );
+          // EmailMessage is a Workers-only runtime class from cloudflare:email
+          const { EmailMessage } = await import("cloudflare:email");
+          const replyMessage = new EmailMessage(message.to, message.from, replyMime);
+          await message.reply(replyMessage);
+          console.log(`${logPrefix} Auto-reply sent`);
+        } catch (replyErr) {
+          // Reply failures are non-fatal (DMARC check may fail, etc.)
+          console.warn(`${logPrefix} Auto-reply failed: ${replyErr}`);
+        }
       }
     }
 

--- a/src/api/route-resolver/service.ts
+++ b/src/api/route-resolver/service.ts
@@ -59,19 +59,29 @@ async function loadPromptContent(
  * 1. inbound_destination by (address, channel_type) — if agent_id is set, use overrides
  * 2. channel_default by (namespace, channel_type) — fallback
  * 3. null — no routing configured (message stored but not dispatched)
+ *
+ * When namespace is undefined (e.g. unauthenticated webhooks like Cloudflare
+ * email), the destination lookup is not scoped by namespace — the email
+ * address alone identifies the route. The destination's own namespace is used
+ * for prompt template resolution. Channel defaults are not consulted when
+ * namespace is unknown (they require a namespace).
  */
 export async function resolveRoute(
   pool: Pool,
   recipient: string,
   channelType: ChannelType,
-  namespace: string,
+  namespace?: string,
 ): Promise<ResolvedRoute | null> {
-  // Step 1: Check inbound_destination (scoped to namespace)
-  const dest = await getDestinationByAddress(pool, recipient, channelType, [namespace]);
+  // Step 1: Check inbound_destination
+  // When namespace is provided, scope the lookup; otherwise search all namespaces.
+  const queryNamespaces = namespace ? [namespace] : undefined;
+  const dest = await getDestinationByAddress(pool, recipient, channelType, queryNamespaces);
 
   if (dest?.agent_id) {
+    // Use the destination's own namespace for prompt template resolution
+    const destNamespace = dest.namespace ?? namespace ?? 'default';
     const promptContent = dest.prompt_template_id
-      ? await loadPromptContent(pool, dest.prompt_template_id, namespace)
+      ? await loadPromptContent(pool, dest.prompt_template_id, destNamespace)
       : null;
 
     return {
@@ -82,21 +92,23 @@ export async function resolveRoute(
     };
   }
 
-  // Step 2: Check channel_default
-  const { getChannelDefault } = await import('../channel-default/service.ts');
-  const channelDefault = await getChannelDefault(pool, channelType, [namespace]);
+  // Step 2: Check channel_default (requires a namespace)
+  if (namespace) {
+    const { getChannelDefault } = await import('../channel-default/service.ts');
+    const channelDefault = await getChannelDefault(pool, channelType, [namespace]);
 
-  if (channelDefault) {
-    const promptContent = channelDefault.prompt_template_id
-      ? await loadPromptContent(pool, channelDefault.prompt_template_id, namespace)
-      : null;
+    if (channelDefault) {
+      const promptContent = channelDefault.prompt_template_id
+        ? await loadPromptContent(pool, channelDefault.prompt_template_id, namespace)
+        : null;
 
-    return {
-      agentId: channelDefault.agent_id,
-      promptContent,
-      contextId: channelDefault.context_id ?? null,
-      source: 'channel_default',
-    };
+      return {
+        agentId: channelDefault.agent_id,
+        promptContent,
+        contextId: channelDefault.context_id ?? null,
+        source: 'channel_default',
+      };
+    }
   }
 
   // Step 3: No routing configured

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -12373,7 +12373,10 @@ export function buildServer(options: ProjectsApiOptions = {}): FastifyInstance {
           );
           const routingAddress = originalRecipient || payload.to.toLowerCase();
 
-          route = await resolveRoute(pool, routingAddress, 'email', getStoreNamespace(req));
+          // Cloudflare email webhook is unauthenticated — no namespace context.
+          // Pass undefined to search all namespaces; the destination's own namespace
+          // is used for prompt template resolution (#2065).
+          route = await resolveRoute(pool, routingAddress, 'email');
           if (route) {
             await enqueueWebhook(pool, 'email_received', '/hooks/agent', {
               event_type: 'email_received',
@@ -12400,12 +12403,12 @@ export function buildServer(options: ProjectsApiOptions = {}): FastifyInstance {
         // Default: accept (backwards compatible — unrouted messages are still stored).
         if (!route) {
           console.log(
-            `[Cloudflare Email] No route for ${payload.to} — signalling reject to Worker`,
+            `[Cloudflare Email] No route resolved — signalling reject to Worker`,
           );
           return reply.code(200).send({
             success: true,
             action: 'reject' as const,
-            reject_reason: `No agent configured for ${payload.to}`,
+            reject_reason: 'No agent configured for this address',
             receipt_id: result.message_id,
             contact_id: result.contact_id,
             thread_id: result.thread_id,


### PR DESCRIPTION
Closes #2065

## Summary

- **MIME header injection**: New `sanitizeHeaderValue()` strips CR/LF from all header values in `buildReplyMime`, preventing header injection attacks
- **Mail loop prevention (RFC 3834)**: Auto-replies now include `Auto-Submitted: auto-replied` and `Precedence: bulk` headers; auto-reply is skipped for automated senders (noreply@, mailer-daemon@, etc.) and when inbound headers indicate automated origin
- **Information disclosure**: Triage rejection no longer echoes the recipient address — uses generic "No agent configured for this address"
- **Namespace scoping**: `resolveRoute()` now accepts optional namespace; unauthenticated webhooks (Cloudflare email) search all namespaces for destination match, using the destination's own namespace for prompt template resolution

## Findings addressed

| # | Finding | Status |
|---|---------|--------|
| 1 | MIME header injection in `buildReplyMime` | Fixed |
| 2 | Namespace scoping bypass on webhook route | Fixed |
| 3 | Mail loop amplification (no RFC 3834 compliance) | Fixed |
| 4 | Information disclosure in rejection reason | Fixed |
| 5 | Rejected emails persist in database | By design — audit trail, Worker uses `action` field |
| 6 | Worker tests need standalone install | Pre-existing — example is standalone project |

## Test plan

- [x] Typecheck passes (`pnpm run build`)
- [x] 17 integration tests pass (`tests/cloudflare-email/`)
- [x] 42 Worker unit tests pass (`examples/cloudflare-email-worker/`)
- [x] New tests for `sanitizeHeaderValue`, `isAutomatedSender`, `hasAutoSubmittedHeader`
- [x] New tests for `buildReplyMime` security (Auto-Submitted header, Precedence header, header sanitization)

🤖 Generated with [Claude Code](https://claude.com/claude-code)