### PR TITLE
[#2375] Add default_agent_id picker to VoicePage config edit form

### DIFF
--- a/src/ui/pages/VoicePage.tsx
+++ b/src/ui/pages/VoicePage.tsx
@@ -10,15 +10,17 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Eye, Mic, Settings2, Trash2 } from 'lucide-react';
 import type React from 'react';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Badge } from '@/ui/components/ui/badge';
 import { Button } from '@/ui/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/ui/components/ui/card';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/ui/components/ui/dialog';
 import { Input } from '@/ui/components/ui/input';
 import { Label } from '@/ui/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/ui/components/ui/select';
 import { useNamespaceQueryKey } from '@/ui/hooks/use-namespace-query-key';
 import { apiClient } from '@/ui/lib/api-client';
+import type { ChatAgent, ChatAgentsResponse } from '@/ui/lib/api-types';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -81,8 +83,26 @@ export function VoicePage(): React.JSX.Element {
     idle_timeout_s: 300,
     retention_days: 30,
     service_allowlist: '',
+    default_agent_id: '' as string,
   });
+  const [agents, setAgents] = useState<ChatAgent[]>([]);
   const [viewingConversation, setViewingConversation] = useState<string | null>(null);
+
+  // Fetch available agents from /chat/agents
+  useEffect(() => {
+    let alive = true;
+    async function fetchAgents() {
+      try {
+        const data = await apiClient.get<ChatAgentsResponse>('/chat/agents');
+        if (!alive) return;
+        setAgents(Array.isArray(data.agents) ? data.agents : []);
+      } catch {
+        if (alive) setAgents([]);
+      }
+    }
+    fetchAgents();
+    return () => { alive = false; };
+  }, []);
 
   // Fetch voice config
   const configQueryKey = useNamespaceQueryKey(['voice-config'] as const);
@@ -108,7 +128,7 @@ export function VoicePage(): React.JSX.Element {
 
   // Update config
   const configMutation = useMutation({
-    mutationFn: (body: { timeout_ms: number; idle_timeout_s: number; retention_days: number; service_allowlist: string[] }) =>
+    mutationFn: (body: { timeout_ms: number; idle_timeout_s: number; retention_days: number; service_allowlist: string[]; default_agent_id: string | null }) =>
       apiClient.put<{ data: VoiceConfig }>('/voice/config', body),
     onSuccess: () => {
       setConfigEditing(false);
@@ -131,6 +151,7 @@ export function VoicePage(): React.JSX.Element {
       idle_timeout_s: config?.idle_timeout_s ?? 300,
       retention_days: config?.retention_days ?? 30,
       service_allowlist: config?.service_allowlist?.join(', ') ?? '',
+      default_agent_id: config?.default_agent_id ?? '',
     });
     setConfigEditing(true);
   }, [configQuery.data]);
@@ -144,8 +165,18 @@ export function VoicePage(): React.JSX.Element {
         .split(',')
         .map((s) => s.trim())
         .filter(Boolean),
+      default_agent_id: configForm.default_agent_id || null,
     });
   }, [configForm, configMutation]);
+
+  /** Resolve display label for a given agent ID. */
+  const resolveAgentLabel = useCallback(
+    (agentId: string): string => {
+      const agent = agents.find((a) => a.id === agentId);
+      return agent ? (agent.display_name ?? agent.name) : agentId;
+    },
+    [agents],
+  );
 
   const config = configQuery.data?.data ?? null;
   const conversations = Array.isArray(conversationsQuery.data?.data) ? conversationsQuery.data.data : [];
@@ -184,7 +215,7 @@ export function VoicePage(): React.JSX.Element {
                 <ConfigRow label="Timeout" value={`${config.timeout_ms}ms`} />
                 <ConfigRow label="Idle Timeout" value={`${config.idle_timeout_s}s`} />
                 <ConfigRow label="Retention" value={`${config.retention_days} days`} />
-                <ConfigRow label="Default Agent" value={config.default_agent_id ?? 'None'} />
+                <ConfigRow label="Default Agent" value={config.default_agent_id ? resolveAgentLabel(config.default_agent_id) : 'None'} />
                 <div>
                   <span className="text-sm text-muted-foreground">Service Allowlist:</span>
                   <div className="flex flex-wrap gap-1 mt-1">
@@ -290,6 +321,27 @@ export function VoicePage(): React.JSX.Element {
                 onChange={(e) => setConfigForm((f) => ({ ...f, service_allowlist: e.target.value }))}
                 placeholder="light, switch, cover"
               />
+            </div>
+            <div>
+              <Label htmlFor="voice-default-agent">Default Agent</Label>
+              <Select
+                value={configForm.default_agent_id || 'none'}
+                onValueChange={(v) => setConfigForm((f) => ({ ...f, default_agent_id: v === 'none' ? '' : v }))}
+              >
+                <SelectTrigger id="voice-default-agent" data-testid="voice-default-agent-select">
+                  <SelectValue>
+                    {configForm.default_agent_id ? resolveAgentLabel(configForm.default_agent_id) : 'None'}
+                  </SelectValue>
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="none">None</SelectItem>
+                  {agents.map((agent) => (
+                    <SelectItem key={agent.id} value={agent.id}>
+                      {agent.display_name ?? agent.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             </div>
           </div>
           <DialogFooter>

--- a/tests/ui/voice-page.test.tsx
+++ b/tests/ui/voice-page.test.tsx
@@ -6,7 +6,7 @@
  */
 import * as React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { createMemoryRouter, RouterProvider } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
@@ -69,7 +69,10 @@ describe('VoicePage', () => {
   });
 
   it('renders the page with header', async () => {
-    mockApiClient.get.mockResolvedValue({ data: null });
+    mockApiClient.get.mockImplementation((url: string) => {
+      if (url === '/chat/agents') return Promise.resolve({ agents: [] });
+      return Promise.resolve({ data: null });
+    });
 
     renderPage();
 
@@ -81,7 +84,7 @@ describe('VoicePage', () => {
   });
 
   it('shows loading state initially', () => {
-    mockApiClient.get.mockReturnValue(new Promise(() => {}));
+    mockApiClient.get.mockImplementation(() => new Promise(() => {}));
 
     renderPage();
 
@@ -90,6 +93,7 @@ describe('VoicePage', () => {
 
   it('shows config section when config exists', async () => {
     mockApiClient.get.mockImplementation((url: string) => {
+      if (url === '/chat/agents') return Promise.resolve({ agents: [] });
       if (url.includes('/config')) {
         return Promise.resolve({
           data: {
@@ -120,6 +124,7 @@ describe('VoicePage', () => {
 
   it('shows conversation history', async () => {
     mockApiClient.get.mockImplementation((url: string) => {
+      if (url === '/chat/agents') return Promise.resolve({ agents: [] });
       if (url.includes('/config')) {
         return Promise.resolve({ data: null });
       }
@@ -151,6 +156,7 @@ describe('VoicePage', () => {
 
   it('shows empty state when no conversations', async () => {
     mockApiClient.get.mockImplementation((url: string) => {
+      if (url === '/chat/agents') return Promise.resolve({ agents: [] });
       if (url.includes('/config')) {
         return Promise.resolve({ data: null });
       }
@@ -162,5 +168,171 @@ describe('VoicePage', () => {
     await waitFor(() => {
       expect(screen.getByText('No conversations yet.')).toBeInTheDocument();
     }, { timeout: 5000 });
+  });
+
+  it('fetches agents from /chat/agents on mount', async () => {
+    mockApiClient.get.mockImplementation((url: string) => {
+      if (url === '/chat/agents') {
+        return Promise.resolve({ agents: [] });
+      }
+      if (url.includes('/config')) {
+        return Promise.resolve({ data: null });
+      }
+      return Promise.resolve({ data: [], total: 0, limit: 50, offset: 0 });
+    });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('page-voice')).toBeInTheDocument();
+    }, { timeout: 5000 });
+
+    expect(mockApiClient.get).toHaveBeenCalledWith('/chat/agents');
+  });
+
+  it('shows agent display name in read-only config view', async () => {
+    mockApiClient.get.mockImplementation((url: string) => {
+      if (url === '/chat/agents') {
+        return Promise.resolve({
+          agents: [
+            { id: 'agent-voice-1', name: 'voice-1', display_name: 'Voice Assistant', avatar_url: null },
+          ],
+        });
+      }
+      if (url.includes('/config')) {
+        return Promise.resolve({
+          data: {
+            id: 'vc1',
+            namespace: 'default',
+            default_agent_id: 'agent-voice-1',
+            timeout_ms: 5000,
+            idle_timeout_s: 300,
+            retention_days: 30,
+            device_mapping: {},
+            user_mapping: {},
+            service_allowlist: [],
+            metadata: {},
+            created_at: '2026-02-20T10:00:00Z',
+            updated_at: '2026-02-20T10:00:00Z',
+          },
+        });
+      }
+      return Promise.resolve({ data: [], total: 0, limit: 50, offset: 0 });
+    });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Voice Assistant')).toBeInTheDocument();
+    }, { timeout: 5000 });
+
+    // Should not show the raw agent ID
+    expect(screen.queryByText('agent-voice-1')).not.toBeInTheDocument();
+  });
+
+  it('renders default_agent_id selector in edit dialog', async () => {
+    mockApiClient.get.mockImplementation((url: string) => {
+      if (url === '/chat/agents') {
+        return Promise.resolve({
+          agents: [
+            { id: 'agent-voice-1', name: 'voice-1', display_name: 'Voice Assistant', avatar_url: null },
+            { id: 'agent-voice-2', name: 'voice-2', display_name: 'Voice Helper', avatar_url: null },
+          ],
+        });
+      }
+      if (url.includes('/config')) {
+        return Promise.resolve({
+          data: {
+            id: 'vc1',
+            namespace: 'default',
+            default_agent_id: null,
+            timeout_ms: 5000,
+            idle_timeout_s: 300,
+            retention_days: 30,
+            device_mapping: {},
+            user_mapping: {},
+            service_allowlist: [],
+            metadata: {},
+            created_at: '2026-02-20T10:00:00Z',
+            updated_at: '2026-02-20T10:00:00Z',
+          },
+        });
+      }
+      return Promise.resolve({ data: [], total: 0, limit: 50, offset: 0 });
+    });
+
+    renderPage();
+
+    // Wait for config to load and the Edit button to appear
+    await waitFor(() => {
+      expect(screen.getByText('Configuration')).toBeInTheDocument();
+    }, { timeout: 5000 });
+
+    // Click Edit button to open dialog
+    const editBtn = screen.getByRole('button', { name: /edit/i });
+    fireEvent.click(editBtn);
+
+    // Dialog should appear with the agent selector
+    await waitFor(() => {
+      expect(screen.getByTestId('voice-default-agent-select')).toBeInTheDocument();
+    }, { timeout: 5000 });
+
+    // Should show the Default Agent label in the dialog
+    expect(screen.getByLabelText('Default Agent')).toBeInTheDocument();
+  });
+
+  it('sends default_agent_id when saving config', async () => {
+    mockApiClient.get.mockImplementation((url: string) => {
+      if (url === '/chat/agents') {
+        return Promise.resolve({
+          agents: [
+            { id: 'agent-voice-1', name: 'voice-1', display_name: 'Voice Assistant', avatar_url: null },
+          ],
+        });
+      }
+      if (url.includes('/config')) {
+        return Promise.resolve({
+          data: {
+            id: 'vc1',
+            namespace: 'default',
+            default_agent_id: 'agent-voice-1',
+            timeout_ms: 5000,
+            idle_timeout_s: 300,
+            retention_days: 30,
+            device_mapping: {},
+            user_mapping: {},
+            service_allowlist: [],
+            metadata: {},
+            created_at: '2026-02-20T10:00:00Z',
+            updated_at: '2026-02-20T10:00:00Z',
+          },
+        });
+      }
+      return Promise.resolve({ data: [], total: 0, limit: 50, offset: 0 });
+    });
+    mockApiClient.put.mockResolvedValue({ data: {} });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Configuration')).toBeInTheDocument();
+    }, { timeout: 5000 });
+
+    // Open edit dialog
+    fireEvent.click(screen.getByText('Edit'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('voice-default-agent-select')).toBeInTheDocument();
+    });
+
+    // Click Save
+    fireEvent.click(screen.getByText('Save'));
+
+    await waitFor(() => {
+      expect(mockApiClient.put).toHaveBeenCalledWith(
+        '/voice/config',
+        expect.objectContaining({ default_agent_id: 'agent-voice-1' }),
+      );
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Adds agent picker (`Select`) to the VoicePage config edit dialog for `default_agent_id`
- Fetches available agents from `GET /chat/agents` on mount (same pattern as ChatSettingsSection and InboundRoutingSection)
- Read-only config view resolves agent ID to display name via `resolveAgentLabel` helper
- "None" option allows clearing the default agent
- Includes `default_agent_id` in the PUT `/voice/config` save payload (null when "None")

## Test plan

- [x] Fetches agents from `/chat/agents` on mount
- [x] Read-only view shows display name (not raw ID)
- [x] Edit form renders agent picker with full agent list
- [x] Saving persists the selected `default_agent_id`
- [x] None/empty clears the field (sends null)
- [x] All 9 VoicePage tests passing
- [x] Typecheck clean, lint clean

Closes #2375