### PR TITLE
[#2371] Fix CORS: add X-User-Email to allowlists

### DIFF
--- a/docker/traefik/dynamic-config.yml.template
+++ b/docker/traefik/dynamic-config.yml.template
@@ -80,6 +80,7 @@ http:
           - baggage
           - X-Namespace
           - X-Namespaces
+          - X-User-Email
         accessControlAllowCredentials: true
         accessControlMaxAge: 86400
         addVaryHeader: true

--- a/src/api/cors.test.ts
+++ b/src/api/cors.test.ts
@@ -264,6 +264,29 @@ describe('CORS configuration (Issue #1327)', () => {
     });
   });
 
+  describe('X-User-Email header in allowlist (Issue #2371)', () => {
+    it('includes X-User-Email in preflight Access-Control-Allow-Headers', async () => {
+      process.env.PUBLIC_BASE_URL = 'https://app.example.com';
+      const app = await buildCorsApp();
+
+      const res = await app.inject({
+        method: 'OPTIONS',
+        url: '/test',
+        headers: {
+          origin: 'https://app.example.com',
+          'access-control-request-method': 'GET',
+          'access-control-request-headers': 'X-User-Email',
+        },
+      });
+
+      expect(res.statusCode).toBe(204);
+      const allowedHeaders = res.headers['access-control-allow-headers'];
+      expect(allowedHeaders).toContain('X-User-Email');
+
+      await app.close();
+    });
+  });
+
   describe('Vary header', () => {
     it('includes Vary: Origin for requests with origin header', async () => {
       process.env.PUBLIC_BASE_URL = 'https://app.example.com';

--- a/src/api/cors.ts
+++ b/src/api/cors.ts
@@ -65,6 +65,7 @@ export function registerCors(app: FastifyInstance): void {
     // (frontend → backend trace propagation). See Epic #1998, Issue #2000.
     // X-Namespace and X-Namespaces are required for namespace-scoped API
     // requests (Issue #2369, Epic #2345).
+    // X-User-Email is used by note presence (Issue #2371).
     allowedHeaders: [
       'Authorization',
       'Content-Type',
@@ -73,6 +74,7 @@ export function registerCors(app: FastifyInstance): void {
       'baggage',
       'X-Namespace',
       'X-Namespaces',
+      'X-User-Email',
     ],
     credentials: true,
     maxAge: 86400,

--- a/tests/docker/traefik-entrypoint.test.ts
+++ b/tests/docker/traefik-entrypoint.test.ts
@@ -560,6 +560,15 @@ describe('Traefik dynamic config: api-cors namespace headers (Issue #2369)', () 
     expect(allowedHeaders).toContain('X-Namespace');
     expect(allowedHeaders).toContain('X-Namespaces');
   });
+
+  it('api-cors middleware includes X-User-Email in accessControlAllowHeaders (Issue #2371)', () => {
+    const config = getParsedConfig();
+    const apiCors = config.http.middlewares['api-cors'];
+    expect(apiCors).toBeDefined();
+    const allowedHeaders = apiCors.headers?.accessControlAllowHeaders;
+    expect(allowedHeaders).toBeDefined();
+    expect(allowedHeaders).toContain('X-User-Email');
+  });
 });
 
 describe('ModSecurity ALLOWED_METHODS in compose files (Issue #1917)', () => {


### PR DESCRIPTION
## Summary
- Add `X-User-Email` to Traefik CORS middleware (`docker/traefik/dynamic-config.yml.template`)
- Add `X-User-Email` to Fastify CORS config (`src/api/cors.ts`)
- Add unit tests verifying both allowlists include the new header

The `X-User-Email` header is sent by the UI (note presence feature) but was missing from CORS allowlists, causing preflight rejections.

Closes #2371

## Test plan
- [x] CORS unit test verifies X-User-Email in Fastify allowlist
- [x] Traefik template test verifies X-User-Email in api-cors middleware
- [x] All CORS-related tests passing (66/66)

🤖 Generated with Claude Code