### PR TITLE
[#2522] Fix post-merge test failures from Phase 2

### DIFF
--- a/tests/ci/release/version-propagation.test.ts
+++ b/tests/ci/release/version-propagation.test.ts
@@ -374,8 +374,8 @@ describe('symphony-worker in release body', () => {
 describe('Container provenance SHA', () => {
   it('should use github.sha for VCS_REF build arg', () => {
     const releaseYml = readFileSync(resolve(ROOT, '.github/workflows/release.yml'), 'utf-8');
-    expect(releaseYml).toContain('VCS_REF=${{ github.sha }}');
-    expect(releaseYml).toContain('OCI_REVISION=${{ github.sha }}');
+    expect(releaseYml).toContain('VCS_REF=${{ needs.validate.outputs.version_bump_sha }}');
+    expect(releaseYml).toContain('OCI_REVISION=${{ needs.validate.outputs.version_bump_sha }}');
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes a test failure introduced by Phase 2 release workflow merges (PRs #2556 and #2557):

- **version-propagation.test.ts**: Update VCS_REF and OCI_REVISION assertions to match implementation. The implementation correctly uses `needs.validate.outputs.version_bump_sha` (the version bump commit SHA) rather than `github.sha` (the tag trigger SHA), providing more accurate container provenance. The test was not updated when the workflow was changed.

Note: The `connection-manage-panel.test.tsx` failure described in the issue was not reproducible — all 50 tests in that file pass on the current main branch without any changes needed.

## Related

Closes #2535
Part of Epic #2522