### PR TITLE
[#2369] Fix CORS: add X-Namespace headers to allowlists

### DIFF
--- a/docker/traefik/dynamic-config.yml.template
+++ b/docker/traefik/dynamic-config.yml.template
@@ -78,6 +78,8 @@ http:
           - Accept
           - sentry-trace
           - baggage
+          - X-Namespace
+          - X-Namespaces
         accessControlAllowCredentials: true
         accessControlMaxAge: 86400
         addVaryHeader: true

--- a/src/api/cors.test.ts
+++ b/src/api/cors.test.ts
@@ -240,6 +240,30 @@ describe('CORS configuration (Issue #1327)', () => {
     });
   });
 
+  describe('namespace headers in allowlist (Issue #2369)', () => {
+    it('includes X-Namespace and X-Namespaces in preflight Access-Control-Allow-Headers', async () => {
+      process.env.PUBLIC_BASE_URL = 'https://app.example.com';
+      const app = await buildCorsApp();
+
+      const res = await app.inject({
+        method: 'OPTIONS',
+        url: '/test',
+        headers: {
+          origin: 'https://app.example.com',
+          'access-control-request-method': 'GET',
+          'access-control-request-headers': 'X-Namespace',
+        },
+      });
+
+      expect(res.statusCode).toBe(204);
+      const allowedHeaders = res.headers['access-control-allow-headers'];
+      expect(allowedHeaders).toContain('X-Namespace');
+      expect(allowedHeaders).toContain('X-Namespaces');
+
+      await app.close();
+    });
+  });
+
   describe('Vary header', () => {
     it('includes Vary: Origin for requests with origin header', async () => {
       process.env.PUBLIC_BASE_URL = 'https://app.example.com';

--- a/src/api/cors.ts
+++ b/src/api/cors.ts
@@ -63,7 +63,17 @@ export function registerCors(app: FastifyInstance): void {
     methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
     // sentry-trace and baggage are required for Sentry distributed tracing
     // (frontend → backend trace propagation). See Epic #1998, Issue #2000.
-    allowedHeaders: ['Authorization', 'Content-Type', 'Accept', 'sentry-trace', 'baggage'],
+    // X-Namespace and X-Namespaces are required for namespace-scoped API
+    // requests (Issue #2369, Epic #2345).
+    allowedHeaders: [
+      'Authorization',
+      'Content-Type',
+      'Accept',
+      'sentry-trace',
+      'baggage',
+      'X-Namespace',
+      'X-Namespaces',
+    ],
     credentials: true,
     maxAge: 86400,
   });

--- a/tests/docker/traefik-entrypoint.test.ts
+++ b/tests/docker/traefik-entrypoint.test.ts
@@ -527,6 +527,41 @@ describe('Traefik entrypoint: copy_custom_configs (Issue #2338)', () => {
   });
 });
 
+describe('Traefik dynamic config: api-cors namespace headers (Issue #2369)', () => {
+  const defaultEnv = {
+    DOMAIN: 'test.example.com',
+    ACME_EMAIL: 'test@example.com',
+    TRUSTED_IPS: '',
+    DISABLE_HTTP: 'false',
+    SERVICE_HOST: '[::1]',
+    MODSEC_HOST_PORT: '8080',
+    API_HOST_PORT: '3001',
+    APP_HOST_PORT: '8081',
+    GATEWAY_HOST_PORT: '18789',
+    SEAWEEDFS_HOST_PORT: '8333',
+  };
+
+  function getParsedConfig(env = defaultEnv) {
+    const output = runSedSubstitution(env);
+    return parseYaml(output) as {
+      http: {
+        middlewares: Record<string, { headers?: { accessControlAllowHeaders?: string[] } }>;
+        routers: Record<string, unknown>;
+      };
+    };
+  }
+
+  it('api-cors middleware includes X-Namespace and X-Namespaces in accessControlAllowHeaders', () => {
+    const config = getParsedConfig();
+    const apiCors = config.http.middlewares['api-cors'];
+    expect(apiCors).toBeDefined();
+    const allowedHeaders = apiCors.headers?.accessControlAllowHeaders;
+    expect(allowedHeaders).toBeDefined();
+    expect(allowedHeaders).toContain('X-Namespace');
+    expect(allowedHeaders).toContain('X-Namespaces');
+  });
+});
+
 describe('ModSecurity ALLOWED_METHODS in compose files (Issue #1917)', () => {
   const COMPOSE_FILES = ['docker-compose.traefik.yml', 'docker-compose.full.yml'];
 

--- a/vitest.config.unit.ts
+++ b/vitest.config.unit.ts
@@ -73,6 +73,8 @@ export default defineProject({
       'src/api/geolocation/registry.test.ts',
       'src/api/geolocation/bootstrap.test.ts',
       'src/api/geolocation/crypto.test.ts',
+      'src/api/cors.test.ts',
+      'src/api/sse-cors.test.ts',
       'src/api/gateway/connection.test.ts',
       'src/worker/**/*.test.ts',
       'src/symphony-worker/**/*.test.ts',


### PR DESCRIPTION
## Summary
- Add `X-Namespace` and `X-Namespaces` to Traefik CORS middleware (`docker/traefik/dynamic-config.yml.template`)
- Add `X-Namespace` and `X-Namespaces` to Fastify CORS config (`src/api/cors.ts`)
- Add unit tests verifying both allowlists include the new headers
- Register `src/api/cors.test.ts` and `src/api/sse-cors.test.ts` in vitest unit project

Fixes P0 login regression on Traefik deployments after namespace UI deployment (v0.0.55+).

Closes #2369

## Test plan
- [x] CORS unit test verifies new headers in Fastify allowlist
- [x] Traefik template test verifies new headers in api-cors middleware
- [x] Traefik template valid YAML confirmed
- [x] All CORS-related tests passing (64/64)

🤖 Generated with Claude Code