### PR TITLE
[#2242] Fix chat agent namespace mismatch in DB fallback

### DIFF
--- a/src/api/chat/routes.ts
+++ b/src/api/chat/routes.ts
@@ -176,15 +176,16 @@ export async function chatRoutesPlugin(
 
   // GET /chat/agents — List available agents
   // Issue #2157: Prefers live agents from gateway WS; falls back to DB.
+  // Issue #2242: Use read namespaces (not write) — consistent with other GET endpoints.
   app.get('/chat/agents', async (req, reply) => {
     const identity = await getAuthIdentity(req);
     if (!identity?.email) return reply.code(401).send({ error: 'Unauthorized' });
 
-    const namespace = getStoreNamespace(req);
+    const namespaces = getEffectiveNamespaces(req);
 
     try {
       const cache = getAgentCache();
-      const agents = await cache.getAgents(pool, namespace);
+      const agents = await cache.getAgents(pool, namespaces);
       return reply.send({ agents });
     } catch (err) {
       req.log.error(err, 'Failed to list chat agents');

--- a/src/api/gateway/agent-cache.test.ts
+++ b/src/api/gateway/agent-cache.test.ts
@@ -391,6 +391,40 @@ describe('AgentCache', () => {
     expect(Array.isArray(result)).toBe(true);
   });
 
+  // ── Issue #2242: DB fallback accepts multiple namespaces ─────────
+
+  it('DB fallback accepts namespace array and uses ANY($1::text[])', async () => {
+    const conn = createMockConnection(); // connected: false
+    const tracker = createMockPresenceTracker();
+    const pool = createMockPool([
+      { agent_id: 'agent-1', display_name: 'Agent 1', avatar_url: null, is_default: false },
+    ]);
+    cache = new AgentCache(conn, tracker);
+
+    await cache.getAgents(pool, ['ns1', 'ns2']);
+
+    const queryCall = (pool.query as ReturnType<typeof vi.fn>).mock.calls[0];
+    const sql = queryCall[0] as string;
+    const params = queryCall[1] as unknown[];
+    expect(sql).toContain('ANY($1::text[])');
+    expect(params[0]).toEqual(['ns1', 'ns2']);
+  });
+
+  it('DB fallback returns agents from any of the provided namespaces', async () => {
+    const conn = createMockConnection(); // connected: false
+    const tracker = createMockPresenceTracker();
+    const pool = createMockPool([
+      { agent_id: 'agent-1', display_name: 'Agent 1', avatar_url: null, is_default: true },
+      { agent_id: 'agent-2', display_name: 'Agent 2', avatar_url: null, is_default: false },
+    ]);
+    cache = new AgentCache(conn, tracker);
+
+    const result = await cache.getAgents(pool, ['troy', 'default']);
+    expect(result).toHaveLength(2);
+    expect(result[0].id).toBe('agent-1');
+    expect(result[1].id).toBe('agent-2');
+  });
+
   // ── Issue #2242: Gateway enrichment preserves extra fields ───────
 
   it('gateway enrichment includes display_name, avatar_url, is_default', async () => {

--- a/src/api/gateway/agent-cache.ts
+++ b/src/api/gateway/agent-cache.ts
@@ -53,10 +53,11 @@ export class AgentCache {
 
   /**
    * Get the list of agents. Prefers live gateway data, falls back to DB.
+   * Issue #2242: Accepts namespace array for multi-namespace read access.
    * @param pool - Database connection pool for fallback query
-   * @param namespace - Namespace to filter DB results
+   * @param namespaces - Namespace(s) to filter DB results
    */
-  async getAgents(pool: Pool, namespace: string): Promise<CachedAgent[]> {
+  async getAgents(pool: Pool, namespaces: string[] | string): Promise<CachedAgent[]> {
     const status = this.connection.getStatus();
 
     if (status.connected) {
@@ -68,8 +69,9 @@ export class AgentCache {
       }
     }
 
-    // Fallback to DB
-    return this._getFromDb(pool, namespace);
+    // Normalize to array for DB query
+    const nsArray = Array.isArray(namespaces) ? namespaces : [namespaces];
+    return this._getFromDb(pool, nsArray);
   }
 
   /** Eagerly refresh cache from gateway. Safe to call; errors are logged and ignored. */
@@ -112,14 +114,14 @@ export class AgentCache {
     return this._enrichWithPresence(agents);
   }
 
-  private async _getFromDb(pool: Pool, namespace: string): Promise<CachedAgent[]> {
+  private async _getFromDb(pool: Pool, namespaces: string[]): Promise<CachedAgent[]> {
     try {
       const result = await pool.query(
         `SELECT agent_id, display_name, avatar_url, is_default
          FROM gateway_agent_cache
-         WHERE namespace = $1
+         WHERE namespace = ANY($1::text[])
          ORDER BY is_default DESC, agent_id`,
-        [namespace],
+        [namespaces],
       );
 
       return result.rows.map((row: { agent_id: string; display_name: string | null; avatar_url: string | null; is_default: boolean }) => ({


### PR DESCRIPTION
## Summary

- **Root cause**: `GET /chat/agents` used `getStoreNamespace()` (single write namespace) instead of `getEffectiveNamespaces()` (read namespace array). When gateway WS is disconnected, the DB fallback queries `gateway_agent_cache WHERE namespace = $1` with the user's home namespace, but agents were synced under a different namespace — returning empty results.
- Changed route to use `getEffectiveNamespaces(req)` (consistent with every other GET endpoint in chat routes)
- Updated `AgentCache.getAgents()` to accept `string[]` for multi-namespace support
- Updated `_getFromDb()` to use `WHERE namespace = ANY($1::text[])`

**Production data fix**: Updated 12 agents from `namespace = 'unknown'` to `namespace = 'troy'` directly in the database (immediate fix, no deploy required).

Closes #2242

## Test plan
- [x] Existing 20 agent-cache unit tests pass
- [x] 2 new tests for multi-namespace DB fallback
- [x] All 149 chat + gateway tests pass
- [x] TypeScript build passes (`tsc --noEmit`)
- [x] Verified on production: API now returns 12 agents after data fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)