### PR TITLE
[#2416] Fix Yjs WebSocket lifecycle: CollaborationPlugin disconnect race

### DIFF
--- a/src/ui/hooks/use-yjs-provider.ts
+++ b/src/ui/hooks/use-yjs-provider.ts
@@ -61,8 +61,11 @@ export function useYjsProvider(noteId: string | null): UseYjsProviderResult {
     const wsBase = getWsBaseUrl();
     const wsUrl = wsBase ? `${wsBase}/yjs` : '/yjs';
 
+    // connect: false — CollaborationPlugin owns the connect/disconnect lifecycle.
+    // If we connect here, CollaborationPlugin's useProvider effect cleanup will
+    // call disconnect() on re-render, killing the WebSocket within milliseconds.
     const provider = new WebsocketProvider(wsUrl, noteId, doc, {
-      connect: true,
+      connect: false,
       params: { token: token ?? '' },
     });
 
@@ -79,7 +82,9 @@ export function useYjsProvider(noteId: string | null): UseYjsProviderResult {
       }
     });
 
-    setState({ doc, provider, status: 'connecting' });
+    // Status starts as 'disconnected' since connect: false — CollaborationPlugin
+    // will call connect() and provider events will update status from there.
+    setState({ doc, provider, status: 'disconnected' });
 
     return () => {
       provider.destroy();


### PR DESCRIPTION
## Summary
- Fix Notes page WebSocket connection dying within ~12ms of establishment
- Root cause: dual ownership of WebSocket lifecycle between `useYjsProvider` (`connect: true`) and Lexical's `CollaborationPlugin` (calls `disconnect()` on effect cleanup)
- Fix: create `WebsocketProvider` with `connect: false`, letting `CollaborationPlugin` be the sole owner of connect/disconnect

## Test plan
- [ ] Notes page loads without Lexical warning #319
- [ ] WebSocket connection to Yjs server stays open (no "closed before established" error)
- [ ] Yjs collaborative editing syncs content between sessions
- [ ] Switching between Edit/Markdown/Preview modes preserves content
- [ ] Creating new notes still works (Yjs provider created after first save)

Closes #2416

🤖 Generated with [Claude Code](https://claude.com/claude-code)