### PR TITLE
[#2155] Fix 503 when no gateway configured — store without dispatch

### DIFF
--- a/src/api/chat/ws-dispatch.integration.test.ts
+++ b/src/api/chat/ws-dispatch.integration.test.ts
@@ -211,15 +211,17 @@ describe('Chat WS dispatch fallback integration', () => {
     expect(mockEnqueueWebhook).toHaveBeenCalledOnce();
   });
 
-  it('returns 503-compatible result when no gateway configured at all', async () => {
+  it('succeeds without dispatch when no gateway configured at all', async () => {
     delete process.env.OPENCLAW_GATEWAY_URL;
     delete process.env.WEBHOOK_DESTINATION_URL;
 
     const pool = { query: vi.fn() } as unknown as Pool;
     const result = await dispatchChatMessage(pool, makeSession(), makeMessage(), 'user@example.com');
 
-    expect(result.dispatched).toBe(false);
-    expect(result.error).toContain('no gateway configured');
+    // No gateway = message stored, no dispatch. Not an error.
+    expect(result.dispatched).toBe(true);
+    expect(result.method).toBeUndefined();
+    expect(result.error).toBeUndefined();
   });
 
   it('abort is no-op when WS not connected', async () => {

--- a/src/api/gateway/chat-dispatch.test.ts
+++ b/src/api/gateway/chat-dispatch.test.ts
@@ -176,7 +176,10 @@ describe('dispatchChatMessage', () => {
 
   // ── Error handling ───────────────────────────────────────────
 
-  it('returns 503 status when WS unavailable AND no gateway URL configured', async () => {
+  it('succeeds without dispatch when no gateway URL is configured', async () => {
+    // When no gateway is configured, the message is stored in the DB but not
+    // dispatched to any agent. This is not an error — it matches the pre-WS
+    // behavior where the webhook was silently skipped.
     mockGetStatus.mockReturnValue({ connected: false, gateway_url: null });
     delete process.env.OPENCLAW_GATEWAY_URL;
     delete process.env.WEBHOOK_DESTINATION_URL;
@@ -184,8 +187,9 @@ describe('dispatchChatMessage', () => {
     const pool = makeMockPool();
     const result = await dispatchChatMessage(pool, makeSession(), makeMessage(), 'user@example.com');
 
-    expect(result.dispatched).toBe(false);
-    expect(result.error).toContain('no gateway configured');
+    expect(result.dispatched).toBe(true);
+    expect(result.method).toBeUndefined();
+    expect(result.error).toBeUndefined();
     expect(mockRequest).not.toHaveBeenCalled();
     expect(mockEnqueueWebhook).not.toHaveBeenCalled();
   });

--- a/src/api/gateway/chat-dispatch.ts
+++ b/src/api/gateway/chat-dispatch.ts
@@ -106,9 +106,12 @@ export async function dispatchChatMessage(
   // ── HTTP webhook fallback ────────────────────────────────────
   const webhookDestination = process.env.OPENCLAW_GATEWAY_URL || process.env.WEBHOOK_DESTINATION_URL;
   if (!webhookDestination) {
-    const error = 'Message dispatch unavailable — no gateway configured';
-    console.error(`${LOG_PREFIX} ${error}`);
-    return { dispatched: false, error };
+    // No gateway configured at all — message is already persisted in DB.
+    // This is not an error: the system can operate without a gateway
+    // (e.g. in test environments or before gateway is provisioned).
+    // The message is stored but not dispatched to any agent.
+    console.log(`${LOG_PREFIX} no gateway configured, message stored without dispatch session=${session.id}`);
+    return { dispatched: true, method: undefined };
   }
 
   try {


### PR DESCRIPTION
## Summary

Fixes 4 failing integration tests in `tests/chat_message_api.test.ts` caused by `dispatchChatMessage()` returning 503 when no gateway URL is configured.

**Root cause:** The dispatch function treated "no gateway configured" as a fatal error, but the original code simply skipped the webhook silently and returned 201. Test environments don't set `OPENCLAW_GATEWAY_URL`.

**Fix:** When no gateway is configured, return `{ dispatched: true, method: undefined }` — message is stored in DB without dispatch. The 503 path now only triggers on actual dispatch failures (both WS and HTTP attempted and both failed).

## Test Plan

- [x] `pnpm exec vitest run tests/chat_message_api.test.ts --config vitest.config.integration.ts` -- 17/17 pass (was 13/17)
- [x] `pnpm exec vitest run src/api/gateway/chat-dispatch.test.ts` -- 18/18 pass
- [x] `pnpm exec vitest run src/api/chat/ws-dispatch.integration.test.ts` -- 6/6 pass
- [x] `pnpm test:unit` -- 4100 tests pass
- [x] `pnpm run build` -- typecheck clean

Closes #2155

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>