### PR TITLE
[#2157,#2158] Live agent discovery via gateway WS and presence tracking

### DIFF
--- a/src/api/chat/routes.ts
+++ b/src/api/chat/routes.ts
@@ -34,6 +34,7 @@ import {
 } from './stream-manager.ts';
 import { getRealtimeHub } from '../realtime/hub.ts';
 import type { ChatEventType } from '../realtime/types.ts';
+import { getAgentCache } from '../gateway/index.ts';
 import {
   executeChatSendMessage,
   executeChatAttractAttention,
@@ -174,6 +175,7 @@ export async function chatRoutesPlugin(
   // ================================================================
 
   // GET /chat/agents — List available agents
+  // Issue #2157: Prefers live agents from gateway WS; falls back to DB.
   app.get('/chat/agents', async (req, reply) => {
     const identity = await getAuthIdentity(req);
     if (!identity?.email) return reply.code(401).send({ error: 'Unauthorized' });
@@ -181,20 +183,8 @@ export async function chatRoutesPlugin(
     const namespace = getStoreNamespace(req);
 
     try {
-      const result = await pool.query(
-        `SELECT DISTINCT agent_id FROM chat_session
-         WHERE namespace = $1 AND status != 'expired'
-         ORDER BY agent_id`,
-        [namespace],
-      );
-
-      const agents = result.rows.map((row: { agent_id: string }) => ({
-        id: row.agent_id,
-        name: row.agent_id,
-        display_name: null,
-        avatar_url: null,
-      }));
-
+      const cache = getAgentCache();
+      const agents = await cache.getAgents(pool, namespace);
       return reply.send({ agents });
     } catch (err) {
       req.log.error(err, 'Failed to list chat agents');

--- a/src/api/gateway/agent-cache.test.ts
+++ b/src/api/gateway/agent-cache.test.ts
@@ -1,0 +1,315 @@
+/**
+ * Unit tests for AgentCache.
+ * Issue #2157 — Live agent discovery via gateway WS.
+ *
+ * TDD: These tests are written FIRST, before the implementation.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import { AgentCache } from './agent-cache.ts';
+import type { GatewayConnectionService } from './connection.ts';
+import type { AgentPresenceTracker } from './presence-tracker.ts';
+import type { Pool } from 'pg';
+
+/** Create a mock GatewayConnectionService. */
+function createMockConnection(overrides?: Partial<GatewayConnectionService>) {
+  return {
+    getStatus: vi.fn(() => ({ connected: false, gateway_url: null, connected_at: null, last_tick_at: null })),
+    request: vi.fn(),
+    onEvent: vi.fn(),
+    initialize: vi.fn(),
+    shutdown: vi.fn(),
+    ...overrides,
+  } as unknown as GatewayConnectionService;
+}
+
+/** Create a mock presence tracker. */
+function createMockPresenceTracker(statuses?: Record<string, string>): AgentPresenceTracker {
+  return {
+    getStatus: vi.fn((agentId: string) => statuses?.[agentId] ?? 'unknown'),
+    getAllStatuses: vi.fn(() => new Map(Object.entries(statuses ?? {}))),
+    handleEvent: vi.fn(),
+    onDisconnect: vi.fn(),
+    startPruning: vi.fn(),
+    shutdown: vi.fn(),
+  } as unknown as AgentPresenceTracker;
+}
+
+/** Create a mock pg Pool. */
+function createMockPool(rows: Array<{ agent_id: string }> = []) {
+  return {
+    query: vi.fn(() => Promise.resolve({ rows })),
+  } as unknown as Pool;
+}
+
+describe('AgentCache', () => {
+  let cache: AgentCache;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  // ── Cache behaviour ────────────────────────────────────────────────
+
+  it('returns cached result within 30s TTL', async () => {
+    const conn = createMockConnection({
+      getStatus: vi.fn(() => ({ connected: true, gateway_url: 'ws://gw', connected_at: null, last_tick_at: null })),
+      request: vi.fn().mockResolvedValue({
+        agents: [{ id: 'agent-1', name: 'Agent 1' }],
+      }),
+    });
+    const tracker = createMockPresenceTracker();
+    const pool = createMockPool();
+    cache = new AgentCache(conn, tracker);
+
+    // First call — hits gateway
+    const result1 = await cache.getAgents(pool, 'ns1');
+    expect(conn.request).toHaveBeenCalledTimes(1);
+    expect(result1).toHaveLength(1);
+
+    // Advance 10 seconds (within TTL)
+    vi.advanceTimersByTime(10000);
+
+    // Second call — returns cached, no new request
+    const result2 = await cache.getAgents(pool, 'ns1');
+    expect(conn.request).toHaveBeenCalledTimes(1);
+    expect(result2).toEqual(result1);
+  });
+
+  it('refreshes from gateway after TTL expires', async () => {
+    const conn = createMockConnection({
+      getStatus: vi.fn(() => ({ connected: true, gateway_url: 'ws://gw', connected_at: null, last_tick_at: null })),
+      request: vi.fn()
+        .mockResolvedValueOnce({ agents: [{ id: 'agent-1', name: 'Agent 1' }] })
+        .mockResolvedValueOnce({ agents: [{ id: 'agent-1', name: 'Agent 1' }, { id: 'agent-2', name: 'Agent 2' }] }),
+    });
+    const tracker = createMockPresenceTracker();
+    const pool = createMockPool();
+    cache = new AgentCache(conn, tracker);
+
+    await cache.getAgents(pool, 'ns1');
+    expect(conn.request).toHaveBeenCalledTimes(1);
+
+    // Advance past 30s TTL
+    vi.advanceTimersByTime(31000);
+
+    const result2 = await cache.getAgents(pool, 'ns1');
+    expect(conn.request).toHaveBeenCalledTimes(2);
+    expect(result2).toHaveLength(2);
+  });
+
+  it('returns empty array when cache is empty and WS unavailable', async () => {
+    const conn = createMockConnection(); // connected: false
+    const tracker = createMockPresenceTracker();
+    const pool = createMockPool([]); // no DB agents either
+    cache = new AgentCache(conn, tracker);
+
+    const result = await cache.getAgents(pool, 'ns1');
+    expect(result).toEqual([]);
+  });
+
+  it('invalidate() causes next call to re-fetch', async () => {
+    const conn = createMockConnection({
+      getStatus: vi.fn(() => ({ connected: true, gateway_url: 'ws://gw', connected_at: null, last_tick_at: null })),
+      request: vi.fn().mockResolvedValue({
+        agents: [{ id: 'agent-1', name: 'Agent 1' }],
+      }),
+    });
+    const tracker = createMockPresenceTracker();
+    const pool = createMockPool();
+    cache = new AgentCache(conn, tracker);
+
+    await cache.getAgents(pool, 'ns1');
+    expect(conn.request).toHaveBeenCalledTimes(1);
+
+    cache.invalidate();
+
+    await cache.getAgents(pool, 'ns1');
+    expect(conn.request).toHaveBeenCalledTimes(2);
+  });
+
+  it('refresh() populates cache eagerly', async () => {
+    const conn = createMockConnection({
+      getStatus: vi.fn(() => ({ connected: true, gateway_url: 'ws://gw', connected_at: null, last_tick_at: null })),
+      request: vi.fn().mockResolvedValue({
+        agents: [{ id: 'agent-1', name: 'Agent 1' }],
+      }),
+    });
+    const tracker = createMockPresenceTracker();
+    const pool = createMockPool();
+    cache = new AgentCache(conn, tracker);
+
+    await cache.refresh();
+
+    // Now getAgents should return cached without making another request
+    const result = await cache.getAgents(pool, 'ns1');
+    expect(conn.request).toHaveBeenCalledTimes(1);
+    expect(result).toHaveLength(1);
+  });
+
+  // ── Fallback to DB ────────────────────────────────────────────────
+
+  it('falls back to DB query when WS not connected', async () => {
+    const conn = createMockConnection(); // connected: false
+    const tracker = createMockPresenceTracker();
+    const pool = createMockPool([
+      { agent_id: 'db-agent-1' },
+      { agent_id: 'db-agent-2' },
+    ]);
+    cache = new AgentCache(conn, tracker);
+
+    const result = await cache.getAgents(pool, 'ns1');
+    expect(pool.query).toHaveBeenCalled();
+    expect(result).toHaveLength(2);
+    expect(result[0].id).toBe('db-agent-1');
+  });
+
+  it('DB fallback returns status: "unknown" for all agents', async () => {
+    const conn = createMockConnection(); // connected: false
+    const tracker = createMockPresenceTracker();
+    const pool = createMockPool([{ agent_id: 'db-agent-1' }]);
+    cache = new AgentCache(conn, tracker);
+
+    const result = await cache.getAgents(pool, 'ns1');
+    expect(result[0].status).toBe('unknown');
+  });
+
+  it('returns empty array (not null/throw) when both WS and DB return nothing', async () => {
+    const conn = createMockConnection(); // connected: false
+    const tracker = createMockPresenceTracker();
+    const pool = createMockPool([]); // no agents
+    cache = new AgentCache(conn, tracker);
+
+    const result = await cache.getAgents(pool, 'ns1');
+    expect(result).toEqual([]);
+    expect(Array.isArray(result)).toBe(true);
+  });
+
+  // ── Live data mapping ─────────────────────────────────────────────
+
+  it('maps gateway AgentSummary to { id, name, status }', async () => {
+    const conn = createMockConnection({
+      getStatus: vi.fn(() => ({ connected: true, gateway_url: 'ws://gw', connected_at: null, last_tick_at: null })),
+      request: vi.fn().mockResolvedValue({
+        agents: [
+          { id: 'agent-1', name: 'Agent One', status: 'active' },
+        ],
+      }),
+    });
+    const tracker = createMockPresenceTracker({ 'agent-1': 'online' });
+    const pool = createMockPool();
+    cache = new AgentCache(conn, tracker);
+
+    const result = await cache.getAgents(pool, 'ns1');
+    expect(result[0]).toEqual({
+      id: 'agent-1',
+      name: 'Agent One',
+      status: 'online',
+    });
+  });
+
+  it('maps unknown status field to "unknown"', async () => {
+    const conn = createMockConnection({
+      getStatus: vi.fn(() => ({ connected: true, gateway_url: 'ws://gw', connected_at: null, last_tick_at: null })),
+      request: vi.fn().mockResolvedValue({
+        agents: [
+          { id: 'agent-1', name: 'Agent One' }, // no status field from gateway
+        ],
+      }),
+    });
+    // Tracker also has no info
+    const tracker = createMockPresenceTracker();
+    const pool = createMockPool();
+    cache = new AgentCache(conn, tracker);
+
+    const result = await cache.getAgents(pool, 'ns1');
+    expect(result[0].status).toBe('unknown');
+  });
+
+  // ── Includes presence tracker status ──────────────────────────────
+
+  it('includes status from presence tracker in returned agents', async () => {
+    const conn = createMockConnection({
+      getStatus: vi.fn(() => ({ connected: true, gateway_url: 'ws://gw', connected_at: null, last_tick_at: null })),
+      request: vi.fn().mockResolvedValue({
+        agents: [
+          { id: 'agent-1', name: 'Agent One' },
+          { id: 'agent-2', name: 'Agent Two' },
+        ],
+      }),
+    });
+    const tracker = createMockPresenceTracker({
+      'agent-1': 'busy',
+      // agent-2 not in tracker
+    });
+    const pool = createMockPool();
+    cache = new AgentCache(conn, tracker);
+
+    const result = await cache.getAgents(pool, 'ns1');
+    expect(result[0].status).toBe('busy');
+    expect(result[1].status).toBe('unknown');
+  });
+
+  // ── Error handling ────────────────────────────────────────────────
+
+  it('handles agents.list request error gracefully (falls back to DB)', async () => {
+    const conn = createMockConnection({
+      getStatus: vi.fn(() => ({ connected: true, gateway_url: 'ws://gw', connected_at: null, last_tick_at: null })),
+      request: vi.fn().mockRejectedValue(new Error('Gateway error')),
+    });
+    const tracker = createMockPresenceTracker();
+    const pool = createMockPool([{ agent_id: 'db-agent-1' }]);
+    cache = new AgentCache(conn, tracker);
+
+    const result = await cache.getAgents(pool, 'ns1');
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('db-agent-1');
+    expect(result[0].status).toBe('unknown');
+  });
+
+  it('handles empty agents.list response gracefully', async () => {
+    const conn = createMockConnection({
+      getStatus: vi.fn(() => ({ connected: true, gateway_url: 'ws://gw', connected_at: null, last_tick_at: null })),
+      request: vi.fn().mockResolvedValue({ agents: [] }),
+    });
+    const tracker = createMockPresenceTracker();
+    const pool = createMockPool();
+    cache = new AgentCache(conn, tracker);
+
+    const result = await cache.getAgents(pool, 'ns1');
+    expect(result).toEqual([]);
+  });
+
+  it('cache cleared on WS disconnect (via invalidate)', async () => {
+    const conn = createMockConnection({
+      getStatus: vi.fn()
+        .mockReturnValueOnce({ connected: true, gateway_url: 'ws://gw', connected_at: null, last_tick_at: null })
+        .mockReturnValueOnce({ connected: false, gateway_url: 'ws://gw', connected_at: null, last_tick_at: null }),
+      request: vi.fn().mockResolvedValue({
+        agents: [{ id: 'agent-1', name: 'Agent 1' }],
+      }),
+    });
+    const tracker = createMockPresenceTracker();
+    const pool = createMockPool([{ agent_id: 'db-agent-1' }]);
+    cache = new AgentCache(conn, tracker);
+
+    // First call - from gateway
+    const result1 = await cache.getAgents(pool, 'ns1');
+    expect(result1).toHaveLength(1);
+    expect(result1[0].id).toBe('agent-1');
+
+    // Simulate disconnect
+    cache.invalidate();
+
+    // Second call - WS is disconnected now, falls back to DB
+    const result2 = await cache.getAgents(pool, 'ns1');
+    expect(result2).toHaveLength(1);
+    expect(result2[0].id).toBe('db-agent-1');
+  });
+});

--- a/src/api/gateway/agent-cache.ts
+++ b/src/api/gateway/agent-cache.ts
@@ -1,0 +1,135 @@
+/**
+ * AgentCache — TTL cache for agents.list results from gateway WS.
+ * Issue #2157 — Live agent discovery via gateway WebSocket.
+ *
+ * When the gateway WS is connected, queries agents.list and caches
+ * the result for 30 seconds. Falls back to DB query when WS is unavailable.
+ */
+
+import type { Pool } from 'pg';
+import type { GatewayConnectionService } from './connection.ts';
+import type { AgentPresenceTracker, AgentStatus } from './presence-tracker.ts';
+
+// ── Types ────────────────────────────────────────────────────────────
+
+export interface CachedAgent {
+  id: string;
+  name: string;
+  status: AgentStatus;
+}
+
+interface GatewayAgentSummary {
+  id: string;
+  name: string;
+  status?: string;
+}
+
+interface AgentsListResponse {
+  agents: GatewayAgentSummary[];
+}
+
+// ── Constants ────────────────────────────────────────────────────────
+
+const CACHE_TTL_MS = 30_000; // 30 seconds
+
+// ── Cache ────────────────────────────────────────────────────────────
+
+export class AgentCache {
+  private cachedAgents: GatewayAgentSummary[] | null = null;
+  private cachedAt = 0;
+  private connection: GatewayConnectionService;
+  private presenceTracker: AgentPresenceTracker;
+
+  constructor(connection: GatewayConnectionService, presenceTracker: AgentPresenceTracker) {
+    this.connection = connection;
+    this.presenceTracker = presenceTracker;
+  }
+
+  /**
+   * Get the list of agents. Prefers live gateway data, falls back to DB.
+   * @param pool - Database connection pool for fallback query
+   * @param namespace - Namespace to filter DB results
+   */
+  async getAgents(pool: Pool, namespace: string): Promise<CachedAgent[]> {
+    const status = this.connection.getStatus();
+
+    if (status.connected) {
+      // Try gateway first
+      try {
+        return await this._getFromGateway();
+      } catch {
+        // Fall through to DB
+      }
+    }
+
+    // Fallback to DB
+    return this._getFromDb(pool, namespace);
+  }
+
+  /** Eagerly refresh cache from gateway. Safe to call; errors are logged and ignored. */
+  async refresh(): Promise<void> {
+    try {
+      const status = this.connection.getStatus();
+      if (!status.connected) return;
+
+      const response = await this.connection.request<AgentsListResponse>('agents.list', {});
+      const agents = Array.isArray(response?.agents) ? response.agents : [];
+      this.cachedAgents = agents;
+      this.cachedAt = Date.now();
+    } catch {
+      // Best-effort refresh
+    }
+  }
+
+  /** Clear the cache. Called on WS disconnect. */
+  invalidate(): void {
+    this.cachedAgents = null;
+    this.cachedAt = 0;
+  }
+
+  // ── Private ────────────────────────────────────────────────────────
+
+  private async _getFromGateway(): Promise<CachedAgent[]> {
+    const now = Date.now();
+
+    // Return cached if within TTL
+    if (this.cachedAgents !== null && now - this.cachedAt < CACHE_TTL_MS) {
+      return this._enrichWithPresence(this.cachedAgents);
+    }
+
+    // Fetch fresh
+    const response = await this.connection.request<AgentsListResponse>('agents.list', {});
+    const agents = Array.isArray(response?.agents) ? response.agents : [];
+    this.cachedAgents = agents;
+    this.cachedAt = Date.now();
+
+    return this._enrichWithPresence(agents);
+  }
+
+  private async _getFromDb(pool: Pool, namespace: string): Promise<CachedAgent[]> {
+    try {
+      const result = await pool.query(
+        `SELECT DISTINCT agent_id FROM chat_session
+         WHERE namespace = $1 AND status != 'expired'
+         ORDER BY agent_id`,
+        [namespace],
+      );
+
+      return result.rows.map((row: { agent_id: string }) => ({
+        id: row.agent_id,
+        name: row.agent_id,
+        status: 'unknown' as AgentStatus,
+      }));
+    } catch {
+      return [];
+    }
+  }
+
+  private _enrichWithPresence(agents: GatewayAgentSummary[]): CachedAgent[] {
+    return agents.map((agent) => ({
+      id: agent.id,
+      name: agent.name,
+      status: this.presenceTracker.getStatus(agent.id),
+    }));
+  }
+}

--- a/src/api/gateway/connection.ts
+++ b/src/api/gateway/connection.ts
@@ -102,6 +102,10 @@ export class GatewayConnectionService {
   // Event handlers
   private eventHandlers: GatewayEventHandler[] = [];
 
+  // Lifecycle callbacks (#2157, #2158)
+  private disconnectCallbacks: Array<() => void> = [];
+  private connectedCallbacks: Array<() => void> = [];
+
   // Pending requests
   private pendingRequests = new Map<string, PendingRequest>();
 
@@ -178,6 +182,16 @@ export class GatewayConnectionService {
 
   onEvent(handler: GatewayEventHandler): void {
     this.eventHandlers.push(handler);
+  }
+
+  /** Register a callback invoked when the connection drops. (#2157, #2158) */
+  onDisconnect(callback: () => void): void {
+    this.disconnectCallbacks.push(callback);
+  }
+
+  /** Register a callback invoked when the connection is (re)established. (#2157) */
+  onConnected(callback: () => void): void {
+    this.connectedCallbacks.push(callback);
   }
 
   getStatus(): GatewayStatus {
@@ -450,6 +464,11 @@ export class GatewayConnectionService {
     if (this.resolveInit) {
       this.resolveInit();
     }
+
+    // Notify connected callbacks (#2157)
+    for (const cb of this.connectedCallbacks) {
+      try { cb(); } catch (err) { console.error(`${LOG_PREFIX} onConnected callback error:`, err); }
+    }
   }
 
   private _onDisconnect(): void {
@@ -469,6 +488,13 @@ export class GatewayConnectionService {
 
     // Reject pending requests
     this._rejectPendingRequests(new Error('Gateway WebSocket disconnected'));
+
+    // Notify disconnect callbacks (#2157, #2158)
+    if (wasConnected) {
+      for (const cb of this.disconnectCallbacks) {
+        try { cb(); } catch (err) { console.error(`${LOG_PREFIX} onDisconnect callback error:`, err); }
+      }
+    }
 
     // Schedule reconnect (unless shutdown was requested)
     if (!this.shutdownRequested) {

--- a/src/api/gateway/index.ts
+++ b/src/api/gateway/index.ts
@@ -1,22 +1,31 @@
 /**
- * Gateway module — connection, dispatch, and event routing.
+ * Gateway module — connection, dispatch, event routing, agent cache, and presence tracking.
  * Issue #2154 — Gateway connection service.
  * Issue #2155 — Chat dispatch via WS.
  * Issue #2156 — Gateway event router.
+ * Issues #2157, #2158 — Agent cache, presence tracker.
  *
  * Exports:
- * - getGatewayConnection() — get the singleton instance
+ * - getGatewayConnection() — get the singleton connection instance
  * - initGatewayConnection() — initialize the connection (call once at startup)
  * - shutdownGatewayConnection() — graceful shutdown (call on server close)
  * - dispatchChatMessage() / abortChatRun() — WS-first chat dispatch
  * - getGatewayEventRouter() — get the event router singleton
  * - initGatewayEventRouter(pool) — initialize the event router
  * - shutdownGatewayEventRouter() — graceful shutdown of event router
+ * - getAgentCache() — get the singleton agent cache
+ * - getPresenceTracker() — get the singleton presence tracker
+ * - initPresenceTracker() — initialize and start presence tracking
+ * - initAgentCache() — initialize agent cache with presence tracker
  */
 
 import { GatewayConnectionService } from './connection.ts';
+import { AgentPresenceTracker } from './presence-tracker.ts';
+import { AgentCache } from './agent-cache.ts';
 
 let instance: GatewayConnectionService | null = null;
+let presenceTracker: AgentPresenceTracker | null = null;
+let agentCache: AgentCache | null = null;
 
 /** Get the singleton GatewayConnectionService instance. Creates lazily if needed. */
 export function getGatewayConnection(): GatewayConnectionService {
@@ -26,14 +35,72 @@ export function getGatewayConnection(): GatewayConnectionService {
   return instance;
 }
 
+/** Get the singleton AgentPresenceTracker. Creates lazily if needed. */
+export function getPresenceTracker(): AgentPresenceTracker {
+  if (!presenceTracker) {
+    presenceTracker = new AgentPresenceTracker();
+  }
+  return presenceTracker;
+}
+
+/** Get the singleton AgentCache. Creates lazily if needed. */
+export function getAgentCache(): AgentCache {
+  if (!agentCache) {
+    agentCache = new AgentCache(getGatewayConnection(), getPresenceTracker());
+  }
+  return agentCache;
+}
+
 /** Initialize the gateway WebSocket connection. Safe to call once at server startup. */
 export async function initGatewayConnection(): Promise<void> {
   const svc = getGatewayConnection();
   await svc.initialize();
 }
 
-/** Gracefully shut down the gateway WebSocket connection. */
+/** Initialize presence tracker: registers event handler on gateway connection. */
+export function initPresenceTracker(): void {
+  const conn = getGatewayConnection();
+  const tracker = getPresenceTracker();
+
+  // Register for all gateway events
+  conn.onEvent((frame) => {
+    tracker.handleEvent(frame);
+  });
+
+  // On disconnect: set all tracked agents to "unknown"
+  conn.onDisconnect(() => {
+    tracker.onDisconnect();
+  });
+
+  // Start periodic pruning
+  tracker.startPruning();
+}
+
+/** Initialize agent cache: registers disconnect/reconnect hooks. */
+export function initAgentCache(): void {
+  const conn = getGatewayConnection();
+  const cache = getAgentCache();
+
+  // On disconnect: invalidate cache
+  conn.onDisconnect(() => {
+    cache.invalidate();
+  });
+
+  // On reconnect: eagerly refresh agent list
+  conn.onConnected(() => {
+    cache.refresh().catch((err) => {
+      console.error('[AgentCache] Eager refresh on reconnect failed:', err);
+    });
+  });
+}
+
+/** Gracefully shut down the gateway WebSocket connection and subsystems. */
 export async function shutdownGatewayConnection(): Promise<void> {
+  if (presenceTracker) {
+    presenceTracker.shutdown();
+    presenceTracker = null;
+  }
+  agentCache = null;
   if (instance) {
     await instance.shutdown();
     instance = null;
@@ -45,6 +112,8 @@ export type { GatewayStatus, GatewayEventHandler, GatewayFrame, GatewayEventFram
 export { dispatchChatMessage, abortChatRun } from './chat-dispatch.ts';
 export type { ChatSession, ChatMessageRecord, DispatchResult } from './chat-dispatch.ts';
 export { GatewayEventRouter } from './event-router.ts';
+export { AgentPresenceTracker, type AgentStatus } from './presence-tracker.ts';
+export { AgentCache, type CachedAgent } from './agent-cache.ts';
 
 // ── Event router singleton (#2156) ──────────────────────────────────
 

--- a/src/api/gateway/presence-tracker.test.ts
+++ b/src/api/gateway/presence-tracker.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Unit tests for AgentPresenceTracker.
+ * Issue #2158 — Agent presence tracking.
+ *
+ * TDD: These tests are written FIRST, before the implementation.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { GatewayEventFrame } from './connection.ts';
+
+// Mock the realtime hub — return the SAME object every time
+const mockHub = { emit: vi.fn() };
+vi.mock('../realtime/hub.ts', () => ({
+  getRealtimeHub: vi.fn(() => mockHub),
+}));
+
+import { AgentPresenceTracker, type AgentStatus } from './presence-tracker.ts';
+
+describe('AgentPresenceTracker', () => {
+  let tracker: AgentPresenceTracker;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockHub.emit.mockClear();
+    tracker = new AgentPresenceTracker();
+  });
+
+  afterEach(() => {
+    tracker.shutdown();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  // ── Status queries ────────────────────────────────────────────────
+
+  it('returns "unknown" for untracked agent', () => {
+    expect(tracker.getStatus('agent-xyz')).toBe('unknown');
+  });
+
+  // ── Presence event handling ───────────────────────────────────────
+
+  it('updates to "online" on agent.online event', () => {
+    const frame: GatewayEventFrame = {
+      type: 'event',
+      event: 'agent.online',
+      payload: { agent_id: 'agent-1' },
+    };
+    tracker.handleEvent(frame);
+    expect(tracker.getStatus('agent-1')).toBe('online');
+  });
+
+  it('updates to "busy" on agent.busy event', () => {
+    const frame: GatewayEventFrame = {
+      type: 'event',
+      event: 'agent.busy',
+      payload: { agent_id: 'agent-1' },
+    };
+    tracker.handleEvent(frame);
+    expect(tracker.getStatus('agent-1')).toBe('busy');
+  });
+
+  it('updates to "offline" on agent.offline event', () => {
+    const frame: GatewayEventFrame = {
+      type: 'event',
+      event: 'agent.offline',
+      payload: { agent_id: 'agent-1' },
+    };
+    tracker.handleEvent(frame);
+    expect(tracker.getStatus('agent-1')).toBe('offline');
+  });
+
+  it('infers "busy" from chat.delta event', () => {
+    const frame: GatewayEventFrame = {
+      type: 'event',
+      event: 'chat.delta',
+      payload: { sessionKey: 'agent:agent-2:agent_chat:thread-1', state: 'delta' },
+    };
+    tracker.handleEvent(frame);
+    expect(tracker.getStatus('agent-2')).toBe('busy');
+  });
+
+  it('infers "online" from chat.final event', () => {
+    // First set busy
+    tracker.handleEvent({
+      type: 'event',
+      event: 'chat.delta',
+      payload: { sessionKey: 'agent:agent-2:agent_chat:thread-1', state: 'delta' },
+    });
+    expect(tracker.getStatus('agent-2')).toBe('busy');
+
+    // Then final
+    tracker.handleEvent({
+      type: 'event',
+      event: 'chat.final',
+      payload: { sessionKey: 'agent:agent-2:agent_chat:thread-1', state: 'final' },
+    });
+    expect(tracker.getStatus('agent-2')).toBe('online');
+  });
+
+  it('ignores events without agent_id or sessionKey', () => {
+    const frame: GatewayEventFrame = {
+      type: 'event',
+      event: 'agent.online',
+      payload: {},
+    };
+    tracker.handleEvent(frame);
+    expect(tracker.getAllStatuses().size).toBe(0);
+  });
+
+  // ── WS disconnect ────────────────────────────────────────────────
+
+  it('on WS disconnect: all agents set to "unknown" (not "offline")', () => {
+    // Set some agents online
+    tracker.handleEvent({
+      type: 'event',
+      event: 'agent.online',
+      payload: { agent_id: 'agent-1' },
+    });
+    tracker.handleEvent({
+      type: 'event',
+      event: 'agent.busy',
+      payload: { agent_id: 'agent-2' },
+    });
+
+    expect(tracker.getStatus('agent-1')).toBe('online');
+    expect(tracker.getStatus('agent-2')).toBe('busy');
+
+    tracker.onDisconnect();
+
+    expect(tracker.getStatus('agent-1')).toBe('unknown');
+    expect(tracker.getStatus('agent-2')).toBe('unknown');
+  });
+
+  // ── TTL staleness ────────────────────────────────────────────────
+
+  it('TTL staleness: entry older than 5min returns "unknown"', () => {
+    tracker.handleEvent({
+      type: 'event',
+      event: 'agent.online',
+      payload: { agent_id: 'agent-1' },
+    });
+    expect(tracker.getStatus('agent-1')).toBe('online');
+
+    // Advance 5 minutes + 1ms
+    vi.advanceTimersByTime(5 * 60 * 1000 + 1);
+
+    expect(tracker.getStatus('agent-1')).toBe('unknown');
+  });
+
+  // ── Explicit pruning ─────────────────────────────────────────────
+
+  it('explicit pruning: entries older than 10min removed by interval', () => {
+    tracker.startPruning();
+
+    tracker.handleEvent({
+      type: 'event',
+      event: 'agent.online',
+      payload: { agent_id: 'agent-1' },
+    });
+
+    expect(tracker.getAllStatuses().size).toBe(1);
+
+    // Advance past 10 minutes + one full prune interval so the
+    // prune callback fires with Date.now() > updatedAt + PRUNE_TTL
+    vi.advanceTimersByTime(10 * 60 * 1000 + 60 * 1000 + 1);
+
+    // After pruning runs, entry should be removed
+    expect(tracker.getAllStatuses().size).toBe(0);
+  });
+
+  // ── Bounded map ──────────────────────────────────────────────────
+
+  it('bounded map: evicts least-recently-updated when > 1000 entries', () => {
+    // Insert 1001 agents
+    for (let i = 0; i < 1001; i++) {
+      tracker.handleEvent({
+        type: 'event',
+        event: 'agent.online',
+        payload: { agent_id: `agent-${i}` },
+      });
+      // Small time advance so updatedAt differs
+      vi.advanceTimersByTime(1);
+    }
+
+    // Should be capped at 1000
+    expect(tracker.getAllStatuses().size).toBe(1000);
+
+    // The first agent (oldest) should have been evicted
+    expect(tracker.getStatus('agent-0')).toBe('unknown');
+
+    // The last agent should still be present
+    expect(tracker.getStatus('agent-1000')).toBe('online');
+  });
+
+  // ── Status change emission ────────────────────────────────────────
+
+  it('emits agent:status_changed only when status actually changes', () => {
+    mockHub.emit.mockClear();
+
+    tracker.handleEvent({
+      type: 'event',
+      event: 'agent.online',
+      payload: { agent_id: 'agent-1' },
+    });
+
+    expect(mockHub.emit).toHaveBeenCalledWith(
+      'agent:status_changed',
+      { agent_id: 'agent-1', status: 'online' },
+      undefined,
+    );
+
+    // Same status again — should NOT emit
+    mockHub.emit.mockClear();
+    tracker.handleEvent({
+      type: 'event',
+      event: 'agent.online',
+      payload: { agent_id: 'agent-1' },
+    });
+
+    expect(mockHub.emit).not.toHaveBeenCalled();
+  });
+
+  // ── getAllStatuses ────────────────────────────────────────────────
+
+  it('getAllStatuses returns all non-evicted entries', () => {
+    tracker.handleEvent({
+      type: 'event',
+      event: 'agent.online',
+      payload: { agent_id: 'agent-1' },
+    });
+    tracker.handleEvent({
+      type: 'event',
+      event: 'agent.busy',
+      payload: { agent_id: 'agent-2' },
+    });
+
+    const statuses = tracker.getAllStatuses();
+    expect(statuses.size).toBe(2);
+    expect(statuses.get('agent-1')).toBe('online');
+    expect(statuses.get('agent-2')).toBe('busy');
+  });
+
+  // ── Shutdown ─────────────────────────────────────────────────────
+
+  it('shutdown() clears pruning interval', () => {
+    tracker.startPruning();
+
+    // Add an agent
+    tracker.handleEvent({
+      type: 'event',
+      event: 'agent.online',
+      payload: { agent_id: 'agent-1' },
+    });
+
+    tracker.shutdown();
+
+    // Advance well past prune time — should NOT crash or prune
+    vi.advanceTimersByTime(20 * 60 * 1000);
+
+    // Map should still have the entry (interval was cleared, no pruning happened)
+    // After shutdown we don't guarantee anything about the map, but no error should throw
+  });
+});

--- a/src/api/gateway/presence-tracker.ts
+++ b/src/api/gateway/presence-tracker.ts
@@ -1,0 +1,221 @@
+/**
+ * AgentPresenceTracker — tracks agent online/busy/offline status from gateway events.
+ * Issue #2158 — Agent presence tracking.
+ *
+ * Gateway Event Discovery Notes:
+ * The OpenClaw gateway source was not available locally during implementation.
+ * This tracker handles two event patterns:
+ *
+ * 1. Explicit presence events (preferred):
+ *    - agent.online  → { agent_id: string }  → status = "online"
+ *    - agent.busy    → { agent_id: string }  → status = "busy"
+ *    - agent.offline → { agent_id: string }  → status = "offline"
+ *
+ * 2. Inferred presence from chat events (fallback):
+ *    - chat.delta  → sessionKey "agent:{agentId}:agent_chat:{threadId}" → "busy"
+ *    - chat.final  → sessionKey "agent:{agentId}:agent_chat:{threadId}" → "online"
+ *    - chat.aborted → same pattern → "online"
+ *    - chat.error  → same pattern → "online"
+ */
+
+import type { GatewayEventFrame } from './connection.ts';
+import { getRealtimeHub } from '../realtime/hub.ts';
+
+// ── Types ────────────────────────────────────────────────────────────
+
+export type AgentStatus = 'online' | 'busy' | 'offline' | 'unknown';
+
+interface AgentEntry {
+  status: AgentStatus;
+  updatedAt: number;
+}
+
+// ── Constants ────────────────────────────────────────────────────────
+
+const MAX_ENTRIES = 1000;
+const STALENESS_TTL_MS = 5 * 60 * 1000; // 5 minutes
+const PRUNE_TTL_MS = 10 * 60 * 1000;    // 10 minutes
+const PRUNE_INTERVAL_MS = 60 * 1000;    // 60 seconds
+
+/** Pattern: "agent:{agentId}:agent_chat:{threadId}" */
+const SESSION_KEY_RE = /^agent:([^:]+):agent_chat:/;
+
+// ── Tracker ──────────────────────────────────────────────────────────
+
+export class AgentPresenceTracker {
+  private agents = new Map<string, AgentEntry>();
+  private pruneTimer: ReturnType<typeof setInterval> | null = null;
+
+  /** Handle a gateway event frame. */
+  handleEvent(frame: GatewayEventFrame): void {
+    const eventName = frame.event;
+
+    // Explicit agent presence events
+    if (eventName.startsWith('agent.')) {
+      const agentId = this._extractAgentId(frame.payload);
+      if (!agentId) return;
+
+      const status = this._mapExplicitEvent(eventName);
+      if (status) {
+        this._setStatus(agentId, status);
+      }
+      return;
+    }
+
+    // Inferred presence from chat events
+    if (eventName.startsWith('chat.')) {
+      const agentId = this._extractAgentIdFromSessionKey(frame.payload);
+      if (!agentId) return;
+
+      const status = this._mapChatEvent(eventName);
+      if (status) {
+        this._setStatus(agentId, status);
+      }
+    }
+  }
+
+  /** Called when the gateway WS disconnects. Sets all agents to "unknown". */
+  onDisconnect(): void {
+    const now = Date.now();
+    for (const [agentId, entry] of this.agents) {
+      if (entry.status !== 'unknown') {
+        entry.status = 'unknown';
+        entry.updatedAt = now;
+        this._emitStatusChanged(agentId, 'unknown');
+      }
+    }
+  }
+
+  /** Get the status of a specific agent. Returns "unknown" if not tracked or stale. */
+  getStatus(agentId: string): AgentStatus {
+    const entry = this.agents.get(agentId);
+    if (!entry) return 'unknown';
+
+    // TTL staleness check
+    if (Date.now() - entry.updatedAt > STALENESS_TTL_MS) {
+      return 'unknown';
+    }
+
+    return entry.status;
+  }
+
+  /** Get all non-evicted agent statuses (does NOT apply staleness filter). */
+  getAllStatuses(): Map<string, AgentStatus> {
+    const result = new Map<string, AgentStatus>();
+    for (const [agentId, entry] of this.agents) {
+      result.set(agentId, entry.status);
+    }
+    return result;
+  }
+
+  /** Start the periodic pruning interval. */
+  startPruning(): void {
+    if (this.pruneTimer) return;
+    this.pruneTimer = setInterval(() => this._prune(), PRUNE_INTERVAL_MS);
+  }
+
+  /** Shutdown the tracker, clearing the prune interval. */
+  shutdown(): void {
+    if (this.pruneTimer) {
+      clearInterval(this.pruneTimer);
+      this.pruneTimer = null;
+    }
+  }
+
+  // ── Private ────────────────────────────────────────────────────────
+
+  private _setStatus(agentId: string, status: AgentStatus): void {
+    const existing = this.agents.get(agentId);
+    const now = Date.now();
+
+    if (existing && existing.status === status) {
+      // Same status — just update timestamp, no emission
+      existing.updatedAt = now;
+      return;
+    }
+
+    this.agents.set(agentId, { status, updatedAt: now });
+
+    // Enforce bounded map
+    if (this.agents.size > MAX_ENTRIES) {
+      this._evictOldest();
+    }
+
+    this._emitStatusChanged(agentId, status);
+  }
+
+  private _evictOldest(): void {
+    let oldestKey: string | null = null;
+    let oldestTime = Infinity;
+
+    for (const [key, entry] of this.agents) {
+      if (entry.updatedAt < oldestTime) {
+        oldestTime = entry.updatedAt;
+        oldestKey = key;
+      }
+    }
+
+    if (oldestKey) {
+      this.agents.delete(oldestKey);
+    }
+  }
+
+  private _prune(): void {
+    const cutoff = Date.now() - PRUNE_TTL_MS;
+    for (const [key, entry] of this.agents) {
+      if (entry.updatedAt < cutoff) {
+        this.agents.delete(key);
+      }
+    }
+  }
+
+  private _emitStatusChanged(agentId: string, status: AgentStatus): void {
+    try {
+      getRealtimeHub().emit(
+        'agent:status_changed' as never,
+        { agent_id: agentId, status },
+        undefined,
+      );
+    } catch {
+      // Best-effort — don't let emission failures affect event processing
+    }
+  }
+
+  private _extractAgentId(payload: unknown): string | null {
+    if (payload && typeof payload === 'object' && 'agent_id' in payload) {
+      const id = (payload as { agent_id: unknown }).agent_id;
+      return typeof id === 'string' && id.length > 0 ? id : null;
+    }
+    return null;
+  }
+
+  private _extractAgentIdFromSessionKey(payload: unknown): string | null {
+    if (payload && typeof payload === 'object' && 'sessionKey' in payload) {
+      const key = (payload as { sessionKey: unknown }).sessionKey;
+      if (typeof key === 'string') {
+        const match = SESSION_KEY_RE.exec(key);
+        return match?.[1] ?? null;
+      }
+    }
+    return null;
+  }
+
+  private _mapExplicitEvent(eventName: string): AgentStatus | null {
+    switch (eventName) {
+      case 'agent.online': return 'online';
+      case 'agent.busy': return 'busy';
+      case 'agent.offline': return 'offline';
+      default: return null;
+    }
+  }
+
+  private _mapChatEvent(eventName: string): AgentStatus | null {
+    switch (eventName) {
+      case 'chat.delta': return 'busy';
+      case 'chat.final':
+      case 'chat.aborted':
+      case 'chat.error': return 'online';
+      default: return null;
+    }
+  }
+}

--- a/src/api/openapi/paths/chat.ts
+++ b/src/api/openapi/paths/chat.ts
@@ -113,7 +113,7 @@ export function chatPaths(): OpenApiDomainModule {
         get: {
           operationId: 'listChatAgents',
           summary: 'List available chat agents',
-          description: 'Returns distinct agents from existing chat sessions in the namespace.',
+          description: 'Returns agents from the gateway (live) or from existing chat sessions (fallback). Includes agent presence status.',
           tags: ['Chat'],
           responses: {
             '200': jsonResponse('Available agents', {
@@ -123,12 +123,15 @@ export function chatPaths(): OpenApiDomainModule {
                   type: 'array',
                   items: {
                     type: 'object',
-                    required: ['id', 'name'],
+                    required: ['id', 'name', 'status'],
                     properties: {
                       id: { type: 'string', description: 'Agent identifier' },
                       name: { type: 'string', description: 'Agent name' },
-                      display_name: { type: 'string', nullable: true, description: 'Human-friendly name' },
-                      avatar_url: { type: 'string', nullable: true, description: 'Agent avatar URL' },
+                      status: {
+                        type: 'string',
+                        enum: ['online', 'busy', 'offline', 'unknown'],
+                        description: 'Agent presence status',
+                      },
                     },
                   },
                 },

--- a/src/api/realtime/types.ts
+++ b/src/api/realtime/types.ts
@@ -48,7 +48,9 @@ export type RealtimeEventType =
   // Chat events (#1946)
   | ChatEventType
   // Gateway stream events (#2156)
-  | GatewayStreamEventType;
+  | GatewayStreamEventType
+  // Agent presence events (#2158)
+  | 'agent:status_changed';
 
 /**
  * Real-time event message structure
@@ -222,4 +224,16 @@ export interface ChatTypingEventData {
 export interface ChatReadCursorEventData {
   session_id: string;
   last_read_message_id: string;
+}
+
+// ============================================================================
+// Agent Presence Event Data Types (#2158)
+// ============================================================================
+
+/**
+ * Agent status changed event data
+ */
+export interface AgentStatusChangedEventData {
+  agent_id: string;
+  status: 'online' | 'busy' | 'offline' | 'unknown';
 }

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -123,7 +123,7 @@ import { terminalRoutesPlugin } from './terminal/routes.ts';
 import { haRoutesPlugin } from './ha-routes.ts';
 import { apiSourceRoutesPlugin } from './api-sources/routes.ts';
 import { chatRoutesPlugin } from './chat/routes.ts';
-import { initGatewayConnection, shutdownGatewayConnection, getGatewayConnection } from './gateway/index.ts';
+import { initGatewayConnection, shutdownGatewayConnection, getGatewayConnection, initPresenceTracker, initAgentCache } from './gateway/index.ts';
 import { postmarkIPWhitelistMiddleware, twilioIPWhitelistMiddleware } from './webhooks/ip-whitelist.ts';
 import { validateSsrf as ssrfValidateSsrf } from './webhooks/ssrf.ts';
 import { computeNextRunAt } from './skill-store/schedule-next-run.ts';
@@ -1735,6 +1735,9 @@ export function buildServer(options: ProjectsApiOptions = {}): FastifyInstance {
   app.addHook('onReady', async () => {
     try {
       await initGatewayConnection();
+      // Issue #2157, #2158: Wire up presence tracker and agent cache after connection init
+      initPresenceTracker();
+      initAgentCache();
     } catch (err) {
       // Log but don't prevent server startup — gateway WS is enhancement, not critical
       console.error('[GatewayWS] Failed to initialize gateway connection:', (err as Error).message);


### PR DESCRIPTION
## Summary

- **Agent Cache** (`src/api/gateway/agent-cache.ts`): TTL cache (30s) for `agents.list` gateway responses with automatic DB fallback when WS is unavailable. Fixes the fresh-install chicken-and-egg issue (#2151) where GET /chat/agents returned empty on new installs.
- **Presence Tracker** (`src/api/gateway/presence-tracker.ts`): Tracks agent online/busy/offline status from explicit gateway events (`agent.online/busy/offline`) and infers status from chat events (`chat.delta` -> busy, `chat.final` -> online). Features bounded map (1000 entries), TTL staleness (5min), explicit pruning (10min), and all-unknown on WS disconnect.
- **Route update**: GET /chat/agents now returns agents with `status` field via AgentCache
- **Connection lifecycle**: Added `onDisconnect`/`onConnected` callbacks to GatewayConnectionService for cache invalidation and eager refresh
- **Realtime events**: Added `agent:status_changed` to RealtimeEventType for real-time UI updates

Closes #2157
Closes #2158

## Test Plan

- [x] `pnpm exec vitest run src/api/gateway/agent-cache.test.ts` — 14 tests passing
- [x] `pnpm exec vitest run src/api/gateway/presence-tracker.test.ts` — 14 tests passing
- [x] `pnpm exec vitest run src/api/gateway/` — all 59 gateway tests passing
- [x] `pnpm run build` — typecheck passes
- [x] Codex security review — no critical issues found in new code