### PR TITLE
[#2162,#2164] OpenAPI spec, AGENTS.md docs, and gateway observability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,6 +217,35 @@ For 2 issues or simple sequential work, ralph-loop alone is more cost-effective.
 
 ---
 
+## Gateway WebSocket Connection
+
+The API server maintains a permanent WebSocket connection to the OpenClaw gateway for low-latency chat dispatch and live agent discovery.
+
+### Environment Variables
+
+| Variable | Purpose | Default |
+|----------|---------|---------|
+| `OPENCLAW_GATEWAY_URL` | Gateway base URL (http/https); WS URL derived automatically | — |
+| `OPENCLAW_GATEWAY_TOKEN` | Token for WS authentication | Falls back to `OPENCLAW_HOOK_TOKEN` |
+| `OPENCLAW_GATEWAY_WS_ENABLED` | Set to `false` to disable WS connection | `true` when `OPENCLAW_GATEWAY_URL` is set |
+| `OPENCLAW_GATEWAY_ALLOW_PRIVATE` | Allow private-CIDR gateway URLs (bypasses SSRF validation) | `false` |
+
+### Key Endpoints
+
+- `GET /api/gateway/status` — Connection state + lifecycle metrics (requires auth)
+- `GET /api/chat/agents` — Live agent list with presence status (online/busy/offline/unknown)
+- `POST /api/chat/sessions/:id/abort` — Abort in-flight agent run via gateway WS
+
+### Architecture Notes
+
+- WS connection auto-reconnects with exponential backoff (1s-30s) + jitter
+- Chat dispatch: WS primary, HTTP webhook fallback
+- Agent discovery: live gateway query, DB fallback
+- Presence tracking: explicit gateway events + inferred from chat activity
+- Token is sent in the WS `connect` handshake body only, never in the URL
+
+---
+
 ## Key Technical Patterns
 
 ### Memory APIs (pgvector)

--- a/src/api/gateway/chat-dispatch.test.ts
+++ b/src/api/gateway/chat-dispatch.test.ts
@@ -32,6 +32,7 @@ import {
   type ChatSession,
   type ChatMessageRecord,
 } from './chat-dispatch.ts';
+import { gwChatDispatchWs, gwChatDispatchHttp } from './metrics.ts';
 
 // ── Fixtures ───────────────────────────────────────────────────────
 
@@ -298,5 +299,47 @@ describe('abortChatRun', () => {
 
     // Should not throw
     await expect(abortChatRun(makeSession())).resolves.toBeUndefined();
+  });
+});
+
+// ── Metrics integration (#2164) ───────────────────────────────────────
+
+describe('dispatch metrics', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.OPENCLAW_GATEWAY_URL = 'https://gateway.example.com';
+  });
+
+  it('gwChatDispatchWs increments on successful WS dispatch', async () => {
+    mockGetStatus.mockReturnValue({ connected: true, gateway_url: 'gateway.example.com' });
+    mockRequest.mockResolvedValue({ ok: true });
+
+    const before = gwChatDispatchWs.get();
+    await dispatchChatMessage(makeMockPool(), makeSession(), makeMessage(), 'user@example.com');
+    expect(gwChatDispatchWs.get()).toBe(before + 1);
+  });
+
+  it('gwChatDispatchHttp increments on HTTP fallback dispatch', async () => {
+    mockGetStatus.mockReturnValue({ connected: false, gateway_url: null });
+    mockEnqueueWebhook.mockResolvedValue('webhook-id');
+
+    const before = gwChatDispatchHttp.get();
+    await dispatchChatMessage(makeMockPool(), makeSession(), makeMessage(), 'user@example.com');
+    expect(gwChatDispatchHttp.get()).toBe(before + 1);
+  });
+
+  it('gwChatDispatchHttp increments when WS fails and falls back to HTTP', async () => {
+    mockGetStatus.mockReturnValue({ connected: true, gateway_url: 'gateway.example.com' });
+    mockRequest.mockRejectedValue(new Error('WS unavailable'));
+    mockEnqueueWebhook.mockResolvedValue('webhook-id');
+
+    const beforeWs = gwChatDispatchWs.get();
+    const beforeHttp = gwChatDispatchHttp.get();
+    await dispatchChatMessage(makeMockPool(), makeSession(), makeMessage(), 'user@example.com');
+
+    // WS counter should NOT increment (dispatch failed)
+    expect(gwChatDispatchWs.get()).toBe(beforeWs);
+    // HTTP counter SHOULD increment (fallback succeeded)
+    expect(gwChatDispatchHttp.get()).toBe(beforeHttp + 1);
   });
 });

--- a/src/api/gateway/chat-dispatch.ts
+++ b/src/api/gateway/chat-dispatch.ts
@@ -16,6 +16,7 @@
 import type { Pool } from 'pg';
 import { getGatewayConnection } from './index.ts';
 import { enqueueWebhook } from '../webhooks/dispatcher.ts';
+import { gwChatDispatchWs, gwChatDispatchHttp } from './metrics.ts';
 
 // ── Types ──────────────────────────────────────────────────────────
 
@@ -92,6 +93,7 @@ export async function dispatchChatMessage(
         timeoutMs: resolveTimeoutMs(),
       });
 
+      gwChatDispatchWs.inc();
       console.log(`${LOG_PREFIX} dispatched via WS session=${session.id}`);
       return { dispatched: true, method: 'ws' };
     } catch (err) {
@@ -129,6 +131,7 @@ export async function dispatchChatMessage(
       },
     });
 
+    gwChatDispatchHttp.inc();
     console.log(`${LOG_PREFIX} dispatched via HTTP webhook session=${session.id}`);
     return { dispatched: true, method: 'http' };
   } catch (err) {

--- a/src/api/gateway/connection.ts
+++ b/src/api/gateway/connection.ts
@@ -14,6 +14,7 @@
 import { randomUUID } from 'node:crypto';
 import WebSocket from 'ws';
 import { validateSsrf } from '../webhooks/ssrf.ts';
+import { gwConnectAttempts, gwReconnects, gwAuthFailures, gwEventsReceived } from './metrics.ts';
 
 // ── Types ────────────────────────────────────────────────────────────────
 
@@ -283,6 +284,7 @@ export class GatewayConnectionService {
       }
 
       const url = this.wsUrl!;
+      gwConnectAttempts.inc();
       console.log(`${LOG_PREFIX} connecting to ${this.gatewayHost}`);
 
       // Token MUST NOT be in the URL
@@ -359,6 +361,7 @@ export class GatewayConnectionService {
   }
 
   private _handleEvent(frame: GatewayEventFrame): void {
+    gwEventsReceived.inc();
     const eventName = frame.event;
 
     if (eventName === 'connect.challenge') {
@@ -429,6 +432,7 @@ export class GatewayConnectionService {
           clearTimeout(this.connectResponseTimer);
           this.connectResponseTimer = null;
         }
+        gwAuthFailures.inc();
         console.error(`${LOG_PREFIX} connect rejected:`, err.message);
         this.ws?.close(4002);
       },
@@ -513,6 +517,7 @@ export class GatewayConnectionService {
     const delay = Math.max(100, Math.round(backoff + jitter));
 
     this.reconnectAttempt++;
+    gwReconnects.inc();
     console.log(`${LOG_PREFIX} reconnecting in ${delay}ms (attempt ${this.reconnectAttempt})`);
 
     this.reconnectTimer = setTimeout(() => {

--- a/src/api/gateway/event-router.test.ts
+++ b/src/api/gateway/event-router.test.ts
@@ -44,6 +44,7 @@ vi.mock('./index.ts', () => ({
 
 // Import after mocks
 import { GatewayEventRouter } from './event-router.ts';
+import { gwChatEventsRouted, gwDuplicateEventsSuppressed } from './metrics.ts';
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
@@ -749,6 +750,48 @@ describe('GatewayEventRouter', () => {
     await new Promise((r) => setTimeout(r, 50));
 
     // Should still only have 1 sendToUser call (the aborted one), no delta sent
+    expect(mockSendToUser).toHaveBeenCalledTimes(1);
+  });
+
+  // ── Metrics integration (#2164) ──────────────────────────────────
+
+  it('gwChatEventsRouted increments on each routed chat event', async () => {
+    router.initialize(pool as never);
+    const handler = capturedHandlers[0];
+    mockSessionLookup(pool, {});
+
+    const before = gwChatEventsRouted.get();
+    handler(makeChatEvent({ state: 'delta', seq: 0, message: 'hi' }));
+
+    await vi.waitFor(() => {
+      expect(mockSendToUser).toHaveBeenCalled();
+    });
+
+    expect(gwChatEventsRouted.get()).toBe(before + 1);
+  });
+
+  it('gwDuplicateEventsSuppressed increments on duplicate seq', async () => {
+    router.initialize(pool as never);
+    const handler = capturedHandlers[0];
+    mockSessionLookup(pool, {});
+
+    // First delta with seq=0
+    handler(makeChatEvent({ state: 'delta', seq: 0, runId: 'run-dedup', message: 'first' }));
+    await vi.waitFor(() => {
+      expect(mockSendToUser).toHaveBeenCalledTimes(1);
+    });
+
+    const before = gwDuplicateEventsSuppressed.get();
+
+    // Duplicate delta with same seq=0
+    mockSessionLookup(pool, {});
+    handler(makeChatEvent({ state: 'delta', seq: 0, runId: 'run-dedup', message: 'duplicate' }));
+
+    // Small delay for async processing
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(gwDuplicateEventsSuppressed.get()).toBe(before + 1);
+    // Still only one sendToUser call (duplicate was suppressed)
     expect(mockSendToUser).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/api/gateway/event-router.ts
+++ b/src/api/gateway/event-router.ts
@@ -14,6 +14,7 @@ import type { GatewayEventFrame } from './connection.ts';
 import { getGatewayConnection } from './index.ts';
 import { getRealtimeHub } from '../realtime/hub.ts';
 import type { RealtimeEvent, GatewayStreamEventType, ChatEventType } from '../realtime/types.ts';
+import { gwChatEventsRouted, gwDuplicateEventsSuppressed } from './metrics.ts';
 
 // ── Types ────────────────────────────────────────────────────────────
 
@@ -156,6 +157,7 @@ export class GatewayEventRouter {
     }
 
     // Route by state
+    gwChatEventsRouted.inc();
     switch (event.state) {
       case 'delta':
         this.handleDelta(session, event);
@@ -219,6 +221,7 @@ export class GatewayEventRouter {
 
     // Duplicate seq detection
     if (tracker.seenSeqs.has(event.seq)) {
+      gwDuplicateEventsSuppressed.inc();
       return; // Skip duplicate
     }
 

--- a/src/api/gateway/index.ts
+++ b/src/api/gateway/index.ts
@@ -114,6 +114,7 @@ export type { ChatSession, ChatMessageRecord, DispatchResult } from './chat-disp
 export { GatewayEventRouter } from './event-router.ts';
 export { AgentPresenceTracker, type AgentStatus } from './presence-tracker.ts';
 export { AgentCache, type CachedAgent } from './agent-cache.ts';
+export { getGatewayMetrics, type GatewayMetricsSnapshot } from './metrics.ts';
 
 // ── Event router singleton (#2156) ──────────────────────────────────
 

--- a/src/api/gateway/metrics.test.ts
+++ b/src/api/gateway/metrics.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Tests for gateway WebSocket metrics.
+ * Issue #2164 — Structured logging and metrics for gateway WebSocket lifecycle.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  gwConnectAttempts,
+  gwReconnects,
+  gwEventsReceived,
+  gwChatEventsRouted,
+  gwDuplicateEventsSuppressed,
+  gwAuthFailures,
+  gwChatDispatchWs,
+  gwChatDispatchHttp,
+  getGatewayMetrics,
+} from './metrics.ts';
+
+describe('gateway metrics', () => {
+  // Note: Counter instances are module-level singletons, so values accumulate
+  // across tests within the same vitest run. We test relative increments.
+
+  it('getGatewayMetrics returns all counter values', () => {
+    const snapshot = getGatewayMetrics();
+    expect(snapshot).toEqual(expect.objectContaining({
+      connect_attempts: expect.any(Number),
+      reconnects: expect.any(Number),
+      events_received: expect.any(Number),
+      chat_events_routed: expect.any(Number),
+      duplicate_events_suppressed: expect.any(Number),
+      auth_failures: expect.any(Number),
+      chat_dispatch_ws: expect.any(Number),
+      chat_dispatch_http: expect.any(Number),
+    }));
+  });
+
+  it('connect_attempts increments on inc()', () => {
+    const before = gwConnectAttempts.get();
+    gwConnectAttempts.inc();
+    expect(gwConnectAttempts.get()).toBe(before + 1);
+  });
+
+  it('reconnects increments on inc()', () => {
+    const before = gwReconnects.get();
+    gwReconnects.inc();
+    expect(gwReconnects.get()).toBe(before + 1);
+  });
+
+  it('events_received increments on inc()', () => {
+    const before = gwEventsReceived.get();
+    gwEventsReceived.inc();
+    expect(gwEventsReceived.get()).toBe(before + 1);
+  });
+
+  it('chat_events_routed increments on inc()', () => {
+    const before = gwChatEventsRouted.get();
+    gwChatEventsRouted.inc();
+    expect(gwChatEventsRouted.get()).toBe(before + 1);
+  });
+
+  it('duplicate_events_suppressed increments on inc()', () => {
+    const before = gwDuplicateEventsSuppressed.get();
+    gwDuplicateEventsSuppressed.inc();
+    expect(gwDuplicateEventsSuppressed.get()).toBe(before + 1);
+  });
+
+  it('auth_failures increments on inc()', () => {
+    const before = gwAuthFailures.get();
+    gwAuthFailures.inc();
+    expect(gwAuthFailures.get()).toBe(before + 1);
+  });
+
+  it('chat_dispatch_ws increments on inc()', () => {
+    const before = gwChatDispatchWs.get();
+    gwChatDispatchWs.inc();
+    expect(gwChatDispatchWs.get()).toBe(before + 1);
+  });
+
+  it('chat_dispatch_http increments on inc()', () => {
+    const before = gwChatDispatchHttp.get();
+    gwChatDispatchHttp.inc();
+    expect(gwChatDispatchHttp.get()).toBe(before + 1);
+  });
+
+  it('getGatewayMetrics reflects counter increments', () => {
+    const before = getGatewayMetrics();
+    gwConnectAttempts.inc();
+    gwChatDispatchWs.inc();
+    const after = getGatewayMetrics();
+    expect(after.connect_attempts).toBe(before.connect_attempts + 1);
+    expect(after.chat_dispatch_ws).toBe(before.chat_dispatch_ws + 1);
+  });
+});

--- a/src/api/gateway/metrics.ts
+++ b/src/api/gateway/metrics.ts
@@ -1,0 +1,80 @@
+/**
+ * Gateway WebSocket metrics — in-memory counters for observability.
+ * Issue #2164 — Structured logging and metrics for gateway WebSocket lifecycle.
+ *
+ * Uses the same Counter primitive as the worker metrics (src/worker/metrics.ts).
+ * Counters reset on server restart (in-memory only, no persistence needed).
+ *
+ * Exposed via GET /api/gateway/status in the `metrics` field.
+ */
+
+import { Counter } from '../../worker/metrics.ts';
+
+// ── Counters ──────────────────────────────────────────────────────────
+
+export const gwConnectAttempts = new Counter(
+  'gateway_connect_attempts_total',
+  'Total gateway WS connection attempts',
+);
+
+export const gwReconnects = new Counter(
+  'gateway_reconnects_total',
+  'Total gateway WS reconnection attempts (excludes first connect)',
+);
+
+export const gwEventsReceived = new Counter(
+  'gateway_events_received_total',
+  'Total gateway WS events received',
+);
+
+export const gwChatEventsRouted = new Counter(
+  'gateway_chat_events_routed_total',
+  'Total chat events routed to users via RealtimeHub',
+);
+
+export const gwDuplicateEventsSuppressed = new Counter(
+  'gateway_duplicate_events_suppressed_total',
+  'Total duplicate chat events suppressed by seq dedup',
+);
+
+export const gwAuthFailures = new Counter(
+  'gateway_auth_failures_total',
+  'Total gateway WS authentication failures',
+);
+
+export const gwChatDispatchWs = new Counter(
+  'gateway_chat_dispatch_ws_total',
+  'Total chat messages dispatched via WS',
+);
+
+export const gwChatDispatchHttp = new Counter(
+  'gateway_chat_dispatch_http_total',
+  'Total chat messages dispatched via HTTP fallback',
+);
+
+// ── Snapshot ──────────────────────────────────────────────────────────
+
+export interface GatewayMetricsSnapshot {
+  connect_attempts: number;
+  reconnects: number;
+  events_received: number;
+  chat_events_routed: number;
+  duplicate_events_suppressed: number;
+  auth_failures: number;
+  chat_dispatch_ws: number;
+  chat_dispatch_http: number;
+}
+
+/** Return a snapshot of all gateway metrics for the status endpoint. */
+export function getGatewayMetrics(): GatewayMetricsSnapshot {
+  return {
+    connect_attempts: gwConnectAttempts.get(),
+    reconnects: gwReconnects.get(),
+    events_received: gwEventsReceived.get(),
+    chat_events_routed: gwChatEventsRouted.get(),
+    duplicate_events_suppressed: gwDuplicateEventsSuppressed.get(),
+    auth_failures: gwAuthFailures.get(),
+    chat_dispatch_ws: gwChatDispatchWs.get(),
+    chat_dispatch_http: gwChatDispatchHttp.get(),
+  };
+}

--- a/src/api/gateway/observability.test.ts
+++ b/src/api/gateway/observability.test.ts
@@ -1,0 +1,343 @@
+/**
+ * Tests for gateway WebSocket observability — structured logging and metrics integration.
+ * Issue #2164 — Structured logging and metrics for gateway WebSocket lifecycle.
+ *
+ * Verifies that:
+ * - Critical log lines are emitted with correct prefixes
+ * - Token values are never logged
+ * - Metric counters increment at the right lifecycle points
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vitest';
+
+// ── Mock WebSocket ──────────────────────────────────────────────────
+const { MockWebSocket, getMockInstances, resetMockInstances } = vi.hoisted(() => {
+  let instances: Array<InstanceType<typeof _MockWebSocket>> = [];
+
+  class _MockWebSocket {
+    static OPEN = 1;
+    static CLOSED = 3;
+    static CONNECTING = 0;
+
+    readyState = _MockWebSocket.CONNECTING;
+    url: string;
+    listeners: Record<string, Array<(...args: unknown[]) => void>> = {};
+    _sent: string[] = [];
+
+    constructor(url: string) {
+      this.url = url;
+      instances.push(this);
+    }
+
+    on(event: string, handler: (...args: unknown[]) => void) {
+      if (!this.listeners[event]) this.listeners[event] = [];
+      this.listeners[event].push(handler);
+      return this;
+    }
+
+    send(data: string) {
+      this._sent.push(data);
+    }
+
+    close(code?: number) {
+      this.readyState = _MockWebSocket.CLOSED;
+      this._emitClose(code ?? 1000);
+    }
+
+    ping() {}
+
+    _emitOpen() {
+      this.readyState = _MockWebSocket.OPEN;
+      for (const h of this.listeners['open'] ?? []) h();
+    }
+
+    _emitMessage(data: string) {
+      for (const h of this.listeners['message'] ?? []) h(data);
+    }
+
+    _emitClose(code = 1000) {
+      this.readyState = _MockWebSocket.CLOSED;
+      for (const h of this.listeners['close'] ?? []) h(code);
+    }
+
+    _emitError(err: Error) {
+      for (const h of this.listeners['error'] ?? []) h(err);
+    }
+  }
+
+  return {
+    MockWebSocket: _MockWebSocket,
+    getMockInstances: () => instances,
+    resetMockInstances: () => { instances = []; },
+  };
+});
+
+vi.mock('ws', () => ({
+  default: MockWebSocket,
+  WebSocket: MockWebSocket,
+}));
+
+vi.mock('../webhooks/ssrf.ts', () => ({
+  validateSsrf: vi.fn().mockReturnValue(null),
+}));
+
+import { GatewayConnectionService } from './connection.ts';
+import {
+  gwConnectAttempts,
+  gwReconnects,
+  gwEventsReceived,
+  gwAuthFailures,
+} from './metrics.ts';
+
+type MockWS = InstanceType<typeof MockWebSocket>;
+
+function makeService(envOverrides: Record<string, string | undefined> = {}): GatewayConnectionService {
+  const defaults: Record<string, string | undefined> = {
+    OPENCLAW_GATEWAY_URL: 'https://gateway.example.com',
+    OPENCLAW_GATEWAY_TOKEN: 'super-secret-token-value',
+    OPENCLAW_GATEWAY_WS_ENABLED: undefined,
+    OPENCLAW_HOOK_TOKEN: undefined,
+    OPENCLAW_GATEWAY_ALLOW_PRIVATE: undefined,
+  };
+  return new GatewayConnectionService({ ...defaults, ...envOverrides });
+}
+
+function completeHandshake(ws: MockWS) {
+  ws._emitOpen();
+  ws._emitMessage(JSON.stringify({
+    type: 'event',
+    event: 'connect.challenge',
+    payload: { nonce: 'abc123' },
+  }));
+  const connectReq = ws._sent.find((s) => {
+    const parsed = JSON.parse(s);
+    return parsed.type === 'req' && parsed.method === 'connect';
+  });
+  if (!connectReq) return;
+  const { id } = JSON.parse(connectReq);
+  ws._emitMessage(JSON.stringify({
+    type: 'res',
+    id,
+    ok: true,
+    payload: { tick_interval_ms: 30000 },
+  }));
+}
+
+describe('GatewayWS Observability', () => {
+  let logSpy: Mock;
+  let warnSpy: Mock;
+
+  beforeEach(() => {
+    resetMockInstances();
+    vi.useFakeTimers();
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  // ── Structured Logging ──────────────────────────────────────────
+
+  describe('structured logging', () => {
+    it('logs [GatewayWS] connecting when initialize called', async () => {
+      const svc = makeService();
+      const initPromise = svc.initialize();
+      await vi.advanceTimersByTimeAsync(0);
+      completeHandshake(getMockInstances()[0]);
+      await vi.advanceTimersByTimeAsync(0);
+      await initPromise;
+
+      const connectingLog = logSpy.mock.calls.find(
+        (call: unknown[]) => typeof call[0] === 'string' && call[0].includes('[GatewayWS] connecting'),
+      );
+      expect(connectingLog).toBeDefined();
+      await svc.shutdown();
+    });
+
+    it('logs [GatewayWS] connected after handshake', async () => {
+      const svc = makeService();
+      const initPromise = svc.initialize();
+      await vi.advanceTimersByTimeAsync(0);
+      completeHandshake(getMockInstances()[0]);
+      await vi.advanceTimersByTimeAsync(0);
+      await initPromise;
+
+      const connectedLog = logSpy.mock.calls.find(
+        (call: unknown[]) => typeof call[0] === 'string' && call[0] === '[GatewayWS] connected',
+      );
+      expect(connectedLog).toBeDefined();
+      await svc.shutdown();
+    });
+
+    it('logs [GatewayWS] disconnected with code on close', async () => {
+      const svc = makeService();
+      const initPromise = svc.initialize();
+      await vi.advanceTimersByTimeAsync(0);
+      const ws = getMockInstances()[0];
+      completeHandshake(ws);
+      await vi.advanceTimersByTimeAsync(0);
+      await initPromise;
+
+      // Trigger disconnect
+      ws._emitClose(1006);
+
+      const disconnectedLog = logSpy.mock.calls.find(
+        (call: unknown[]) => typeof call[0] === 'string' && call[0].includes('[GatewayWS] disconnected'),
+      );
+      expect(disconnectedLog).toBeDefined();
+      expect(disconnectedLog![0]).toContain('code 1006');
+      await svc.shutdown();
+    });
+
+    it('logs [GatewayWS] reconnecting with delay and attempt number', async () => {
+      const svc = makeService();
+      const initPromise = svc.initialize();
+      await vi.advanceTimersByTimeAsync(0);
+      const ws = getMockInstances()[0];
+      completeHandshake(ws);
+      await vi.advanceTimersByTimeAsync(0);
+      await initPromise;
+
+      // Trigger disconnect to cause reconnect
+      ws._emitClose(1006);
+
+      const reconnectLog = logSpy.mock.calls.find(
+        (call: unknown[]) =>
+          typeof call[0] === 'string' &&
+          call[0].includes('[GatewayWS] reconnecting in') &&
+          call[0].includes('attempt'),
+      );
+      expect(reconnectLog).toBeDefined();
+      await svc.shutdown();
+    });
+
+    it('never logs token values in any log line', async () => {
+      const TOKEN = 'super-secret-token-value';
+      const svc = makeService();
+      const initPromise = svc.initialize();
+      await vi.advanceTimersByTimeAsync(0);
+      const ws = getMockInstances()[0];
+      completeHandshake(ws);
+      await vi.advanceTimersByTimeAsync(0);
+      await initPromise;
+
+      // Trigger disconnect to also test reconnect logs
+      ws._emitClose(1006);
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Check all console.log, console.warn, console.error calls
+      const allLogs = [
+        ...logSpy.mock.calls,
+        ...warnSpy.mock.calls,
+        ...(console.error as Mock).mock.calls,
+      ];
+
+      for (const call of allLogs) {
+        const logStr = call.map(String).join(' ');
+        expect(logStr).not.toContain(TOKEN);
+      }
+
+      await svc.shutdown();
+    });
+  });
+
+  // ── Metrics Counters ────────────────────────────────────────────
+
+  describe('metrics counters', () => {
+    it('gwConnectAttempts increments on connect', async () => {
+      const before = gwConnectAttempts.get();
+      const svc = makeService();
+      const initPromise = svc.initialize();
+      await vi.advanceTimersByTimeAsync(0);
+      completeHandshake(getMockInstances()[0]);
+      await vi.advanceTimersByTimeAsync(0);
+      await initPromise;
+
+      expect(gwConnectAttempts.get()).toBeGreaterThan(before);
+      await svc.shutdown();
+    });
+
+    it('gwReconnects increments on reconnect (not first connect)', async () => {
+      const svc = makeService();
+      const initPromise = svc.initialize();
+      await vi.advanceTimersByTimeAsync(0);
+      const ws = getMockInstances()[0];
+      completeHandshake(ws);
+      await vi.advanceTimersByTimeAsync(0);
+      await initPromise;
+
+      const beforeReconnects = gwReconnects.get();
+
+      // Trigger disconnect to schedule reconnect
+      ws._emitClose(1006);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(gwReconnects.get()).toBeGreaterThan(beforeReconnects);
+      await svc.shutdown();
+    });
+
+    it('gwEventsReceived increments on each event', async () => {
+      const svc = makeService();
+      const initPromise = svc.initialize();
+      await vi.advanceTimersByTimeAsync(0);
+      const ws = getMockInstances()[0];
+      completeHandshake(ws);
+      await vi.advanceTimersByTimeAsync(0);
+      await initPromise;
+
+      const before = gwEventsReceived.get();
+
+      // Send a tick event (it's an event that goes through _handleEvent)
+      ws._emitMessage(JSON.stringify({
+        type: 'event',
+        event: 'tick',
+      }));
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(gwEventsReceived.get()).toBeGreaterThan(before);
+      await svc.shutdown();
+    });
+
+    it('gwAuthFailures increments on connect rejection', async () => {
+      const svc = makeService();
+      const initPromise = svc.initialize();
+      await vi.advanceTimersByTimeAsync(0);
+      const ws = getMockInstances()[0];
+
+      ws._emitOpen();
+      // Send challenge
+      ws._emitMessage(JSON.stringify({
+        type: 'event',
+        event: 'connect.challenge',
+        payload: { nonce: 'abc123' },
+      }));
+      await vi.advanceTimersByTimeAsync(0);
+
+      const before = gwAuthFailures.get();
+
+      // Find connect request and reject it
+      const connectReq = ws._sent.find((s) => {
+        const parsed = JSON.parse(s);
+        return parsed.type === 'req' && parsed.method === 'connect';
+      });
+      const { id } = JSON.parse(connectReq!);
+      ws._emitMessage(JSON.stringify({
+        type: 'res',
+        id,
+        ok: false,
+        error: { message: 'Invalid token' },
+      }));
+      await vi.advanceTimersByTimeAsync(0);
+
+      // The close from the rejection will resolve the init promise
+      await initPromise;
+
+      expect(gwAuthFailures.get()).toBeGreaterThan(before);
+      await svc.shutdown();
+    });
+  });
+});

--- a/src/api/openapi/index.ts
+++ b/src/api/openapi/index.ts
@@ -50,6 +50,7 @@ import { namespaceMovesPaths } from './paths/namespace-moves.ts';
 import { terminalPaths } from './paths/terminal.ts';
 import { chatPaths } from './paths/chat.ts';
 import { devPromptsPaths } from './paths/dev-prompts.ts';
+import { gatewayPaths } from './paths/gateway.ts';
 
 /** Derive the API server URL from PUBLIC_BASE_URL */
 function deriveApiUrl(publicBaseUrl: string): string {
@@ -119,6 +120,8 @@ function allDomainModules(): OpenApiDomainModule[] {
     chatPaths(),
     // Dev Prompts (Epic #2011)
     devPromptsPaths(),
+    // Gateway WebSocket (Epic #2153)
+    gatewayPaths(),
   ];
 }
 

--- a/src/api/openapi/paths/chat.ts
+++ b/src/api/openapi/paths/chat.ts
@@ -200,6 +200,19 @@ export function chatPaths(): OpenApiDomainModule {
           },
         },
       },
+      '/chat/sessions/{id}/abort': {
+        post: {
+          operationId: 'abortChatRun',
+          summary: 'Abort an in-flight agent run',
+          description: 'Aborts the currently running agent response for this chat session via the gateway WebSocket. Returns 204 on success. No-op if no run is in progress.',
+          tags: ['Chat'],
+          parameters: [uuidParam('id', 'Chat session ID')],
+          responses: {
+            '204': { description: 'Abort signal sent' },
+            ...errorResponses(400, 401, 404, 429, 500),
+          },
+        },
+      },
       '/chat/sessions/{id}/messages': {
         post: {
           operationId: 'sendChatMessage',

--- a/src/api/openapi/paths/gateway.test.ts
+++ b/src/api/openapi/paths/gateway.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Tests for gateway OpenAPI path spec.
+ * Issue #2162 — OpenAPI spec for gateway WebSocket connection.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { gatewayPaths } from './gateway.ts';
+import { assembleSpec } from '../index.ts';
+
+describe('gatewayPaths', () => {
+  const module = gatewayPaths();
+
+  it('defines the Gateway tag', () => {
+    expect(module.tags).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'Gateway' }),
+      ]),
+    );
+  });
+
+  it('defines the GatewayStatus schema', () => {
+    expect(module.schemas).toBeDefined();
+    expect(module.schemas!.GatewayStatus).toBeDefined();
+    expect(module.schemas!.GatewayStatus.required).toContain('connected');
+    expect(module.schemas!.GatewayStatus.properties!.connected.type).toBe('boolean');
+    expect(module.schemas!.GatewayStatus.properties!.gateway_url).toBeDefined();
+    expect(module.schemas!.GatewayStatus.properties!.connected_at).toBeDefined();
+    expect(module.schemas!.GatewayStatus.properties!.last_tick_at).toBeDefined();
+    expect(module.schemas!.GatewayStatus.properties!.metrics).toBeDefined();
+  });
+
+  it('defines the metrics sub-schema with all counter fields', () => {
+    const metrics = module.schemas!.GatewayStatus.properties!.metrics;
+    expect(metrics.properties).toBeDefined();
+    const fields = Object.keys(metrics.properties!);
+    expect(fields).toEqual(expect.arrayContaining([
+      'connect_attempts',
+      'reconnects',
+      'events_received',
+      'chat_events_routed',
+      'duplicate_events_suppressed',
+      'auth_failures',
+      'chat_dispatch_ws',
+      'chat_dispatch_http',
+    ]));
+  });
+
+  it('defines GET /gateway/status path', () => {
+    expect(module.paths['/gateway/status']).toBeDefined();
+    const get = module.paths['/gateway/status'].get;
+    expect(get).toBeDefined();
+    expect(get!.operationId).toBe('getGatewayStatus');
+    expect(get!.tags).toContain('Gateway');
+    expect(get!.responses['200']).toBeDefined();
+    expect(get!.responses['401']).toBeDefined();
+  });
+});
+
+describe('assembleSpec includes gateway paths', () => {
+  const spec = assembleSpec() as {
+    paths: Record<string, Record<string, unknown>>;
+    components: { schemas: Record<string, unknown> };
+    tags: Array<{ name: string }>;
+  };
+
+  it('/gateway/status path is present in assembled spec', () => {
+    expect(spec.paths['/gateway/status']).toBeDefined();
+    expect(spec.paths['/gateway/status'].get).toBeDefined();
+  });
+
+  it('GatewayStatus schema is in components', () => {
+    expect(spec.components.schemas.GatewayStatus).toBeDefined();
+  });
+
+  it('Gateway tag is present', () => {
+    const tagNames = spec.tags.map((t) => t.name);
+    expect(tagNames).toContain('Gateway');
+  });
+});
+
+describe('chat abort endpoint in spec', () => {
+  const spec = assembleSpec() as {
+    paths: Record<string, Record<string, unknown>>;
+  };
+
+  it('/chat/sessions/{id}/abort path is present', () => {
+    expect(spec.paths['/chat/sessions/{id}/abort']).toBeDefined();
+    expect(spec.paths['/chat/sessions/{id}/abort'].post).toBeDefined();
+  });
+});
+
+describe('chat agents status field', () => {
+  const spec = assembleSpec() as {
+    components: { schemas: Record<string, { properties?: Record<string, unknown> }> };
+    paths: Record<string, { get?: { responses: Record<string, unknown> } }>;
+  };
+
+  it('/chat/agents response includes status field in agent schema', () => {
+    const agentsPath = spec.paths['/chat/agents'];
+    expect(agentsPath).toBeDefined();
+    expect(agentsPath.get).toBeDefined();
+  });
+});

--- a/src/api/openapi/paths/gateway.ts
+++ b/src/api/openapi/paths/gateway.ts
@@ -1,0 +1,101 @@
+/**
+ * OpenAPI path definitions for Gateway WebSocket endpoints.
+ * Routes: GET /gateway/status
+ *
+ * Issue #2162 — OpenAPI spec for gateway WebSocket connection.
+ * Epic #2153 — API-to-Gateway Permanent WebSocket Connection.
+ */
+import type { OpenApiDomainModule } from '../types.ts';
+import { errorResponses, jsonResponse } from '../helpers.ts';
+
+export function gatewayPaths(): OpenApiDomainModule {
+  return {
+    tags: [
+      { name: 'Gateway', description: 'Gateway WebSocket connection management and status' },
+    ],
+    schemas: {
+      GatewayStatus: {
+        type: 'object',
+        required: ['connected'],
+        properties: {
+          connected: {
+            type: 'boolean',
+            description: 'Whether the API server is currently connected to the OpenClaw gateway via WebSocket',
+          },
+          gateway_url: {
+            type: 'string',
+            nullable: true,
+            description: 'Gateway host (without credentials). Null when not configured.',
+          },
+          connected_at: {
+            type: 'string',
+            format: 'date-time',
+            nullable: true,
+            description: 'When the last successful connection was established. Null if never connected.',
+          },
+          last_tick_at: {
+            type: 'string',
+            format: 'date-time',
+            nullable: true,
+            description: 'When the last heartbeat tick was received. Null if no tick received yet.',
+          },
+          metrics: {
+            type: 'object',
+            description: 'In-memory counters for gateway WebSocket lifecycle events. Reset on server restart.',
+            properties: {
+              connect_attempts: {
+                type: 'integer',
+                description: 'Total connection attempts',
+              },
+              reconnects: {
+                type: 'integer',
+                description: 'Total reconnection attempts (excludes first connect)',
+              },
+              events_received: {
+                type: 'integer',
+                description: 'Total events received from gateway',
+              },
+              chat_events_routed: {
+                type: 'integer',
+                description: 'Total chat events routed to users',
+              },
+              duplicate_events_suppressed: {
+                type: 'integer',
+                description: 'Total duplicate events suppressed by dedup',
+              },
+              auth_failures: {
+                type: 'integer',
+                description: 'Total authentication failures',
+              },
+              chat_dispatch_ws: {
+                type: 'integer',
+                description: 'Total chat messages dispatched via WebSocket',
+              },
+              chat_dispatch_http: {
+                type: 'integer',
+                description: 'Total chat messages dispatched via HTTP fallback',
+              },
+            },
+          },
+        },
+      },
+    },
+    paths: {
+      '/gateway/status': {
+        get: {
+          operationId: 'getGatewayStatus',
+          summary: 'Gateway WebSocket connection status',
+          description:
+            'Returns the current connection state of the API server\'s permanent WebSocket connection to the OpenClaw gateway, including lifecycle metrics.',
+          tags: ['Gateway'],
+          responses: {
+            '200': jsonResponse('Gateway connection status', {
+              $ref: '#/components/schemas/GatewayStatus',
+            }),
+            ...errorResponses(401),
+          },
+        },
+      },
+    },
+  };
+}

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -124,6 +124,7 @@ import { haRoutesPlugin } from './ha-routes.ts';
 import { apiSourceRoutesPlugin } from './api-sources/routes.ts';
 import { chatRoutesPlugin } from './chat/routes.ts';
 import { initGatewayConnection, shutdownGatewayConnection, getGatewayConnection, initPresenceTracker, initAgentCache } from './gateway/index.ts';
+import { getGatewayMetrics } from './gateway/metrics.ts';
 import { postmarkIPWhitelistMiddleware, twilioIPWhitelistMiddleware } from './webhooks/ip-whitelist.ts';
 import { validateSsrf as ssrfValidateSsrf } from './webhooks/ssrf.ts';
 import { computeNextRunAt } from './skill-store/schedule-next-run.ts';
@@ -921,11 +922,11 @@ export function buildServer(options: ProjectsApiOptions = {}): FastifyInstance {
     return reply.code(status_code).send(enriched);
   });
 
-  // ── Gateway WS status (Issue #2154) ────────────────────────────────
+  // ── Gateway WS status (Issue #2154, #2164) ─────────────────────────
   // Requires auth (not in authSkipPaths) — reveals infrastructure topology
   app.get('/gateway/status', async (_req, reply) => {
     const status = getGatewayConnection().getStatus();
-    return reply.send(status);
+    return reply.send({ ...status, metrics: getGatewayMetrics() });
   });
 
   // ============================================================


### PR DESCRIPTION
## Summary

- **#2162**: OpenAPI spec for `GET /gateway/status` with `GatewayStatus` schema (including metrics), abort endpoint spec, AGENTS.md env vars documentation
- **#2164**: Gateway metrics module (8 counters using existing `Counter` primitive), instrumented connection/dispatch/router lifecycle, metrics exposed via status endpoint, structured logging verified

Closes #2162
Closes #2164

## Changes

### New files
- `src/api/gateway/metrics.ts` — Gateway WebSocket metrics counters
- `src/api/openapi/paths/gateway.ts` — OpenAPI path spec for gateway status
- `src/api/gateway/metrics.test.ts` — 10 tests
- `src/api/gateway/observability.test.ts` — 9 tests (logging + counter integration)
- `src/api/openapi/paths/gateway.test.ts` — 9 tests (spec structure + assembly)

### Modified files
- `src/api/gateway/connection.ts` — +4 counter increments (connect, reconnect, events, auth failure)
- `src/api/gateway/chat-dispatch.ts` — +2 counter increments (WS dispatch, HTTP fallback)
- `src/api/gateway/event-router.ts` — +2 counter increments (routed, duplicate suppressed)
- `src/api/gateway/index.ts` — Export metrics
- `src/api/openapi/index.ts` — Register gateway paths
- `src/api/openapi/paths/chat.ts` — Add `POST /sessions/{id}/abort` spec
- `src/api/server.ts` — Include metrics in gateway status response
- `AGENTS.md` — Gateway WebSocket section (env vars, endpoints, architecture)
- `src/api/gateway/chat-dispatch.test.ts` — +3 dispatch metrics behavioral tests
- `src/api/gateway/event-router.test.ts` — +2 router metrics behavioral tests

## Test plan

- [x] `pnpm run build` — typecheck clean
- [x] `pnpm exec vitest run src/api/gateway/` — 140 tests passing
- [x] `pnpm test:unit` — 4100 tests passing (272 files)
- [x] Codex MCP review completed — all findings addressed

## Codex review findings addressed
- Fixed OpenAPI `connected_at`/`last_tick_at` descriptions to match runtime semantics
- Added `500` error response to abort endpoint spec
- Added dispatch and router counter behavioral tests (finding #5)

Generated with [Claude Code](https://claude.com/claude-code)