### PR TITLE
[#2146] Fix flaky integration test: SSH config import activity

### DIFF
--- a/tests/terminal_hardening.test.ts
+++ b/tests/terminal_hardening.test.ts
@@ -63,7 +63,8 @@ async function waitForActivity(
     if (rows.length >= expectedCount) return rows;
     await new Promise((r) => setTimeout(r, intervalMs));
   }
-  return rows;
+  // Final check after deadline to avoid boundary miss
+  return getActivityByAction(pool, action);
 }
 
 // ── Tests ────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #2146

## Summary

Fixes intermittent failure in `terminal_hardening.test.ts` line 277 ("records activity on SSH config import") by replacing all fixed-delay `setTimeout(100)` waits with a deterministic `waitForActivity()` polling helper.

## Root Cause

The `recordActivity()` function is fire-and-forget (no `await`). All activity recording tests used a fixed 100ms `setTimeout` to wait for the INSERT to complete before asserting. Under CI load, 100ms is insufficient — especially for the SSH config import test which does additional DB work (INSERT loop for each parsed host entry) before the fire-and-forget activity recording.

## Fix

- Added a `waitForActivity()` helper that polls the `terminal_activity` table every 25ms until the expected row appears (up to 2s timeout)
- Replaced all 12 occurrences of `await new Promise((r) => setTimeout(r, 100))` + `getActivityByAction()` with `waitForActivity()`
- Added a final query after the polling loop deadline to prevent boundary-miss edge cases (Codex review feedback)

## Benefits

- **Deterministic**: No more timing races — tests complete as soon as data appears
- **Faster**: Tests complete in ~2s vs ~3.8s before (no longer always sleeping 100ms per assertion)
- **Robust**: 2s timeout provides ample headroom for slow CI environments

## Verification

- 5/5 consecutive runs pass locally
- Typecheck clean (`pnpm run build`)
- Codex review completed and feedback addressed

## Test commands run

```bash
pnpm exec vitest run tests/terminal_hardening.test.ts --reporter=verbose
pnpm run build
```