### PR TITLE
[#2516] Audit server-side timezone usage

### DIFF
--- a/docs/architecture/timezone-audit-2516.md
+++ b/docs/architecture/timezone-audit-2516.md
@@ -22,9 +22,11 @@ Epic: #2509
 |---------|-----------------|--------|
 | Frontend date rendering | Browser timezone via `toLocaleString()` | Dates may differ from stored preference |
 | Bootstrap `due_today` | PostgreSQL `CURRENT_DATE` (server TZ) | Incorrect "due today" for non-UTC users |
-| Note export (PDF/DOCX) | Server timezone (UTC) | Exported dates always in UTC |
+| Note export metadata | API returns ISO timestamps | Export record dates in UTC (generators don't embed dates in documents) |
 | Email digest scheduling | Not implemented | N/A until built |
 | Reminders / `not_before` | UTC `timestamptz` — correct server-side | UI should display in user timezone |
+| Agent context service | `toISOString().split('T')[0]` for due dates | Agent sees UTC day, may shift for non-UTC users |
+| Webhook payloads | UTC ISO timestamps in reminder/nudge payloads | OpenClaw receives UTC; agent must interpret |
 | Recurrence service | No timezone awareness | Recurrence patterns may drift |
 | Calendar API | No timezone parameter | Calendar queries are timezone-agnostic |
 
@@ -40,3 +42,10 @@ The #2510 banner states: "Updating will affect how reminders, quiet hours, and d
 - #2518 — Backend: Use user timezone in bootstrap `due_today`
 - #2519 — Backend: Use user timezone in note export
 - #2520 — Backend: Email digest timezone tracking
+
+## Codex Review Addenda
+
+- **Agent context service** (`src/api/context/service.ts:225,293`): Formats `not_after` dates using `toISOString().split('T')[0]`, showing UTC calendar day to agents. Non-UTC users may see a shifted "due" day.
+- **Webhook payloads** (`src/api/webhooks/payloads.ts:124,145`): Reminder and nudge webhooks send UTC ISO timestamps to OpenClaw. Job dedup keys (`src/api/jobs/processor.ts`, `src/api/server.ts:718,749`) also use UTC day boundaries.
+- **Email ingress** (`src/api/cloudflare-email/`, `src/api/postmark/`): Store provider timestamps as absolute instants — correct behavior, not a timezone gap.
+- **Note export correction**: PDF/DOCX generators convert note content, not date metadata. #2519 scope reduced to export API record timestamps only.


### PR DESCRIPTION
## Summary

Research spike auditing all server-side and frontend uses of `user_setting.timezone`.

**Key finding:** `user_setting.timezone` is stored and returned via the settings API but **not consumed** by any feature. Three other timezone columns exist for specific subsystems (skill store schedules, chat quiet hours, contact quiet hours), each fully functional in isolation.

## Findings

- **Skill store schedules**: Fully timezone-aware via `computeNextRunAt()` with per-schedule timezone
- **Chat quiet hours**: Fully timezone-aware via `isInQuietHours()` with per-preference timezone
- **Contact quiet hours**: Stored and displayed per-contact
- **Frontend date rendering**: Uses browser timezone, NOT stored `user_setting.timezone`
- **Bootstrap `due_today`**: Uses PostgreSQL `CURRENT_DATE` (server UTC), not user timezone
- **Agent context service**: Shows UTC day for due dates, may shift for non-UTC users
- **Email digests**: Not implemented yet
- **Banner copy**: "Updating will affect how reminders, quiet hours, and dates are shown across the app." is **inaccurate** — timezone setting doesn't currently affect any of these

## Child Issues Created

- #2517 — Frontend: Use stored timezone for date rendering across UI
- #2518 — Backend: Use user timezone in bootstrap `due_today` calculation
- #2519 — Backend: Use user timezone in note export date rendering
- #2520 — Backend: Email digest timezone tracking

## Codex Review

Completed. Added findings for agent context service date formatting and webhook payload UTC assumptions.

Closes #2516

🤖 Generated with Claude Code