### PR TITLE
[#2132,#2133] Terminal follow-up: frontend/API contract fixes

### DIFF
--- a/src/ui/hooks/queries/use-terminal-connections.ts
+++ b/src/ui/hooks/queries/use-terminal-connections.ts
@@ -5,7 +5,7 @@
  */
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { apiClient } from '@/ui/lib/api-client.ts';
-import type { TerminalConnection, TerminalConnectionsResponse, TerminalKnownHostsResponse } from '@/ui/lib/api-types.ts';
+import type { TerminalConnection, TerminalConnectionsResponse, TerminalKnownHostsResponse, SshConfigImportResponse } from '@/ui/lib/api-types.ts';
 
 /** Response from POST /terminal/connections/:id/test */
 export interface TestConnectionResponse {
@@ -106,7 +106,7 @@ export function useImportSshConfig() {
 
   return useMutation({
     mutationFn: (config: string) =>
-      apiClient.post<{ connections: TerminalConnection[] }>('/terminal/connections/import-ssh-config', { config_text: config }),
+      apiClient.post<SshConfigImportResponse>('/terminal/connections/import-ssh-config', { config_text: config }),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: terminalConnectionKeys.all });
     },

--- a/src/ui/hooks/queries/use-terminal-search.ts
+++ b/src/ui/hooks/queries/use-terminal-search.ts
@@ -12,7 +12,8 @@ export interface TerminalSearchParams {
   query: string;
   connection_id?: string;
   session_id?: string;
-  kind?: string;
+  /** Filter by entry kinds. Backend expects an array of kind strings. */
+  kind?: string[];
   tags?: string[];
   from?: string;
   to?: string;

--- a/src/ui/lib/api-types.ts
+++ b/src/ui/lib/api-types.ts
@@ -1742,6 +1742,18 @@ export interface TerminalKnownHostsResponse {
   known_hosts: TerminalKnownHost[];
 }
 
+/** An imported connection entry from POST /terminal/connections/import-ssh-config */
+export interface SshConfigImportedEntry {
+  id: string;
+  name: string;
+}
+
+/** Response from POST /terminal/connections/import-ssh-config */
+export interface SshConfigImportResponse {
+  imported: SshConfigImportedEntry[];
+  count: number;
+}
+
 /** Terminal activity log entry. */
 export interface TerminalActivityItem {
   id: string;

--- a/src/ui/pages/terminal/TerminalSearchPage.tsx
+++ b/src/ui/pages/terminal/TerminalSearchPage.tsx
@@ -28,7 +28,7 @@ export function TerminalSearchPage(): React.JSX.Element {
     searchMutation.mutate({
       query,
       connection_id: connectionId !== 'all' ? connectionId : undefined,
-      kind: kind !== 'all' ? kind : undefined,
+      kind: kind !== 'all' ? [kind] : undefined,
     });
   };
 

--- a/tests/ui/terminal-connections.test.tsx
+++ b/tests/ui/terminal-connections.test.tsx
@@ -347,6 +347,58 @@ describe('ConnectionsPage', () => {
     }, { timeout: 5000 });
   });
 
+  // Issue #2133: SSH config import response alignment
+  it('SSH config import uses correct backend response shape { imported, count }', async () => {
+    const mockImportResponse = {
+      imported: [
+        { id: 'new-1', name: 'server-alpha' },
+        { id: 'new-2', name: 'server-beta' },
+      ],
+      count: 2,
+    };
+    mockApiClient.post.mockResolvedValueOnce(mockImportResponse);
+
+    renderWithRouter();
+
+    await waitFor(() => {
+      expect(screen.getByText('Import SSH Config')).toBeInTheDocument();
+    }, { timeout: 5000 });
+
+    // Open import dialog
+    fireEvent.click(screen.getByText('Import SSH Config'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('ssh-config-input')).toBeInTheDocument();
+    }, { timeout: 5000 });
+
+    // Enter SSH config text
+    const textarea = screen.getByTestId('ssh-config-input');
+    fireEvent.change(textarea, { target: { value: 'Host server-alpha\n  HostName 10.0.0.1\n  User admin\n\nHost server-beta\n  HostName 10.0.0.2\n  User admin' } });
+
+    // Click import
+    const importButton = screen.getByRole('button', { name: /^import$/i });
+    fireEvent.click(importButton);
+
+    await waitFor(() => {
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        '/terminal/connections/import-ssh-config',
+        { config_text: expect.any(String) },
+      );
+    }, { timeout: 5000 });
+  });
+
+  it('SshConfigImportResponse type matches backend { imported, count } shape', async () => {
+    const { useImportSshConfig } = await import('@/ui/hooks/queries/use-terminal-connections');
+    expect(useImportSshConfig).toBeDefined();
+
+    // Verify the response type has 'imported' and 'count', not 'connections'
+    type ImportResult = Awaited<ReturnType<ReturnType<typeof useImportSshConfig>['mutateAsync']>>;
+    // This would fail at build time if the type still had `connections` instead of `imported`
+    const mockResult: ImportResult = { imported: [{ id: '1', name: 'test' }], count: 1 };
+    expect(mockResult.imported).toHaveLength(1);
+    expect(mockResult.count).toBe(1);
+  });
+
   it('does not show host key dialog for non-verification failures', async () => {
     mockApiClient.post.mockResolvedValue(mockTestOtherFailure);
     renderWithRouter();

--- a/tests/ui/terminal-search.test.tsx
+++ b/tests/ui/terminal-search.test.tsx
@@ -6,7 +6,7 @@
  */
 import * as React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { createMemoryRouter, RouterProvider } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { TerminalConnectionsResponse } from '@/ui/lib/api-types';
@@ -129,6 +129,42 @@ describe('TerminalSearchPage', () => {
 
     await waitFor(() => {
       expect(screen.getByText('Terminal Search')).toBeInTheDocument();
+    }, { timeout: 5000 });
+  });
+
+  // Issue #2132: kind filter must send string[] to backend
+  it('TerminalSearchParams.kind accepts string[] matching backend contract', async () => {
+    const mod = await import('@/ui/hooks/queries/use-terminal-search');
+    expect(mod.useTerminalSearch).toBeDefined();
+
+    // If kind were still typed as `string`, this assignment would fail at build time.
+    type Params = Parameters<ReturnType<typeof mod.useTerminalSearch>['mutate']>[0];
+    const params: Params = { query: 'test', kind: ['command', 'output'] };
+    expect(Array.isArray(params.kind)).toBe(true);
+    expect(params.kind).toEqual(['command', 'output']);
+  });
+
+  it('sends kind as undefined when "all" is selected (no filter)', async () => {
+    renderWithRouter();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('terminal-search-filters')).toBeInTheDocument();
+    }, { timeout: 5000 });
+
+    const input = screen.getByTestId('search-query-input');
+    fireEvent.change(input, { target: { value: 'test query' } });
+
+    const searchButton = screen.getByRole('button', { name: /search/i });
+    fireEvent.click(searchButton);
+
+    await waitFor(() => {
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        '/terminal/search',
+        expect.objectContaining({ query: 'test query' }),
+      );
+      // When "all" is selected, kind should be undefined (not sent as string or empty array)
+      const callArgs = mockApiClient.post.mock.calls[0][1];
+      expect(callArgs.kind).toBeUndefined();
     }, { timeout: 5000 });
   });
 });


### PR DESCRIPTION
Closes #2132
Closes #2133

## Summary

Follow-up fixes from Epic #2130 Phase 0 Codex review addressing frontend/backend API contract mismatches:

### #2132: Search kind filter sends string, backend expects string[]
- `TerminalSearchParams.kind` changed from `string` to `string[]`
- `TerminalSearchPage` now wraps the selected kind value in an array (`[kind]`) before sending
- Backend route handler at `src/api/terminal/routes.ts:2829` validates with `Array.isArray(body.kind)`, so a bare string was silently ignored

### #2133: SSH config import response type mismatch
- Frontend expected `{ connections: TerminalConnection[] }` but backend returns `{ imported: Array<{id, name}>, count: number }`
- Added `SshConfigImportResponse` and `SshConfigImportedEntry` types to `api-types.ts`
- Updated `useImportSshConfig` hook to use correct response type

## Files Changed
- `src/ui/hooks/queries/use-terminal-search.ts` — kind type `string` → `string[]`
- `src/ui/pages/terminal/TerminalSearchPage.tsx` — wrap kind in array
- `src/ui/lib/api-types.ts` — add `SshConfigImportResponse` type
- `src/ui/hooks/queries/use-terminal-connections.ts` — use correct import response type
- `tests/ui/terminal-search.test.tsx` — tests for kind array contract
- `tests/ui/terminal-connections.test.tsx` — tests for import response shape

## Local Verification
```
pnpm run build  # TypeScript clean
pnpm test:unit  # 267 test files, 4057 tests passed
```