### PR TITLE
[#2338] Fix traefik-custom bind-mount into named volume subdirectory

### DIFF
--- a/docker/traefik/entrypoint.sh
+++ b/docker/traefik/entrypoint.sh
@@ -231,16 +231,49 @@ generate_config() {
     echo "Generated dynamic config at ${OUTPUT_FILE}"
 }
 
+# Copy custom config files from a staging directory into the named volume.
+# Docker silently ignores bind-mounts into named volume subdirectories,
+# so we mount custom configs at a staging path (CUSTOM_CONFIG_SOURCE_DIR)
+# and copy .yml files into the writable named volume at startup.
+# See: https://github.com/troykelly/openclaw-projects/issues/2338
+copy_custom_configs() {
+    local source_dir="${CUSTOM_CONFIG_SOURCE_DIR:-/etc/traefik/custom-source}"
+
+    if [ ! -d "${source_dir}" ]; then
+        echo "  No custom config source directory at ${source_dir} — skipping"
+        return 0
+    fi
+
+    # Copy only .yml files from source into CUSTOM_CONFIG_DIR
+    local copied=0
+    for f in "${source_dir}"/*.yml; do
+        # Guard against the glob matching nothing (literal *.yml)
+        [ -f "${f}" ] || continue
+        cp "${f}" "${CUSTOM_CONFIG_DIR}/"
+        echo "  Copied custom config: $(basename "${f}")"
+        copied=$((copied + 1))
+    done
+
+    if [ "${copied}" -eq 0 ]; then
+        echo "  No custom config .yml files found in ${source_dir}"
+    else
+        echo "  Copied ${copied} custom config file(s) to ${CUSTOM_CONFIG_DIR}"
+    fi
+}
+
 # Main execution
 main() {
     echo "Traefik entrypoint: Validating environment..."
     validate_env
-    
+
     echo "Traefik entrypoint: Initializing ACME certificate storage..."
     init_acme_storage
 
     echo "Traefik entrypoint: Generating dynamic configuration..."
     generate_config
+
+    echo "Traefik entrypoint: Copying custom configs..."
+    copy_custom_configs
 
     echo "Traefik entrypoint: Sanitizing DNS credentials..."
     sanitize_dns_credentials

--- a/docker/traefik/examples/docker-compose.override.example.yml
+++ b/docker/traefik/examples/docker-compose.override.example.yml
@@ -129,9 +129,13 @@ services:
   #
   traefik:
     volumes:
-      # Mount custom config directory for file provider routes
-      # Place your *.yml files in traefik-custom/ and they'll be auto-loaded
-      - ./traefik-custom:/etc/traefik/dynamic/custom:ro
+      # Mount custom config directory as a staging source for the entrypoint.
+      # IMPORTANT: Do NOT mount directly into /etc/traefik/dynamic/custom —
+      # Docker silently ignores bind-mounts into named volume subdirectories
+      # (the traefik_dynamic named volume takes precedence). Instead, mount
+      # to /etc/traefik/custom-source and the entrypoint copies .yml files
+      # into the named volume at startup. See issue #2338.
+      - ./traefik-custom:/etc/traefik/custom-source:ro
 
 # Uncomment if using Grafana example:
 # volumes:

--- a/docker/traefik/tests/test-entrypoint.sh
+++ b/docker/traefik/tests/test-entrypoint.sh
@@ -877,6 +877,94 @@ test_api_cors_no_wildcard() {
     cleanup_test_env "${test_dir}"
 }
 
+# Test 35: Custom configs should be copied from source dir to dynamic/custom
+test_custom_configs_copied_from_source() {
+    run_test
+    local test_dir
+    test_dir=$(setup_test_env)
+
+    export DOMAIN="example.com"
+    export ACME_EMAIL="test@example.com"
+
+    # Create a custom-source directory with .yml files
+    local custom_source="${test_dir}/etc/traefik/custom-source"
+    mkdir -p "${custom_source}"
+    echo "http: {}" > "${custom_source}/abs-proxy.yml"
+    echo "http: {}" > "${custom_source}/moltbot-gateway.yml"
+
+    # Set the env var to point at our custom source
+    export CUSTOM_CONFIG_SOURCE_DIR="${custom_source}"
+
+    "${test_dir}/entrypoint-test.sh" >/dev/null 2>&1
+
+    local custom_dir="${test_dir}/etc/traefik/dynamic/custom"
+
+    if [ -f "${custom_dir}/abs-proxy.yml" ] && [ -f "${custom_dir}/moltbot-gateway.yml" ]; then
+        pass "Custom configs copied from source to dynamic/custom"
+    else
+        fail "Custom configs should be copied from source to dynamic/custom"
+    fi
+
+    unset CUSTOM_CONFIG_SOURCE_DIR
+    cleanup_test_env "${test_dir}"
+}
+
+# Test 36: No error when CUSTOM_CONFIG_SOURCE_DIR is absent
+test_custom_configs_no_error_when_source_absent() {
+    run_test
+    local test_dir
+    test_dir=$(setup_test_env)
+
+    export DOMAIN="example.com"
+    export ACME_EMAIL="test@example.com"
+
+    # Point to a non-existent directory
+    export CUSTOM_CONFIG_SOURCE_DIR="${test_dir}/nonexistent-source"
+
+    if "${test_dir}/entrypoint-test.sh" >/dev/null 2>&1; then
+        pass "No error when custom config source dir is absent"
+    else
+        fail "Should not error when custom config source dir is absent"
+    fi
+
+    unset CUSTOM_CONFIG_SOURCE_DIR
+    cleanup_test_env "${test_dir}"
+}
+
+# Test 37: Non-.yml files in source should NOT be copied
+test_custom_configs_non_yml_not_copied() {
+    run_test
+    local test_dir
+    test_dir=$(setup_test_env)
+
+    export DOMAIN="example.com"
+    export ACME_EMAIL="test@example.com"
+
+    # Create a custom-source directory with mixed files
+    local custom_source="${test_dir}/etc/traefik/custom-source"
+    mkdir -p "${custom_source}"
+    echo "http: {}" > "${custom_source}/valid-route.yml"
+    echo "not a config" > "${custom_source}/readme.txt"
+    echo "some notes" > "${custom_source}/notes.md"
+
+    export CUSTOM_CONFIG_SOURCE_DIR="${custom_source}"
+
+    "${test_dir}/entrypoint-test.sh" >/dev/null 2>&1
+
+    local custom_dir="${test_dir}/etc/traefik/dynamic/custom"
+
+    if [ -f "${custom_dir}/valid-route.yml" ] && \
+       [ ! -f "${custom_dir}/readme.txt" ] && \
+       [ ! -f "${custom_dir}/notes.md" ]; then
+        pass "Non-.yml files are not copied to dynamic/custom"
+    else
+        fail "Only .yml files should be copied to dynamic/custom"
+    fi
+
+    unset CUSTOM_CONFIG_SOURCE_DIR
+    cleanup_test_env "${test_dir}"
+}
+
 # Run all tests
 echo "======================================"
 echo "Traefik Entrypoint Script Test Suite"
@@ -917,6 +1005,9 @@ test_api_router_has_cors
 test_api_cors_methods
 test_api_cors_vary_header
 test_api_cors_no_wildcard
+test_custom_configs_copied_from_source
+test_custom_configs_no_error_when_source_absent
+test_custom_configs_non_yml_not_copied
 
 echo ""
 echo "======================================"

--- a/tests/docker/traefik-entrypoint.test.ts
+++ b/tests/docker/traefik-entrypoint.test.ts
@@ -406,6 +406,127 @@ describe('Traefik dynamic config: api-webhook-router (Issue #2167)', () => {
   });
 });
 
+describe('Traefik entrypoint: copy_custom_configs (Issue #2338)', () => {
+  const ENTRYPOINT = resolve(ROOT_DIR, 'docker/traefik/entrypoint.sh');
+  const TEMPLATE = resolve(ROOT_DIR, 'docker/traefik/dynamic-config.yml.template');
+
+  function runEntrypointWithCustomSource(opts: {
+    sourceFiles?: Record<string, string>;
+    sourceExists?: boolean;
+  }): { exitCode: number; customDir: string; stdout: string } {
+    const testTmpDir = mkdtempSync(join(tmpdir(), 'traefik-custom-test-'));
+    const testDir = join(testTmpDir, 'etc/traefik');
+
+    // Create required directories
+    const systemDir = join(testDir, 'dynamic/system');
+    const customDir = join(testDir, 'dynamic/custom');
+    const acmeDir = join(testDir, 'acme');
+    const templateDir = join(testDir, 'templates');
+
+    execFileSync('mkdir', ['-p', systemDir, customDir, acmeDir, templateDir]);
+
+    // Copy template
+    execFileSync('cp', [TEMPLATE, join(templateDir, 'dynamic-config.yml.template')]);
+
+    // Create test entrypoint with patched paths
+    const testEntrypoint = join(testTmpDir, 'entrypoint-test.sh');
+    let script = readFileSync(ENTRYPOINT, 'utf-8');
+    script = script.replace(/exec traefik/, 'echo "Would exec traefik"');
+    script = script.replace(/\/etc\/traefik/g, testDir);
+    writeFileSync(testEntrypoint, script, { mode: 0o755 });
+
+    // Set up custom source
+    let customSourceDir = join(testTmpDir, 'custom-source');
+    if (opts.sourceExists !== false) {
+      execFileSync('mkdir', ['-p', customSourceDir]);
+      if (opts.sourceFiles) {
+        for (const [name, content] of Object.entries(opts.sourceFiles)) {
+          writeFileSync(join(customSourceDir, name), content);
+        }
+      }
+    } else {
+      customSourceDir = join(testTmpDir, 'nonexistent-source');
+    }
+
+    let stdout = '';
+    let exitCode = 0;
+    try {
+      stdout = execFileSync('/bin/sh', [testEntrypoint], {
+        encoding: 'utf-8',
+        timeout: 10_000,
+        env: {
+          ...process.env,
+          DOMAIN: 'example.com',
+          ACME_EMAIL: 'test@example.com',
+          CUSTOM_CONFIG_SOURCE_DIR: customSourceDir,
+        },
+      });
+    } catch (err: unknown) {
+      exitCode = (err as { status?: number }).status ?? 1;
+    }
+
+    return { exitCode, customDir, stdout };
+  }
+
+  it('copies .yml files from source dir to dynamic/custom', () => {
+    const { exitCode, customDir } = runEntrypointWithCustomSource({
+      sourceFiles: {
+        'abs-proxy.yml': 'http: {}',
+        'moltbot-gateway.yml': 'http: {}',
+        'voice-call.yml': 'http: {}',
+      },
+    });
+
+    expect(exitCode).toBe(0);
+    expect(readFileSync(join(customDir, 'abs-proxy.yml'), 'utf-8')).toBe('http: {}');
+    expect(readFileSync(join(customDir, 'moltbot-gateway.yml'), 'utf-8')).toBe('http: {}');
+    expect(readFileSync(join(customDir, 'voice-call.yml'), 'utf-8')).toBe('http: {}');
+  });
+
+  it('does not fail when source dir is absent', () => {
+    const { exitCode } = runEntrypointWithCustomSource({
+      sourceExists: false,
+    });
+
+    expect(exitCode).toBe(0);
+  });
+
+  it('does not copy non-.yml files', () => {
+    const { exitCode, customDir } = runEntrypointWithCustomSource({
+      sourceFiles: {
+        'valid-route.yml': 'http: {}',
+        'readme.txt': 'not a config',
+        'notes.md': 'some notes',
+      },
+    });
+
+    expect(exitCode).toBe(0);
+    expect(readFileSync(join(customDir, 'valid-route.yml'), 'utf-8')).toBe('http: {}');
+
+    // Non-.yml files should not exist
+    expect(() => readFileSync(join(customDir, 'readme.txt'))).toThrow();
+    expect(() => readFileSync(join(customDir, 'notes.md'))).toThrow();
+  });
+
+  it('logs copied file names', () => {
+    const { stdout } = runEntrypointWithCustomSource({
+      sourceFiles: {
+        'abs-proxy.yml': 'http: {}',
+      },
+    });
+
+    expect(stdout).toContain('abs-proxy.yml');
+  });
+
+  it('logs message when no custom configs found', () => {
+    const { stdout } = runEntrypointWithCustomSource({
+      sourceFiles: {},
+    });
+
+    expect(stdout.toLowerCase()).toMatch(/no custom config/);
+  });
+});
+
 describe('ModSecurity ALLOWED_METHODS in compose files (Issue #1917)', () => {
   const COMPOSE_FILES = ['docker-compose.traefik.yml', 'docker-compose.full.yml'];
 


### PR DESCRIPTION
Closes #2338

## Summary

Docker silently ignores bind-mounts into named volume subdirectories. The production `docker-compose.override.yml` mounts `./traefik-custom` into `/etc/traefik/dynamic/custom` — a subdirectory of the `traefik_dynamic` named volume — so custom route files (abs-proxy.yml, moltbot-gateway.yml, voice-call.yml) were never available to Traefik.

## Solution (Option C — Entrypoint Copy Pattern)

- **`docker/traefik/entrypoint.sh`**: Add `copy_custom_configs()` function that copies `.yml` files from a staging directory (`CUSTOM_CONFIG_SOURCE_DIR`, default `/etc/traefik/custom-source`) into the writable named volume at `/etc/traefik/dynamic/custom` during startup. Non-.yml files are excluded. Missing source directory is handled gracefully.
- **`docker/traefik/examples/docker-compose.override.example.yml`**: Change bind-mount from `/etc/traefik/dynamic/custom` to `/etc/traefik/custom-source` with explanatory comment about why.

## Tests

- **Shell tests** (`docker/traefik/tests/test-entrypoint.sh`): 3 new tests (35-37) covering copy behavior, graceful absent-dir handling, and non-.yml exclusion. All 37/37 pass.
- **TypeScript vitest tests** (`tests/docker/traefik-entrypoint.test.ts`): 5 new tests covering copy, absent dir, non-.yml exclusion, log output for copied files, and log output for empty source. All 48/48 pass.

## Migration Note

Production `docker-compose.override.yml` must update the traefik-custom bind-mount:
```yaml
# OLD (broken — Docker ignores this):
- ./traefik-custom:/etc/traefik/dynamic/custom:ro

# NEW (entrypoint copies files at startup):
- ./traefik-custom:/etc/traefik/custom-source:ro
```

## Local test commands run

```bash
bash docker/traefik/tests/test-entrypoint.sh  # 37/37 passed
npx vitest run tests/docker/traefik-entrypoint.test.ts  # 48/48 passed
```