### PR TITLE
[#2388] Fix agent DB fallback to return all agents regardless of namespace

### DIFF
--- a/src/api/gateway/agent-cache.test.ts
+++ b/src/api/gateway/agent-cache.test.ts
@@ -391,9 +391,9 @@ describe('AgentCache', () => {
     expect(Array.isArray(result)).toBe(true);
   });
 
-  // ── Issue #2242: DB fallback accepts multiple namespaces ─────────
+  // ── Issue #2388: DB fallback returns all agents (no namespace filter) ──────
 
-  it('DB fallback accepts namespace array and uses ANY($1::text[])', async () => {
+  it('DB fallback uses DISTINCT ON and does not filter by namespace', async () => {
     const conn = createMockConnection(); // connected: false
     const tracker = createMockPresenceTracker();
     const pool = createMockPool([
@@ -401,28 +401,34 @@ describe('AgentCache', () => {
     ]);
     cache = new AgentCache(conn, tracker);
 
-    await cache.getAgents(pool, ['ns1', 'ns2']);
+    await cache.getAgents(pool);
 
     const queryCall = (pool.query as ReturnType<typeof vi.fn>).mock.calls[0];
     const sql = queryCall[0] as string;
-    const params = queryCall[1] as unknown[];
-    expect(sql).toContain('ANY($1::text[])');
-    expect(params[0]).toEqual(['ns1', 'ns2']);
+    // Must NOT filter by namespace — gateway agents.list is global
+    expect(sql).not.toContain('namespace');
+    expect(sql).not.toContain('ANY($1');
+    // Must use DISTINCT ON to deduplicate agent_id across namespaces
+    expect(sql).toContain('DISTINCT ON (agent_id)');
+    // Called with no parameters (no $1 binding)
+    expect(queryCall[1]).toBeUndefined();
   });
 
-  it('DB fallback returns agents from any of the provided namespaces', async () => {
+  it('DB fallback returns agents from all namespaces (global, not namespace-scoped)', async () => {
     const conn = createMockConnection(); // connected: false
     const tracker = createMockPresenceTracker();
+    // Simulate two agents registered under different namespaces — both must be returned
     const pool = createMockPool([
-      { agent_id: 'agent-1', display_name: 'Agent 1', avatar_url: null, is_default: true },
+      { agent_id: 'troy', display_name: 'Troy', avatar_url: null, is_default: true },
       { agent_id: 'agent-2', display_name: 'Agent 2', avatar_url: null, is_default: false },
     ]);
     cache = new AgentCache(conn, tracker);
 
-    const result = await cache.getAgents(pool, ['troy', 'default']);
+    // Namespace arg is accepted but ignored — both agents returned regardless
+    const result = await cache.getAgents(pool, ['default']);
     expect(result).toHaveLength(2);
-    expect(result[0].id).toBe('agent-1');
-    expect(result[1].id).toBe('agent-2');
+    expect(result.map((a) => a.id)).toContain('troy');
+    expect(result.map((a) => a.id)).toContain('agent-2');
   });
 
   // ── Issue #2242: Gateway enrichment preserves extra fields ───────

--- a/src/api/gateway/agent-cache.ts
+++ b/src/api/gateway/agent-cache.ts
@@ -53,11 +53,16 @@ export class AgentCache {
 
   /**
    * Get the list of agents. Prefers live gateway data, falls back to DB.
+   *
    * Issue #2242: Accepts namespace array for multi-namespace read access.
+   * Issue #2388: DB fallback no longer filters by namespace — the gateway
+   * `agents.list` response is not namespace-scoped, so the DB fallback must
+   * be consistent and return all known agents regardless of which namespace
+   * they were first registered under.
+   *
    * @param pool - Database connection pool for fallback query
-   * @param namespaces - Namespace(s) to filter DB results
    */
-  async getAgents(pool: Pool, namespaces: string[] | string): Promise<CachedAgent[]> {
+  async getAgents(pool: Pool, _namespaces?: string[] | string): Promise<CachedAgent[]> {
     const status = this.connection.getStatus();
 
     if (status.connected) {
@@ -69,9 +74,7 @@ export class AgentCache {
       }
     }
 
-    // Normalize to array for DB query
-    const nsArray = Array.isArray(namespaces) ? namespaces : [namespaces];
-    return this._getFromDb(pool, nsArray);
+    return this._getFromDb(pool);
   }
 
   /** Eagerly refresh cache from gateway. Safe to call; errors are logged and ignored. */
@@ -114,14 +117,17 @@ export class AgentCache {
     return this._enrichWithPresence(agents);
   }
 
-  private async _getFromDb(pool: Pool, namespaces: string[]): Promise<CachedAgent[]> {
+  private async _getFromDb(pool: Pool): Promise<CachedAgent[]> {
     try {
+      // Issue #2388: Return all distinct agents, not filtered by namespace.
+      // The gateway agents.list response is global (not namespace-scoped), so the
+      // DB fallback must mirror that. An agent registered under any namespace is
+      // still a valid agent for all callers. DISTINCT ON deduplicates by agent_id,
+      // preferring rows where is_default is true.
       const result = await pool.query(
-        `SELECT agent_id, display_name, avatar_url, is_default
+        `SELECT DISTINCT ON (agent_id) agent_id, display_name, avatar_url, is_default
          FROM gateway_agent_cache
-         WHERE namespace = ANY($1::text[])
-         ORDER BY is_default DESC, agent_id`,
-        [namespaces],
+         ORDER BY agent_id, is_default DESC`,
       );
 
       return result.rows.map((row: { agent_id: string; display_name: string | null; avatar_url: string | null; is_default: boolean }) => ({


### PR DESCRIPTION
## Summary

- `_getFromDb()` previously filtered `gateway_agent_cache` by namespace using `WHERE namespace = ANY($1::text[])`, which excluded agents registered under non-default namespaces when the gateway WS is disconnected
- Root cause: the `troy` agent is stored under namespace `troy`, not `default`; the caller only passed `['default']`, so the agent was invisible during WS-disconnected fallback
- Fix: remove the namespace filter entirely and use `DISTINCT ON (agent_id)` to deduplicate rows across namespaces (preferring `is_default = true`)
- The gateway `agents.list` response is global (not namespace-scoped), so the DB fallback must match that behaviour
- The `_namespaces` parameter on `getAgents()` is kept for API compatibility but is intentionally unused

## Test plan

- [x] `pnpm run build` — TypeScript clean
- [x] `pnpm run test:unit` — 326 files / 5119 tests pass
- New tests added:
  - verifies SQL uses `DISTINCT ON` and contains no namespace filter
  - verifies agents from any namespace are returned when gateway WS is down

## Migration notes

No schema changes. Query change only.

Closes #2388

🤖 Generated with [Claude Code](https://claude.com/claude-code)