### PR TITLE
[#2588] Fix release workflow: pin all checkout steps to github.sha

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -418,8 +418,14 @@ jobs:
       contents: read
 
     steps:
+      # #2588 — Use github.sha (the commit that was tagged when the workflow
+      # was triggered) instead of the default ref. The validate job force-pushes
+      # the tag to the version bump commit (#2525), which causes checkout@v6 to
+      # reject the default ref with "ref may have been updated after trigger".
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.sha }}
 
       - name: Build + start devcontainer services
         run: |
@@ -516,8 +522,12 @@ jobs:
       id-token: write  # npm provenance
 
     steps:
+      # #2588 — Pin to github.sha to avoid checkout@v6 rejection after
+      # validate force-pushes the tag. Artifact overlay provides version-bumped files.
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.sha }}
 
       - name: Download bumped version files
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -602,8 +612,12 @@ jobs:
       packages: write
 
     steps:
+      # #2588 — Pin to github.sha to avoid checkout@v6 rejection after
+      # validate force-pushes the tag. Artifact overlay provides version-bumped files.
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.sha }}
 
       - name: Download bumped version files
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -714,8 +728,12 @@ jobs:
             dockerfile: docker/symphony-worker/Dockerfile
 
     steps:
+      # #2588 — Pin to github.sha to avoid checkout@v6 rejection after
+      # validate force-pushes the tag. Artifact overlay provides version-bumped files.
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.sha }}
 
       - name: Download bumped version files
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -839,10 +857,13 @@ jobs:
             echo "::notice::Sentry not configured — skipping release finalization"
           fi
 
+      # #2588 — Pin to github.sha to avoid checkout@v6 rejection after
+      # validate force-pushes the tag.
       - name: Checkout repository
         if: steps.sentry-check.outputs.configured == 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          ref: ${{ github.sha }}
           fetch-depth: 0
 
       - name: Setup Node.js


### PR DESCRIPTION
## Summary

- Fix 5 bare `actions/checkout@v6` steps in the release workflow that fail after the validate job force-pushes the tag to the version bump commit (#2525)
- Add `ref: ${{ github.sha }}` to all affected checkout steps: test, publish-npm, publish-github-packages, publish-containers, finalize-sentry-release
- The `release` job was already fixed in #2576 — this extends that fix to all remaining jobs

## Root Cause

`actions/checkout@v6` has a safety check that compares the current tag ref against `github.sha`. When the validate job force-pushes the tag to the version bump commit, the checkout action detects the mismatch and refuses to proceed with: `"ref may have been updated after the workflow was triggered"`.

## Test plan

- [ ] Merge this PR
- [ ] Delete tag v0.0.61 and the version bump commits on main
- [ ] Push a fresh v0.0.61 tag
- [ ] Verify the release workflow completes: validate → test → publish-npm + publish-containers → release
- [ ] Verify npm package published
- [ ] Verify container images published

Closes #2588

🤖 Generated with [Claude Code](https://claude.com/claude-code)