### PR TITLE
[#2563] Fix namespace selection lost on page refresh

### DIFF
--- a/src/ui/contexts/namespace-context.tsx
+++ b/src/ui/contexts/namespace-context.tsx
@@ -150,14 +150,17 @@ export function NamespaceProvider({ children }: { children: React.ReactNode }): 
     }
   }, [fetchedGrants]);
 
-  // Persist to localStorage whenever activeNamespaces changes
+  // Persist to localStorage whenever activeNamespaces changes.
+  // Guard with isNamespaceReady to avoid clobbering stored selection
+  // with ['default'] before grants load (#2563).
   React.useEffect(() => {
+    if (!isNamespaceReady) return;
     try {
       localStorage.setItem(ACTIVE_NAMESPACES_KEY, JSON.stringify(activeNamespaces));
     } catch {
       // localStorage may be unavailable
     }
-  }, [activeNamespaces]);
+  }, [activeNamespaces, isNamespaceReady]);
 
   // Sync namespace resolver for api-client header injection (#2349)
   React.useEffect(() => {
@@ -185,6 +188,7 @@ export function NamespaceProvider({ children }: { children: React.ReactNode }): 
       setNamespaceVersion((v) => v + 1);
       try {
         localStorage.setItem(ACTIVE_NAMESPACE_KEY, namespace);
+        localStorage.setItem(ACTIVE_NAMESPACES_KEY, JSON.stringify([namespace]));
       } catch {
         // localStorage may be unavailable
       }

--- a/tests/ui/namespace-context-multi.test.tsx
+++ b/tests/ui/namespace-context-multi.test.tsx
@@ -402,4 +402,69 @@ describe('API-fetch fallback when bootstrap is empty (Issue #2405)', () => {
     expect(result.current.grants).toHaveLength(0);
     expect(result.current.activeNamespace).toBe('default');
   });
+
+  it('does not clobber localStorage before grants load (#2563)', async () => {
+    // Pre-populate localStorage with a previously saved namespace
+    localStorage.setItem('openclaw-active-namespaces', JSON.stringify(['my-saved-ns']));
+
+    // No bootstrap data — simulates production static nginx
+    const apiGrants = [
+      { namespace: 'my-saved-ns', access: 'readwrite', is_home: true },
+    ];
+
+    let resolveFn: (value: unknown) => void;
+    const fetchPromise = new Promise((resolve) => { resolveFn = resolve; });
+    mockApiGet.mockReturnValue(fetchPromise);
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+    const Wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>
+        <NamespaceProvider>{children}</NamespaceProvider>
+      </QueryClientProvider>
+    );
+
+    renderHook(() => useNamespace(), { wrapper: Wrapper });
+
+    // Before grants arrive, localStorage should NOT have been overwritten
+    // with ['default'] — the persist effect must be guarded by isNamespaceReady
+    const storedBeforeGrants = localStorage.getItem('openclaw-active-namespaces');
+    expect(storedBeforeGrants).toBe(JSON.stringify(['my-saved-ns']));
+
+    // Now resolve the API fetch
+    await act(async () => {
+      resolveFn!({
+        namespace_grants: apiGrants,
+        active_namespaces: ['my-saved-ns'],
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // After grants load, localStorage should reflect the resolved namespace
+    const storedAfterGrants = localStorage.getItem('openclaw-active-namespaces');
+    expect(storedAfterGrants).toBe(JSON.stringify(['my-saved-ns']));
+  });
+
+  it('setActiveNamespace writes to both legacy and multi-namespace localStorage keys (#2563)', () => {
+    setBootstrapData({ namespace_grants: MULTI_GRANTS });
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+    const Wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>
+        <NamespaceProvider>{children}</NamespaceProvider>
+      </QueryClientProvider>
+    );
+
+    const { result } = renderHook(() => useNamespace(), { wrapper: Wrapper });
+
+    act(() => {
+      result.current.setActiveNamespace('household');
+    });
+
+    expect(localStorage.getItem('openclaw-active-namespace')).toBe('household');
+    expect(localStorage.getItem('openclaw-active-namespaces')).toBe(JSON.stringify(['household']));
+  });
 });


### PR DESCRIPTION
Closes #2563

## Summary

- Guard the localStorage persist effect with `isNamespaceReady` to prevent clobbering the user's saved namespace with `['default']` before grants load
- Fix `setActiveNamespace` to write to both `ACTIVE_NAMESPACE_KEY` and `ACTIVE_NAMESPACES_KEY` for consistency between legacy and multi-namespace localStorage keys

## Root cause

In production (static nginx), `activeNamespaces` initializes to `['default']` because `getInitialNamespaces([])` can't validate any localStorage value against an empty grant set. The persist effect immediately fires and overwrites localStorage. When `/me/grants` later resolves, it reads the already-clobbered value.

## Changes

- `src/ui/contexts/namespace-context.tsx`: Added `isNamespaceReady` guard to persist effect, added `ACTIVE_NAMESPACES_KEY` write to `setActiveNamespace`
- `tests/ui/namespace-context-multi.test.tsx`: Added 2 regression tests verifying localStorage is not clobbered before grants load and that both keys are written consistently

## Test plan

- [x] Unit test: verify localStorage not clobbered before grants load
- [x] Unit test: verify setActiveNamespace writes both localStorage keys
- [x] `pnpm test:unit` passes (358/359 files; 1 pre-existing chat-rich-card jsdom failure)