### PR TITLE
[#2402][#2403][#2405] Fix namespace create, grant aliases, bootstrap fallback

### DIFF
--- a/packages/openclaw-plugin/src/register-openclaw.ts
+++ b/packages/openclaw-plugin/src/register-openclaw.ts
@@ -4338,7 +4338,7 @@ function createToolHandlers(state: PluginState) {
         is_default?: boolean;
       };
       try {
-        const response = await apiClient.post<{ id: string; email: string; namespace: string; role: string; is_default: boolean }>(
+        const response = await apiClient.post<{ id: string; email: string; namespace: string; access: string; is_home: boolean }>(
           `/namespaces/${encodeURIComponent(namespace)}/grants`,
           { email, role: role || 'member', is_default: is_default ?? false },
           reqOpts(),
@@ -4347,7 +4347,7 @@ function createToolHandlers(state: PluginState) {
           return { success: false, error: response.error.message || 'Failed to grant namespace access' };
         }
         const d = response.data;
-        return { success: true, data: { content: `Granted **${d.role}** access to **${d.namespace}** for ${d.email}.`, details: d } };
+        return { success: true, data: { content: `Granted **${d.access}** access to **${d.namespace}** for ${d.email}.`, details: d } };
       } catch (error) {
         logger.error('namespace_grant failed', { error });
         return { success: false, error: 'Failed to grant namespace access' };

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -1099,7 +1099,12 @@ export function buildServer(options: ProjectsApiOptions = {}): FastifyInstance {
             [grantEmail, name],
           );
         } else {
-          req.log.warn({ grantEmail, userEmail, agentId }, 'M2M namespace_create: target user not found in user_setting — no owner grant created');
+          // Issue #2402: Return error instead of silently succeeding without a grant.
+          // A namespace with no grants is invisible in namespace_list, creating confusion.
+          req.log.warn({ grantEmail, userEmail, agentId }, 'M2M namespace_create: target user not found in user_setting — aborting');
+          return reply.code(422).send({
+            error: `Cannot create namespace: user '${grantEmail}' not found in user_setting. Provision the user first via POST /users.`,
+          });
         }
       }
 
@@ -1192,15 +1197,17 @@ export function buildServer(options: ProjectsApiOptions = {}): FastifyInstance {
     }
 
     const params = req.params as { ns: string };
-    const body = req.body as { email?: string; access?: string; is_home?: boolean } | null;
+    const body = req.body as { email?: string; access?: string; role?: string; is_home?: boolean; is_default?: boolean } | null;
 
     if (!body?.email) {
       return reply.code(400).send({ error: 'email is required' });
     }
 
     const email = body.email.trim().toLowerCase();
-    const access = body.access || 'readwrite';
-    const isHome = body.is_home ?? false;
+    // Accept 'role' as alias for 'access' (plugin sends 'role', Issue #2403)
+    const access = body.access || body.role || 'readwrite';
+    // Accept 'is_default' as alias for 'is_home' (plugin sends 'is_default', Issue #2403)
+    const isHome = body.is_home ?? body.is_default ?? false;
 
     if (!['read', 'readwrite'].includes(access)) {
       return reply.code(400).send({ error: 'access must be one of: read, readwrite' });
@@ -3159,6 +3166,47 @@ export function buildServer(options: ProjectsApiOptions = {}): FastifyInstance {
     const email = await getSessionEmail(req);
     if (!email) return reply.code(401).send({ error: 'unauthorized' });
     return reply.send({ email });
+  });
+
+  // Issue #2405: Client-side grant fetching for production (static nginx serves /app/*,
+  // bypassing server-side bootstrap injection). NamespaceProvider fetches this on mount.
+  app.get('/me/grants', async (req, reply) => {
+    const email = await getSessionEmail(req);
+    if (!email) return reply.code(401).send({ error: 'unauthorized' });
+
+    const pool = createPool();
+    try {
+      const [grants, settings] = await Promise.all([
+        pool.query(
+          `SELECT namespace, access, is_home FROM namespace_grant WHERE email = $1 ORDER BY is_home DESC, namespace`,
+          [email],
+        ),
+        pool.query(
+          `SELECT active_namespaces FROM user_setting WHERE email = $1`,
+          [email],
+        ),
+      ]);
+
+      const grantRows = grants.rows as Array<{ namespace: string; access: string; is_home: boolean }>;
+      const grantedNs = new Set(grantRows.map((r) => r.namespace));
+      const rawActiveNs: string[] = (settings.rows[0]?.active_namespaces as string[] | undefined) ?? [];
+      let activeNamespaces = rawActiveNs.filter((ns: string) => grantedNs.has(ns));
+      if (activeNamespaces.length === 0) {
+        const homeGrant = grantRows.find((r) => r.is_home);
+        activeNamespaces = homeGrant
+          ? [homeGrant.namespace]
+          : grantedNs.size > 0
+            ? [grantRows[0].namespace]
+            : ['default'];
+      }
+
+      return reply.send({
+        namespace_grants: grantRows,
+        active_namespaces: activeNamespaces,
+      });
+    } finally {
+      await pool.end();
+    }
   });
 
   // User Settings API (issue #179 - Platform Completeness)

--- a/src/ui/contexts/namespace-context.tsx
+++ b/src/ui/contexts/namespace-context.tsx
@@ -14,7 +14,7 @@
 
 import { type QueryClient, useQueryClient } from '@tanstack/react-query';
 import * as React from 'react';
-import { setNamespaceResolver } from '@/ui/lib/api-client';
+import { apiClient, setNamespaceResolver } from '@/ui/lib/api-client';
 import type { AppBootstrap, NamespaceGrant } from '@/ui/lib/api-types';
 import { readBootstrap } from '@/ui/lib/work-item-utils';
 
@@ -95,14 +95,50 @@ function getInitialNamespaces(grants: NamespaceGrant[]): string[] {
   return [grants[0]?.namespace ?? 'default'];
 }
 
+/** Response shape from GET /api/me/grants (Issue #2405). */
+interface MeGrantsResponse {
+  namespace_grants: NamespaceGrant[];
+  active_namespaces: string[];
+}
+
 export function NamespaceProvider({ children }: { children: React.ReactNode }): React.JSX.Element {
   const bootstrap = React.useMemo(() => readBootstrap<AppBootstrap>(), []);
-  const grants = React.useMemo(() => bootstrap?.namespace_grants ?? [], [bootstrap]);
+  const bootstrapGrants = React.useMemo(() => bootstrap?.namespace_grants ?? [], [bootstrap]);
   const queryClient = useQueryClientSafe();
+
+  // Issue #2405: In production, static nginx serves /app/* without bootstrap injection.
+  // When bootstrap grants are empty, fetch from the API on mount.
+  const [fetchedGrants, setFetchedGrants] = React.useState<NamespaceGrant[] | null>(null);
+  const [isNamespaceReady, setIsNamespaceReady] = React.useState(bootstrapGrants.length > 0);
+  const grants = fetchedGrants ?? bootstrapGrants;
+
+  React.useEffect(() => {
+    if (bootstrapGrants.length > 0) return; // Bootstrap data available, no fetch needed
+
+    let cancelled = false;
+    apiClient.get<MeGrantsResponse>('/me/grants')
+      .then((data) => {
+        if (cancelled) return;
+        setFetchedGrants(data.namespace_grants ?? []);
+        setIsNamespaceReady(true);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        // On failure, mark ready with empty grants (graceful degradation)
+        setIsNamespaceReady(true);
+      });
+    return () => { cancelled = true; };
+  }, [bootstrapGrants.length]);
 
   const [activeNamespaces, setActiveNamespacesState] = React.useState(() => getInitialNamespaces(grants));
   const [namespaceVersion, setNamespaceVersion] = React.useState(0);
-  const isNamespaceReady = true; // Synchronously initialized from bootstrap
+
+  // Issue #2405: Re-initialize activeNamespaces when API-fetched grants arrive
+  React.useEffect(() => {
+    if (fetchedGrants && fetchedGrants.length > 0) {
+      setActiveNamespacesState(getInitialNamespaces(fetchedGrants));
+    }
+  }, [fetchedGrants]);
 
   // Persist to localStorage whenever activeNamespaces changes
   React.useEffect(() => {
@@ -187,7 +223,7 @@ export function NamespaceProvider({ children }: { children: React.ReactNode }): 
       isNamespaceReady,
       namespaceVersion,
     }),
-    [grants, activeNamespace, setActiveNamespace, activeNamespaces, setActiveNamespaces, toggleNamespace, namespaceVersion],
+    [grants, activeNamespace, setActiveNamespace, activeNamespaces, setActiveNamespaces, toggleNamespace, isNamespaceReady, namespaceVersion],
   );
 
   return <NamespaceContext.Provider value={value}>{children}</NamespaceContext.Provider>;

--- a/tests/namespace_api.test.ts
+++ b/tests/namespace_api.test.ts
@@ -208,8 +208,9 @@ describe('Namespace & User Provisioning API', () => {
         expect(grant.rows[0].access).toBe('readwrite');
       });
 
-      it('skips grant when identity has no matching user_setting row (#1567)', async () => {
+      it('returns 422 when M2M identity has no matching user_setting row (#1567, #2402)', async () => {
         // Use an M2M identity that is NOT in user_setting
+        // Issue #2402: Changed from silent success (201) to explicit error (422)
         const token = await signM2MToken('agent-no-user-setting-row', ['api:full']);
         const headers = { authorization: `Bearer ${token}` };
         const res = await app.inject({
@@ -217,13 +218,8 @@ describe('Namespace & User Provisioning API', () => {
           headers: { ...headers, 'content-type': 'application/json' },
           payload: { name: 'test-ns-no-grant' },
         });
-        expect(res.statusCode).toBe(201);
-
-        // No grant should be created (identity doesn't match user_setting)
-        const grant = await pool.query(
-          `SELECT email FROM namespace_grant WHERE namespace = 'test-ns-no-grant'`,
-        );
-        expect(grant.rows).toHaveLength(0);
+        expect(res.statusCode).toBe(422);
+        expect(res.json().error).toContain('not found in user_setting');
       });
 
       it('creates namespace with user token and grants readwrite access', async () => {
@@ -537,6 +533,150 @@ describe('Namespace & User Provisioning API', () => {
         });
         expect(res.statusCode).toBe(403);
       });
+    });
+  });
+
+  // ============================================================
+  // Issue #2402: namespace_create returns error for unknown M2M user
+  // ============================================================
+  describe('namespace_create M2M user validation (Issue #2402)', () => {
+    it('returns 422 when M2M user has no user_setting row', async () => {
+      const token = await signM2MToken('agent-no-user-row', ['api:full']);
+      const headers = { authorization: `Bearer ${token}` };
+      const res = await app.inject({
+        method: 'POST', url: '/namespaces',
+        headers: { ...headers, 'content-type': 'application/json' },
+        payload: { name: 'test-ns-no-user-422' },
+      });
+      expect(res.statusCode).toBe(422);
+      expect(res.json().error).toContain('not found in user_setting');
+    });
+
+    it('succeeds when M2M user has user_setting row', async () => {
+      await pool.query(`INSERT INTO user_setting (email) VALUES ($1) ON CONFLICT DO NOTHING`, [TEST_EMAIL]);
+      const headers = await getM2MHeaders();
+      const res = await app.inject({
+        method: 'POST', url: '/namespaces',
+        headers: {
+          ...headers,
+          'content-type': 'application/json',
+          'x-user-email': TEST_EMAIL,
+        },
+        payload: { name: 'test-ns-m2m-user-ok' },
+      });
+      expect(res.statusCode).toBe(201);
+
+      // Verify the grant was created
+      const grant = await pool.query(
+        `SELECT email, access FROM namespace_grant WHERE namespace = 'test-ns-m2m-user-ok'`,
+      );
+      expect(grant.rows).toHaveLength(1);
+      expect(grant.rows[0].email).toBe(TEST_EMAIL);
+    });
+  });
+
+  // ============================================================
+  // Issue #2403: namespace_grant accepts 'role' as alias for 'access'
+  // ============================================================
+  describe('namespace_grant role alias (Issue #2403)', () => {
+    it('accepts role param as alias for access', async () => {
+      await pool.query(`INSERT INTO user_setting (email) VALUES ($1) ON CONFLICT DO NOTHING`, [TEST_EMAIL]);
+      await pool.query(`INSERT INTO user_setting (email) VALUES ($1) ON CONFLICT DO NOTHING`, [TEST_EMAIL_2]);
+      await pool.query(
+        `INSERT INTO namespace_grant (email, namespace, access) VALUES ($1, 'test-ns-role-alias', 'readwrite')`,
+        [TEST_EMAIL],
+      );
+
+      const headers = await getAuthHeaders(TEST_EMAIL);
+      const res = await app.inject({
+        method: 'POST', url: '/namespaces/test-ns-role-alias/grants',
+        headers: { ...headers, 'content-type': 'application/json' },
+        payload: { email: TEST_EMAIL_2, role: 'read' },
+      });
+      expect(res.statusCode).toBe(201);
+      const body = res.json();
+      expect(body.access).toBe('read');
+      expect(body.email).toBe(TEST_EMAIL_2);
+    });
+
+    it('accepts is_default as alias for is_home', async () => {
+      await pool.query(`INSERT INTO user_setting (email) VALUES ($1) ON CONFLICT DO NOTHING`, [TEST_EMAIL]);
+      await pool.query(`INSERT INTO user_setting (email) VALUES ($1) ON CONFLICT DO NOTHING`, [TEST_EMAIL_2]);
+      await pool.query(
+        `INSERT INTO namespace_grant (email, namespace, access) VALUES ($1, 'test-ns-default-alias', 'readwrite')`,
+        [TEST_EMAIL],
+      );
+
+      const headers = await getAuthHeaders(TEST_EMAIL);
+      const res = await app.inject({
+        method: 'POST', url: '/namespaces/test-ns-default-alias/grants',
+        headers: { ...headers, 'content-type': 'application/json' },
+        payload: { email: TEST_EMAIL_2, access: 'read', is_default: true },
+      });
+      expect(res.statusCode).toBe(201);
+      expect(res.json().is_home).toBe(true);
+    });
+
+    it('prefers access over role when both provided', async () => {
+      await pool.query(`INSERT INTO user_setting (email) VALUES ($1) ON CONFLICT DO NOTHING`, [TEST_EMAIL]);
+      await pool.query(`INSERT INTO user_setting (email) VALUES ($1) ON CONFLICT DO NOTHING`, [TEST_EMAIL_2]);
+      await pool.query(
+        `INSERT INTO namespace_grant (email, namespace, access) VALUES ($1, 'test-ns-access-pref', 'readwrite')`,
+        [TEST_EMAIL],
+      );
+
+      const headers = await getAuthHeaders(TEST_EMAIL);
+      const res = await app.inject({
+        method: 'POST', url: '/namespaces/test-ns-access-pref/grants',
+        headers: { ...headers, 'content-type': 'application/json' },
+        payload: { email: TEST_EMAIL_2, access: 'readwrite', role: 'read' },
+      });
+      expect(res.statusCode).toBe(201);
+      expect(res.json().access).toBe('readwrite');
+    });
+  });
+
+  // ============================================================
+  // Issue #2405: GET /me/grants endpoint
+  // ============================================================
+  describe('GET /me/grants (Issue #2405)', () => {
+    it('returns 401 without auth', async () => {
+      const res = await app.inject({ method: 'GET', url: '/me/grants' });
+      expect(res.statusCode).toBe(401);
+    });
+
+    it('returns namespace grants for authenticated user', async () => {
+      await pool.query(`INSERT INTO user_setting (email) VALUES ($1) ON CONFLICT DO NOTHING`, [TEST_EMAIL]);
+      await pool.query(
+        `INSERT INTO namespace_grant (email, namespace, access, is_home) VALUES ($1, 'test-ns-me-home', 'readwrite', true)`,
+        [TEST_EMAIL],
+      );
+      await pool.query(
+        `INSERT INTO namespace_grant (email, namespace, access, is_home) VALUES ($1, 'test-ns-me-other', 'read', false)`,
+        [TEST_EMAIL],
+      );
+
+      const headers = await getAuthHeaders(TEST_EMAIL);
+      const res = await app.inject({ method: 'GET', url: '/me/grants', headers });
+      expect(res.statusCode).toBe(200);
+
+      const body = res.json();
+      expect(body.namespace_grants).toHaveLength(2);
+      expect(body.namespace_grants[0].namespace).toBe('test-ns-me-home');
+      expect(body.namespace_grants[0].is_home).toBe(true);
+      expect(body.active_namespaces).toContain('test-ns-me-home');
+    });
+
+    it('returns empty grants for user with no namespace access', async () => {
+      await pool.query(`INSERT INTO user_setting (email) VALUES ($1) ON CONFLICT DO NOTHING`, [TEST_EMAIL]);
+
+      const headers = await getAuthHeaders(TEST_EMAIL);
+      const res = await app.inject({ method: 'GET', url: '/me/grants', headers });
+      expect(res.statusCode).toBe(200);
+
+      const body = res.json();
+      expect(body.namespace_grants).toHaveLength(0);
+      expect(body.active_namespaces).toEqual(['default']);
     });
   });
 

--- a/tests/ui/namespace-context-multi.test.tsx
+++ b/tests/ui/namespace-context-multi.test.tsx
@@ -11,10 +11,22 @@
  */
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import React from 'react';
-import { render, screen, act } from '@testing-library/react';
+import { act } from '@testing-library/react';
 import { renderHook } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import '@testing-library/jest-dom';
+
+// Partial mock for api-client: only mock apiClient.get, keep real setNamespaceResolver
+vi.mock('@/ui/lib/api-client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/ui/lib/api-client')>();
+  return {
+    ...actual,
+    apiClient: { ...actual.apiClient, get: vi.fn() },
+  };
+});
+// Re-import after mock to get the mocked function reference
+import { apiClient as mockedApiClient } from '@/ui/lib/api-client';
+const mockApiGet = mockedApiClient.get as ReturnType<typeof vi.fn>;
 
 import {
   NamespaceProvider,
@@ -66,6 +78,7 @@ describe('Multi-namespace context (#2351)', () => {
   beforeEach(() => {
     clearBootstrapData();
     localStorage.clear();
+    mockApiGet.mockReset();
   });
 
   afterEach(() => {
@@ -270,5 +283,116 @@ describe('Namespace race prevention (#2360)', () => {
     });
 
     expect(result.current.namespaceVersion).toBeGreaterThan(initialVersion);
+  });
+});
+
+describe('API-fetch fallback when bootstrap is empty (Issue #2405)', () => {
+  beforeEach(() => {
+    clearBootstrapData();
+    localStorage.clear();
+    mockApiGet.mockReset();
+  });
+
+  afterEach(() => {
+    clearBootstrapData();
+  });
+
+  it('fetches grants from /me/grants when bootstrap has no namespace_grants', async () => {
+    // Do NOT set bootstrap data — simulates production static serving
+    const apiGrants = [
+      { namespace: 'fetched-ns', access: 'readwrite', is_home: true },
+    ];
+
+    let resolveFn: (value: unknown) => void;
+    const fetchPromise = new Promise((resolve) => { resolveFn = resolve; });
+    mockApiGet.mockReturnValue(fetchPromise);
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+    const Wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>
+        <NamespaceProvider>{children}</NamespaceProvider>
+      </QueryClientProvider>
+    );
+
+    const { result } = renderHook(() => useNamespace(), { wrapper: Wrapper });
+
+    // Initially not ready (no bootstrap)
+    expect(result.current.isNamespaceReady).toBe(false);
+
+    // Resolve the fetch and flush React state
+    await act(async () => {
+      resolveFn!({
+        namespace_grants: apiGrants,
+        active_namespaces: ['fetched-ns'],
+      });
+      // Flush microtasks
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(result.current.isNamespaceReady).toBe(true);
+    expect(result.current.grants).toHaveLength(1);
+    expect(result.current.grants[0].namespace).toBe('fetched-ns');
+    expect(result.current.activeNamespace).toBe('fetched-ns');
+  });
+
+  it('uses bootstrap grants when available (no API fetch)', () => {
+    setBootstrapData({
+      namespace_grants: [
+        { namespace: 'bootstrap-ns', access: 'readwrite', is_home: true },
+      ],
+    });
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+    const Wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>
+        <NamespaceProvider>{children}</NamespaceProvider>
+      </QueryClientProvider>
+    );
+
+    const { result } = renderHook(() => useNamespace(), { wrapper: Wrapper });
+
+    // Immediately ready from bootstrap
+    expect(result.current.isNamespaceReady).toBe(true);
+    expect(result.current.grants).toHaveLength(1);
+    expect(result.current.grants[0].namespace).toBe('bootstrap-ns');
+  });
+
+  it('degrades gracefully when API fetch fails', async () => {
+    // No bootstrap data — simulates production with static nginx.
+    // Use a controlled promise so rejection happens inside act().
+    let rejectFn: (err: Error) => void;
+    const fetchPromise = new Promise((_resolve, reject) => { rejectFn = reject; });
+    fetchPromise.catch(() => {}); // Prevent Node unhandled-rejection warning
+    mockApiGet.mockReturnValue(fetchPromise);
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+    const Wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>
+        <NamespaceProvider>{children}</NamespaceProvider>
+      </QueryClientProvider>
+    );
+
+    const { result } = renderHook(() => useNamespace(), { wrapper: Wrapper });
+
+    expect(mockApiGet).toHaveBeenCalledWith('/me/grants');
+    expect(result.current.isNamespaceReady).toBe(false);
+
+    // Reject inside act to trigger .catch() → setIsNamespaceReady(true)
+    await act(async () => {
+      rejectFn!(new Error('Network error'));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(result.current.isNamespaceReady).toBe(true);
+    expect(result.current.grants).toHaveLength(0);
+    expect(result.current.activeNamespace).toBe('default');
   });
 });


### PR DESCRIPTION
## Summary

Omnibus fix for three related namespace/bootstrap bugs:

- **#2402 — `namespace_create` silent failure for M2M tokens**: When an M2M token calls `namespace_create` and the target user has no `user_setting` row, the endpoint now returns HTTP 422 with a descriptive error instead of silently succeeding without creating a `namespace_grant` row.

- **#2403 — `namespace_grant` tool shows 'undefined' for role**: The OpenClaw plugin sends `role`/`is_default` but the API expected `access`/`is_home`. The grant endpoint now accepts both field name variants (`role` as alias for `access`, `is_default` as alias for `is_home`). The plugin response template now correctly references the API response fields.

- **#2405 — Bootstrap data not injected in production**: In production, Traefik routes `/app/*` to static nginx, bypassing the API's `sendAppHtml()` bootstrap injection. Added a new `GET /me/grants` endpoint that returns namespace grants and active namespaces. `NamespaceProvider` now falls back to this API endpoint when no bootstrap data is present. Also fixed a missing `isNamespaceReady` dependency in `useMemo` that prevented context updates on fetch failure.

## Test plan

- [x] 54 integration tests pass (`tests/namespace_api.test.ts`) — includes new tests for #2402 (M2M user validation), #2403 (role/is_default aliases), #2405 (GET /me/grants endpoint)
- [x] 20 unit tests pass (`tests/ui/namespace-context-multi.test.tsx`) — includes new tests for API fetch fallback, bootstrap-first behavior, graceful degradation on fetch failure
- [x] Lint passes (no errors)
- [x] Typecheck passes (`tsc --noEmit`)
- [x] Pre-existing test failures unchanged (docker, symphony-config, work-item-detail-navigation)

Closes #2402
Closes #2403
Closes #2405