### PR TITLE
[#2252] Add session purge and SSH-only warning badge

### DIFF
--- a/src/api/openapi/paths/terminal-sessions.ts
+++ b/src/api/openapi/paths/terminal-sessions.ts
@@ -222,6 +222,23 @@ export function terminalSessionsPaths(): OpenApiDomainModule {
         },
       },
 
+      '/terminal/sessions/{id}/purge': {
+        parameters: [uuidParam('id', 'Session UUID')],
+        delete: {
+          operationId: 'purgeTerminalSession',
+          summary: 'Permanently delete a session',
+          description:
+            'Hard-deletes a terminated, error, or disconnected session and all related data ' +
+            '(windows, panes, entries). Active sessions cannot be purged — terminate them first.',
+          tags: ['Terminal Sessions'],
+          parameters: [namespaceParam()],
+          responses: {
+            '204': { description: 'Session purged' },
+            ...errorResponses(400, 401, 403, 404, 409),
+          },
+        },
+      },
+
       '/terminal/sessions/{id}/resize': {
         parameters: [uuidParam('id', 'Session UUID')],
         post: {

--- a/src/api/terminal/routes.ts
+++ b/src/api/terminal/routes.ts
@@ -1328,6 +1328,53 @@ export async function terminalRoutesPlugin(
     }
   });
 
+  // DELETE /api/terminal/sessions/:id/purge — Hard-delete a terminated/error/disconnected session
+  // Permanently removes the session and all related data (windows, panes, entries via FK CASCADE).
+  // Only sessions in terminal states can be purged.
+  app.delete('/terminal/sessions/:id/purge', async (req, reply) => {
+    const params = req.params as { id: string };
+    if (!UUID_REGEX.test(params.id)) {
+      return reply.code(400).send({ error: 'Invalid session ID format' });
+    }
+
+    if (!(await verifyWriteScope(pool, 'terminal_session', params.id, req))) {
+      return reply.code(404).send({ error: 'Session not found' });
+    }
+
+    const actor = await getActor(req);
+    const traceId = extractOrCreateTraceId(req);
+
+    // Only allow purge of sessions in terminal states
+    const statusResult = await pool.query(
+      `SELECT status FROM terminal_session WHERE id = $1`,
+      [params.id],
+    );
+    if (statusResult.rows.length === 0) {
+      return reply.code(404).send({ error: 'Session not found' });
+    }
+
+    const PURGEABLE_STATUSES = ['terminated', 'error', 'disconnected'];
+    const status = (statusResult.rows[0] as { status: string }).status;
+    if (!PURGEABLE_STATUSES.includes(status)) {
+      return reply.code(409).send({
+        error: `Cannot purge session in '${status}' state. Only terminated, error, or disconnected sessions can be purged.`,
+      });
+    }
+
+    app.log.info(traceLogContext(traceId, 'rest'), 'Purging session=%s (status=%s)', params.id, status);
+
+    await pool.query(`DELETE FROM terminal_session WHERE id = $1`, [params.id]);
+
+    recordActivity(pool, {
+      namespace: getStoreNamespace(req),
+      session_id: params.id,
+      actor,
+      action: 'session.purge',
+    });
+
+    return reply.code(204).send();
+  });
+
   // POST /api/terminal/sessions/:id/resize — Resize terminal via gRPC
   app.post('/terminal/sessions/:id/resize', async (req, reply) => {
     const params = req.params as { id: string };

--- a/src/ui/components/terminal/session-card.tsx
+++ b/src/ui/components/terminal/session-card.tsx
@@ -44,7 +44,13 @@ export function SessionCard({ session }: SessionCardProps): React.JSX.Element {
             </span>
           )}
           {session.tags.length > 0 && session.tags.slice(0, 2).map((tag) => (
-            <Badge key={tag} variant="outline" className="text-xs">{tag}</Badge>
+            <Badge
+              key={tag}
+              variant="outline"
+              className={`text-xs ${tag === 'no-tmux' ? 'border-amber-500/50 bg-amber-500/10 text-amber-600 dark:text-amber-400' : ''}`}
+            >
+              {tag === 'no-tmux' ? 'SSH Only' : tag}
+            </Badge>
           ))}
         </div>
       </div>

--- a/src/ui/components/terminal/session-info-sidebar.tsx
+++ b/src/ui/components/terminal/session-info-sidebar.tsx
@@ -68,7 +68,13 @@ export function SessionInfoSidebar({ session }: SessionInfoSidebarProps): React.
           <CardContent>
             <div className="flex flex-wrap gap-1">
               {session.tags.map((tag) => (
-                <Badge key={tag} variant="outline" className="text-xs">{tag}</Badge>
+                <Badge
+                  key={tag}
+                  variant="outline"
+                  className={`text-xs ${tag === 'no-tmux' ? 'border-amber-500/50 bg-amber-500/10 text-amber-600 dark:text-amber-400' : ''}`}
+                >
+                  {tag === 'no-tmux' ? 'SSH Only' : tag}
+                </Badge>
               ))}
             </div>
           </CardContent>

--- a/src/ui/hooks/queries/use-terminal-sessions.ts
+++ b/src/ui/hooks/queries/use-terminal-sessions.ts
@@ -122,6 +122,18 @@ export function useSplitTerminalPane() {
   });
 }
 
+/** Purge (hard-delete) a terminated/error/disconnected session. */
+export function usePurgeTerminalSession() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => apiClient.delete(`/terminal/sessions/${id}/purge`),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: terminalSessionKeys.all });
+    },
+  });
+}
+
 /** Add annotation to a session. */
 export function useAnnotateTerminalSession() {
   const queryClient = useQueryClient();

--- a/src/ui/pages/terminal/SessionsListPage.tsx
+++ b/src/ui/pages/terminal/SessionsListPage.tsx
@@ -10,11 +10,11 @@ import { Link } from 'react-router';
 import { Button } from '@/ui/components/ui/button';
 import { Input } from '@/ui/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/ui/components/ui/select';
-import { ArrowLeft, Search, StopCircle, Loader2 } from 'lucide-react';
+import { ArrowLeft, Search, StopCircle, Trash2, Loader2 } from 'lucide-react';
 import { SessionCard } from '@/ui/components/terminal/session-card';
 import { SessionStatusBadge } from '@/ui/components/terminal/session-status-badge';
 import { Badge } from '@/ui/components/ui/badge';
-import { useTerminalSessions, useTerminateTerminalSession } from '@/ui/hooks/queries/use-terminal-sessions';
+import { useTerminalSessions, useTerminateTerminalSession, usePurgeTerminalSession } from '@/ui/hooks/queries/use-terminal-sessions';
 import { Eye, Wand2 } from 'lucide-react';
 
 const STATUS_OPTIONS = [
@@ -35,6 +35,7 @@ export function SessionsListPage(): React.JSX.Element {
   const filters = statusFilter !== 'all' ? { status: statusFilter } : undefined;
   const sessionsQuery = useTerminalSessions(filters);
   const terminateSession = useTerminateTerminalSession();
+  const purgeSession = usePurgeTerminalSession();
 
   const allSessions = Array.isArray(sessionsQuery.data?.sessions) ? sessionsQuery.data.sessions : [];
 
@@ -149,6 +150,23 @@ export function SessionsListPage(): React.JSX.Element {
                     <StopCircle className="size-4" />
                   </Button>
                 ) : null}
+                {['terminated', 'error', 'disconnected'].includes(session.status) && (
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    className="text-muted-foreground hover:text-red-500 shrink-0"
+                    onClick={() => {
+                      if (confirm('Permanently delete this session and all its history?')) {
+                        purgeSession.mutate(session.id);
+                      }
+                    }}
+                    disabled={purgeSession.isPending}
+                    title="Delete session"
+                    data-testid="purge-session-btn"
+                  >
+                    <Trash2 className="size-4" />
+                  </Button>
+                )}
               </div>
             );
           })}


### PR DESCRIPTION
## Summary
- Add `DELETE /terminal/sessions/:id/purge` endpoint for hard-deleting terminated/error/disconnected sessions
- Only allows purge of sessions in terminal states (returns 409 for active sessions)
- Cascades delete to windows, panes, entries via FK CASCADE
- Render `no-tmux` tag as amber "SSH Only" warning badge in session card and sidebar
- Add trash icon button on sessions list for purgeable sessions (with confirmation)
- Update OpenAPI spec with purge endpoint

Related to #2252

## Test plan
- [ ] Verify `pnpm run build` passes
- [ ] Purge a terminated session — should return 204 and remove all data
- [ ] Try to purge an active session — should return 409
- [ ] Verify SSH-only badge renders for sessions with `no-tmux` tag
- [ ] Verify trash button shows only for terminated/error/disconnected sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)