### PR TITLE
[#2365] Fix release finalize: make sentry-cli set-commits non-fatal for GlitchTip

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -685,7 +685,11 @@ jobs:
         run: |
           set -euo pipefail
           pnpm exec sentry-cli releases new "${RELEASE_VERSION}"
-          pnpm exec sentry-cli releases set-commits "${RELEASE_VERSION}" --auto
+          # GlitchTip may not support set-commits — treat as informational only.
+          # sentry-cli v3 changed the API; self-hosted instances return HTTP 500.
+          if ! pnpm exec sentry-cli releases set-commits "${RELEASE_VERSION}" --auto; then
+            echo "::warning::set-commits failed (GlitchTip may not support this endpoint) — continuing"
+          fi
           pnpm exec sentry-cli releases finalize "${RELEASE_VERSION}"
 
   # ──────────────────────────────────────────────────────────────

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -37,7 +37,7 @@ export default defineConfig({
     tailwindcss(),
     // Sentry source map upload — only active in CI when SENTRY_AUTH_TOKEN is set.
     // Uses @sentry/vite-plugin with debug IDs for reliable source map association.
-    // GlitchTip compatibility: pin to @sentry/vite-plugin@^2.
+    // Source map upload via @sentry/vite-plugin. The errorHandler ensures build failures are non-fatal if the Sentry/GlitchTip API is unreachable.
     ...(process.env.SENTRY_AUTH_TOKEN
       ? [
           sentryVitePlugin({


### PR DESCRIPTION
## Summary

- **`.github/workflows/release.yml`**: Make `sentry-cli releases set-commits --auto` non-fatal by appending `|| echo "::warning::..."`. GlitchTip does not support the set-commits endpoint, which returns HTTP 500 with sentry-cli v3 and kills the `finalize-sentry-release` job under `set -euo pipefail`.
- **`vite.config.ts`**: Replace stale "pin to @sentry/vite-plugin@^2" comment with accurate description of the errorHandler pattern (we're now on v5.1.1).

Closes #2365

## Test plan

- [ ] Trigger a release workflow run and verify `finalize-sentry-release` completes successfully
- [ ] Confirm `::warning::` annotation appears in the Actions log for the set-commits step
- [ ] Verify `releases new` and `releases finalize` still execute under `set -euo pipefail`