### PR TITLE
[#2179] Agent-driven synchronous email triage via gateway WebSocket

### DIFF
--- a/src/api/cloudflare-email/index.ts
+++ b/src/api/cloudflare-email/index.ts
@@ -5,3 +5,4 @@
 
 export * from './types.ts';
 export * from './service.ts';
+export * from './triage.ts';

--- a/src/api/cloudflare-email/triage.ts
+++ b/src/api/cloudflare-email/triage.ts
@@ -1,0 +1,176 @@
+/**
+ * Synchronous email triage via gateway WebSocket.
+ * Issue #2179 — Agent-driven email triage.
+ *
+ * Consults an OpenClaw agent (e.g. email-triage) for a triage decision
+ * (accept/reject/discard) before responding to the Cloudflare Email Worker.
+ * Falls back gracefully when the gateway is unavailable or the agent errors.
+ */
+
+import type { GatewayConnectionService } from '../gateway/connection.ts';
+
+// ── Types ────────────────────────────────────────────────────────────────
+
+export interface TriageDecision {
+  action: 'accept' | 'reject';
+  reject_reason?: string;
+}
+
+export interface TriageEmailMetadata {
+  from: string;
+  to: string;
+  subject: string;
+  body: string;
+  timestamp: string;
+  messageId: string;
+}
+
+export interface TriageParams {
+  threadId: string;
+  agentId: string;
+  promptContent: string | null;
+  email: TriageEmailMetadata;
+}
+
+// ── Constants ────────────────────────────────────────────────────────────
+
+const LOG_PREFIX = '[EmailTriage]';
+const DEFAULT_TIMEOUT_MS = 25_000;
+const DEFAULT_REJECT_REASON = 'Rejected by email triage';
+const MAX_BODY_LENGTH = 2000;
+
+// ── Response Parsing ─────────────────────────────────────────────────────
+
+/**
+ * Parse the agent's triage response text into a decision.
+ *
+ * | Agent Response        | Decision                                    |
+ * |-----------------------|---------------------------------------------|
+ * | Starts with `REJECT:` | reject with extracted reason                |
+ * | Equals `NO_REPLY`     | accept (silent discard)                    |
+ * | Anything else          | accept (agent escalated or processed it)  |
+ */
+export function parseTriageResponse(responseText: string): TriageDecision {
+  // Use only the first line for parsing
+  const firstLine = responseText.split('\n')[0].trim();
+
+  if (firstLine.startsWith('REJECT:')) {
+    const reason = firstLine.slice('REJECT:'.length).trim();
+    return {
+      action: 'reject',
+      reject_reason: reason || DEFAULT_REJECT_REASON,
+    };
+  }
+
+  // NO_REPLY and everything else → accept
+  return { action: 'accept' };
+}
+
+// ── Prompt Building ──────────────────────────────────────────────────────
+
+/**
+ * Build a structured triage prompt from email metadata.
+ *
+ * When promptContent is provided (from route's prompt_template), it is
+ * prepended as a custom preamble, allowing per-destination triage rules.
+ */
+export function buildTriagePrompt(
+  email: TriageEmailMetadata,
+  promptContent: string | null,
+): string {
+  const truncatedBody = email.body.slice(0, MAX_BODY_LENGTH);
+
+  const emailSection = [
+    'Inbound email received for triage.',
+    '',
+    `To: ${email.to}`,
+    `From: ${email.from}`,
+    `Subject: ${email.subject}`,
+    `Date: ${email.timestamp}`,
+    `Message-ID: ${email.messageId}`,
+    '',
+    'Body:',
+    truncatedBody,
+    '---',
+    'Evaluate this email and respond with one of:',
+    '- REJECT: <reason> — to bounce at SMTP level',
+    '- NO_REPLY — to silently discard',
+    '- Or escalate by forwarding to the appropriate agent',
+  ].join('\n');
+
+  if (promptContent) {
+    return `${promptContent}\n\n${emailSection}`;
+  }
+
+  return emailSection;
+}
+
+// ── Triage Dispatch ──────────────────────────────────────────────────────
+
+/** Resolve the triage timeout from env or default. */
+function resolveTriageTimeoutMs(): number {
+  const raw = process.env.OPENCLAW_EMAIL_TRIAGE_TIMEOUT_MS;
+  if (!raw) return DEFAULT_TIMEOUT_MS;
+  const parsed = parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_TIMEOUT_MS;
+}
+
+/** Check if synchronous email triage is enabled. */
+function isTriageSyncEnabled(): boolean {
+  const value = process.env.OPENCLAW_EMAIL_TRIAGE_SYNC;
+  // Default to true when not set; only disable on explicit 'false'
+  return value !== 'false';
+}
+
+/**
+ * Attempt synchronous email triage via the gateway WebSocket.
+ *
+ * Returns a TriageDecision if the agent responds within the timeout,
+ * or null if triage is disabled, the gateway is disconnected, or
+ * the agent errors/times out (fail-open).
+ *
+ * @param params - Triage parameters (thread, agent, email metadata)
+ * @param gateway - GatewayConnectionService instance (injected for testability)
+ */
+export async function triageEmailViaGateway(
+  params: TriageParams,
+  gateway: Pick<GatewayConnectionService, 'getStatus' | 'request'>,
+): Promise<TriageDecision | null> {
+  if (!isTriageSyncEnabled()) {
+    return null;
+  }
+
+  const status = gateway.getStatus();
+  if (!status.connected) {
+    return null;
+  }
+
+  const timeoutMs = resolveTriageTimeoutMs();
+  const sessionKey = `agent:${params.agentId}:email_triage:${params.threadId}`;
+  const message = buildTriagePrompt(params.email, params.promptContent);
+
+  try {
+    const response = await gateway.request<{ message: string }>(
+      'chat.send',
+      {
+        sessionKey,
+        message,
+        idempotencyKey: params.email.messageId,
+        deliver: true,
+      },
+      { timeoutMs },
+    );
+
+    const decision = parseTriageResponse(response.message);
+    console.log(
+      `${LOG_PREFIX} triage decision=${decision.action} agent=${params.agentId} thread=${params.threadId}`,
+    );
+    return decision;
+  } catch (err) {
+    console.warn(
+      `${LOG_PREFIX} triage failed, failing open: agent=${params.agentId} thread=${params.threadId}`,
+      err instanceof Error ? err.message : err,
+    );
+    return null;
+  }
+}

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -25,6 +25,7 @@ import {
   exchangeRateLimit,
 } from './auth/rate-limiter.ts';
 import { type CloudflareEmailPayload, processCloudflareEmail } from './cloudflare-email/index.ts';
+import { triageEmailViaGateway } from './cloudflare-email/triage.ts';
 import {
   backfillMemoryEmbeddings,
   backfillWorkItemEmbeddings,
@@ -12520,6 +12521,51 @@ export function buildServer(options: ProjectsApiOptions = {}): FastifyInstance {
             thread_id: result.thread_id,
             message_id: result.message_id,
           });
+        }
+
+        // Synchronous agent triage via gateway WebSocket (#2179)
+        // When the gateway is connected, consult the routed agent for a triage
+        // decision before returning to the Cloudflare Worker. This allows the
+        // agent to reject spam at the SMTP level. Fails open on error/timeout.
+        try {
+          const { getGatewayConnection } = await import('./gateway/index.ts');
+          const { getBestPlainText } = await import('./postmark/email-utils.ts');
+          const body = getBestPlainText(payload.text_body, payload.html_body);
+
+          const triageDecision = await triageEmailViaGateway(
+            {
+              threadId: result.thread_id,
+              agentId: route.agentId,
+              promptContent: route.promptContent,
+              email: {
+                from: payload.from,
+                to: payload.to,
+                subject: payload.subject,
+                body,
+                timestamp: payload.timestamp,
+                messageId: result.message_id,
+              },
+            },
+            getGatewayConnection(),
+          );
+
+          if (triageDecision?.action === 'reject') {
+            console.log(
+              `[Cloudflare Email] Agent triage rejected: reason="${triageDecision.reject_reason}"`,
+            );
+            return reply.code(200).send({
+              success: true,
+              action: 'reject' as const,
+              reject_reason: triageDecision.reject_reason,
+              receipt_id: result.message_id,
+              contact_id: result.contact_id,
+              thread_id: result.thread_id,
+              message_id: result.message_id,
+            });
+          }
+        } catch (triageErr) {
+          // Fail open — log and continue to accept
+          console.warn('[Cloudflare Email] Triage integration error, failing open:', triageErr);
         }
 
         // Return success with receipt ID and accept action

--- a/tests/unit/cloudflare-email-triage.test.ts
+++ b/tests/unit/cloudflare-email-triage.test.ts
@@ -1,0 +1,330 @@
+/**
+ * Unit tests for synchronous email triage via gateway WebSocket.
+ * Issue #2179 — Agent-driven email triage.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  parseTriageResponse,
+  buildTriagePrompt,
+  triageEmailViaGateway,
+  type TriageDecision,
+} from '../../src/api/cloudflare-email/triage.ts';
+
+describe('parseTriageResponse', () => {
+  it('parses REJECT: response and extracts reason', () => {
+    const result = parseTriageResponse('REJECT: Spam from known bulk sender');
+    expect(result).toEqual({
+      action: 'reject',
+      reject_reason: 'Spam from known bulk sender',
+    });
+  });
+
+  it('parses REJECT: with leading/trailing whitespace', () => {
+    const result = parseTriageResponse('  REJECT: Invalid recipient  ');
+    expect(result).toEqual({
+      action: 'reject',
+      reject_reason: 'Invalid recipient',
+    });
+  });
+
+  it('handles REJECT: with empty reason — uses default', () => {
+    const result = parseTriageResponse('REJECT:');
+    expect(result).toEqual({
+      action: 'reject',
+      reject_reason: 'Rejected by email triage',
+    });
+  });
+
+  it('handles REJECT: with only whitespace after colon — uses default', () => {
+    const result = parseTriageResponse('REJECT:   ');
+    expect(result).toEqual({
+      action: 'reject',
+      reject_reason: 'Rejected by email triage',
+    });
+  });
+
+  it('parses NO_REPLY response as accept', () => {
+    const result = parseTriageResponse('NO_REPLY');
+    expect(result).toEqual({ action: 'accept' });
+  });
+
+  it('parses NO_REPLY with whitespace', () => {
+    const result = parseTriageResponse('  NO_REPLY  ');
+    expect(result).toEqual({ action: 'accept' });
+  });
+
+  it('treats any other text as accept (agent escalated)', () => {
+    const result = parseTriageResponse('Forwarding to troy for review');
+    expect(result).toEqual({ action: 'accept' });
+  });
+
+  it('treats empty response as accept', () => {
+    const result = parseTriageResponse('');
+    expect(result).toEqual({ action: 'accept' });
+  });
+
+  it('handles multi-line response — uses first line for parsing', () => {
+    const result = parseTriageResponse('REJECT: Fabricated recipient\nThis address does not exist.');
+    expect(result).toEqual({
+      action: 'reject',
+      reject_reason: 'Fabricated recipient',
+    });
+  });
+
+  it('is case-sensitive — lowercase reject is treated as accept', () => {
+    const result = parseTriageResponse('reject: not valid');
+    expect(result).toEqual({ action: 'accept' });
+  });
+});
+
+describe('buildTriagePrompt', () => {
+  const baseEmail = {
+    from: 'sender@example.com',
+    to: 'support@myapp.com',
+    subject: 'Test Email',
+    body: 'Hello, this is a test email body.',
+    timestamp: '2026-03-05T12:00:00.000Z',
+    messageId: 'abc123@example.com',
+  };
+
+  it('includes all email metadata in the prompt', () => {
+    const prompt = buildTriagePrompt(baseEmail, null);
+    expect(prompt).toContain('To: support@myapp.com');
+    expect(prompt).toContain('From: sender@example.com');
+    expect(prompt).toContain('Subject: Test Email');
+    expect(prompt).toContain('Message-ID: abc123@example.com');
+    expect(prompt).toContain('Hello, this is a test email body.');
+  });
+
+  it('truncates body to 2000 characters', () => {
+    const longBody = 'x'.repeat(3000);
+    const prompt = buildTriagePrompt({ ...baseEmail, body: longBody }, null);
+    const bodyMatch = prompt.match(/Body:\n([\s\S]*?)\n---/);
+    expect(bodyMatch).toBeTruthy();
+    expect(bodyMatch![1].length).toBeLessThanOrEqual(2000);
+  });
+
+  it('uses promptContent as template prefix when provided', () => {
+    const customPrompt = 'You are an email triage agent for myapp.com.';
+    const prompt = buildTriagePrompt(baseEmail, customPrompt);
+    expect(prompt.startsWith(customPrompt)).toBe(true);
+    expect(prompt).toContain('From: sender@example.com');
+  });
+
+  it('includes response format instructions', () => {
+    const prompt = buildTriagePrompt(baseEmail, null);
+    expect(prompt).toContain('REJECT:');
+    expect(prompt).toContain('NO_REPLY');
+  });
+
+  it('handles missing body gracefully', () => {
+    const prompt = buildTriagePrompt({ ...baseEmail, body: '' }, null);
+    expect(prompt).toContain('Body:\n');
+  });
+});
+
+describe('triageEmailViaGateway', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    process.env.OPENCLAW_EMAIL_TRIAGE_SYNC = 'true';
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.restoreAllMocks();
+  });
+
+  const triageParams = {
+    threadId: 'thread-uuid-123',
+    agentId: 'email-triage',
+    promptContent: null as string | null,
+    email: {
+      from: 'spam@bulk.example',
+      to: 'support@myapp.com',
+      subject: 'Buy cheap stuff',
+      body: 'Click here for deals!',
+      timestamp: '2026-03-05T12:00:00.000Z',
+      messageId: 'spam-msg-id@bulk.example',
+    },
+  };
+
+  it('returns null when OPENCLAW_EMAIL_TRIAGE_SYNC is false', async () => {
+    process.env.OPENCLAW_EMAIL_TRIAGE_SYNC = 'false';
+
+    const mockGw = { getStatus: () => ({ connected: true }), request: vi.fn() };
+    const result = await triageEmailViaGateway(triageParams, mockGw as any);
+    expect(result).toBeNull();
+    expect(mockGw.request).not.toHaveBeenCalled();
+  });
+
+  it('returns null when gateway is not connected', async () => {
+    const mockGw = { getStatus: () => ({ connected: false }), request: vi.fn() };
+    const result = await triageEmailViaGateway(triageParams, mockGw as any);
+    expect(result).toBeNull();
+    expect(mockGw.request).not.toHaveBeenCalled();
+  });
+
+  it('sends triage request via gateway WS and returns reject decision', async () => {
+    const mockGw = {
+      getStatus: () => ({ connected: true }),
+      request: vi.fn().mockResolvedValue({ message: 'REJECT: Fabricated address' }),
+    };
+
+    const result = await triageEmailViaGateway(triageParams, mockGw as any);
+
+    expect(result).toEqual({
+      action: 'reject',
+      reject_reason: 'Fabricated address',
+    });
+
+    expect(mockGw.request).toHaveBeenCalledWith(
+      'chat.send',
+      expect.objectContaining({
+        sessionKey: 'agent:email-triage:email_triage:thread-uuid-123',
+        deliver: true,
+      }),
+      expect.objectContaining({ timeoutMs: expect.any(Number) }),
+    );
+  });
+
+  it('sends triage request and returns accept for NO_REPLY', async () => {
+    const mockGw = {
+      getStatus: () => ({ connected: true }),
+      request: vi.fn().mockResolvedValue({ message: 'NO_REPLY' }),
+    };
+
+    const result = await triageEmailViaGateway(triageParams, mockGw as any);
+    expect(result).toEqual({ action: 'accept' });
+  });
+
+  it('sends triage request and returns accept for escalation', async () => {
+    const mockGw = {
+      getStatus: () => ({ connected: true }),
+      request: vi.fn().mockResolvedValue({ message: 'Forwarding to troy' }),
+    };
+
+    const result = await triageEmailViaGateway(triageParams, mockGw as any);
+    expect(result).toEqual({ action: 'accept' });
+  });
+
+  it('uses email thread_id in session key', async () => {
+    const mockGw = {
+      getStatus: () => ({ connected: true }),
+      request: vi.fn().mockResolvedValue({ message: 'NO_REPLY' }),
+    };
+
+    await triageEmailViaGateway(
+      { ...triageParams, threadId: 'my-thread-42' },
+      mockGw as any,
+    );
+
+    expect(mockGw.request).toHaveBeenCalledWith(
+      'chat.send',
+      expect.objectContaining({
+        sessionKey: 'agent:email-triage:email_triage:my-thread-42',
+      }),
+      expect.anything(),
+    );
+  });
+
+  it('includes email metadata in triage prompt', async () => {
+    const mockGw = {
+      getStatus: () => ({ connected: true }),
+      request: vi.fn().mockResolvedValue({ message: 'NO_REPLY' }),
+    };
+
+    await triageEmailViaGateway(triageParams, mockGw as any);
+
+    const sentMessage = mockGw.request.mock.calls[0][1].message as string;
+    expect(sentMessage).toContain('From: spam@bulk.example');
+    expect(sentMessage).toContain('Subject: Buy cheap stuff');
+  });
+
+  it('fails open on triage timeout — returns null', async () => {
+    process.env.OPENCLAW_EMAIL_TRIAGE_TIMEOUT_MS = '100';
+    const mockGw = {
+      getStatus: () => ({ connected: true }),
+      request: vi.fn().mockRejectedValue(new Error('request timed out')),
+    };
+
+    const result = await triageEmailViaGateway(triageParams, mockGw as any);
+    expect(result).toBeNull();
+  });
+
+  it('fails open on agent error — returns null', async () => {
+    const mockGw = {
+      getStatus: () => ({ connected: true }),
+      request: vi.fn().mockRejectedValue(new Error('agent crashed')),
+    };
+
+    const result = await triageEmailViaGateway(triageParams, mockGw as any);
+    expect(result).toBeNull();
+  });
+
+  it('uses custom timeout from OPENCLAW_EMAIL_TRIAGE_TIMEOUT_MS', async () => {
+    process.env.OPENCLAW_EMAIL_TRIAGE_TIMEOUT_MS = '5000';
+    const mockGw = {
+      getStatus: () => ({ connected: true }),
+      request: vi.fn().mockResolvedValue({ message: 'NO_REPLY' }),
+    };
+
+    await triageEmailViaGateway(triageParams, mockGw as any);
+
+    expect(mockGw.request).toHaveBeenCalledWith(
+      'chat.send',
+      expect.anything(),
+      expect.objectContaining({ timeoutMs: 5000 }),
+    );
+  });
+
+  it('uses default 25s timeout when env var not set', async () => {
+    delete process.env.OPENCLAW_EMAIL_TRIAGE_TIMEOUT_MS;
+    const mockGw = {
+      getStatus: () => ({ connected: true }),
+      request: vi.fn().mockResolvedValue({ message: 'NO_REPLY' }),
+    };
+
+    await triageEmailViaGateway(triageParams, mockGw as any);
+
+    expect(mockGw.request).toHaveBeenCalledWith(
+      'chat.send',
+      expect.anything(),
+      expect.objectContaining({ timeoutMs: 25000 }),
+    );
+  });
+
+  it('uses promptContent in triage prompt when provided', async () => {
+    const mockGw = {
+      getStatus: () => ({ connected: true }),
+      request: vi.fn().mockResolvedValue({ message: 'NO_REPLY' }),
+    };
+
+    await triageEmailViaGateway(
+      { ...triageParams, promptContent: 'Custom triage rules here.' },
+      mockGw as any,
+    );
+
+    const sentMessage = mockGw.request.mock.calls[0][1].message as string;
+    expect(sentMessage).toMatch(/^Custom triage rules here\./);
+  });
+
+  it('uses idempotencyKey from messageId', async () => {
+    const mockGw = {
+      getStatus: () => ({ connected: true }),
+      request: vi.fn().mockResolvedValue({ message: 'NO_REPLY' }),
+    };
+
+    await triageEmailViaGateway(triageParams, mockGw as any);
+
+    expect(mockGw.request).toHaveBeenCalledWith(
+      'chat.send',
+      expect.objectContaining({
+        idempotencyKey: 'spam-msg-id@bulk.example',
+      }),
+      expect.anything(),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Closes #2179

- Adds synchronous agent triage to the Cloudflare email inbound handler (`POST /api/cloudflare/email`)
- When the gateway WebSocket is connected, consults the routed agent (e.g. `email-triage`) for a triage decision before responding to the Cloudflare Worker
- Agent can return `REJECT: <reason>` (SMTP 550 bounce), `NO_REPLY` (silent discard), or escalate — enabling SMTP-level spam rejection
- Fails open on timeout, error, or gateway disconnect (falls back to current accept + async webhook behavior)

### Changes

| File | Change |
|------|--------|
| `src/api/cloudflare-email/triage.ts` | New triage module: `parseTriageResponse`, `buildTriagePrompt`, `triageEmailViaGateway` |
| `src/api/cloudflare-email/index.ts` | Export triage module |
| `src/api/server.ts` | Wire triage into Cloudflare email handler between route resolution and accept response |
| `tests/unit/cloudflare-email-triage.test.ts` | 28 unit tests covering all triage paths |

### Configuration

| Env Var | Default | Purpose |
|---------|---------|---------|
| `OPENCLAW_EMAIL_TRIAGE_SYNC` | `true` | Enable/disable synchronous triage |
| `OPENCLAW_EMAIL_TRIAGE_TIMEOUT_MS` | `25000` | Max time to wait for agent response |

### Test plan

- [x] 28 unit tests: response parsing (REJECT/NO_REPLY/escalation/empty/multi-line/case-sensitive), prompt building (metadata inclusion, body truncation, custom template, response instructions), gateway integration (WS dispatch, session key format, timeout handling, error fallback, env config, idempotency)
- [x] 17 existing cloudflare email integration tests still pass
- [x] Full unit suite: 278 files, 4175 tests pass
- [x] Full integration suite: 329 files, 6679 tests pass
- [x] Typecheck passes (`tsc --noEmit`)

Depends on: Epic #2153 (merged in #2182)

🤖 Generated with [Claude Code](https://claude.com/claude-code)