### PR TITLE
[#2311] Fix gateway client.id to valid node-host constant

### DIFF
--- a/src/api/gateway/connection.test.ts
+++ b/src/api/gateway/connection.test.ts
@@ -220,9 +220,9 @@ describe('GatewayConnectionService', () => {
       expect(parsed.params?.auth?.token).toBe('fallback-token');
       expect(parsed.params?.minProtocol).toBe(3);
       expect(parsed.params?.maxProtocol).toBe(3);
-      expect(parsed.params?.client?.id).toBe('openclaw-projects-api');
+      expect(parsed.params?.client?.id).toBe('node-host');
       expect(parsed.params?.client?.platform).toBe('node');
-      expect(parsed.params?.client?.mode).toBe('node');
+      expect(parsed.params?.client?.mode).toBe('backend');
 
       // Complete the handshake
       ws._emitMessage(JSON.stringify({

--- a/src/api/gateway/connection.ts
+++ b/src/api/gateway/connection.ts
@@ -479,10 +479,10 @@ export class GatewayConnectionService {
         minProtocol: GATEWAY_PROTOCOL_VERSION,
         maxProtocol: GATEWAY_PROTOCOL_VERSION,
         client: {
-          id: 'openclaw-projects-api',
+          id: 'node-host',
           version: PKG_VERSION,
           platform: 'node',
-          mode: 'node',
+          mode: 'backend',
         },
         auth: { token: this.token },
       },


### PR DESCRIPTION
## Summary
- Gateway protocol v3 only accepts registered `client.id` constants (`cli`, `webchat`, `node-host`, `test`, etc.)
- Changed `client.id` from invalid `'openclaw-projects-api'` to `'node-host'`
- Changed `mode` from `'node'` to `'backend'` per [gateway protocol docs](https://docs.openclaw.ai/gateway/protocol)
- Production hotfix deployed — gateway now accepts the connection format but needs correct `OPENCLAW_GATEWAY_TOKEN` env var set

Closes #2311

## Test plan
- [x] Unit tests updated and passing (146 gateway tests)
- [x] Typecheck passes
- [x] Production hotfix confirms gateway accepts the protocol format
- [ ] Set `OPENCLAW_GATEWAY_TOKEN` in production `.env` to match gateway auth token
- [ ] Verify gateway connects successfully (no "Agent connection degraded" banner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)