### PR TITLE
[#2341] Fix Yjs WebSocket 401 — add /yjs/* to auth skip list

### DIFF
--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -774,6 +774,11 @@ export function buildServer(options: ProjectsApiOptions = {}): FastifyInstance {
       return;
     }
 
+    // Yjs WebSocket endpoint handles its own auth via JWT query param (Issue #2341)
+    if (url.startsWith('/yjs/')) {
+      return;
+    }
+
     // Skip auth for explicitly allowed paths
     if (authSkipPaths.has(url)) {
       return;

--- a/tests/yjs_auth_skip.test.ts
+++ b/tests/yjs_auth_skip.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Tests that the /yjs/:noteId WebSocket endpoint skips the global JWT auth hook.
+ * Issue #2341: The onRequest hook was rejecting Yjs WebSocket connections with 401
+ * before the WS handler could check the ?token=JWT query param.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { buildServer } from '../src/api/server.ts';
+
+// Enable auth so we can verify the skip paths work
+process.env.JWT_SECRET = 'test-jwt-secret-at-least-32-bytes-long!!';
+delete process.env.OPENCLAW_PROJECTS_AUTH_DISABLED;
+
+import { runMigrate } from './helpers/migrate.ts';
+
+describe('Yjs WebSocket auth skip (Issue #2341)', () => {
+  const app = buildServer();
+
+  beforeAll(async () => {
+    await runMigrate('up');
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('GET /yjs/:noteId does NOT return 401 (auth handled by WS handler)', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/yjs/00000000-0000-0000-0000-000000000001',
+      // No Authorization header — token would be in query param for real WS
+    });
+
+    // Should NOT be 401 (auth middleware should skip this path).
+    // The actual response may be a different error (no WS upgrade, missing route, etc.),
+    // but it must not be 401 from the global auth hook.
+    expect(res.statusCode).not.toBe(401);
+  });
+
+  it('GET /yjs/:noteId with query params does NOT return 401', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/yjs/00000000-0000-0000-0000-000000000002?token=some-jwt-token',
+      // No Authorization header
+    });
+
+    expect(res.statusCode).not.toBe(401);
+  });
+
+  it('GET /notes (authenticated endpoint) still returns 401 without auth', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/notes',
+      // No Authorization header
+    });
+
+    expect(res.statusCode).toBe(401);
+  });
+});


### PR DESCRIPTION
Closes #2341

## Root Cause

The global `onRequest` auth hook in `src/api/server.ts` rejects `/yjs/:noteId` WebSocket connections with HTTP 401 **before** the Yjs WebSocket handler gets a chance to authenticate via the `?token=JWT` query parameter.

Production logs confirmed: `GET /yjs/<uuid>?token=... → 401 in 0.88ms`.

## Fix

Added a `/yjs/` prefix check to the auth skip list in the `onRequest` hook, following the same pattern used for:
- `/terminal/sessions/.*/attach` (Epic #1667)
- `/files/shared/` and `/shared/` (Issue #610, #1549)

The Yjs WebSocket handler already validates the JWT from the query string internally, so the global auth hook just needs to step aside.

## Changes

- **`src/api/server.ts`**: Added 4-line skip block for `/yjs/` prefix in the `onRequest` auth hook
- **`tests/yjs_auth_skip.test.ts`**: New integration test verifying `/yjs/:noteId` is not blocked by the global auth hook (follows pattern from `tests/shared_endpoint_auth_skip.test.ts`)

## Test Plan

- [x] `pnpm run build` (typecheck) passes
- [x] New test `tests/yjs_auth_skip.test.ts` passes (3 tests)
- [x] Existing unit test suite passes (317 files, 5026 tests)
- [x] Verified authenticated endpoint `/notes` still returns 401 without auth (regression check)