### PR TITLE
[#2092, #2076] Deterministic route resolver ordering and remove notification RPC registration

### DIFF
--- a/packages/openclaw-plugin/src/register-openclaw.ts
+++ b/packages/openclaw-plugin/src/register-openclaw.ts
@@ -13,7 +13,10 @@ import { type ApiClient, createApiClient } from './api-client.js';
 import { type PluginConfig, type RawPluginConfig, redactConfig, resolveConfigSecretsSync, resolveNamespaceConfig, validateRawConfig } from './config.js';
 import { extractContext, getUserScopeKey, resolveAgentId } from './context.js';
 import { createOAuthGatewayMethods, registerOAuthGatewayRpcMethods } from './gateway/oauth-rpc-methods.js';
-import { createGatewayMethods, registerGatewayRpcMethods } from './gateway/rpc-methods.js';
+// Notification gateway RPC methods (subscribe/unsubscribe/getNotifications)
+// are intentionally NOT registered — the notification system is unused and
+// the SDK may poll getNotifications automatically, producing 401s (#2076).
+// Implementation kept in gateway/rpc-methods.ts for future use.
 import { createAutoCaptureHook, createGraphAwareRecallHook } from './hooks.js';
 import { createLogger, type Logger } from './logger.js';
 import {
@@ -5720,13 +5723,9 @@ export const registerOpenClaw: PluginInitializer = (api: OpenClawPluginApi) => {
     logger.debug('api.registerCommand not available — slash commands not registered (#2054)');
   }
 
-  // Register Gateway RPC methods (Issue #324)
-  const gatewayMethods = createGatewayMethods({
-    logger,
-    apiClient,
-    getAgentId: () => state.agentId,
-  });
-  registerGatewayRpcMethods(api, gatewayMethods);
+  // Notification gateway RPC methods NOT registered — see #2076.
+  // The notification table is unused and the webhook outbox handles
+  // event delivery. Re-enable when the notification system is built.
 
   // Register OAuth Gateway RPC methods (Issue #1054)
   const oauthGatewayMethods = createOAuthGatewayMethods({

--- a/src/api/channel-default/service.ts
+++ b/src/api/channel-default/service.ts
@@ -49,21 +49,25 @@ export async function listChannelDefaults(
 
 /**
  * Get channel default for a specific channel type, optionally scoped to namespaces.
+ *
+ * When queryNamespaces is omitted, all namespaces are searched. The 'default'
+ * namespace is preferred so results are deterministic (#2092).
  */
 export async function getChannelDefault(
   pool: Pool,
   channelType: string,
   queryNamespaces?: string[],
 ): Promise<ChannelDefault | null> {
+  const orderBy = `ORDER BY CASE WHEN namespace = 'default' THEN 0 ELSE 1 END, namespace`;
   if (queryNamespaces) {
     const result = await pool.query(
-      `SELECT ${COLUMNS} FROM channel_default WHERE channel_type = $1 AND namespace = ANY($2::text[])`,
+      `SELECT ${COLUMNS} FROM channel_default WHERE channel_type = $1 AND namespace = ANY($2::text[]) ${orderBy}`,
       [channelType, queryNamespaces],
     );
     return (result.rows[0] as ChannelDefault) ?? null;
   }
   const result = await pool.query(
-    `SELECT ${COLUMNS} FROM channel_default WHERE channel_type = $1`,
+    `SELECT ${COLUMNS} FROM channel_default WHERE channel_type = $1 ${orderBy}`,
     [channelType],
   );
   return (result.rows[0] as ChannelDefault) ?? null;

--- a/src/api/route-resolver/service.ts
+++ b/src/api/route-resolver/service.ts
@@ -12,6 +12,10 @@ type ChannelType = 'sms' | 'email' | 'ha_observation';
 /**
  * Look up an inbound_destination by (address, channel_type).
  * Returns the row if active; null otherwise.
+ *
+ * The UNIQUE (address, channel_type) constraint on inbound_destination
+ * prevents duplicate rows, but we add ORDER BY as defensive coding so
+ * results are deterministic even if the constraint is ever relaxed (#2092).
  */
 async function getDestinationByAddress(
   pool: Pool,
@@ -25,14 +29,16 @@ async function getDestinationByAddress(
     FROM inbound_destination
     WHERE address = $1 AND channel_type = $2 AND is_active = true`;
 
+  const orderBy = `ORDER BY CASE WHEN namespace = 'default' THEN 0 ELSE 1 END, namespace`;
+
   if (queryNamespaces) {
     const result = await pool.query(
-      `${base} AND namespace = ANY($3::text[])`,
+      `${base} AND namespace = ANY($3::text[]) ${orderBy}`,
       [address, channelType, queryNamespaces],
     );
     return result.rows[0] ?? null;
   }
-  const result = await pool.query(base, [address, channelType]);
+  const result = await pool.query(`${base} ${orderBy}`, [address, channelType]);
   return result.rows[0] ?? null;
 }
 

--- a/tests/route-resolver.test.ts
+++ b/tests/route-resolver.test.ts
@@ -1,15 +1,17 @@
 /**
- * Tests for route resolver service (Issue #2086).
+ * Tests for route resolver service (Issues #2086, #2092).
  *
  * Verifies that resolveRoute() correctly falls back to channel_default
  * in the 'default' namespace when namespace is undefined (unauthenticated
- * webhooks like Cloudflare email).
+ * webhooks like Cloudflare email), and that lookups are deterministic
+ * when multiple namespaces contain channel defaults for the same type.
  */
 import type { Pool } from 'pg';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { createTestPool, truncateAllTables, ensureTestNamespace } from './helpers/db.ts';
 import { runMigrate } from './helpers/migrate.ts';
 import { resolveRoute } from '../src/api/route-resolver/service.ts';
+import { getChannelDefault } from '../src/api/channel-default/service.ts';
 
 describe('resolveRoute (Issue #2086)', () => {
   let pool: Pool;
@@ -125,5 +127,45 @@ describe('resolveRoute (Issue #2086)', () => {
     expect(result!.agentId).toBe('agent-catchall');
     expect(result!.promptContent).toBe('You are a helpful agent.');
     expect(result!.source).toBe('channel_default');
+  });
+
+  // ── Bug #2092: deterministic ordering across namespaces ──
+
+  it('getChannelDefault prefers default namespace when multiple exist (#2092)', async () => {
+    // Insert channel defaults in two namespaces for the same channel type.
+    // Create 'zzz-ns' first to verify ORDER BY wins over insertion order.
+    await pool.query(
+      `INSERT INTO channel_default (namespace, channel_type, agent_id)
+       VALUES ('zzz-ns', 'email', 'agent-zzz')`,
+    );
+    await pool.query(
+      `INSERT INTO channel_default (namespace, channel_type, agent_id)
+       VALUES ('default', 'email', 'agent-default')`,
+    );
+
+    // Query without namespace scope — should deterministically return 'default'
+    const result = await getChannelDefault(pool, 'email');
+
+    expect(result).not.toBeNull();
+    expect(result!.agent_id).toBe('agent-default');
+    expect(result!.namespace).toBe('default');
+  });
+
+  it('getChannelDefault returns alphabetically first non-default namespace when no default exists (#2092)', async () => {
+    // Insert beta before alpha to verify ORDER BY namespace wins over insertion order
+    await pool.query(
+      `INSERT INTO channel_default (namespace, channel_type, agent_id)
+       VALUES ('beta-ns', 'sms', 'agent-beta')`,
+    );
+    await pool.query(
+      `INSERT INTO channel_default (namespace, channel_type, agent_id)
+       VALUES ('alpha-ns', 'sms', 'agent-alpha')`,
+    );
+
+    const result = await getChannelDefault(pool, 'sms');
+
+    expect(result).not.toBeNull();
+    expect(result!.agent_id).toBe('agent-alpha');
+    expect(result!.namespace).toBe('alpha-ns');
   });
 });


### PR DESCRIPTION
## Summary

- **#2092**: Add `ORDER BY` to `getDestinationByAddress()` and `getChannelDefault()` to prefer the `default` namespace when multiple namespaces match. The `UNIQUE (address, channel_type)` constraint on `inbound_destination` already prevents duplicates, but `channel_default` can have multiple rows per channel type across namespaces — this makes the lookup deterministic.
- **#2076**: Remove notification gateway RPC method registration (`subscribe`, `unsubscribe`, `getNotifications`) from the plugin. The OpenClaw SDK may poll `getNotifications` automatically when subscriptions are registered, producing 401s every 30 seconds since M2M tokens lack `user_email`. The webhook outbox already handles event delivery. Implementation kept in `rpc-methods.ts` for future use.

## Test plan

- [x] `pnpm run build` — typecheck passes
- [x] `pnpm exec vitest run src/api/route-resolver/service.test.ts` — 13 existing tests pass
- [x] `pnpm exec vitest run tests/route-resolver.test.ts` — 9 tests pass (2 new for #2092)
- [x] `pnpm exec vitest run packages/openclaw-plugin/tests/gateway-rpc.test.ts` — 15 tests pass (methods still work, just not registered)
- [x] `pnpm exec vitest run tests/unit/` — 404 unit tests pass

Closes #2092
Closes #2076

🤖 Generated with [Claude Code](https://claude.com/claude-code)