### PR TITLE
[#2476] Fix migration reversibility test to handle additional migrations

### DIFF
--- a/tests/note_export_schema.test.ts
+++ b/tests/note_export_schema.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
 import { Pool } from 'pg';
 import { createTestPool, ensureTestNamespace } from './helpers/db.ts';
-import { runMigrate } from './helpers/migrate.ts';
+import { runMigrate, stepsToRollbackTo } from './helpers/migrate.ts';
 
 /**
  * Tests for Issue #2476 — note_export schema (Migration 166)
@@ -278,8 +278,10 @@ describe('note_export Schema (Migration 166)', () => {
 
   describe('migration reversibility', () => {
     it('down migration removes all objects cleanly', async () => {
-      // Run down for migration 166
-      await runMigrate('down', 1);
+      // Roll back migration 166 and any later migrations that may have been added.
+      // stepsToRollbackTo(166) returns the count of migrations at version >= 166,
+      // ensuring we always reach a state where migration 166 itself is undone.
+      await runMigrate('down', stepsToRollbackTo(166));
 
       // Table should not exist
       const tableCheck = await pool.query(


### PR DESCRIPTION
## Summary

Fixes `tests/note_export_schema.test.ts > migration reversibility > down migration removes all objects cleanly` which started failing after migration 167 was added in PR #2571.

**Root cause:** The test called `runMigrate('down', 1)` which rolls back the *latest* migration (167, not 166). The test then checks that `note_export` table doesn't exist — but it does, because migration 166 was never rolled back.

**Fix:** Uses the existing `stepsToRollbackTo(166)` helper (already exported from `tests/helpers/migrate.ts`) to dynamically compute how many migrations exist at version >= 166 and roll back all of them. This ensures the test correctly targets migration 166 regardless of how many later migrations exist.

Closes #2476

## Related

- #2571 (PR that introduced migration 167, indirectly breaking this test)