### PR TITLE
[#2068] Fix notification poll missing user_email causing persistent 401

### DIFF
--- a/packages/openclaw-plugin/src/register-openclaw.ts
+++ b/packages/openclaw-plugin/src/register-openclaw.ts
@@ -5757,6 +5757,7 @@ export const registerOpenClaw: PluginInitializer = (api: OpenClawPluginApi) => {
     logger,
     apiClient,
     getAgentId: () => state.agentId,
+    getAgentEmail: () => state.agentEmail,
     events: eventEmitter,
     config: {
       enabled: config.autoRecall, // Only enable if auto-recall is enabled

--- a/packages/openclaw-plugin/src/services/notification-service.ts
+++ b/packages/openclaw-plugin/src/services/notification-service.ts
@@ -40,6 +40,8 @@ export interface NotificationServiceOptions {
   apiClient: ApiClient;
   /** Getter for current user ID (reads from mutable state, Issue #1644) */
   getAgentId: () => string;
+  /** Getter for current agent email for M2M identity resolution (Issue #2068) */
+  getAgentEmail?: () => string | undefined;
   /** Event emitter for notifications */
   events: NotificationServiceEvents;
   /** Service configuration */
@@ -80,7 +82,7 @@ const EVENT_MAP: Record<NotificationEvent, string> = {
  * @returns Service definition for registration
  */
 export function createNotificationService(options: NotificationServiceOptions): NotificationService {
-  const { logger, apiClient, getAgentId, events, config: userConfig } = options;
+  const { logger, apiClient, getAgentId, getAgentEmail, events, config: userConfig } = options;
   const config = { ...DEFAULT_CONFIG, ...userConfig };
 
   // Service state
@@ -117,6 +119,7 @@ export function createNotificationService(options: NotificationServiceOptions): 
    */
   async function poll(): Promise<void> {
     const user_id = getAgentId();
+    const user_email = getAgentEmail?.();
     try {
       const queryParams = new URLSearchParams();
       queryParams.set('limit', '20');
@@ -125,11 +128,22 @@ export function createNotificationService(options: NotificationServiceOptions): 
         // only notifications created after this ID, providing cursor-based pagination.
         queryParams.set('since', lastSeenId);
       }
+      // Issue #2068: M2M tokens require user_email for resolveUserEmail() to bind
+      // the request to a specific user. Send in both query params (server reads from
+      // query) and request options (maps to X-User-Email header as defense-in-depth).
+      if (user_email) {
+        queryParams.set('user_email', user_email);
+      }
+
+      const reqOpts: { user_id: string; user_email?: string } = { user_id };
+      if (user_email) {
+        reqOpts.user_email = user_email;
+      }
 
       const response = await apiClient.get<{
         notifications: Notification[];
         total: number;
-      }>(`/notifications?${queryParams}`, { user_id });
+      }>(`/notifications?${queryParams}`, reqOpts);
 
       if (!response.success) {
         logger.error('Notification poll failed', {

--- a/packages/openclaw-plugin/tests/services/notification-service.test.ts
+++ b/packages/openclaw-plugin/tests/services/notification-service.test.ts
@@ -278,6 +278,86 @@ describe('Notification Service', () => {
     }
   });
 
+  // Issue #2068: Notification poll must send user_email for M2M auth
+  describe('User Email Propagation (#2068)', () => {
+    it('should pass user_email in request options when getAgentEmail is provided', async () => {
+      (mockApiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+        success: true,
+        data: { notifications: [], total: 0 },
+      });
+
+      const service = createNotificationService({
+        logger: mockLogger,
+        apiClient: mockApiClient,
+        getAgentId: () => 'agent-123',
+        getAgentEmail: () => 'agent@example.com',
+        events: mockEmitter,
+        config: { enabled: true, pollIntervalMs: 5000 },
+      });
+
+      await service.start();
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(mockApiClient.get).toHaveBeenCalledTimes(1);
+      const [url, opts] = (mockApiClient.get as ReturnType<typeof vi.fn>).mock.calls[0];
+      // user_email should be in the query params
+      expect(url).toContain('user_email=agent%40example.com');
+      // user_email should also be in request options (maps to X-User-Email header)
+      expect(opts).toEqual(expect.objectContaining({
+        user_id: 'agent-123',
+        user_email: 'agent@example.com',
+      }));
+    });
+
+    it('should omit user_email when getAgentEmail returns undefined', async () => {
+      (mockApiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+        success: true,
+        data: { notifications: [], total: 0 },
+      });
+
+      const service = createNotificationService({
+        logger: mockLogger,
+        apiClient: mockApiClient,
+        getAgentId: () => 'agent-123',
+        getAgentEmail: () => undefined,
+        events: mockEmitter,
+        config: { enabled: true, pollIntervalMs: 5000 },
+      });
+
+      await service.start();
+      await vi.advanceTimersByTimeAsync(0);
+
+      const [url, opts] = (mockApiClient.get as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).not.toContain('user_email');
+      expect(opts.user_email).toBeUndefined();
+    });
+
+    it('should work without getAgentEmail for backward compatibility', async () => {
+      (mockApiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+        success: true,
+        data: { notifications: [], total: 0 },
+      });
+
+      // No getAgentEmail provided — simulates older callers
+      const service = createNotificationService({
+        logger: mockLogger,
+        apiClient: mockApiClient,
+        getAgentId: () => 'agent-123',
+        events: mockEmitter,
+        config: { enabled: true, pollIntervalMs: 5000 },
+      });
+
+      await service.start();
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Should still poll without error
+      expect(mockApiClient.get).toHaveBeenCalledTimes(1);
+      const [url, opts] = (mockApiClient.get as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).not.toContain('user_email');
+      expect(opts.user_email).toBeUndefined();
+    });
+  });
+
   describe('Service State', () => {
     it('should track running state', async () => {
       const service = createNotificationService({

--- a/src/api/auth/middleware.test.ts
+++ b/src/api/auth/middleware.test.ts
@@ -361,5 +361,48 @@ describe('JWT auth middleware', () => {
 
       expect(result).toBe('alice@example.com');
     });
+
+    // Issue #2068: M2M tokens should fall back to X-User-Email header when
+    // no requestedEmail parameter is provided (e.g. notification polling).
+    it('should fall back to X-User-Email header for M2M tokens when requestedEmail is undefined', async () => {
+      const { signAccessToken } = await loadJwt();
+      const token = await signAccessToken('gateway-service', { type: 'm2m' });
+      const { resolveUserEmail } = await loadMiddleware();
+
+      const result = await resolveUserEmail(
+        fakeRequest({ authorization: `Bearer ${token}`, 'x-user-email': 'agent@example.com' }),
+        undefined,
+      );
+
+      expect(result).toBe('agent@example.com');
+    });
+
+    it('should prefer requestedEmail over X-User-Email header for M2M tokens', async () => {
+      const { signAccessToken } = await loadJwt();
+      const token = await signAccessToken('gateway-service', { type: 'm2m' });
+      const { resolveUserEmail } = await loadMiddleware();
+
+      const result = await resolveUserEmail(
+        fakeRequest({ authorization: `Bearer ${token}`, 'x-user-email': 'header@example.com' }),
+        'param@example.com',
+      );
+
+      // Explicit requestedEmail takes precedence over header
+      expect(result).toBe('param@example.com');
+    });
+
+    it('should ignore X-User-Email header for user tokens (principal binding takes priority)', async () => {
+      const { signAccessToken } = await loadJwt();
+      const token = await signAccessToken('alice@example.com');
+      const { resolveUserEmail } = await loadMiddleware();
+
+      const result = await resolveUserEmail(
+        fakeRequest({ authorization: `Bearer ${token}`, 'x-user-email': 'attacker@example.com' }),
+        undefined,
+      );
+
+      // User tokens always use the JWT identity, never X-User-Email
+      expect(result).toBe('alice@example.com');
+    });
   });
 });

--- a/src/api/auth/middleware.ts
+++ b/src/api/auth/middleware.ts
@@ -191,7 +191,13 @@ export async function resolveUserEmail(
   }
 
   if (identity.type === 'm2m') {
-    return requestedEmail?.trim() || null;
+    // Issue #2068: fall back to X-User-Email header when no explicit
+    // requestedEmail param is provided (e.g. notification polling).
+    const fromParam = requestedEmail?.trim() || null;
+    if (fromParam) return fromParam;
+    const headerVal = req.headers['x-user-email'];
+    const fromHeader = typeof headerVal === 'string' ? headerVal.trim() : null;
+    return fromHeader || null;
   }
 
   // User tokens: always use the authenticated identity's email


### PR DESCRIPTION
## Summary

- **Plugin**: Added `getAgentEmail` callback to `NotificationServiceOptions` and wired it in `register-openclaw.ts` — the notification poll now sends `user_email` in both query params and `X-User-Email` header
- **Server**: `resolveUserEmail()` now falls back to `X-User-Email` header for M2M tokens when no explicit `requestedEmail` parameter is provided (defense-in-depth)
- **Tests**: 3 new plugin tests for email propagation + 3 new middleware tests for header fallback

## Root Cause

`notification-service.ts:poll()` called `apiClient.get('/notifications?...', { user_id })` — only passed `user_id` (maps to `X-Agent-Id` header), but NOT `user_email`. The server's `resolveUserEmail(req, query.user_email)` received `undefined` for M2M tokens → returned `null` → 401.

## Test plan

- [x] New failing tests written first (TDD)
- [x] Plugin test: `user_email` in query params and request options when `getAgentEmail` provided
- [x] Plugin test: omits `user_email` when `getAgentEmail` returns undefined
- [x] Plugin test: backward-compatible when `getAgentEmail` not provided
- [x] Middleware test: M2M falls back to `X-User-Email` header
- [x] Middleware test: explicit `requestedEmail` takes precedence over header
- [x] Middleware test: user tokens ignore `X-User-Email` header
- [x] Full build passes (`pnpm run build`)
- [x] All 3889 unit tests pass (`pnpm run test:unit`)

Closes #2068

🤖 Generated with [Claude Code](https://claude.com/claude-code)