### PR TITLE
[#2086] Fix route resolver channel_default fallback for unauthenticated webhooks

### DIFF
--- a/src/api/route-resolver/service.ts
+++ b/src/api/route-resolver/service.ts
@@ -63,8 +63,8 @@ async function loadPromptContent(
  * When namespace is undefined (e.g. unauthenticated webhooks like Cloudflare
  * email), the destination lookup is not scoped by namespace — the email
  * address alone identifies the route. The destination's own namespace is used
- * for prompt template resolution. Channel defaults are not consulted when
- * namespace is unknown (they require a namespace).
+ * for prompt template resolution. Channel defaults fall back to the 'default'
+ * namespace when namespace is not provided, enabling catch-all routing.
  */
 export async function resolveRoute(
   pool: Pool,
@@ -92,14 +92,19 @@ export async function resolveRoute(
     };
   }
 
-  // Step 2: Check channel_default (requires a namespace)
-  if (namespace) {
+  // Step 2: Check channel_default
+  // When namespace is provided, check that namespace.
+  // When namespace is undefined (e.g. unauthenticated Cloudflare email webhook),
+  // fall back to the 'default' namespace so catch-all routing still works.
+  {
+    const namespacesToCheck = namespace ? [namespace] : ['default'];
     const { getChannelDefault } = await import('../channel-default/service.ts');
-    const channelDefault = await getChannelDefault(pool, channelType, [namespace]);
+    const channelDefault = await getChannelDefault(pool, channelType, namespacesToCheck);
 
     if (channelDefault) {
+      const resolvedNamespace = namespace ?? channelDefault.namespace ?? 'default';
       const promptContent = channelDefault.prompt_template_id
-        ? await loadPromptContent(pool, channelDefault.prompt_template_id, namespace)
+        ? await loadPromptContent(pool, channelDefault.prompt_template_id, resolvedNamespace)
         : null;
 
       return {

--- a/tests/route-resolver.test.ts
+++ b/tests/route-resolver.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Tests for route resolver service (Issue #2086).
+ *
+ * Verifies that resolveRoute() correctly falls back to channel_default
+ * in the 'default' namespace when namespace is undefined (unauthenticated
+ * webhooks like Cloudflare email).
+ */
+import type { Pool } from 'pg';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { createTestPool, truncateAllTables, ensureTestNamespace } from './helpers/db.ts';
+import { runMigrate } from './helpers/migrate.ts';
+import { resolveRoute } from '../src/api/route-resolver/service.ts';
+
+describe('resolveRoute (Issue #2086)', () => {
+  let pool: Pool;
+
+  beforeAll(async () => {
+    await runMigrate('up');
+    pool = createTestPool();
+  });
+
+  beforeEach(async () => {
+    await truncateAllTables(pool);
+    await ensureTestNamespace(pool, 'test@example.com');
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  // ── Existing behavior: namespace provided ──────────────
+
+  it('returns destination_override when inbound_destination matches', async () => {
+    await pool.query(
+      `INSERT INTO inbound_destination (namespace, address, channel_type, agent_id, is_active)
+       VALUES ('default', 'hello@example.com', 'email', 'agent-dest', true)`,
+    );
+
+    const result = await resolveRoute(pool, 'hello@example.com', 'email', 'default');
+
+    expect(result).not.toBeNull();
+    expect(result!.agentId).toBe('agent-dest');
+    expect(result!.source).toBe('destination_override');
+  });
+
+  it('falls back to channel_default when no destination matches (namespace provided)', async () => {
+    await pool.query(
+      `INSERT INTO channel_default (namespace, channel_type, agent_id)
+       VALUES ('default', 'email', 'agent-default')`,
+    );
+
+    const result = await resolveRoute(pool, 'unknown@example.com', 'email', 'default');
+
+    expect(result).not.toBeNull();
+    expect(result!.agentId).toBe('agent-default');
+    expect(result!.source).toBe('channel_default');
+  });
+
+  it('returns null when nothing matches', async () => {
+    const result = await resolveRoute(pool, 'unknown@example.com', 'email', 'default');
+    expect(result).toBeNull();
+  });
+
+  // ── Bug #2086: namespace undefined (unauthenticated webhook) ──
+
+  it('falls back to channel_default in default namespace when namespace is undefined', async () => {
+    await pool.query(
+      `INSERT INTO channel_default (namespace, channel_type, agent_id)
+       VALUES ('default', 'email', 'agent-catchall')`,
+    );
+
+    // Cloudflare email webhook calls resolveRoute without a namespace
+    const result = await resolveRoute(pool, 'anything@example.com', 'email');
+
+    expect(result).not.toBeNull();
+    expect(result!.agentId).toBe('agent-catchall');
+    expect(result!.source).toBe('channel_default');
+  });
+
+  it('prefers inbound_destination over channel_default even without namespace', async () => {
+    await pool.query(
+      `INSERT INTO inbound_destination (namespace, address, channel_type, agent_id, is_active)
+       VALUES ('default', 'specific@example.com', 'email', 'agent-specific', true)`,
+    );
+    await pool.query(
+      `INSERT INTO channel_default (namespace, channel_type, agent_id)
+       VALUES ('default', 'email', 'agent-catchall')`,
+    );
+
+    const result = await resolveRoute(pool, 'specific@example.com', 'email');
+
+    expect(result).not.toBeNull();
+    expect(result!.agentId).toBe('agent-specific');
+    expect(result!.source).toBe('destination_override');
+  });
+
+  it('returns null when no namespace and no default-namespace channel_default', async () => {
+    // channel_default exists but in a different namespace
+    await pool.query(
+      `INSERT INTO channel_default (namespace, channel_type, agent_id)
+       VALUES ('other-ns', 'email', 'agent-other')`,
+    );
+
+    const result = await resolveRoute(pool, 'anything@example.com', 'email');
+    expect(result).toBeNull();
+  });
+
+  it('resolves prompt_template_id from channel_default when namespace is undefined', async () => {
+    await pool.query(
+      `INSERT INTO prompt_template (namespace, label, content, channel_type, is_active)
+       VALUES ('default', 'catch-all prompt', 'You are a helpful agent.', 'email', true)`,
+    );
+    const ptRow = await pool.query(`SELECT id FROM prompt_template WHERE label = 'catch-all prompt'`);
+    const promptTemplateId = ptRow.rows[0].id;
+
+    await pool.query(
+      `INSERT INTO channel_default (namespace, channel_type, agent_id, prompt_template_id)
+       VALUES ('default', 'email', 'agent-catchall', $1)`,
+      [promptTemplateId],
+    );
+
+    const result = await resolveRoute(pool, 'anything@example.com', 'email');
+
+    expect(result).not.toBeNull();
+    expect(result!.agentId).toBe('agent-catchall');
+    expect(result!.promptContent).toBe('You are a helpful agent.');
+    expect(result!.source).toBe('channel_default');
+  });
+});


### PR DESCRIPTION
## Summary
- `resolveRoute()` now falls back to the `default` namespace for `channel_default` lookup when `namespace` is undefined (e.g. Cloudflare email webhooks)
- Previously, the `if (namespace)` guard skipped channel_default entirely for unauthenticated webhooks, causing all inbound emails to be rejected unless an exact `inbound_destination` row existed
- Uses `channelDefault.namespace` for prompt template resolution when the caller doesn't provide a namespace

## Test plan
- [x] Integration test: channel_default fallback works when namespace is undefined
- [x] Integration test: prompt_template_id resolves correctly through the fallback path
- [x] Integration test: inbound_destination still preferred over channel_default (with and without namespace)
- [x] Integration test: returns null when no default-namespace channel_default exists
- [x] Full test suite: 10382 tests pass, 0 failures
- [x] Build: `tsc` clean

Closes #2086

🤖 Generated with [Claude Code](https://claude.com/claude-code)