### PR TITLE
[#2159,#2160] Frontend: gateway status hook and agent status badge

### DIFF
--- a/src/ui/components/chat/agent-status-badge.tsx
+++ b/src/ui/components/chat/agent-status-badge.tsx
@@ -1,0 +1,51 @@
+/**
+ * Agent status badge (Epic #2153, Issue #2160).
+ *
+ * Renders a colored dot with accessible text label indicating
+ * whether an agent is online, busy, or offline. Returns null
+ * for unknown status.
+ */
+
+import * as React from 'react';
+import { cn } from '@/ui/lib/utils';
+
+export type AgentStatus = 'online' | 'busy' | 'offline' | 'unknown';
+
+interface AgentStatusBadgeProps {
+  status: AgentStatus;
+}
+
+const STATUS_CONFIG: Record<Exclude<AgentStatus, 'unknown'>, { label: string; dotClass: string }> = {
+  online: {
+    label: 'Online',
+    dotClass: 'bg-green-500 dark:bg-green-400',
+  },
+  busy: {
+    label: 'Busy',
+    dotClass: 'bg-amber-500 dark:bg-amber-400',
+  },
+  offline: {
+    label: 'Offline',
+    dotClass: 'bg-gray-400 dark:bg-gray-500',
+  },
+};
+
+export function AgentStatusBadge({ status }: AgentStatusBadgeProps): React.JSX.Element | null {
+  const config = STATUS_CONFIG[status as Exclude<AgentStatus, 'unknown'>];
+  if (!config) return null;
+
+  return (
+    <span
+      role="status"
+      aria-label={`Agent status: ${status}`}
+      className="inline-flex items-center"
+    >
+      <span
+        data-testid="agent-status-dot"
+        title={config.label}
+        className={cn('inline-block size-2 rounded-full', config.dotClass)}
+      />
+      <span className="sr-only">{config.label}</span>
+    </span>
+  );
+}

--- a/src/ui/components/chat/chat-agent-selector.tsx
+++ b/src/ui/components/chat/chat-agent-selector.tsx
@@ -2,11 +2,15 @@
  * Agent selector dropdown for chat (Epic #1940, Issue #1950).
  *
  * Dropdown of available agents. Default agent pre-selected.
+ * Shows AgentStatusBadge per agent (Issue #2160).
  */
 
 import * as React from 'react';
 import { cn } from '@/ui/lib/utils';
 import { useAvailableAgents } from '@/ui/hooks/queries/use-chat';
+import { useRealtimeOptional } from '@/ui/components/realtime/realtime-context';
+import { useQueryClient } from '@tanstack/react-query';
+import { chatKeys } from '@/ui/hooks/queries/use-chat';
 import {
   Select,
   SelectContent,
@@ -14,6 +18,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/ui/components/ui/select';
+import { AgentStatusBadge } from './agent-status-badge';
+import type { AgentStatus } from './agent-status-badge';
 
 interface ChatAgentSelectorProps {
   value?: string;
@@ -23,6 +29,17 @@ interface ChatAgentSelectorProps {
 
 export function ChatAgentSelector({ value, onChange, className }: ChatAgentSelectorProps): React.JSX.Element | null {
   const { data } = useAvailableAgents();
+  const realtime = useRealtimeOptional();
+  const queryClient = useQueryClient();
+
+  // Subscribe to agent status changes from RealtimeHub
+  React.useEffect(() => {
+    if (!realtime) return;
+    const cleanup = realtime.addEventHandler('agent:status_changed', () => {
+      void queryClient.invalidateQueries({ queryKey: chatKeys.agents() });
+    });
+    return cleanup;
+  }, [realtime, queryClient]);
 
   const agents = React.useMemo(
     () => (Array.isArray(data?.agents) ? data.agents : []),
@@ -43,7 +60,10 @@ export function ChatAgentSelector({ value, onChange, className }: ChatAgentSelec
       <SelectContent>
         {agents.map((agent) => (
           <SelectItem key={agent.id} value={agent.id}>
-            {agent.display_name ?? agent.name}
+            <span className="inline-flex items-center gap-1.5">
+              {agent.display_name ?? agent.name}
+              <AgentStatusBadge status={(agent.status ?? 'unknown') as AgentStatus} />
+            </span>
           </SelectItem>
         ))}
       </SelectContent>

--- a/src/ui/components/chat/chat-connection-banner.tsx
+++ b/src/ui/components/chat/chat-connection-banner.tsx
@@ -18,6 +18,8 @@ export type ChatConnectionStatus =
 interface ChatConnectionBannerProps {
   status: ChatConnectionStatus;
   onRetry?: () => void;
+  /** When false, shows degraded banner even if browser WS is connected (Issue #2159). */
+  gatewayConnected?: boolean;
 }
 
 const STATUS_CONFIG: Record<
@@ -42,10 +44,17 @@ const STATUS_CONFIG: Record<
   },
 };
 
-export function ChatConnectionBanner({ status, onRetry }: ChatConnectionBannerProps): React.JSX.Element | null {
-  if (status === 'connected') return null;
+export function ChatConnectionBanner({ status, onRetry, gatewayConnected }: ChatConnectionBannerProps): React.JSX.Element | null {
+  // When browser WS is connected but gateway WS is down, show degraded state
+  const isGatewayDegraded = status === 'connected' && gatewayConnected === false;
+  const effectiveStatus: ChatConnectionStatus = isGatewayDegraded ? 'degraded' : status;
 
-  const config = STATUS_CONFIG[status];
+  if (effectiveStatus === 'connected') return null;
+
+  const config = STATUS_CONFIG[effectiveStatus];
+  const label = isGatewayDegraded
+    ? 'Agent connection degraded \u2014 using fallback mode'
+    : config.label;
 
   return (
     <div
@@ -58,17 +67,17 @@ export function ChatConnectionBanner({ status, onRetry }: ChatConnectionBannerPr
       )}
     >
       {/* Spinner for connecting/reconnecting */}
-      {(status === 'connecting' || status === 'reconnecting') && (
+      {(effectiveStatus === 'connecting' || effectiveStatus === 'reconnecting') && (
         <span
           className="inline-block size-3 animate-spin rounded-full border-2 border-current border-t-transparent"
           aria-hidden="true"
         />
       )}
 
-      <span>{config.label}</span>
+      <span>{label}</span>
 
       {/* Retry button for disconnected/degraded */}
-      {onRetry && (status === 'disconnected' || status === 'degraded') && (
+      {onRetry && (effectiveStatus === 'disconnected' || effectiveStatus === 'degraded') && (
         <button
           type="button"
           onClick={onRetry}

--- a/src/ui/components/chat/chat-panel.tsx
+++ b/src/ui/components/chat/chat-panel.tsx
@@ -19,11 +19,14 @@ import { ChatConversation } from './chat-conversation';
 import { ChatHeader } from './chat-header';
 import { ChatInput } from './chat-input';
 import { ChatEmptyState } from './chat-empty-state';
+import { ChatConnectionBanner } from './chat-connection-banner';
+import { useGatewayStatus } from '@/ui/hooks/use-gateway-status';
 
 export function ChatPanel(): React.JSX.Element | null {
   const { isPanelOpen, closePanel, activeSessionId } = useChat();
   const isMobile = useMediaQuery(MEDIA_QUERIES.mobile);
   const prefersReducedMotion = useMediaQuery(MEDIA_QUERIES.reducedMotion);
+  const gatewayStatus = useGatewayStatus();
   const panelRef = React.useRef<HTMLDivElement>(null);
 
   // Escape to close
@@ -53,6 +56,10 @@ export function ChatPanel(): React.JSX.Element | null {
   const panelContent = (
     <ErrorBoundary title="Chat error" description="Something went wrong with the chat. Please try again.">
       <div className="flex h-full flex-col">
+        <ChatConnectionBanner
+          status="connected"
+          gatewayConnected={gatewayStatus.loading ? undefined : gatewayStatus.connected}
+        />
         {activeSessionId ? (
           <>
             <ChatHeader />

--- a/src/ui/components/chat/index.ts
+++ b/src/ui/components/chat/index.ts
@@ -11,6 +11,7 @@ export { ChatNewMessagesPill } from './chat-new-messages-pill';
 export { ChatInput } from './chat-input';
 export { ChatHeader } from './chat-header';
 export { ChatAgentSelector } from './chat-agent-selector';
+export { AgentStatusBadge } from './agent-status-badge';
 export { ChatEmptyState } from './chat-empty-state';
 export { ChatSkeletonLoader } from './chat-skeleton-loader';
 export { ChatSessionEndedState } from './chat-session-ended-state';

--- a/src/ui/components/realtime/types.ts
+++ b/src/ui/components/realtime/types.ts
@@ -35,7 +35,8 @@ export type RealtimeEventType =
   | 'chat:session_created'
   | 'chat:session_ended'
   | 'chat:typing'
-  | 'chat:read_cursor_updated';
+  | 'chat:read_cursor_updated'
+  | 'agent:status_changed';
 
 export interface RealtimeEvent<T = unknown> {
   type: RealtimeEventType;

--- a/src/ui/hooks/use-gateway-status.ts
+++ b/src/ui/hooks/use-gateway-status.ts
@@ -1,0 +1,76 @@
+/**
+ * Hook to poll the gateway WebSocket connection status (Epic #2153, Issue #2159).
+ *
+ * Polls GET /api/gateway/status every 30 seconds and returns whether the
+ * API server's WebSocket connection to the OpenClaw gateway is healthy.
+ * Re-polls immediately when the browser tab becomes visible.
+ */
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { getApiBaseUrl } from '@/ui/lib/api-config';
+
+const POLL_INTERVAL_MS = 30_000;
+
+export interface GatewayStatus {
+  connected: boolean;
+  loading: boolean;
+  error: boolean;
+}
+
+export function useGatewayStatus(): GatewayStatus {
+  const [status, setStatus] = useState<GatewayStatus>({
+    connected: false,
+    loading: true,
+    error: false,
+  });
+  const mountedRef = useRef(true);
+
+  const fetchStatus = useCallback(async () => {
+    try {
+      const baseUrl = getApiBaseUrl();
+      const res = await fetch(`${baseUrl}/gateway/status`);
+      if (!mountedRef.current) return;
+      if (!res.ok) {
+        setStatus({ connected: false, loading: false, error: true });
+        return;
+      }
+      const data: { connected?: boolean } = await res.json();
+      if (!mountedRef.current) return;
+      setStatus({
+        connected: data.connected === true,
+        loading: false,
+        error: false,
+      });
+    } catch {
+      if (!mountedRef.current) return;
+      setStatus({ connected: false, loading: false, error: true });
+    }
+  }, []);
+
+  useEffect(() => {
+    mountedRef.current = true;
+
+    // Initial fetch
+    void fetchStatus();
+
+    // Set up polling interval
+    const intervalId = setInterval(() => {
+      void fetchStatus();
+    }, POLL_INTERVAL_MS);
+
+    // Re-poll on tab visibility change
+    const onVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        void fetchStatus();
+      }
+    };
+    document.addEventListener('visibilitychange', onVisibilityChange);
+
+    return () => {
+      mountedRef.current = false;
+      clearInterval(intervalId);
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+    };
+  }, [fetchStatus]);
+
+  return status;
+}

--- a/src/ui/lib/api-types.ts
+++ b/src/ui/lib/api-types.ts
@@ -1870,6 +1870,8 @@ export interface ChatAgent {
   name: string;
   display_name: string | null;
   avatar_url: string | null;
+  /** Agent presence status from gateway WS (Issue #2160). */
+  status?: 'online' | 'busy' | 'offline' | 'unknown';
 }
 
 /** Response from GET /chat/agents */

--- a/tests/ui/agent-status-badge.test.tsx
+++ b/tests/ui/agent-status-badge.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Tests for AgentStatusBadge component (Epic #2153, Issue #2160).
+ *
+ * Verifies: color variants, accessibility attributes, sr-only label,
+ * null render for unknown, and no animation.
+ */
+import * as React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { AgentStatusBadge } from '@/ui/components/chat/agent-status-badge';
+
+describe('AgentStatusBadge', () => {
+  it('renders green element for status "online"', () => {
+    const { container } = render(<AgentStatusBadge status="online" />);
+    const dot = container.querySelector('[data-testid="agent-status-dot"]');
+    expect(dot).toBeInTheDocument();
+    expect(dot?.className).toMatch(/bg-green/);
+  });
+
+  it('renders amber element for status "busy"', () => {
+    const { container } = render(<AgentStatusBadge status="busy" />);
+    const dot = container.querySelector('[data-testid="agent-status-dot"]');
+    expect(dot).toBeInTheDocument();
+    expect(dot?.className).toMatch(/bg-amber/);
+  });
+
+  it('renders gray element for status "offline"', () => {
+    const { container } = render(<AgentStatusBadge status="offline" />);
+    const dot = container.querySelector('[data-testid="agent-status-dot"]');
+    expect(dot).toBeInTheDocument();
+    expect(dot?.className).toMatch(/bg-gray/);
+  });
+
+  it('renders nothing for status "unknown"', () => {
+    const { container } = render(<AgentStatusBadge status="unknown" />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('has role="status" on container', () => {
+    render(<AgentStatusBadge status="online" />);
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it('has aria-label="Agent status: online" for online status', () => {
+    render(<AgentStatusBadge status="online" />);
+    expect(screen.getByRole('status')).toHaveAttribute('aria-label', 'Agent status: online');
+  });
+
+  it('has aria-label with correct status for busy', () => {
+    render(<AgentStatusBadge status="busy" />);
+    expect(screen.getByRole('status')).toHaveAttribute('aria-label', 'Agent status: busy');
+  });
+
+  it('has title attribute with status text', () => {
+    const { container } = render(<AgentStatusBadge status="online" />);
+    const dot = container.querySelector('[data-testid="agent-status-dot"]');
+    expect(dot).toHaveAttribute('title', 'Online');
+  });
+
+  it('has sr-only text label (not hidden from screen readers)', () => {
+    const { container } = render(<AgentStatusBadge status="online" />);
+    const srOnly = container.querySelector('.sr-only');
+    expect(srOnly).toBeInTheDocument();
+    expect(srOnly?.textContent).toBe('Online');
+  });
+
+  it('does not render animations', () => {
+    const { container } = render(<AgentStatusBadge status="online" />);
+    const dot = container.querySelector('[data-testid="agent-status-dot"]');
+    expect(dot?.className).not.toMatch(/animate/);
+  });
+});

--- a/tests/ui/chat-agent-selector.test.tsx
+++ b/tests/ui/chat-agent-selector.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Tests for ChatAgentSelector component (Epic #2153, Issue #2160).
+ *
+ * Verifies: agent status badge rendering and graceful fallback.
+ */
+import * as React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+vi.mock('@/ui/hooks/queries/use-chat', () => ({
+  chatKeys: {
+    all: ['chat'],
+    agents: () => ['chat', 'agents'],
+  },
+  useAvailableAgents: vi.fn(),
+}));
+
+vi.mock('@/ui/components/realtime/realtime-context', () => ({
+  useRealtimeOptional: vi.fn(() => null),
+}));
+
+import { ChatAgentSelector } from '@/ui/components/chat/chat-agent-selector';
+import { useAvailableAgents } from '@/ui/hooks/queries/use-chat';
+
+function createWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        {children}
+      </QueryClientProvider>
+    );
+  };
+}
+
+describe('ChatAgentSelector', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders AgentStatusBadge for each agent with status', () => {
+    vi.mocked(useAvailableAgents).mockReturnValue({
+      data: {
+        agents: [
+          { id: 'a1', name: 'Agent1', display_name: 'Agent One', avatar_url: null, status: 'online' },
+          { id: 'a2', name: 'Agent2', display_name: 'Agent Two', avatar_url: null, status: 'busy' },
+        ],
+      },
+    } as ReturnType<typeof useAvailableAgents>);
+
+    render(
+      <ChatAgentSelector value="a1" onChange={vi.fn()} />,
+      { wrapper: createWrapper() },
+    );
+
+    // Should have status badges (role="status")
+    const badges = screen.getAllByRole('status');
+    expect(badges.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('does not crash when status field is absent', () => {
+    vi.mocked(useAvailableAgents).mockReturnValue({
+      data: {
+        agents: [
+          { id: 'a1', name: 'Agent1', display_name: 'Agent One', avatar_url: null },
+          { id: 'a2', name: 'Agent2', display_name: 'Agent Two', avatar_url: null },
+        ],
+      },
+    } as ReturnType<typeof useAvailableAgents>);
+
+    expect(() => {
+      render(
+        <ChatAgentSelector value="a1" onChange={vi.fn()} />,
+        { wrapper: createWrapper() },
+      );
+    }).not.toThrow();
+  });
+
+  it('returns null when only one agent', () => {
+    vi.mocked(useAvailableAgents).mockReturnValue({
+      data: {
+        agents: [
+          { id: 'a1', name: 'Agent1', display_name: 'Agent One', avatar_url: null, status: 'online' },
+        ],
+      },
+    } as ReturnType<typeof useAvailableAgents>);
+
+    const { container } = render(
+      <ChatAgentSelector value="a1" onChange={vi.fn()} />,
+      { wrapper: createWrapper() },
+    );
+    expect(container.querySelector('[data-testid="chat-agent-selector"]')).toBeNull();
+  });
+});

--- a/tests/ui/chat-connection-banner.test.tsx
+++ b/tests/ui/chat-connection-banner.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Tests for ChatConnectionBanner component (Epic #2153, Issue #2159).
+ *
+ * Verifies: gateway degraded state, hiding on connected, and existing behavior.
+ */
+import * as React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { ChatConnectionBanner } from '@/ui/components/chat/chat-connection-banner';
+
+describe('ChatConnectionBanner', () => {
+  it('does not render when status is connected and gateway is connected', () => {
+    const { container } = render(
+      <ChatConnectionBanner status="connected" gatewayConnected={true} />,
+    );
+    expect(container.querySelector('[data-testid="connection-banner"]')).toBeNull();
+  });
+
+  it('does not render when status is connected and gatewayConnected is undefined', () => {
+    const { container } = render(
+      <ChatConnectionBanner status="connected" />,
+    );
+    expect(container.querySelector('[data-testid="connection-banner"]')).toBeNull();
+  });
+
+  it('renders degraded banner when gatewayConnected=false and browser WS is connected', () => {
+    render(
+      <ChatConnectionBanner status="connected" gatewayConnected={false} />,
+    );
+    const banner = screen.getByTestId('connection-banner');
+    expect(banner).toBeInTheDocument();
+    expect(banner).toHaveTextContent(/degraded/i);
+  });
+
+  it('renders disconnected state when browser WS is disconnected regardless of gateway', () => {
+    render(
+      <ChatConnectionBanner status="disconnected" gatewayConnected={true} />,
+    );
+    const banner = screen.getByTestId('connection-banner');
+    expect(banner).toBeInTheDocument();
+    expect(banner).toHaveTextContent('Disconnected');
+  });
+
+  it('renders connecting state normally', () => {
+    render(
+      <ChatConnectionBanner status="connecting" />,
+    );
+    expect(screen.getByTestId('connection-banner')).toHaveTextContent('Connecting...');
+  });
+
+  it('renders reconnecting state normally', () => {
+    render(
+      <ChatConnectionBanner status="reconnecting" />,
+    );
+    expect(screen.getByTestId('connection-banner')).toHaveTextContent('Reconnecting...');
+  });
+});

--- a/tests/ui/use-gateway-status.test.ts
+++ b/tests/ui/use-gateway-status.test.ts
@@ -1,0 +1,178 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Tests for useGatewayStatus hook (Epic #2153, Issue #2159).
+ *
+ * Verifies: initial loading state, successful/failed fetch, polling, unmount cleanup,
+ * and re-poll on window focus.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+
+// Mock the api-config module to provide a base URL
+vi.mock('@/ui/lib/api-config', () => ({
+  getApiBaseUrl: vi.fn(() => 'http://localhost:3000/api'),
+}));
+
+import { useGatewayStatus } from '@/ui/hooks/use-gateway-status';
+
+describe('useGatewayStatus', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, 'fetch');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('returns { loading: true } on initial render before fetch completes', () => {
+    fetchSpy.mockReturnValue(new Promise(() => {})); // never resolves
+    const { result } = renderHook(() => useGatewayStatus());
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.connected).toBe(false);
+    expect(result.current.error).toBe(false);
+  });
+
+  it('returns { connected: true, loading: false } on successful response', async () => {
+    fetchSpy.mockResolvedValue(
+      new Response(JSON.stringify({ connected: true, connected_at: '2026-03-05T10:00:00Z', last_tick_at: '2026-03-05T10:00:30Z' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const { result } = renderHook(() => useGatewayStatus());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(result.current.connected).toBe(true);
+    expect(result.current.error).toBe(false);
+  });
+
+  it('returns { connected: false, loading: false } when API returns connected=false', async () => {
+    fetchSpy.mockResolvedValue(
+      new Response(JSON.stringify({ connected: false, connected_at: null, last_tick_at: null }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const { result } = renderHook(() => useGatewayStatus());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(result.current.connected).toBe(false);
+    expect(result.current.error).toBe(false);
+  });
+
+  it('returns { connected: false, error: true } on fetch failure', async () => {
+    fetchSpy.mockRejectedValue(new Error('Network error'));
+
+    const { result } = renderHook(() => useGatewayStatus());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(result.current.connected).toBe(false);
+    expect(result.current.error).toBe(true);
+  });
+
+  it('polls again after 30 seconds', async () => {
+    vi.useFakeTimers();
+
+    fetchSpy.mockResolvedValue(
+      new Response(JSON.stringify({ connected: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    renderHook(() => useGatewayStatus());
+
+    // Flush initial fetch
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    // Advance by 30 seconds
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000);
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('stops polling when component unmounts', async () => {
+    vi.useFakeTimers();
+
+    fetchSpy.mockResolvedValue(
+      new Response(JSON.stringify({ connected: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const { unmount } = renderHook(() => useGatewayStatus());
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    unmount();
+
+    // Advance by 30 seconds — should NOT trigger another fetch
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000);
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-polls on window focus (visibilitychange)', async () => {
+    fetchSpy.mockResolvedValue(
+      new Response(JSON.stringify({ connected: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    renderHook(() => useGatewayStatus());
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    // Simulate tab becoming visible
+    Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true });
+    act(() => {
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('returns { connected: false, error: true } on non-ok HTTP response', async () => {
+    fetchSpy.mockResolvedValue(
+      new Response('Internal Server Error', { status: 500 }),
+    );
+
+    const { result } = renderHook(() => useGatewayStatus());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(result.current.connected).toBe(false);
+    expect(result.current.error).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- **useGatewayStatus hook** (#2159): Polls `GET /api/gateway/status` every 30s, re-polls on visibility change, cleans up on unmount. Returns `{ connected, loading, error }`.
- **AgentStatusBadge component** (#2160): Colored dot (green/amber/gray) with accessible text label, `role="status"`, `aria-label`, `title` tooltip, `sr-only` text. Returns null for unknown status. No animation.
- **ChatConnectionBanner**: Added optional `gatewayConnected` prop. Shows "Agent connection degraded -- using fallback mode" when gateway WS is down but browser WS is connected.
- **ChatPanel**: Wires `useGatewayStatus` to `ChatConnectionBanner`. Suppresses degraded banner during initial loading.
- **ChatAgentSelector**: Renders `AgentStatusBadge` per agent. Subscribes to `agent:status_changed` RealtimeHub events for live status updates without re-polling.
- **Type updates**: Added optional `status` field to `ChatAgent` interface. Added `agent:status_changed` to `RealtimeEventType`.
- **Barrel export**: `AgentStatusBadge` exported from `src/ui/components/chat/index.ts`.

## Test plan

- [x] 8 unit tests for `useGatewayStatus` hook (loading, connected, disconnected, error, polling interval, unmount cleanup, visibility change, non-ok HTTP)
- [x] 10 unit tests for `AgentStatusBadge` (green/amber/gray dots, unknown=null, role, aria-label, title, sr-only, no animation)
- [x] 6 unit tests for `ChatConnectionBanner` (degraded when gateway down, hides when connected, existing states preserved)
- [x] 3 unit tests for `ChatAgentSelector` (badge rendering, graceful fallback for missing status, single-agent returns null)
- [x] All 1945 existing UI tests still pass
- [x] TypeScript build passes (`pnpm run build`)
- [x] Codex security review passed (addressed findings #1 and #4)

Closes #2159, Closes #2160