### PR TITLE
[#2069] Add Traefik WebSocket bypass route for terminal attach

### DIFF
--- a/docker/traefik/dynamic-config.yml.template
+++ b/docker/traefik/dynamic-config.yml.template
@@ -120,8 +120,13 @@ http:
     # This router sends terminal attach requests directly to the Fastify API,
     # following the same pattern as openclaw-ws-router for the OpenClaw Gateway.
     # Priority 110 ensures this matches before the catch-all api-router.
+    #
+    # Security hardening:
+    #   - PathRegexp enforces UUID format so only valid session IDs bypass the WAF
+    #   - HeadersRegexp limits bypass to actual WebSocket upgrades; plain HTTP
+    #     requests to the same path fall through to api-router (ModSecurity)
     api-ws-router:
-      rule: "Host(`api.${DOMAIN}`) && PathRegexp(`^/terminal/sessions/[^/]+/attach$`)"
+      rule: "Host(`api.${DOMAIN}`) && PathRegexp(`^/terminal/sessions/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/attach$`) && HeadersRegexp(`Upgrade`, `(?i)^websocket$`)"
       service: api-service
       priority: 110
       entryPoints:

--- a/tests/docker/traefik-entrypoint.test.ts
+++ b/tests/docker/traefik-entrypoint.test.ts
@@ -272,6 +272,35 @@ describe('Traefik dynamic config: api-ws-router (Issue #2069)', () => {
     expect(router.rule).toContain('/attach');
   });
 
+  it('api-ws-router requires Upgrade: websocket header (HeadersRegexp)', () => {
+    const config = getParsedConfig();
+    const router = config.http.routers['api-ws-router'];
+    expect(router.rule).toContain('HeadersRegexp(`Upgrade`');
+    expect(router.rule).toMatch(/websocket/i);
+  });
+
+  it('api-ws-router PathRegexp enforces UUID format for session ID', () => {
+    const config = getParsedConfig();
+    const router = config.http.routers['api-ws-router'];
+    // Extract the PathRegexp value from the rule
+    const pathRegexpMatch = router.rule.match(/PathRegexp\(`([^`]+)`\)/);
+    expect(pathRegexpMatch).not.toBeNull();
+    const regex = new RegExp(pathRegexpMatch![1]);
+
+    // Valid UUID path — should match
+    expect(regex.test('/terminal/sessions/7996e974-6396-4f1e-bac8-c191dd23341e/attach')).toBe(true);
+
+    // Non-UUID session ID — should NOT match
+    expect(regex.test('/terminal/sessions/not-a-uuid/attach')).toBe(false);
+    expect(regex.test('/terminal/sessions/../../etc/passwd/attach')).toBe(false);
+
+    // Trailing suffix after attach — should NOT match
+    expect(regex.test('/terminal/sessions/7996e974-6396-4f1e-bac8-c191dd23341e/attach/extra')).toBe(false);
+
+    // Prefix before /terminal — should NOT match
+    expect(regex.test('/api/terminal/sessions/7996e974-6396-4f1e-bac8-c191dd23341e/attach')).toBe(false);
+  });
+
   it('api-ws-router has security-headers and rate-limit middlewares', () => {
     const config = getParsedConfig();
     const router = config.http.routers['api-ws-router'];


### PR DESCRIPTION
## Summary

- Terminal WebSocket connections (`wss://api.*/terminal/sessions/{id}/attach`) fail silently because ModSecurity (Apache `mod_proxy_http`) cannot proxy WebSocket upgrade requests
- Added a dedicated `api-ws-router` in Traefik that routes terminal attach WebSocket connections directly to the Fastify API, bypassing the ModSecurity WAF
- Follows the existing pattern used by `openclaw-ws-router` for OpenClaw Gateway WebSocket connections

## Root Cause

The proxy chain is: `Client → Traefik → ModSecurity (Apache) → Fastify API`

Apache's `mod_proxy_http` does not support WebSocket upgrades — that requires `mod_proxy_wstunnel`, which is not loaded in the OWASP CRS Docker image. When the browser sends the HTTP upgrade request, Apache drops it silently.

## Fix

New Traefik router `api-ws-router` with:
- **Rule**: `Host(api.DOMAIN) && PathRegexp(^/terminal/sessions/[^/]+/attach$)`
- **Service**: `api-service` (direct to Fastify, bypassing ModSecurity)
- **Priority**: 110 (higher than catch-all `api-router`)
- Rate limiting and security headers still applied

## Test plan

- [ ] Deploy and verify terminal WebSocket upgrade succeeds (browser dev tools Network tab should show 101 Switching Protocols)
- [ ] Verify xterm.js terminal I/O works end-to-end
- [ ] Verify non-WebSocket API requests still route through ModSecurity WAF
- [ ] Verify REST terminal endpoints (list, create, delete) still work through ModSecurity

Closes #2069

🤖 Generated with [Claude Code](https://claude.com/claude-code)