### PR TITLE
[#2077, #2078] Fix WebSocket terminal namespace resolution and add chat unread-count

### DIFF
--- a/src/api/chat/routes.ts
+++ b/src/api/chat/routes.ts
@@ -383,6 +383,50 @@ export async function chatRoutesPlugin(
     return reply.send({ sessions, next_cursor: nextCursor });
   });
 
+  // GET /api/chat/sessions/unread-count — Count of unread messages across all sessions
+  // Issue #2078: Registered before the parametric :id route so the static path matches first.
+  app.get('/chat/sessions/unread-count', async (req, reply) => {
+    const userEmail = await getUserEmail(req);
+    if (!userEmail) {
+      return reply.code(401).send({ error: 'Authentication required' });
+    }
+
+    const namespaces = getEffectiveNamespaces(req);
+    if (namespaces.length === 0) {
+      return reply.send({ count: 0 });
+    }
+
+    try {
+      // Count inbound (agent → user) messages received after the user's read cursor.
+      // Sessions without a read cursor have ALL inbound messages counted as unread.
+      const result = await pool.query(
+        `WITH user_sessions AS (
+           SELECT s.id AS session_id, s.thread_id
+           FROM chat_session s
+           WHERE s.user_email = $1
+             AND s.namespace = ANY($2::text[])
+             AND s.status = 'active'
+         )
+         SELECT COUNT(*)::int AS count
+         FROM user_sessions us
+         JOIN external_message m ON m.thread_id = us.thread_id AND m.direction = 'inbound'
+         LEFT JOIN LATERAL (
+           SELECT rm.received_at
+           FROM chat_read_cursor c
+           JOIN external_message rm ON rm.id = c.last_read_message_id
+           WHERE c.session_id = us.session_id AND c.user_email = $1
+           LIMIT 1
+         ) cursor_msg ON true
+         WHERE cursor_msg.received_at IS NULL OR m.received_at > cursor_msg.received_at`,
+        [userEmail, namespaces],
+      );
+      return reply.send({ count: result.rows[0]?.count ?? 0 });
+    } catch (err) {
+      req.log.error(err, 'Failed to count unread chat messages');
+      return reply.code(500).send({ error: 'Internal server error' });
+    }
+  });
+
   // GET /api/chat/sessions/:id — Get session details
   app.get('/chat/sessions/:id', async (req, reply) => {
     const userEmail = await getUserEmail(req);

--- a/src/api/terminal/routes.ts
+++ b/src/api/terminal/routes.ts
@@ -25,7 +25,7 @@ import type { FastifyInstance, FastifyRequest } from 'fastify';
 import type { Pool } from 'pg';
 import type { WebSocket } from 'ws';
 
-import { getAuthIdentity } from '../auth/middleware.ts';
+import { getAuthIdentity, resolveNamespaces } from '../auth/middleware.ts';
 import { isAuthDisabled, verifyAccessToken } from '../auth/jwt.ts';
 import {
   encryptCredential,
@@ -1302,6 +1302,15 @@ export async function terminalRoutesPlugin(
     if (!authenticated) {
       socket.close(4401, 'Authentication required');
       return;
+    }
+
+    // Issue #2077: WebSocket connections cannot set custom HTTP headers.
+    // The JWT arrives in ?token= query param, but the global preHandler
+    // namespace resolution hook only checks req.headers.authorization.
+    // Re-resolve namespaces now that we've confirmed the token is valid.
+    if (query.token && !req.namespaceContext) {
+      (req.headers as Record<string, string>).authorization = `Bearer ${query.token}`;
+      req.namespaceContext = await resolveNamespaces(req, pool);
     }
 
     // Verify session access


### PR DESCRIPTION
## Summary

- **WebSocket terminal attach (#2077)**: The global preHandler namespace resolution hook can't see the JWT (sent via `?token=` query param, not `Authorization` header). After authenticating, re-inject the token and re-resolve namespaces so `verifyReadScope()` has proper context. This was causing silent 4404 close codes.
- **Chat unread-count (#2078)**: `GET /chat/sessions/unread-count` didn't exist — requests matched `/chat/sessions/:id` with `id="unread-count"` → failed UUID validation → 400. Added the endpoint before the parametric route.

## Root Cause

**#2077**: WebSocket connections cannot set custom HTTP headers (browser limitation). The JWT is only in `?token=` query param. The namespace preHandler hook calls `getAuthIdentity(req)` which only checks `Authorization` header → returns null → `req.namespaceContext = null` → `getEffectiveNamespaces()` returns `[]` → `verifyReadScope()` returns false → socket closes with 4404.

**#2078**: Frontend `useChatUnreadCount()` calls `/chat/sessions/unread-count` every 30s. No such route exists. Fastify matches it to `/chat/sessions/:id` parametric route → `isValidUUID("unread-count")` → false → 400.

## Test plan

- [x] Build passes (`pnpm run build`)
- [x] All 3889 unit tests pass (`pnpm run test:unit`)
- [ ] Manual verification: terminal WebSocket connects successfully
- [ ] Manual verification: chat unread badge shows correct count

Closes #2077
Closes #2078

🤖 Generated with [Claude Code](https://claude.com/claude-code)