### PR TITLE
[#2469] Fix NamespaceProvider: gate /me/grants on auth state

### DIFF
--- a/src/ui/contexts/namespace-context.tsx
+++ b/src/ui/contexts/namespace-context.tsx
@@ -16,6 +16,7 @@ import { type QueryClient, useQueryClient } from '@tanstack/react-query';
 import * as React from 'react';
 import { apiClient, setNamespaceResolver } from '@/ui/lib/api-client';
 import type { AppBootstrap, NamespaceGrant } from '@/ui/lib/api-types';
+import { useUser } from '@/ui/contexts/user-context';
 import { readBootstrap } from '@/ui/lib/work-item-utils';
 
 /**
@@ -105,6 +106,7 @@ export function NamespaceProvider({ children }: { children: React.ReactNode }): 
   const bootstrap = React.useMemo(() => readBootstrap<AppBootstrap>(), []);
   const bootstrapGrants = React.useMemo(() => bootstrap?.namespace_grants ?? [], [bootstrap]);
   const queryClient = useQueryClientSafe();
+  const { isAuthenticated, isLoading: isAuthLoading } = useUser();
 
   // Issue #2405: In production, static nginx serves /app/* without bootstrap injection.
   // When bootstrap grants are empty, fetch from the API on mount.
@@ -112,8 +114,16 @@ export function NamespaceProvider({ children }: { children: React.ReactNode }): 
   const [isNamespaceReady, setIsNamespaceReady] = React.useState(bootstrapGrants.length > 0);
   const grants = fetchedGrants ?? bootstrapGrants;
 
+  // Issue #2469: Gate /me/grants on auth state to prevent 401 redirect loops
+  // on the login page. NamespaceProvider is inside UserProvider in the tree,
+  // so useUser() is safe to call here.
   React.useEffect(() => {
     if (bootstrapGrants.length > 0) return; // Bootstrap data available, no fetch needed
+    if (isAuthLoading) return; // Wait for auth bootstrap to complete
+    if (!isAuthenticated) {
+      setIsNamespaceReady(true); // Not authenticated — skip gracefully
+      return;
+    }
 
     let cancelled = false;
     apiClient.get<MeGrantsResponse>('/me/grants')
@@ -128,7 +138,7 @@ export function NamespaceProvider({ children }: { children: React.ReactNode }): 
         setIsNamespaceReady(true);
       });
     return () => { cancelled = true; };
-  }, [bootstrapGrants.length]);
+  }, [bootstrapGrants.length, isAuthenticated, isAuthLoading]);
 
   const [activeNamespaces, setActiveNamespacesState] = React.useState(() => getInitialNamespaces(grants));
   const [namespaceVersion, setNamespaceVersion] = React.useState(0);

--- a/tests/ui/namespace-auth-gate.test.tsx
+++ b/tests/ui/namespace-auth-gate.test.tsx
@@ -1,0 +1,140 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Tests for NamespaceProvider auth gating (issue #2469).
+ *
+ * Verifies that NamespaceProvider does NOT call /me/grants when the user
+ * is not authenticated, preventing infinite redirect loops on the login page.
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import type React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import '@testing-library/jest-dom';
+
+// ── Mocks ──────────────────────────────────────────────────────────
+
+// Mock user-context with controllable state
+const mockUserState = {
+  email: null as string | null,
+  isLoading: false,
+  isAuthenticated: false,
+  logout: vi.fn(),
+  signalAuthenticated: vi.fn(),
+};
+
+vi.mock('@/ui/contexts/user-context', () => ({
+  useUser: () => ({ ...mockUserState }),
+  useUserEmail: () => mockUserState.email,
+  UserProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+// Mock api-client: track calls to apiClient.get
+vi.mock('@/ui/lib/api-client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/ui/lib/api-client')>();
+  return {
+    ...actual,
+    apiClient: { ...actual.apiClient, get: vi.fn() },
+  };
+});
+
+import { apiClient as mockedApiClient } from '@/ui/lib/api-client';
+const mockApiGet = mockedApiClient.get as ReturnType<typeof vi.fn>;
+
+import { NamespaceProvider, useNamespace } from '@/ui/contexts/namespace-context';
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+function clearBootstrapData(): void {
+  const el = document.getElementById('app-bootstrap');
+  if (el) el.remove();
+}
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <NamespaceProvider>{children}</NamespaceProvider>
+    </QueryClientProvider>
+  );
+  return { Wrapper, queryClient };
+}
+
+// ── Tests ──────────────────────────────────────────────────────────
+
+describe('NamespaceProvider auth gating (#2469)', () => {
+  beforeEach(() => {
+    clearBootstrapData();
+    localStorage.clear();
+    mockApiGet.mockReset();
+    mockUserState.email = null;
+    mockUserState.isLoading = false;
+    mockUserState.isAuthenticated = false;
+  });
+
+  it('does NOT call /me/grants when user is not authenticated', async () => {
+    // No bootstrap data → would normally trigger API fetch
+    const { Wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useNamespace(), { wrapper: Wrapper });
+
+    // Wait for the effect to settle
+    await waitFor(() => {
+      expect(result.current.isNamespaceReady).toBe(true);
+    });
+
+    // /me/grants should NOT have been called
+    expect(mockApiGet).not.toHaveBeenCalled();
+  });
+
+  it('does NOT call /me/grants while auth is still loading', async () => {
+    mockUserState.isLoading = true;
+    const { Wrapper } = createWrapper();
+
+    renderHook(() => useNamespace(), { wrapper: Wrapper });
+
+    // Give effects time to run
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(mockApiGet).not.toHaveBeenCalled();
+  });
+
+  it('calls /me/grants when user IS authenticated and no bootstrap data', async () => {
+    mockUserState.email = 'test@example.com';
+    mockUserState.isAuthenticated = true;
+    mockUserState.isLoading = false;
+
+    mockApiGet.mockResolvedValueOnce({
+      namespace_grants: [{ namespace: 'test', access: 'readwrite', is_home: true }],
+      active_namespaces: ['test'],
+    });
+
+    const { Wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useNamespace(), { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isNamespaceReady).toBe(true);
+    });
+
+    expect(mockApiGet).toHaveBeenCalledWith('/me/grants');
+    expect(result.current.grants).toEqual([
+      { namespace: 'test', access: 'readwrite', is_home: true },
+    ]);
+  });
+
+  it('sets isNamespaceReady=true immediately for unauthenticated users', async () => {
+    const { Wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useNamespace(), { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isNamespaceReady).toBe(true);
+    });
+
+    // Should be ready with empty grants, not stuck loading
+    expect(result.current.grants).toEqual([]);
+  });
+});

--- a/tests/ui/namespace-components.test.tsx
+++ b/tests/ui/namespace-components.test.tsx
@@ -8,10 +8,17 @@
  * - NamespacePicker shows/hides based on namespace grants
  * - NamespaceProvider reads bootstrap data and persists selection
  */
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import type * as React from 'react';
+
+// Mock user-context so useUser() doesn't throw inside NamespaceProvider (#2469)
+vi.mock('@/ui/contexts/user-context', () => ({
+  useUser: () => ({ email: 'test@test.com', isLoading: false, isAuthenticated: true, logout: vi.fn(), signalAuthenticated: vi.fn() }),
+  useUserEmail: () => 'test@test.com',
+  UserProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
 
 import { NamespaceProvider, useNamespace } from '@/ui/contexts/namespace-context';
 import { NamespaceBadge } from '@/ui/components/namespace/namespace-badge';

--- a/tests/ui/namespace-context-multi.test.tsx
+++ b/tests/ui/namespace-context-multi.test.tsx
@@ -16,6 +16,13 @@ import { renderHook } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import '@testing-library/jest-dom';
 
+// Mock user-context so useUser() doesn't throw inside NamespaceProvider (#2469)
+vi.mock('@/ui/contexts/user-context', () => ({
+  useUser: () => ({ email: 'test@test.com', isLoading: false, isAuthenticated: true, logout: vi.fn(), signalAuthenticated: vi.fn() }),
+  useUserEmail: () => 'test@test.com',
+  UserProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
 // Partial mock for api-client: only mock apiClient.get, keep real setNamespaceResolver
 vi.mock('@/ui/lib/api-client', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/ui/lib/api-client')>();

--- a/tests/ui/namespace-enhanced-components.test.tsx
+++ b/tests/ui/namespace-enhanced-components.test.tsx
@@ -9,10 +9,17 @@
  * - Entity list pages show NamespaceBadge in multi-namespace mode (#2355)
  * - Namespace strings used from constants (#2357)
  */
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import type * as React from 'react';
+
+// Mock user-context so useUser() doesn't throw inside NamespaceProvider (#2469)
+vi.mock('@/ui/contexts/user-context', () => ({
+  useUser: () => ({ email: 'test@test.com', isLoading: false, isAuthenticated: true, logout: vi.fn(), signalAuthenticated: vi.fn() }),
+  useUserEmail: () => 'test@test.com',
+  UserProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
 
 import { NamespaceProvider, useNamespace } from '@/ui/contexts/namespace-context';
 import { NamespaceBadge } from '@/ui/components/namespace/namespace-badge';

--- a/tests/ui/use-namespace-query-key.test.tsx
+++ b/tests/ui/use-namespace-query-key.test.tsx
@@ -7,11 +7,18 @@
  * - Keys change when namespace changes
  * - Works with various base key shapes
  */
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import React from 'react';
 import { renderHook, act } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import '@testing-library/jest-dom';
+
+// Mock user-context so useUser() doesn't throw inside NamespaceProvider (#2469)
+vi.mock('@/ui/contexts/user-context', () => ({
+  useUser: () => ({ email: 'test@test.com', isLoading: false, isAuthenticated: true, logout: vi.fn(), signalAuthenticated: vi.fn() }),
+  useUserEmail: () => 'test@test.com',
+  UserProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
 
 import { NamespaceProvider, useNamespace } from '@/ui/contexts/namespace-context';
 import { useNamespaceQueryKey } from '@/ui/hooks/use-namespace-query-key';


### PR DESCRIPTION
Closes #2469

## Problem

After v0.0.57, users cannot log in — infinite redirect loop. NamespaceProvider calls apiClient.get('/me/grants') unconditionally on mount when bootstrapGrants.length === 0. Since NamespaceProvider wraps the entire app (including the login page), this fires on the login page with no token. /me/grants returns 401 -> api-client.ts tries refresh -> also 401 -> redirects to /app/login -> infinite loop.

## Fix

Gate the /me/grants fetch on auth state from UserContext:
- Import useUser() in NamespaceProvider (safe — it is inside UserProvider in the tree)
- When isAuthLoading: wait (do not fetch yet)
- When !isAuthenticated: set isNamespaceReady=true and skip the fetch
- When isAuthenticated: proceed with existing fetch logic unchanged

The signalAuthenticated() flow still works: after magic link consume, isAuthenticated flips to true, the effect re-runs due to the dependency array, and grants are fetched.

## Test plan

- [x] New test suite tests/ui/namespace-auth-gate.test.tsx with 4 tests
- [x] Updated existing namespace tests with user-context mocks
- [x] All 335 unit test files pass (5218 tests)
- [x] pnpm run build — clean, no type errors