### PR TITLE
[#2186] Fix gateway_connection migration down-test rollback depth

### DIFF
--- a/tests/gateway_connection_migration.test.ts
+++ b/tests/gateway_connection_migration.test.ts
@@ -1,12 +1,28 @@
 /**
- * Integration tests for gateway_connection migration 134 (Epic #2153, Issue #2161).
+ * Integration tests for gateway_connection migration 135 (Epic #2153, Issue #2161).
  * Verifies table creation, constraints, indexes, triggers, pg_cron job,
  * idempotency, and clean rollback.
  */
 import type { Pool } from 'pg';
+import { readdirSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { createTestPool, truncateAllTables } from './helpers/db.ts';
 import { runMigrate } from './helpers/migrate.ts';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const migrationsDir = resolve(__dirname, '../migrations');
+
+/** Count how many migrations have version >= the given version. */
+function migrationsFromVersion(minVersion: number): number {
+  return readdirSync(migrationsDir)
+    .filter((f) => f.endsWith('.up.sql'))
+    .filter((f) => {
+      const m = f.match(/^(\d+)_/);
+      return m ? parseInt(m[1], 10) >= minVersion : false;
+    }).length;
+}
 
 describe('Gateway Connection Migration 134 (#2161)', () => {
   let pool: Pool;
@@ -304,9 +320,10 @@ describe('Gateway Connection Migration 134 (#2161)', () => {
   });
 
   describe('Down migration', () => {
-    it('cleanly rolls back migration 134', async () => {
-      // Roll back just migration 134
-      await runMigrate('down', 1);
+    it('cleanly rolls back migration 135', async () => {
+      // Roll back migration 135 (gateway_connection) and all migrations above it
+      const steps = migrationsFromVersion(135);
+      await runMigrate('down', steps);
 
       // Verify table is gone
       const tableResult = await pool.query(


### PR DESCRIPTION
## Summary

Fixes the `gateway_connection_migration.test.ts` integration test that was failing because it hard-coded `runMigrate('down', 1)` assuming migration 135 was the latest. After Phase 0 added migrations 136-139, rolling back 1 step only removed migration 139, leaving the gateway_connection table intact and causing the test to fail.

The fix dynamically calculates how many migrations exist at or above version 135, so the test correctly rolls back all of them before verifying the table is removed.

Related to #2186 (Phase 0 omnibus PR #2217)

## Test plan

- [ ] Integration test `gateway_connection_migration.test.ts > Down migration > cleanly rolls back migration 135` passes
- [ ] All other integration tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)