### PR TITLE
[#2404] Fix Yjs WebSocket 4003 — resolve namespaces for authorization

### DIFF
--- a/src/api/realtime/yjs-ws-handler.ts
+++ b/src/api/realtime/yjs-ws-handler.ts
@@ -55,9 +55,10 @@ export class YjsWsHandler {
     clientId: string,
     userEmail: string,
     noteId: string,
+    namespaces: string[] = [],
   ): Promise<void> {
     // Join the room (auth check happens inside docManager.joinRoom)
-    const doc = await this.docManager.joinRoom(clientId, userEmail, noteId);
+    const doc = await this.docManager.joinRoom(clientId, userEmail, noteId, namespaces);
 
     const client: YjsClient = { clientId, userEmail, noteId, socket };
 

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -1871,12 +1871,25 @@ export function buildServer(options: ProjectsApiOptions = {}): FastifyInstance {
         const noteId = (req.params as { noteId: string }).noteId;
         const client_id = `yjs-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 
+        // Resolve user's namespaces for authorization (Issue #2404).
+        // WebSocket handlers bypass the preHandler hook that normally populates
+        // req.namespaceContext, so we query namespace_grant directly.
+        let namespaces: string[] = [];
+        if (user_email && yjsPool) {
+          const nsResult = await yjsPool.query<{ namespace: string }>(
+            `SELECT namespace FROM namespace_grant WHERE email = $1`,
+            [user_email],
+          );
+          namespaces = nsResult.rows.map((r: { namespace: string }) => r.namespace);
+        }
+
         try {
           await yjsWsHandler.handleConnection(
             socket as Parameters<typeof yjsWsHandler.handleConnection>[0],
             client_id,
             user_email ?? '',
             noteId,
+            namespaces,
           );
         } catch (err) {
           const msg = err instanceof Error ? err.message : 'Connection failed';


### PR DESCRIPTION
## Summary

- WebSocket handler was calling `joinRoom` with empty namespaces array because `wsHandler` bypasses the `preHandler` hook that normally resolves namespace context
- `userCanAccessNote(pool, noteId, [], email, 'read_write')` always failed — the `ANY($2::text[])` clause never matched with an empty array
- Result: all Yjs WebSocket connections got 4003 "Access denied" even for the user's own notes

## Fix

Query `namespace_grant` directly in the WebSocket handler after JWT verification, and pass resolved namespaces to `handleConnection` → `joinRoom`.

## Test plan

- [ ] Unit tests pass (5177 tests, 331 files)
- [ ] Typecheck passes
- [ ] Verified WebSocket upgrade returns 101 (existing fix from PR #2406)
- [ ] With namespaces resolved, `userCanAccessNote` should match the user's notes

Closes #2404

🤖 Generated with [Claude Code](https://claude.com/claude-code)