### PR TITLE
[#2566] Chain lint:no-manual-prefix into plugin lint script

### DIFF
--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -27,7 +27,7 @@
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
-    "lint": "biome lint .",
+    "lint": "biome lint . && pnpm run lint:no-manual-prefix",
     "lint:no-manual-prefix": "! grep -rn --include='*.ts' -E '\\[(openclaw-projects|plugins)\\]' src/ --exclude='logger.ts' --exclude='startup.ts' | grep -v 'biome-ignore' | grep -v '// eslint-disable' | grep -qv '^$'",
     "prepublishOnly": "pnpm run clean && pnpm run build && pnpm run test && pnpm run typecheck && pnpm run lint"
   },


### PR DESCRIPTION
## Summary

Chains the existing `lint:no-manual-prefix` script into the main `lint` script in `packages/openclaw-plugin/package.json`. Previously, the `lint:no-manual-prefix` script existed but was never executed as part of `lint` or `prepublishOnly`, meaning manual `[openclaw-projects]` or `[plugins]` prefix regressions could land undetected.

## Changes

- **`packages/openclaw-plugin/package.json`**: Changed `lint` from `biome lint .` to `biome lint . && pnpm run lint:no-manual-prefix`
- Since `prepublishOnly` already calls `pnpm run lint`, it now transitively runs `lint:no-manual-prefix` too

## Verification

- `pnpm run lint` passes (both biome lint and no-manual-prefix check)
- `pnpm run lint:no-manual-prefix` passes independently (no existing violations)
- `pnpm run typecheck` passes
- All plugin unit tests pass (1 pre-existing failure in `plugin-exports.test.ts` requires `dist/` build — same on `main`)

Closes #2566