### PR TITLE
[#2576][#2577][#2578] Fix release workflow: checkout SHA, artifact sequencing, verify placement

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -280,9 +280,47 @@ jobs:
           # Credentials are NOT persisted (persist-credentials: false on checkout).
           git remote set-url origin "https://x-access-token:${REPO_PAT}@github.com/${{ github.repository }}.git"
 
+      # #2578 — Verify BEFORE edge restore. compose files still have :<version> tags here.
+      # Moving this step before the restore ensures the verification runs against versioned
+      # files. If placed after restore (as before), verify will always fail on real releases
+      # because compose files are :edge at that point.
+      - name: Verify release version consistency
+        if: steps.reentry-guard.outputs.skip != 'true'
+        env:
+          FILE_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          # Strip build metadata for comparison
+          CHECK_VERSION="${FILE_VERSION%%+*}"
+          echo "Verifying release version consistency for ${CHECK_VERSION}..."
+          bash scripts/verify-release-versions.sh --version "${CHECK_VERSION}" --mode ci
+
+      # #2577 — Upload artifact BEFORE edge restore. compose files still have :<version> tags here.
+      # Moving this step before the restore ensures the artifact captures versioned compose files.
+      # If placed after restore (as before), the artifact contains :edge tags which defeats the
+      # purpose of downstream jobs (publish-npm, publish-containers) consuming versioned files.
+      - name: Upload bumped version files
+        if: steps.reentry-guard.outputs.skip != 'true'
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: version-bumped-files
+          path: |
+            package.json
+            packages/openclaw-plugin/package.json
+            packages/openclaw-plugin/openclaw.plugin.json
+            packages/openclaw-plugin/tests/__snapshots__/schema-snapshots.test.ts.snap
+            pnpm-lock.yaml
+            docker-compose.yml
+            docker-compose.traefik.yml
+            docker-compose.quickstart.yml
+            docker-compose.full.yml
+          if-no-files-found: error
+          retention-days: 3
+
       # #2526 — Restore compose files to :edge for main branch.
       # The version bump commit has versioned tags; this commit restores :edge
       # so that main always references edge builds for development.
+      # NOTE: Verify and artifact upload happen BEFORE this step (#2577, #2578).
       - name: Restore compose files to :edge after version bump
         if: steps.reentry-guard.outputs.skip != 'true'
         env:
@@ -336,34 +374,6 @@ jobs:
           # Reset remote URL to remove REPO_PAT from .git/config
           # (minimize exposure of branch-protection-bypass token)
           git remote set-url origin "https://github.com/${{ github.repository }}.git"
-
-      - name: Verify release version consistency
-        env:
-          FILE_VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          set -euo pipefail
-          # Strip build metadata for comparison
-          CHECK_VERSION="${FILE_VERSION%%+*}"
-          echo "Verifying release version consistency for ${CHECK_VERSION}..."
-          bash scripts/verify-release-versions.sh --version "${CHECK_VERSION}" --mode ci
-
-      - name: Upload bumped version files
-        if: steps.reentry-guard.outputs.skip != 'true'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-        with:
-          name: version-bumped-files
-          path: |
-            package.json
-            packages/openclaw-plugin/package.json
-            packages/openclaw-plugin/openclaw.plugin.json
-            packages/openclaw-plugin/tests/__snapshots__/schema-snapshots.test.ts.snap
-            pnpm-lock.yaml
-            docker-compose.yml
-            docker-compose.traefik.yml
-            docker-compose.quickstart.yml
-            docker-compose.full.yml
-          if-no-files-found: error
-          retention-days: 3
 
       - name: Determine release type
         if: steps.reentry-guard.outputs.skip != 'true'
@@ -879,8 +889,15 @@ jobs:
       contents: write
 
     steps:
+      # #2576 — Explicitly check out the tag that was force-pushed by the validate job.
+      # Without ref:, actions/checkout uses github.sha — the commit the tag pointed to when
+      # the workflow was triggered (before validate force-pushed the tag to the version-bump
+      # commit). That original SHA has :edge compose files. We must use the tag ref so we get
+      # the version-bump commit (with :<version> compose files) that validate moved the tag to.
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ needs.validate.outputs.tag }}
 
       # #2527 — Compose files are now versioned in the tag checkout itself
       # (via #2524 and #2525). No sed replacement needed — just copy them.

--- a/tests/workflows/release.test.ts
+++ b/tests/workflows/release.test.ts
@@ -287,6 +287,50 @@ describe('release.yml workflow', () => {
       expect(run).toContain('chore(release): restore :edge image tags [skip ci]');
     });
 
+    // #2577 — artifact upload must occur BEFORE the edge-restore step
+    // If the artifact is uploaded after the edge restore, the compose files in the artifact
+    // will contain :edge tags instead of the pinned version tags.
+    it('version-bumped-files artifact upload should occur before edge-restore step', () => {
+      const steps = workflow.jobs.validate.steps;
+      const uploadIdx = steps.findIndex(
+        (s) =>
+          s.uses?.includes('actions/upload-artifact') ||
+          s.name?.toLowerCase().includes('upload bumped'),
+      );
+      const restoreIdx = steps.findIndex(
+        (s) =>
+          s.name?.toLowerCase().includes('restore') && s.name?.toLowerCase().includes('edge'),
+      );
+      expect(uploadIdx, 'upload-artifact step must exist').toBeGreaterThanOrEqual(0);
+      expect(restoreIdx, 'edge-restore step must exist').toBeGreaterThanOrEqual(0);
+      expect(
+        uploadIdx,
+        'upload-artifact step must come BEFORE edge-restore step (artifact must capture :VERSION files)',
+      ).toBeLessThan(restoreIdx);
+    });
+
+    // #2578 — verify-release-versions step must occur BEFORE the edge-restore step
+    // If verification runs after the edge restore, compose files are :edge and the check
+    // for versioned tags will always fail on real release runs.
+    it('verify-release-versions step should appear before edge-restore step', () => {
+      const steps = workflow.jobs.validate.steps;
+      const verifyIdx = steps.findIndex(
+        (s) =>
+          s.name?.toLowerCase().includes('verify release') ||
+          (s.run?.includes('verify-release-versions.sh') ?? false),
+      );
+      const restoreIdx = steps.findIndex(
+        (s) =>
+          s.name?.toLowerCase().includes('restore') && s.name?.toLowerCase().includes('edge'),
+      );
+      expect(verifyIdx, 'verify step must exist').toBeGreaterThanOrEqual(0);
+      expect(restoreIdx, 'edge-restore step must exist').toBeGreaterThanOrEqual(0);
+      expect(
+        verifyIdx,
+        'verify-release-versions step must come BEFORE edge-restore step (must run while files have :VERSION tags)',
+      ).toBeLessThan(restoreIdx);
+    });
+
     // #2533 — atomic push for multi-ref mutations
     it('should use git push --atomic for multi-ref pushes', () => {
       const steps = workflow.jobs.validate.steps;
@@ -377,6 +421,22 @@ describe('release.yml workflow', () => {
     it('should checkout code', () => {
       const checkout = releaseSteps.find((s) => s.uses?.includes('actions/checkout'));
       expect(checkout).toBeDefined();
+    });
+
+    // #2576 — release job checkout must use the tag ref, not implicit github.sha
+    // Without an explicit ref, actions/checkout uses github.sha (the original trigger SHA,
+    // before the validate job force-pushed the tag to the version-bump commit). This means
+    // compose files in the release assets contain :edge instead of the pinned version.
+    it('release job checkout should use the tag ref, not implicit github.sha', () => {
+      const checkoutStep = releaseSteps.find((s) => s.uses?.startsWith('actions/checkout'));
+      expect(checkoutStep).toBeDefined();
+      expect(
+        checkoutStep?.with?.ref,
+        'checkout must specify ref: pointing to the tag — absent ref means github.sha which is pre-force-push',
+      ).toBeDefined();
+      // The ref must reference the tag output from the validate job
+      const ref = String(checkoutStep?.with?.ref ?? '');
+      expect(ref).toContain('validate.outputs.tag');
     });
 
     // #2527 — the release job should copy compose files from tag checkout, NOT use sed


### PR DESCRIPTION
## Summary

Fixes three high-severity bugs found in Phase 4 dual review of Epic #2522 that defeat the core goal of the epic (versioned compose files in release assets):

1. **#2576**: `release` job checkout now uses `ref: ${{ needs.validate.outputs.tag }}` — ensures the release job checks out the tag after it was re-pointed to the version-bump commit (not the original trigger SHA where compose files are `:edge`)

2. **#2577**: `version-bumped-files` artifact upload moved to BEFORE the edge-restore step — artifact now contains `:VERSION` compose files as intended, not `:edge`

3. **#2578**: `verify-release-versions.sh --mode ci` invocation moved to BEFORE the edge-restore step — verification now runs while compose files contain `:VERSION` tags, so it passes correctly

## Step Order (validate job) After Fix

1. Update compose files (`:edge` → `:VERSION`)
2. Commit version bump
3. **Verify release version consistency** ← moved before restore
4. **Upload version-bumped-files artifact** ← moved before restore
5. Restore compose files to `:edge`
6. Commit edge restore
7. Re-point tag and push

## Testing

All release workflow tests pass: `pnpm exec vitest run tests/ci/release/version-propagation.test.ts tests/workflows/release.test.ts`

3 new regression tests added (one per bug), 54 total tests pass.

## Codex Review

Codex MCP review: **No findings.** Confirmed all three fixes are correct and step ordering is logically sound.

Closes #2576
Closes #2577
Closes #2578

Part of Epic #2522