### PR TITLE
[#2566] Chain lint:no-manual-prefix into lint script

### DIFF
--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -27,7 +27,7 @@
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
-    "lint": "biome lint .",
+    "lint": "biome lint . && pnpm run lint:no-manual-prefix",
     "lint:no-manual-prefix": "! grep -rn --include='*.ts' -E '\\[(openclaw-projects|plugins)\\]' src/ --exclude='logger.ts' --exclude='startup.ts' | grep -v 'biome-ignore' | grep -v '// eslint-disable' | grep -qv '^$'",
     "prepublishOnly": "pnpm run clean && pnpm run build && pnpm run test && pnpm run typecheck && pnpm run lint"
   },


### PR DESCRIPTION
## Summary

Chains the `lint:no-manual-prefix` grep-based check into the main `lint` script so that manual `[openclaw-projects]` or `[plugins]` prefix regressions are caught by `pnpm run lint` and `prepublishOnly`.

Closes #2566
Related to #2536

## Changes

- Updated `lint` script in `packages/openclaw-plugin/package.json` to run `lint:no-manual-prefix` after biome lint

## Verification

- [x] `pnpm run lint` runs both biome lint and prefix check
- [x] `pnpm run lint:no-manual-prefix` passes independently
- [x] No existing code violates the check
- [x] Full unit test suite passes (363 files, 5620 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)