### PR TITLE
[#2416] Fix yjs-ws-handler test expectation for namespaces param

### DIFF
--- a/tests/realtime/yjs-ws-handler.test.ts
+++ b/tests/realtime/yjs-ws-handler.test.ts
@@ -79,7 +79,7 @@ describe('YjsWsHandler', () => {
         'note-uuid-1',
       );
 
-      expect(mockManager.manager.joinRoom).toHaveBeenCalledWith('client-1', 'user@test.com', 'note-uuid-1');
+      expect(mockManager.manager.joinRoom).toHaveBeenCalledWith('client-1', 'user@test.com', 'note-uuid-1', []);
       // Should send at least sync step 1 and sync step 2
       expect(socket.send.mock.calls.length).toBeGreaterThanOrEqual(2);
     });


### PR DESCRIPTION
## Summary
- Fix failing CI test: `yjs-ws-handler.test.ts` expects `joinRoom` with 3 args but it now takes 4 (namespaces `[]` default from #2415)

## Test plan
- [ ] `pnpm run test` passes (specifically `tests/realtime/yjs-ws-handler.test.ts`)

Closes #2416

🤖 Generated with [Claude Code](https://claude.com/claude-code)