### PR TITLE
[#2226] Fix DER INTEGER encoding for Node 25 strict OpenSSL

### DIFF
--- a/scripts/generate-certs.cjs
+++ b/scripts/generate-certs.cjs
@@ -98,6 +98,12 @@ function derPrintableString(str) {
  * Encode an ASN.1 INTEGER.
  */
 function derInteger(buf) {
+  // Strip leading zero bytes (DER requires minimal encoding)
+  let start = 0;
+  while (start < buf.length - 1 && buf[start] === 0x00) {
+    start++;
+  }
+  buf = buf.subarray(start);
   // Ensure positive (add leading 0 if high bit set)
   if (buf[0] & 0x80) {
     buf = Buffer.concat([Buffer.from([0x00]), buf]);


### PR DESCRIPTION
## Summary

- Strip leading zero bytes in `derInteger()` before encoding serial numbers
- `randomBytes(16)` can produce values starting with `0x00`, which is illegal DER padding rejected by Node 25's stricter OpenSSL

Closes #2226

## Test plan

- [x] All 7 `generate-certs.test.ts` tests pass on Node 25.6.1
- [x] Existing cert skip/permission tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)